### PR TITLE
`azurerm_availability_set` Import Tests + Refactoring

### DIFF
--- a/azurerm/import_arm_availability_set_test.go
+++ b/azurerm/import_arm_availability_set_test.go
@@ -3,8 +3,6 @@ package azurerm
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -13,18 +11,18 @@ func TestAccAzureRMAvailabilitySet_importBasic(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
+	config := testAccAzureRMAvailabilitySet_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_availability_set_test.go
+++ b/azurerm/import_arm_availability_set_test.go
@@ -30,3 +30,75 @@ func TestAccAzureRMAvailabilitySet_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMAvailabilitySet_importWithTags(t *testing.T) {
+	resourceName := "azurerm_availability_set.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAvailabilitySet_withTags(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAvailabilitySet_importWithDomainCounts(t *testing.T) {
+	resourceName := "azurerm_availability_set.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAvailabilitySet_withDomainCounts(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAvailabilitySet_importManaged(t *testing.T) {
+	resourceName := "azurerm_availability_set.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAvailabilitySet_managed(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_availability_set.go
+++ b/azurerm/resource_arm_availability_set.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/jen20/riviera/azure"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/jen20/riviera/azure"
 )
 
 func resourceArmAvailabilitySet() *schema.Resource {
@@ -38,18 +38,18 @@ func resourceArmAvailabilitySet() *schema.Resource {
 			"location": locationSchema(),
 
 			"platform_update_domain_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  5,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      5,
+				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(1, 20),
 			},
 
 			"platform_fault_domain_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  3,
-				ForceNew: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      3,
+				ForceNew:     true,
 				ValidateFunc: validation.IntBetween(1, 3),
 			},
 

--- a/azurerm/resource_arm_availability_set.go
+++ b/azurerm/resource_arm_availability_set.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jen20/riviera/azure"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceArmAvailabilitySet() *schema.Resource {
@@ -41,14 +42,7 @@ func resourceArmAvailabilitySet() *schema.Resource {
 				Optional: true,
 				Default:  5,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-					if value > 20 {
-						errors = append(errors, fmt.Errorf(
-							"Maximum value for `platform_update_domain_count` is 20"))
-					}
-					return
-				},
+				ValidateFunc: validation.IntBetween(1, 20),
 			},
 
 			"platform_fault_domain_count": {
@@ -56,14 +50,7 @@ func resourceArmAvailabilitySet() *schema.Resource {
 				Optional: true,
 				Default:  3,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(int)
-					if value > 3 {
-						errors = append(errors, fmt.Errorf(
-							"Maximum value for (%s) is 3", k))
-					}
-					return
-				},
+				ValidateFunc: validation.IntBetween(1, 3),
 			},
 
 			"managed": {
@@ -79,18 +66,17 @@ func resourceArmAvailabilitySet() *schema.Resource {
 }
 
 func resourceArmAvailabilitySetCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
-	availSetClient := client.availSetClient
+	client := meta.(*ArmClient).availSetClient
 
-	log.Printf("[INFO] preparing arguments for Azure ARM Availability Set creation.")
+	log.Printf("[INFO] preparing arguments for AzureRM Availability Set creation.")
 
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	updateDomainCount := d.Get("platform_update_domain_count").(int)
 	faultDomainCount := d.Get("platform_fault_domain_count").(int)
-	tags := d.Get("tags").(map[string]interface{})
 	managed := d.Get("managed").(bool)
+	tags := d.Get("tags").(map[string]interface{})
 
 	availSet := compute.AvailabilitySet{
 		Name:     &name,
@@ -109,7 +95,7 @@ func resourceArmAvailabilitySetCreate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	resp, err := availSetClient.CreateOrUpdate(resGroup, name, availSet)
+	resp, err := client.CreateOrUpdate(resGroup, name, availSet)
 	if err != nil {
 		return err
 	}
@@ -120,7 +106,7 @@ func resourceArmAvailabilitySetCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) error {
-	availSetClient := meta.(*ArmClient).availSetClient
+	client := meta.(*ArmClient).availSetClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -129,7 +115,7 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 	resGroup := id.ResourceGroup
 	name := id.Path["availabilitySets"]
 
-	resp, err := availSetClient.Get(resGroup, name)
+	resp, err := client.Get(resGroup, name)
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -139,11 +125,11 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	availSet := *resp.AvailabilitySetProperties
+	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 	d.Set("platform_update_domain_count", availSet.PlatformUpdateDomainCount)
 	d.Set("platform_fault_domain_count", availSet.PlatformFaultDomainCount)
-	d.Set("name", resp.Name)
-	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
 	if resp.Sku != nil && resp.Sku.Name != nil {
 		d.Set("managed", strings.EqualFold(*resp.Sku.Name, "Aligned"))
@@ -155,7 +141,7 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmAvailabilitySetDelete(d *schema.ResourceData, meta interface{}) error {
-	availSetClient := meta.(*ArmClient).availSetClient
+	client := meta.(*ArmClient).availSetClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -164,7 +150,7 @@ func resourceArmAvailabilitySetDelete(d *schema.ResourceData, meta interface{}) 
 	resGroup := id.ResourceGroup
 	name := id.Path["availabilitySets"]
 
-	_, err = availSetClient.Delete(resGroup, name)
+	_, err = client.Delete(resGroup, name)
 
 	return err
 }

--- a/azurerm/resource_arm_availability_set_test.go
+++ b/azurerm/resource_arm_availability_set_test.go
@@ -11,23 +11,21 @@ import (
 )
 
 func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
-
+	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
+	config := testAccAzureRMAvailabilitySet_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "platform_update_domain_count", "5"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "platform_fault_domain_count", "3"),
+					testCheckAzureRMAvailabilitySetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "platform_update_domain_count", "5"),
+					resource.TestCheckResourceAttr(resourceName, "platform_fault_domain_count", "3"),
 				),
 			},
 		},
