### PR TITLE
`azurerm_dns_ptr_record` - refactoring to match the DNS updates

### DIFF
--- a/azurerm/import_arm_dns_ptr_record_test.go
+++ b/azurerm/import_arm_dns_ptr_record_test.go
@@ -18,11 +18,33 @@ func TestAccAzureRMDnsPtrRecord_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMDnsPtrRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 
-			resource.TestStep{
+func TestAccAzureRMDnsPtrRecord_importWithTags(t *testing.T) {
+	resourceName := "azurerm_dns_ptr_record.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMDnsPtrRecord_withTags(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsPtrRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/resource_arm_dns_ptr_record.go
+++ b/azurerm/resource_arm_dns_ptr_record.go
@@ -106,11 +106,12 @@ func resourceArmDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error
 
 	resp, err := dnsClient.Get(resGroup, zoneName, name, dns.PTR)
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("Error reading DNS PTR record %s: %+v", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("name", name)

--- a/azurerm/resource_arm_dns_ptr_record_test.go
+++ b/azurerm/resource_arm_dns_ptr_record_test.go
@@ -133,13 +133,14 @@ func testCheckAzureRMDnsPtrRecordDestroy(s *terraform.State) error {
 		resp, err := conn.Get(resourceGroup, zoneName, ptrName, dns.PTR)
 
 		if err != nil {
-			return nil
+			if resp.StatusCode != http.StatusNotFound {
+				return nil
+			}
+
+			return err
 		}
 
-		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("DNS PTR record still exists:\n%#v", resp.RecordSetProperties)
-		}
-
+		fmt.Errorf("DNS PTR record still exists:\n%#v", resp)
 	}
 
 	return nil
@@ -151,6 +152,7 @@ resource "azurerm_resource_group" "test" {
     name = "acctestRG_%[1]d"
     location = "West US"
 }
+
 resource "azurerm_dns_zone" "test" {
     name = "acctestzone%[1]d.com"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -172,6 +174,7 @@ resource "azurerm_resource_group" "test" {
     name = "acctestRG_%[1]d"
     location = "West US"
 }
+
 resource "azurerm_dns_zone" "test" {
     name = "acctestzone%[1]d.com"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -193,6 +196,7 @@ resource "azurerm_resource_group" "test" {
     name = "acctestRG_%[1]d"
     location = "West US"
 }
+
 resource "azurerm_dns_zone" "test" {
     name = "acctestzone%[1]d.com"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -219,6 +223,7 @@ resource "azurerm_resource_group" "test" {
     name = "acctestRG_%[1]d"
     location = "West US"
 }
+
 resource "azurerm_dns_zone" "test" {
     name = "acctestzone%[1]d.com"
     resource_group_name = "${azurerm_resource_group.test.name}"

--- a/azurerm/resource_arm_dns_ptr_record_test.go
+++ b/azurerm/resource_arm_dns_ptr_record_test.go
@@ -133,14 +133,14 @@ func testCheckAzureRMDnsPtrRecordDestroy(s *terraform.State) error {
 		resp, err := conn.Get(resourceGroup, zoneName, ptrName, dns.PTR)
 
 		if err != nil {
-			if resp.StatusCode != http.StatusNotFound {
+			if resp.StatusCode == http.StatusNotFound {
 				return nil
 			}
 
 			return err
 		}
 
-		fmt.Errorf("DNS PTR record still exists:\n%#v", resp)
+		return fmt.Errorf("DNS PTR record still exists:\n%#v", resp)
 	}
 
 	return nil

--- a/website/docs/r/dns_ptr_record.html.markdown
+++ b/website/docs/r/dns_ptr_record.html.markdown
@@ -54,8 +54,6 @@ The following attributes are exported:
 
 * `id` - The DNS PTR Record ID.
 
-* `etag` - The etag of the record set.
-
 ## Import
 
 PTR records can be imported using the `resource id`, e.g.


### PR DESCRIPTION
Removing the computed `etag` field - from what I can see we shouldn't be supporting it (this may need to be marked as Removed first instead?)

Tests pass:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccAzureRMDnsPtr
=== RUN   TestAccAzureRMDnsPtrRecord_importBasic
--- PASS: TestAccAzureRMDnsPtrRecord_importBasic (69.87s)
=== RUN   TestAccAzureRMDnsPtrRecord_importWithTags
--- PASS: TestAccAzureRMDnsPtrRecord_importWithTags (89.69s)
=== RUN   TestAccAzureRMDnsPtrRecord_basic
--- PASS: TestAccAzureRMDnsPtrRecord_basic (68.51s)
=== RUN   TestAccAzureRMDnsPtrRecord_updateRecords
--- PASS: TestAccAzureRMDnsPtrRecord_updateRecords (82.06s)
=== RUN   TestAccAzureRMDnsPtrRecord_withTags
--- PASS: TestAccAzureRMDnsPtrRecord_withTags (102.56s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	412.721s
```