### PR TITLE
Readme fix and ignore VS Code folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ website/node_modules
 
 website/vendor
 
+.vscode
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ website/node_modules
 
 website/vendor
 
-.vscode
+.vscode/
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-$PROVIDER_NAME`
+Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-$PROVIDER_NAME`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
 $ git clone git@github.com:hashicorp/terraform-provider-$PROVIDER_NAME
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-$PROVIDER_NAME
+$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-$PROVIDER_NAME
 $ make build
 ```
 
@@ -42,7 +42,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-$PROVIDER_NAME
 ...


### PR DESCRIPTION
Fix a few things in README.
Added .vscode folder created by VS Code to .gitignore. - Since a few folks are using VS Code for dev, test & Git, it would be nice to have .vscode ignored so test settings won't be accidentally checked in.