@@ -35,24 +33,22 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAvailabilitySet_disappears(t *testing.T) {
-
+	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
+	config := testAccAzureRMAvailabilitySet_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "platform_update_domain_count", "5"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "platform_fault_domain_count", "3"),
-					testCheckAzureRMAvailabilitySetDisappears("azurerm_availability_set.test"),
+					testCheckAzureRMAvailabilitySetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "platform_update_domain_count", "5"),
+					resource.TestCheckResourceAttr(resourceName, "platform_fault_domain_count", "3"),
+					testCheckAzureRMAvailabilitySetDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -61,37 +57,31 @@ func TestAccAzureRMAvailabilitySet_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
-
+	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withTags, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withUpdatedTags, ri, ri)
+	preConfig := testAccAzureRMAvailabilitySet_withTags(ri)
+	postConfig := testAccAzureRMAvailabilitySet_withUpdatedTags(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "tags.environment", "Production"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "tags.cost_center", "MSFT"),
+					testCheckAzureRMAvailabilitySetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
 				),
 			},
-
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "tags.environment", "staging"),
+					testCheckAzureRMAvailabilitySetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),
 			},
 		},
@@ -99,23 +89,21 @@ func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
 }
 
 func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
-
+	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withDomainCounts, ri, ri)
+	config := testAccAzureRMAvailabilitySet_withDomainCounts(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "platform_update_domain_count", "10"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "platform_fault_domain_count", "1"),
+					testCheckAzureRMAvailabilitySetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "platform_update_domain_count", "10"),
+					resource.TestCheckResourceAttr(resourceName, "platform_fault_domain_count", "1"),
 				),
 			},
 		},
@@ -123,20 +111,20 @@ func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
 }
 
 func TestAccAzureRMAvailabilitySet_managed(t *testing.T) {
+	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_managed, ri, ri)
+	config := testAccAzureRMAvailabilitySet_managed(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAvailabilitySetExists("azurerm_availability_set.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_availability_set.test", "managed", "true"),
+					testCheckAzureRMAvailabilitySetExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "managed", "true"),
 				),
 			},
 		},
@@ -190,7 +178,7 @@ func testCheckAzureRMAvailabilitySetDisappears(name string) resource.TestCheckFu
 
 		_, err := conn.Delete(resourceGroup, availSetName)
 		if err != nil {
-			return fmt.Errorf("Bad: Delete on availSetClient: %s", err)
+			return fmt.Errorf("Bad: Delete on availSetClient: %+v", err)
 		}
 
 		return nil
