### PR TITLE
`azurerm_cdn_endpoint` - documentation updates

### DIFF
--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -75,7 +75,7 @@ The `origin` block supports:
 
 * `name` - (Required) The name of the origin. This is an arbitrary value. However, this value needs to be unique under endpoint.
 
-* `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string could be a domain name, IPv4 address or IPv6 address.
+* `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string can be a domain name, Storage Account endpoint, Web App endpoint, IPv4 address or IPv6 address.
 
 * `http_port` - (Optional) The HTTP port of the origin. Defaults to null. When null, 80 will be used for HTTP.
 


### PR DESCRIPTION
Better documenting the CDN endpoints. Fixes #56 

Including references to Storage Account and Web App endpoints as per the relevant ARM Templates: [Storage Account](https://github.com/Azure/azure-quickstart-templates/blob/master/201-cdn-with-storage-account/azuredeploy.json#L61) / [Web Apps](https://github.com/Azure/azure-quickstart-templates/blob/master/201-cdn-with-web-app/azuredeploy.json#L86)