### PR TITLE
Static -> Dynamic Test Data

### DIFF
--- a/azurerm/data_source_arm_public_ip_test.go
+++ b/azurerm/data_source_arm_public_ip_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceAzureRMPublicIP_basic(t *testing.T) {
 	name := fmt.Sprintf("acctestpublicip-%d", ri)
 	resourceGroupName := fmt.Sprintf("acctestRG-%d", ri)
 
-	config := testAccDatSourceAzureRMPublicIPBasic(name, resourceGroupName)
+	config := testAccDatSourceAzureRMPublicIPBasic(name, resourceGroupName, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -26,7 +26,7 @@ func TestAccDataSourceAzureRMPublicIP_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "name", name),
 					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "resource_group_name", resourceGroupName),
-					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "domain_name_label", "mylabel01"),
+					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "domain_name_label", fmt.Sprintf("acctest-%d", ri)),
 					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "idle_timeout_in_minutes", "30"),
 					resource.TestCheckResourceAttrSet("data.azurerm_public_ip.test", "fqdn"),
 					resource.TestCheckResourceAttrSet("data.azurerm_public_ip.test", "ip_address"),
@@ -38,7 +38,7 @@ func TestAccDataSourceAzureRMPublicIP_basic(t *testing.T) {
 	})
 }
 
-func testAccDatSourceAzureRMPublicIPBasic(name string, resourceGroupName string) string {
+func testAccDatSourceAzureRMPublicIPBasic(name string, resourceGroupName string, rInt int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "%s"
@@ -49,11 +49,11 @@ resource "azurerm_public_ip" "test" {
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
-	domain_name_label = "mylabel01"
-	idle_timeout_in_minutes = 30
+    domain_name_label = "acctest-%d"
+    idle_timeout_in_minutes = 30
 	
     tags {
-		environment = "test"
+	environment = "test"
     }
 }
 
@@ -61,5 +61,5 @@ data "azurerm_public_ip" "test" {
     name = "${azurerm_public_ip.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, resourceGroupName, name)
+`, resourceGroupName, name, rInt)
 }

--- a/azurerm/resource_arm_public_ip_test.go
+++ b/azurerm/resource_arm_public_ip_test.go
@@ -187,7 +187,7 @@ func TestAccAzureRMPublicIpStatic_update(t *testing.T) {
 
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_update, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_update, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -206,7 +206,7 @@ func TestAccAzureRMPublicIpStatic_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
 					resource.TestCheckResourceAttr(
-						"azurerm_public_ip.test", "domain_name_label", "mylabel01"),
+						"azurerm_public_ip.test", "domain_name_label", fmt.Sprintf("acctest-%d", ri)),
 				),
 			},
 		},
@@ -336,7 +336,7 @@ resource "azurerm_public_ip" "test" {
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
-    domain_name_label = "mylabel01"
+    domain_name_label = "acctest-%d"
 }
 `
 


### PR DESCRIPTION
Swapping out the hard-coded test data `mylabel01` for a randomly assigned variable

Fixes a couple of failing tests:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccDataSourceAzureRMPublicIP_basic
=== RUN   TestAccDataSourceAzureRMPublicIP_basic
--- PASS: TestAccDataSourceAzureRMPublicIP_basic (95.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	95.460s
```

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccAzureRMPublicIpStatic_update
=== RUN   TestAccAzureRMPublicIpStatic_update
--- PASS: TestAccAzureRMPublicIpStatic_update (108.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	108.326s
```