### PR TITLE
Remove - must be PEM format string

### DIFF
--- a/website/docs/r/container_service.html.markdown
+++ b/website/docs/r/container_service.html.markdown
@@ -187,7 +187,7 @@ The following arguments are supported:
 
 `ssh_key` supports the following:
 
-* `key_data` - (Required) The Public SSH Key used to access the cluster. The certificate must be in PEM format with or without headers.
+* `key_data` - (Required) The Public SSH Key used to access the cluster.
 
 `agent_pool_profile` supports the following:
 


### PR DESCRIPTION
The documentation states that the key must to be in PEM format, however this is not accepted and a PKCS#1 format has to be used, as suggested by above examples and other ssh_key blocks into pages for other resources in azure.

I think the example should be self explanatory hence I propose to remove the PEM stuff only.