### PR TITLE
Making the Test Location an Environment Variable: Part 2

### DIFF
--- a/azurerm/import_arm_subnet_test.go
+++ b/azurerm/import_arm_subnet_test.go
@@ -11,18 +11,17 @@ func TestAccAzureRMSubnet_importBasic(t *testing.T) {
 	resourceName := "azurerm_subnet.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMSubnet_basic(ri)
+	config := testAccAzureRMSubnet_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSubnetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -35,18 +34,17 @@ func TestAccAzureRMSubnet_importWithRouteTable(t *testing.T) {
 	resourceName := "azurerm_subnet.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMSubnet_routeTable(ri)
+	config := testAccAzureRMSubnet_routeTable(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSubnetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_traffic_manager_endpoint_test.go
+++ b/azurerm/import_arm_traffic_manager_endpoint_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMTrafficManagerEndpoint_importBasic(t *testing.T) {
 	resourceName := "azurerm_traffic_manager_endpoint.testExternal"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basic, ri, ri, ri, ri, ri, ri, ri)
+	config := testAccAzureRMTrafficManagerEndpoint_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_traffic_manager_profile_test.go
+++ b/azurerm/import_arm_traffic_manager_profile_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMTrafficManagerProfile_importBasic(t *testing.T) {
 	resourceName := "azurerm_traffic_manager_profile.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_performance, ri, ri, ri)
+	config := testAccAzureRMTrafficManagerProfile_performance(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -33,8 +33,13 @@ func testAccPreCheck(t *testing.T) {
 	clientID := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
 	tenantID := os.Getenv("ARM_TENANT_ID")
+	testLocation := os.Getenv("ARM_TEST_LOCATION")
 
-	if subscriptionID == "" || clientID == "" || clientSecret == "" || tenantID == "" {
-		t.Fatal("ARM_SUBSCRIPTION_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET and ARM_TENANT_ID must be set for acceptance tests")
+	if subscriptionID == "" || clientID == "" || clientSecret == "" || tenantID == "" || testLocation == "" {
+		t.Fatal("ARM_SUBSCRIPTION_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID and ARM_TEST_LOCATION must be set for acceptance tests")
 	}
+}
+
+func testLocation() string {
+	return os.Getenv("ARM_TEST_LOCATION")
 }

--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -157,7 +157,7 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure Subnet %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure Subnet %s: %+v", name, err)
 	}
 
 	d.Set("name", name)

--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccAzureRMSubnet_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMSubnet_basic(ri)
+	config := testAccAzureRMSubnet_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,8 +35,9 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 
 	ri := acctest.RandInt()
-	initConfig := testAccAzureRMSubnet_routeTable(ri)
-	updatedConfig := testAccAzureRMSubnet_updatedRouteTable(ri)
+	location := testLocation()
+	initConfig := testAccAzureRMSubnet_routeTable(ri, location)
+	updatedConfig := testAccAzureRMSubnet_updatedRouteTable(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -62,7 +63,7 @@ func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 
 func TestAccAzureRMSubnet_bug7986(t *testing.T) {
 	ri := acctest.RandInt()
-	initConfig := testAccAzureRMSubnet_bug7986(ri)
+	initConfig := testAccAzureRMSubnet_bug7986(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,7 +83,7 @@ func TestAccAzureRMSubnet_bug7986(t *testing.T) {
 
 func TestAccAzureRMSubnet_bug15204(t *testing.T) {
 	ri := acctest.RandInt()
-	initConfig := testAccAzureRMSubnet_bug15204(ri)
+	initConfig := testAccAzureRMSubnet_bug15204(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -102,7 +103,7 @@ func TestAccAzureRMSubnet_bug15204(t *testing.T) {
 func TestAccAzureRMSubnet_disappears(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMSubnet_basic(ri)
+	config := testAccAzureRMSubnet_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -142,7 +143,7 @@ func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
 
 		resp, err := conn.Get(resourceGroup, vnetName, name, "")
 		if err != nil {
-			return fmt.Errorf("Bad: Get on subnetClient: %s", err)
+			return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -177,7 +178,7 @@ func testCheckAzureRMSubnetRouteTableExists(subnetName string, routeTableId stri
 		vnetConn := testAccProvider.Meta().(*ArmClient).vnetClient
 		vnetResp, vnetErr := vnetConn.Get(resourceGroup, vnetName, "")
 		if vnetErr != nil {
-			return fmt.Errorf("Bad: Get on vnetClient: %s", vnetErr)
+			return fmt.Errorf("Bad: Get on vnetClient: %+v", vnetErr)
 		}
 
 		if vnetResp.Subnets == nil {
@@ -188,7 +189,7 @@ func testCheckAzureRMSubnetRouteTableExists(subnetName string, routeTableId stri
 
 		resp, err := conn.Get(resourceGroup, vnetName, name, "")
 		if err != nil {
-			return fmt.Errorf("Bad: Get on subnetClient: %s", err)
+			return fmt.Errorf("Bad: Get on subnetClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -227,7 +228,7 @@ func testCheckAzureRMSubnetDisappears(name string) resource.TestCheckFunc {
 		_, error := conn.Delete(resourceGroup, vnetName, name, make(chan struct{}))
 		err := <-error
 		if err != nil {
-			return fmt.Errorf("Bad: Delete on subnetClient: %s", err)
+			return fmt.Errorf("Bad: Delete on subnetClient: %+v", err)
 		}
 
 		return nil
@@ -260,17 +261,17 @@ func testCheckAzureRMSubnetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMSubnet_basic(rInt int) string {
+func testAccAzureRMSubnet_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
@@ -279,28 +280,28 @@ resource "azurerm_subnet" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     virtual_network_name = "${azurerm_virtual_network.test.name}"
     address_prefix = "10.0.2.0/24"
-	route_table_id = "${azurerm_route_table.test.id}" 
+    route_table_id = "${azurerm_route_table.test.id}"
 }
 
 resource "azurerm_route_table" "test" {
-	name = "acctestroutetable%d"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	location = "West US"
+    name = "acctestroutetable%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US"
 }
 
 resource "azurerm_route" "test" {
-	name = "acctestroute%d"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	route_table_name  = "${azurerm_route_table.test.name}" 
+    name = "acctestroute%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    route_table_name  = "${azurerm_route_table.test.name}"
 
-	address_prefix = "10.100.0.0/14" 
-	next_hop_type = "VirtualAppliance" 
-	next_hop_in_ip_address = "10.10.1.1" 
+    address_prefix = "10.100.0.0/14"
+    next_hop_type = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.1.1"
 }
-`, rInt, rInt, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMSubnet_routeTable(rInt int) string {
+func testAccAzureRMSubnet_routeTable(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
@@ -310,7 +311,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
@@ -339,11 +340,11 @@ resource "azurerm_route" "route_a" {
 }`, rInt, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMSubnet_updatedRouteTable(rInt int) string {
+func testAccAzureRMSubnet_updatedRouteTable(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 	tags {
 		environment = "Testing"
 	}
@@ -351,7 +352,7 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_network_security_group" "test_secgroup" {
     name = "acctest-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
     security_rule {
@@ -374,7 +375,7 @@ resource "azurerm_network_security_group" "test_secgroup" {
 resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 	tags {
 		environment = "Testing"
@@ -391,7 +392,7 @@ resource "azurerm_subnet" "test" {
 
 resource "azurerm_route_table" "test" {
   name                = "acctest-%d"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   tags {
     environment = "Testing"
@@ -406,14 +407,14 @@ resource "azurerm_route" "route_a" {
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"
   next_hop_in_ip_address = "10.10.1.1"
-}`, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMSubnet_bug7986(rInt int) string {
+func testAccAzureRMSubnet_bug7986(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctest%d-rg"
-  location = "West Europe"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
@@ -465,14 +466,14 @@ resource "azurerm_subnet" "second" {
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.1.0/24"
   route_table_id       = "${azurerm_route_table.second.id}"
-}`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMSubnet_bug15204(rInt int) string {
+func testAccAzureRMSubnet_bug15204(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctest-%d"
-  location = "West Europe"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
@@ -502,5 +503,5 @@ resource "azurerm_subnet" "test" {
   route_table_id            = "${azurerm_route_table.test.id}"
   network_security_group_id = "${azurerm_network_security_group.test.id}"
 }
-`, rInt, rInt, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt, rInt)
 }

--- a/azurerm/resource_arm_template_deployment.go
+++ b/azurerm/resource_arm_template_deployment.go
@@ -102,7 +102,7 @@ func resourceArmTemplateDeploymentCreate(d *schema.ResourceData, meta interface{
 	_, error := deployClient.CreateOrUpdate(resGroup, name, deployment, make(chan struct{}))
 	err := <-error
 	if err != nil {
-		return fmt.Errorf("Error creating deployment: %s", err)
+		return fmt.Errorf("Error creating deployment: %+v", err)
 	}
 
 	read, err := deployClient.Get(resGroup, name)
@@ -123,7 +123,7 @@ func resourceArmTemplateDeploymentCreate(d *schema.ResourceData, meta interface{
 		Timeout: 40 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Template Deployment (%s) to become available: %s", name, err)
+		return fmt.Errorf("Error waiting for Template Deployment (%s) to become available: %+v", name, err)
 	}
 
 	return resourceArmTemplateDeploymentRead(d, meta)
@@ -149,7 +149,7 @@ func resourceArmTemplateDeploymentRead(d *schema.ResourceData, meta interface{})
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure RM Template Deployment %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure RM Template Deployment %s: %+v", name, err)
 	}
 
 	var outputs map[string]string
@@ -228,7 +228,7 @@ func normalizeJson(jsonString interface{}) string {
 	var j interface{}
 	err := json.Unmarshal([]byte(jsonString.(string)), &j)
 	if err != nil {
-		return fmt.Sprintf("Error parsing JSON: %s", err)
+		return fmt.Sprintf("Error parsing JSON: %+v", err)
 	}
 	b, _ := json.Marshal(j)
 	return string(b[:])
@@ -238,7 +238,7 @@ func templateDeploymentStateRefreshFunc(client *ArmClient, resourceGroupName str
 	return func() (interface{}, string, error) {
 		res, err := client.deploymentsClient.Get(resourceGroupName, name)
 		if err != nil {
-			return nil, "", fmt.Errorf("Error issuing read request in templateDeploymentStateRefreshFunc to Azure ARM for Template Deployment '%s' (RG: '%s'): %s", name, resourceGroupName, err)
+			return nil, "", fmt.Errorf("Error issuing read request in templateDeploymentStateRefreshFunc to Azure ARM for Template Deployment '%s' (RG: '%s'): %+v", name, resourceGroupName, err)
 		}
 
 		return res, strings.ToLower(*res.Properties.ProvisioningState), nil

--- a/azurerm/resource_arm_template_deployment_test.go
+++ b/azurerm/resource_arm_template_deployment_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccAzureRMTemplateDeployment_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_basicMultiple, ri, ri)
+	config := testAccAzureRMTemplateDeployment_basicMultiple(ri, testLocation())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -31,7 +31,7 @@ func TestAccAzureRMTemplateDeployment_basic(t *testing.T) {
 
 func TestAccAzureRMTemplateDeployment_disappears(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_basicSingle, ri, ri, ri)
+	config := testAccAzureRMTemplateDeployment_basicSingle(ri, testLocation())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -51,7 +51,7 @@ func TestAccAzureRMTemplateDeployment_disappears(t *testing.T) {
 
 func TestAccAzureRMTemplateDeployment_withParams(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_withParams, ri, ri, ri)
+	config := testAccAzureRMTemplateDeployment_withParams(ri, testLocation())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -70,7 +70,7 @@ func TestAccAzureRMTemplateDeployment_withParams(t *testing.T) {
 
 func TestAccAzureRMTemplateDeployment_withOutputs(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_withOutputs, ri, ri, ri)
+	config := testAccAzureRMTemplateDeployment_withOutputs(ri, testLocation())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -93,7 +93,7 @@ func TestAccAzureRMTemplateDeployment_withOutputs(t *testing.T) {
 
 func TestAccAzureRMTemplateDeployment_withError(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_withError, ri, ri)
+	config := testAccAzureRMTemplateDeployment_withError(ri, testLocation())
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -187,10 +187,11 @@ func testCheckAzureRMTemplateDeploymentDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMTemplateDeployment_basicSingle = `
-  resource "azurerm_resource_group" "test" {
+func testAccAzureRMTemplateDeployment_basicSingle(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
   }
 
   resource "azurerm_template_deployment" "test" {
@@ -224,13 +225,14 @@ var testAccAzureRMTemplateDeployment_basicSingle = `
 DEPLOY
     deployment_mode = "Complete"
   }
+`, rInt, location, rInt, rInt)
+}
 
-`
-
-var testAccAzureRMTemplateDeployment_basicMultiple = `
+func testAccAzureRMTemplateDeployment_basicMultiple(rInt int, location string) string {
+	return fmt.Sprintf(`
   resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
   }
 
   resource "azurerm_template_deployment" "test" {
@@ -289,13 +291,14 @@ var testAccAzureRMTemplateDeployment_basicMultiple = `
 DEPLOY
     deployment_mode = "Complete"
   }
+`, rInt, location, rInt)
+}
 
-`
-
-var testAccAzureRMTemplateDeployment_withParams = `
+func testAccAzureRMTemplateDeployment_withParams(rInt int, location string) string {
+	return fmt.Sprintf(`
   resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
   }
 
   output "test" {
@@ -384,13 +387,14 @@ DEPLOY
     }
     deployment_mode = "Complete"
   }
+`, rInt, location, rInt, rInt)
+}
 
-`
-
-var testAccAzureRMTemplateDeployment_withOutputs = `
+func testAccAzureRMTemplateDeployment_withOutputs(rInt int, location string) string {
+	return fmt.Sprintf(`
   resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
   }
 
   output "tfStringOutput" {
@@ -504,14 +508,15 @@ DEPLOY
     }
     deployment_mode = "Incremental"
   }
-
-`
+`, rInt, location, rInt, rInt)
+}
 
 // StorageAccount name is too long, forces error
-var testAccAzureRMTemplateDeployment_withError = `
-  resource "azurerm_resource_group" "test" {
+func testAccAzureRMTemplateDeployment_withError(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
   }
 
   output "test" {
@@ -568,4 +573,5 @@ DEPLOY
     }
     deployment_mode = "Complete"
   }
-`
+`, rInt, location, rInt)
+}

--- a/azurerm/resource_arm_traffic_manager_endpoint.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint.go
@@ -28,9 +28,9 @@ func resourceArmTrafficManagerEndpoint() *schema.Resource {
 			},
 
 			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"azureEndpoints",
 					"nestedEndpoints",

--- a/azurerm/resource_arm_traffic_manager_endpoint.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint.go
@@ -31,7 +31,11 @@ func resourceArmTrafficManagerEndpoint() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"azureEndpoints", "nestedEndpoints", "externalEndpoints"}, false),
+				ValidateFunc: validation.StringInSlice([]string{
+					"azureEndpoints",
+					"nestedEndpoints",
+					"externalEndpoints",
+				}, false),
 			},
 
 			"profile_name": {
@@ -159,7 +163,7 @@ func resourceArmTrafficManagerEndpointRead(d *schema.ResourceData, meta interfac
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on TrafficManager Endpoint %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on TrafficManager Endpoint %s: %+v", name, err)
 	}
 
 	endpoint := *resp.EndpointProperties

--- a/azurerm/resource_arm_traffic_manager_endpoint_test.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint_test.go
@@ -12,21 +12,23 @@ import (
 )
 
 func TestAccAzureRMTrafficManagerEndpoint_basic(t *testing.T) {
+	azureResourceName := "azurerm_traffic_manager_endpoint.testAzure"
+	externalResourceName := "azurerm_traffic_manager_endpoint.testExternal"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basic, ri, ri, ri, ri, ri, ri, ri)
+	config := testAccAzureRMTrafficManagerEndpoint_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testAzure"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testAzure", "endpoint_status", "Enabled"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "endpoint_status", "Enabled"),
+					testCheckAzureRMTrafficManagerEndpointExists(azureResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(externalResourceName),
+					resource.TestCheckResourceAttr(azureResourceName, "endpoint_status", "Enabled"),
+					resource.TestCheckResourceAttr(externalResourceName, "endpoint_status", "Enabled"),
 				),
 			},
 		},
@@ -34,22 +36,24 @@ func TestAccAzureRMTrafficManagerEndpoint_basic(t *testing.T) {
 }
 
 func TestAccAzureRMTrafficManagerEndpoint_disappears(t *testing.T) {
+	azureResourceName := "azurerm_traffic_manager_endpoint.testAzure"
+	externalResourceName := "azurerm_traffic_manager_endpoint.testExternal"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basic, ri, ri, ri, ri, ri, ri, ri)
+	config := testAccAzureRMTrafficManagerEndpoint_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testAzure"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testAzure", "endpoint_status", "Enabled"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "endpoint_status", "Enabled"),
-					testCheckAzureRMTrafficManagerEndpointDisappears("azurerm_traffic_manager_endpoint.testAzure"),
+					testCheckAzureRMTrafficManagerEndpointExists(azureResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(externalResourceName),
+					resource.TestCheckResourceAttr(azureResourceName, "endpoint_status", "Enabled"),
+					resource.TestCheckResourceAttr(externalResourceName, "endpoint_status", "Enabled"),
+					testCheckAzureRMTrafficManagerEndpointDisappears(azureResourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -58,9 +62,11 @@ func TestAccAzureRMTrafficManagerEndpoint_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMTrafficManagerEndpoint_basicDisableExternal(t *testing.T) {
+	azureResourceName := "azurerm_traffic_manager_endpoint.testAzure"
+	externalResourceName := "azurerm_traffic_manager_endpoint.testExternal"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basic, ri, ri, ri, ri, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basicDisableExternal, ri, ri, ri, ri, ri, ri, ri)
+	preConfig := testAccAzureRMTrafficManagerEndpoint_basic(ri, testLocation())
+	postConfig := testAccAzureRMTrafficManagerEndpoint_basicDisableExternal(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -70,19 +76,19 @@ func TestAccAzureRMTrafficManagerEndpoint_basicDisableExternal(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testAzure"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testAzure", "endpoint_status", "Enabled"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "endpoint_status", "Enabled"),
+					testCheckAzureRMTrafficManagerEndpointExists(azureResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(externalResourceName),
+					resource.TestCheckResourceAttr(azureResourceName, "endpoint_status", "Enabled"),
+					resource.TestCheckResourceAttr(externalResourceName, "endpoint_status", "Enabled"),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testAzure"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testAzure", "endpoint_status", "Enabled"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "endpoint_status", "Disabled"),
+					testCheckAzureRMTrafficManagerEndpointExists(azureResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(externalResourceName),
+					resource.TestCheckResourceAttr(azureResourceName, "endpoint_status", "Enabled"),
+					resource.TestCheckResourceAttr(externalResourceName, "endpoint_status", "Disabled"),
 				),
 			},
 		},
@@ -91,9 +97,13 @@ func TestAccAzureRMTrafficManagerEndpoint_basicDisableExternal(t *testing.T) {
 
 // Altering weight might be used to ramp up migration traffic
 func TestAccAzureRMTrafficManagerEndpoint_updateWeight(t *testing.T) {
+	firstResourceName := "azurerm_traffic_manager_endpoint.testExternal"
+	secondResourceName := "azurerm_traffic_manager_endpoint.testExternalNew"
+
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_weight, ri, ri, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_updateWeight, ri, ri, ri, ri, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMTrafficManagerEndpoint_weight(ri, location)
+	postConfig := testAccAzureRMTrafficManagerEndpoint_updateWeight(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -103,19 +113,19 @@ func TestAccAzureRMTrafficManagerEndpoint_updateWeight(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternalNew"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "weight", "50"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternalNew", "weight", "50"),
+					testCheckAzureRMTrafficManagerEndpointExists(firstResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(secondResourceName),
+					resource.TestCheckResourceAttr(firstResourceName, "weight", "50"),
+					resource.TestCheckResourceAttr(secondResourceName, "weight", "50"),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternalNew"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "weight", "25"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternalNew", "weight", "75"),
+					testCheckAzureRMTrafficManagerEndpointExists(firstResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(secondResourceName),
+					resource.TestCheckResourceAttr(firstResourceName, "weight", "25"),
+					resource.TestCheckResourceAttr(secondResourceName, "weight", "75"),
 				),
 			},
 		},
@@ -124,9 +134,13 @@ func TestAccAzureRMTrafficManagerEndpoint_updateWeight(t *testing.T) {
 
 // Altering priority might be used to switch failover/active roles
 func TestAccAzureRMTrafficManagerEndpoint_updatePriority(t *testing.T) {
+	firstResourceName := "azurerm_traffic_manager_endpoint.testExternal"
+	secondResourceName := "azurerm_traffic_manager_endpoint.testExternalNew"
+
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_priority, ri, ri, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_updatePriority, ri, ri, ri, ri, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMTrafficManagerEndpoint_priority(ri, location)
+	postConfig := testAccAzureRMTrafficManagerEndpoint_updatePriority(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -136,19 +150,19 @@ func TestAccAzureRMTrafficManagerEndpoint_updatePriority(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternalNew"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "priority", "1"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternalNew", "priority", "2"),
+					testCheckAzureRMTrafficManagerEndpointExists(firstResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(secondResourceName),
+					resource.TestCheckResourceAttr(firstResourceName, "priority", "1"),
+					resource.TestCheckResourceAttr(secondResourceName, "priority", "2"),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternal"),
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.testExternalNew"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternal", "priority", "3"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_endpoint.testExternalNew", "priority", "2"),
+					testCheckAzureRMTrafficManagerEndpointExists(firstResourceName),
+					testCheckAzureRMTrafficManagerEndpointExists(secondResourceName),
+					resource.TestCheckResourceAttr(firstResourceName, "priority", "3"),
+					resource.TestCheckResourceAttr(secondResourceName, "priority", "2"),
 				),
 			},
 		},
@@ -157,7 +171,7 @@ func TestAccAzureRMTrafficManagerEndpoint_updatePriority(t *testing.T) {
 
 func TestAccAzureRMTrafficManagerEndpoint_nestedEndpoints(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_nestedEndpoints, ri, ri, ri, ri, ri, ri, ri)
+	config := testAccAzureRMTrafficManagerEndpoint_nestedEndpoints(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -176,9 +190,11 @@ func TestAccAzureRMTrafficManagerEndpoint_nestedEndpoints(t *testing.T) {
 }
 
 func TestAccAzureRMTrafficManagerEndpoint_location(t *testing.T) {
+	resourceName := "azurerm_traffic_manager_endpoint.test"
 	ri := acctest.RandInt()
-	first := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_location, ri, ri, ri, ri)
-	second := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_locationUpdated, ri, ri, ri, ri)
+	location := testLocation()
+	first := testAccAzureRMTrafficManagerEndpoint_location(ri, location)
+	second := testAccAzureRMTrafficManagerEndpoint_locationUpdated(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -188,13 +204,13 @@ func TestAccAzureRMTrafficManagerEndpoint_location(t *testing.T) {
 			{
 				Config: first,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.test"),
+					testCheckAzureRMTrafficManagerEndpointExists(resourceName),
 				),
 			},
 			{
 				Config: second,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerEndpointExists("azurerm_traffic_manager_endpoint.test"),
+					testCheckAzureRMTrafficManagerEndpointExists(resourceName),
 				),
 			},
 		},
@@ -222,7 +238,7 @@ func testCheckAzureRMTrafficManagerEndpointExists(name string) resource.TestChec
 
 		resp, err := conn.Get(resourceGroup, profileName, path.Base(endpointType), name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on trafficManagerEndpointsClient: %s", err)
+			return fmt.Errorf("Bad: Get on trafficManagerEndpointsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -254,7 +270,7 @@ func testCheckAzureRMTrafficManagerEndpointDisappears(name string) resource.Test
 
 		_, err := conn.Delete(resourceGroup, profileName, path.Base(endpointType), name)
 		if err != nil {
-			return fmt.Errorf("Bad: Delete on trafficManagerEndpointsClient: %s", err)
+			return fmt.Errorf("Bad: Delete on trafficManagerEndpointsClient: %+v", err)
 		}
 
 		return nil
@@ -287,10 +303,11 @@ func testCheckAzureRMTrafficManagerEndpointDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMTrafficManagerEndpoint_basic = `
+func testAccAzureRMTrafficManagerEndpoint_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -312,7 +329,7 @@ resource "azurerm_traffic_manager_profile" "test" {
 
 resource "azurerm_public_ip" "test" {
     name = "acctestpublicip-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
     domain_name_label = "acctestpublicip-%d"
@@ -335,12 +352,15 @@ resource "azurerm_traffic_manager_endpoint" "testExternal" {
     profile_name = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
 
-var testAccAzureRMTrafficManagerEndpoint_basicDisableExternal = `
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMTrafficManagerEndpoint_basicDisableExternal(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -362,7 +382,7 @@ resource "azurerm_traffic_manager_profile" "test" {
 
 resource "azurerm_public_ip" "test" {
     name = "acctestpublicip-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
     domain_name_label = "acctestpublicip-%d"
@@ -386,12 +406,14 @@ resource "azurerm_traffic_manager_endpoint" "testExternal" {
     profile_name = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerEndpoint_weight = `
+func testAccAzureRMTrafficManagerEndpoint_weight(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -428,12 +450,14 @@ resource "azurerm_traffic_manager_endpoint" "testExternalNew" {
     profile_name = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerEndpoint_updateWeight = `
+func testAccAzureRMTrafficManagerEndpoint_updateWeight(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -470,12 +494,13 @@ resource "azurerm_traffic_manager_endpoint" "testExternalNew" {
     profile_name = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
-
-var testAccAzureRMTrafficManagerEndpoint_priority = `
+`, rInt, location, rInt, rInt, rInt, rInt)
+}
+func testAccAzureRMTrafficManagerEndpoint_priority(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -512,12 +537,14 @@ resource "azurerm_traffic_manager_endpoint" "testExternalNew" {
     profile_name = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerEndpoint_updatePriority = `
+func testAccAzureRMTrafficManagerEndpoint_updatePriority(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -554,12 +581,14 @@ resource "azurerm_traffic_manager_endpoint" "testExternalNew" {
     profile_name = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerEndpoint_nestedEndpoints = `
+func testAccAzureRMTrafficManagerEndpoint_nestedEndpoints(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "parent" {
@@ -614,12 +643,15 @@ resource "azurerm_traffic_manager_endpoint" "externalChild" {
     profile_name = "${azurerm_traffic_manager_profile.child.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerEndpoint_location = `
+func testAccAzureRMTrafficManagerEndpoint_location(rInt int, location string) string {
+	return fmt.Sprintf(`
+
 resource "azurerm_resource_group" "test" {
     name     = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -647,12 +679,14 @@ resource "azurerm_traffic_manager_endpoint" "test" {
     profile_name        = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerEndpoint_locationUpdated = `
+func testAccAzureRMTrafficManagerEndpoint_locationUpdated(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name     = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -680,4 +714,5 @@ resource "azurerm_traffic_manager_endpoint" "test" {
     profile_name        = "${azurerm_traffic_manager_profile.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_traffic_manager_profile.go
+++ b/azurerm/resource_arm_traffic_manager_profile.go
@@ -30,16 +30,24 @@ func resourceArmTrafficManagerProfile() *schema.Resource {
 			},
 
 			"profile_status": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Enabled", "Disabled"}, true),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Enabled",
+					"Disabled",
+				}, true),
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"traffic_routing_method": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Performance", "Weighted", "Priority"}, false),
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"Performance",
+					"Weighted",
+					"Priority",
+				}, false),
 			},
 
 			"dns_config": {
@@ -74,9 +82,12 @@ func resourceArmTrafficManagerProfile() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"protocol": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"http", "https"}, false),
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"http",
+								"https",
+							}, false),
 						},
 						"port": {
 							Type:         schema.TypeInt,
@@ -156,7 +167,7 @@ func resourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interface
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Traffic Manager Profile %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Traffic Manager Profile %s: %+v", name, err)
 	}
 
 	profile := *resp.ProfileProperties

--- a/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 func TestAccAzureRMTrafficManagerProfile_weighted(t *testing.T) {
+	resourceName := "azurerm_traffic_manager_profile.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_weighted, ri, ri, ri)
+	config := testAccAzureRMTrafficManagerProfile_weighted(ri, testLocation())
 
 	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
 
@@ -22,12 +23,12 @@ func TestAccAzureRMTrafficManagerProfile_weighted(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerProfileExists("azurerm_traffic_manager_profile.test"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_profile.test", "traffic_routing_method", "Weighted"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_profile.test", "fqdn", fqdn),
+					testCheckAzureRMTrafficManagerProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "traffic_routing_method", "Weighted"),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", fqdn),
 				),
 			},
 		},
@@ -35,8 +36,9 @@ func TestAccAzureRMTrafficManagerProfile_weighted(t *testing.T) {
 }
 
 func TestAccAzureRMTrafficManagerProfile_performance(t *testing.T) {
+	resourceName := "azurerm_traffic_manager_profile.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_performance, ri, ri, ri)
+	config := testAccAzureRMTrafficManagerProfile_performance(ri, testLocation())
 
 	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
 
@@ -45,12 +47,12 @@ func TestAccAzureRMTrafficManagerProfile_performance(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerProfileExists("azurerm_traffic_manager_profile.test"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_profile.test", "traffic_routing_method", "Performance"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_profile.test", "fqdn", fqdn),
+					testCheckAzureRMTrafficManagerProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "traffic_routing_method", "Performance"),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", fqdn),
 				),
 			},
 		},
@@ -58,9 +60,9 @@ func TestAccAzureRMTrafficManagerProfile_performance(t *testing.T) {
 }
 
 func TestAccAzureRMTrafficManagerProfile_priority(t *testing.T) {
+	resourceName := "azurerm_traffic_manager_profile.test"
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_priority, ri, ri, ri)
-
+	config := testAccAzureRMTrafficManagerProfile_priority(ri, testLocation())
 	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
 
 	resource.Test(t, resource.TestCase{
@@ -68,12 +70,12 @@ func TestAccAzureRMTrafficManagerProfile_priority(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerProfileExists("azurerm_traffic_manager_profile.test"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_profile.test", "traffic_routing_method", "Priority"),
-					resource.TestCheckResourceAttr("azurerm_traffic_manager_profile.test", "fqdn", fqdn),
+					testCheckAzureRMTrafficManagerProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "traffic_routing_method", "Priority"),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", fqdn),
 				),
 			},
 		},
@@ -81,36 +83,31 @@ func TestAccAzureRMTrafficManagerProfile_priority(t *testing.T) {
 }
 
 func TestAccAzureRMTrafficManagerProfile_withTags(t *testing.T) {
+	resourceName := "azurerm_traffic_manager_profile.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_withTags, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_withTagsUpdated, ri, ri, ri)
+	preConfig := testAccAzureRMTrafficManagerProfile_withTags(ri, testLocation())
+	postConfig := testAccAzureRMTrafficManagerProfile_withTagsUpdated(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerProfileExists("azurerm_traffic_manager_profile.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_traffic_manager_profile.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						"azurerm_traffic_manager_profile.test", "tags.environment", "Production"),
-					resource.TestCheckResourceAttr(
-						"azurerm_traffic_manager_profile.test", "tags.cost_center", "MSFT"),
+					testCheckAzureRMTrafficManagerProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
 				),
 			},
-
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMTrafficManagerProfileExists("azurerm_traffic_manager_profile.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_traffic_manager_profile.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						"azurerm_traffic_manager_profile.test", "tags.environment", "staging"),
+					testCheckAzureRMTrafficManagerProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),
 			},
 		},
@@ -136,7 +133,7 @@ func testCheckAzureRMTrafficManagerProfileExists(name string) resource.TestCheck
 
 		resp, err := conn.Get(resourceGroup, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on trafficManagerProfilesClient: %s", err)
+			return fmt.Errorf("Bad: Get on trafficManagerProfilesClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -173,10 +170,11 @@ func testCheckAzureRMTrafficManagerProfileDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMTrafficManagerProfile_weighted = `
+func testAccAzureRMTrafficManagerProfile_weighted(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -195,12 +193,14 @@ resource "azurerm_traffic_manager_profile" "test" {
         path = "/"
     }
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerProfile_performance = `
+func testAccAzureRMTrafficManagerProfile_performance(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -219,12 +219,14 @@ resource "azurerm_traffic_manager_profile" "test" {
         path = "/"
     }
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerProfile_priority = `
+func testAccAzureRMTrafficManagerProfile_priority(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -243,12 +245,14 @@ resource "azurerm_traffic_manager_profile" "test" {
         path = "/"
     }
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerProfile_withTags = `
+func testAccAzureRMTrafficManagerProfile_withTags(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -266,18 +270,20 @@ resource "azurerm_traffic_manager_profile" "test" {
         port = 443
         path = "/"
     }
-    
+
     tags {
         environment = "Production"
         cost_center = "MSFT"
     }
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMTrafficManagerProfile_withTagsUpdated = `
+func testAccAzureRMTrafficManagerProfile_withTagsUpdated(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_traffic_manager_profile" "test" {
@@ -295,9 +301,10 @@ resource "azurerm_traffic_manager_profile" "test" {
         port = 443
         path = "/"
     }
-    
+
     tags {
         environment = "staging"
     }
 }
-`
+`, rInt, location, rInt, rInt)
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -222,5 +222,5 @@ It's also possible to create credentials via [the legacy cross-platform CLI](htt
 ## Testing
 
 Credentials must be provided via the `ARM_SUBSCRIPTION_ID`, `ARM_CLIENT_ID`,
-`ARM_CLIENT_SECRET` and `ARM_TENANT_ID` environment variables in order to run
+`ARM_CLIENT_SECRET`, `ARM_TENANT_ID` and `ARM_TEST_LOCATION` environment variables in order to run
 acceptance tests.


### PR DESCRIPTION
So that we're able to run the AzureRM Acceptance Tests against different clouds, we need to make the `Location` field, used to specify where to deploy the resource configurable through some means. This is simplest as an environment variable - as such I've hooked it up as such - but this needs to be added to every resource.

Resources:
- [x] Subnets
- [x] Template Deployments
- [x] Traffic Manager Endpoints
- [x] Traffic Manager Profile

Part of #216