@@ -222,26 +210,31 @@ func testCheckAzureRMAvailabilitySetDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMVAvailabilitySet_basic = `
+func testAccAzureRMAvailabilitySet_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
+
 resource "azurerm_availability_set" "test" {
     name = "acctestavset-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, rInt)
+}
 
-var testAccAzureRMVAvailabilitySet_withTags = `
+func testAccAzureRMAvailabilitySet_withTags(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
+
 resource "azurerm_availability_set" "test" {
     name = "acctestavset-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
     tags {
@@ -249,49 +242,57 @@ resource "azurerm_availability_set" "test" {
        cost_center = "MSFT"
     }
 }
-`
+`, rInt, rInt)
+}
 
-var testAccAzureRMVAvailabilitySet_withUpdatedTags = `
+func testAccAzureRMAvailabilitySet_withUpdatedTags(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
+
 resource "azurerm_availability_set" "test" {
     name = "acctestavset-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
     tags {
        environment = "staging"
     }
 }
-`
+`, rInt, rInt)
+}
 
-var testAccAzureRMVAvailabilitySet_withDomainCounts = `
+func testAccAzureRMAvailabilitySet_withDomainCounts(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
+
 resource "azurerm_availability_set" "test" {
     name = "acctestavset-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     platform_update_domain_count = 10
     platform_fault_domain_count = 1
 }
-`
+`, rInt, rInt)
+}
 
-var testAccAzureRMVAvailabilitySet_managed = `
+func testAccAzureRMAvailabilitySet_managed(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
 resource "azurerm_availability_set" "test" {
     name = "acctestavset-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     platform_update_domain_count = 10
     platform_fault_domain_count = 1
     managed = true
+`, rInt, rInt)
 }
-`

--- a/azurerm/resource_arm_availability_set_test.go
+++ b/azurerm/resource_arm_availability_set_test.go
@@ -287,6 +287,7 @@ resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
+
 resource "azurerm_availability_set" "test" {
     name = "acctestavset-%d"
     location = "${azurerm_resource_group.test.location}"
@@ -294,5 +295,6 @@ resource "azurerm_availability_set" "test" {
     platform_update_domain_count = 10
     platform_fault_domain_count = 1
     managed = true
+}
 `, rInt, rInt)
 }


### PR DESCRIPTION
Adding additional imports covering [Availability Sets](https://docs.microsoft.com/en-us/rest/api/compute/availabilitysets/availabilitysets-create). Tests pass:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccAzureRMAvailabilitySet
=== RUN   TestAccAzureRMAvailabilitySet_importBasic
--- PASS: TestAccAzureRMAvailabilitySet_importBasic (75.86s)
=== RUN   TestAccAzureRMAvailabilitySet_importWithTags
--- PASS: TestAccAzureRMAvailabilitySet_importWithTags (73.37s)
=== RUN   TestAccAzureRMAvailabilitySet_importWithDomainCounts
--- PASS: TestAccAzureRMAvailabilitySet_importWithDomainCounts (79.31s)
=== RUN   TestAccAzureRMAvailabilitySet_importManaged
--- PASS: TestAccAzureRMAvailabilitySet_importManaged (73.44s)
=== RUN   TestAccAzureRMAvailabilitySet_basic
--- PASS: TestAccAzureRMAvailabilitySet_basic (110.21s)
=== RUN   TestAccAzureRMAvailabilitySet_disappears
--- PASS: TestAccAzureRMAvailabilitySet_disappears (59.90s)
=== RUN   TestAccAzureRMAvailabilitySet_withTags
--- PASS: TestAccAzureRMAvailabilitySet_withTags (71.58s)
=== RUN   TestAccAzureRMAvailabilitySet_withDomainCounts
--- PASS: TestAccAzureRMAvailabilitySet_withDomainCounts (59.43s)
=== RUN   TestAccAzureRMAvailabilitySet_managed
--- PASS: TestAccAzureRMAvailabilitySet_managed (74.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	677.298s
```