### PR TITLE
Fix the Container Service Tests

### DIFF
--- a/azurerm/resource_arm_container_service_test.go
+++ b/azurerm/resource_arm_container_service_test.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -96,7 +97,9 @@ func TestAccAzureRMContainerService_dcosBasic(t *testing.T) {
 
 func TestAccAzureRMContainerService_kubernetesBasic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMContainerService_kubernetesBasic, ri, ri, ri, ri, ri)
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMContainerService_kubernetesBasic(ri, clientId, clientSecret)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -115,7 +118,9 @@ func TestAccAzureRMContainerService_kubernetesBasic(t *testing.T) {
 
 func TestAccAzureRMContainerService_kubernetesComplete(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMContainerService_kubernetesComplete, ri, ri, ri, ri, ri)
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMContainerService_kubernetesComplete(ri, clientId, clientSecret)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -189,7 +194,8 @@ resource "azurerm_container_service" "test" {
 }
 `
 
-var testAccAzureRMContainerService_kubernetesBasic = `
+func testAccAzureRMContainerService_kubernetesBasic(rInt int, clientId string, clientSecret string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "East US"
@@ -222,17 +228,19 @@ resource "azurerm_container_service" "test" {
   }
 
   service_principal {
-    client_id     = "00000000-0000-0000-0000-000000000000"
-    client_secret = "00000000000000000000000000000000"
+    client_id     = "%s"
+    client_secret = "%s"
   }
 
   diagnostics_profile {
     enabled = false
   }
 }
-`
+`, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
+}
 
-var testAccAzureRMContainerService_kubernetesComplete = `
+func testAccAzureRMContainerService_kubernetesComplete(rInt int, clientId string, clientSecret string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "East US"
@@ -265,8 +273,8 @@ resource "azurerm_container_service" "test" {
   }
 
   service_principal {
-    client_id     = "00000000-0000-0000-0000-000000000000"
-    client_secret = "00000000000000000000000000000000"
+    client_id     = "%s"
+    client_secret = "%s"
   }
 
   diagnostics_profile {
@@ -277,7 +285,8 @@ resource "azurerm_container_service" "test" {
     you = "me"
   }
 }
-`
+`, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
+}
 
 var testAccAzureRMContainerService_swarmBasic = `
 resource "azurerm_resource_group" "test" {


### PR DESCRIPTION
Whilst looking at migrating PR's to the new repo - I noticed that Azure's recently started validating the ClientID and Client Secret passed in when creating a Kubernetes instance - meaning the following tests have started failing:

```
------- Stdout: -------
=== RUN   TestAccAzureRMContainerService_kubernetesBasic
--- FAIL: TestAccAzureRMContainerService_kubernetesBasic (54.21s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:

        * azurerm_container_service.test: 1 error(s) occurred:

        * azurerm_container_service.test: containerservice.ContainerServicesClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="The credentials in ServicePrincipalProfile were invalid. Please see https://aka.ms/acs-sp-help for more details. (Details: AADSTS70001: Application with identifier '00000000-0000-0000-0000-000000000000' was not found in the directory *******\r\nTrace ID: 0c163194-8067-4f0b-ad6e-1b5a706e2100\r\nCorrelation ID: 75b9e48b-a42c-451a-b37a-794e107e78a8\r\nTimestamp: 2017-06-11 05:22:56Z)"
FAIL

------- Stdout: -------
=== RUN   TestAccAzureRMContainerService_kubernetesComplete
--- FAIL: TestAccAzureRMContainerService_kubernetesComplete (39.33s)
    testing.go:428: Step 0 error: Error applying: 1 error(s) occurred:

        * azurerm_container_service.test: 1 error(s) occurred:

        * azurerm_container_service.test: containerservice.ContainerServicesClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="The credentials in ServicePrincipalProfile were invalid. Please see https://aka.ms/acs-sp-help for more details. (Details: AADSTS70001: Application with identifier '00000000-0000-0000-0000-000000000000' was not found in the directory *******\r\nTrace ID: bc5b01eb-67e3-4c89-9779-678d4bc51c00\r\nCorrelation ID: 231583a9-4169-4671-930c-ab02b50dd43d\r\nTimestamp: 2017-06-11 05:23:01Z)"
FAIL
```

This PR fixes this by passing in a valid ClientID and Client Secret from the Environment Variables provided for testing.

Tests pass:

```
$ envchain azurerm make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMContainerService_kubernetesBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMContainerService_kubernetesBasic -timeout 120m
=== RUN   TestAccAzureRMContainerService_kubernetesBasic
--- PASS: TestAccAzureRMContainerService_kubernetesBasic (845.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	845.243s

$ envchain azurerm make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMContainerService_kubernetesComplete'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMContainerService_kubernetesComplete -timeout 120m
=== RUN   TestAccAzureRMContainerService_kubernetesComplete
--- PASS: TestAccAzureRMContainerService_kubernetesComplete (973.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	973.315s
```
