### PR TITLE
Fix #110 cannot change storage account type

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -61,7 +61,7 @@ func resourceArmStorageAccount() *schema.Resource {
 			"account_type": {
 				Type:             schema.TypeString,
 				Required:         true,
-        ForceNew:         true,
+				ForceNew:         true,
 				ValidateFunc:     validateArmStorageAccountType,
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -61,6 +61,7 @@ func resourceArmStorageAccount() *schema.Resource {
 			"account_type": {
 				Type:             schema.TypeString,
 				Required:         true,
+        ForceNew:         true,
 				ValidateFunc:     validateArmStorageAccountType,
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},


### PR DESCRIPTION
[#110](https://github.com/terraform-providers/terraform-provider-azurerm/issues/110)

Forces a new resource if the account_type changes.