### PR TITLE
Registering the `Microsoft.Insights` resource provider if it's not registered

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -249,19 +249,20 @@ func registerAzureResourceProvidersWithSubscription(providerList []resources.Pro
 	var err error
 	providerRegistrationOnce.Do(func() {
 		providers := map[string]struct{}{
-			"Microsoft.Compute":           struct{}{},
 			"Microsoft.Cache":             struct{}{},
+			"Microsoft.Cdn":               struct{}{},
+			"Microsoft.Compute":           struct{}{},
 			"Microsoft.ContainerRegistry": struct{}{},
 			"Microsoft.ContainerService":  struct{}{},
-			"Microsoft.Network":           struct{}{},
-			"Microsoft.Cdn":               struct{}{},
-			"Microsoft.Storage":           struct{}{},
-			"Microsoft.Sql":               struct{}{},
-			"Microsoft.Search":            struct{}{},
-			"Microsoft.Resources":         struct{}{},
-			"Microsoft.ServiceBus":        struct{}{},
-			"Microsoft.KeyVault":          struct{}{},
 			"Microsoft.EventHub":          struct{}{},
+			"Microsoft.Insights":          struct{}{},
+			"Microsoft.KeyVault":          struct{}{},
+			"Microsoft.Network":           struct{}{},
+			"Microsoft.Resources":         struct{}{},
+			"Microsoft.Search":            struct{}{},
+			"Microsoft.ServiceBus":        struct{}{},
+			"Microsoft.Sql":               struct{}{},
+			"Microsoft.Storage":           struct{}{},
 		}
 
 		// filter out any providers already registered


### PR DESCRIPTION
Sorted the list to make it more scannable