### PR TITLE
Making the Test Location an Environment Variable: Part 3

### DIFF
--- a/azurerm/import_arm_search_service_test.go
+++ b/azurerm/import_arm_search_service_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMSearchService_importBasic(t *testing.T) {
 	resourceName := "azurerm_search_service.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMSearchService_basic(ri)
+	config := testAccAzureRMSearchService_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_servicebus_namespace_test.go
+++ b/azurerm/import_arm_servicebus_namespace_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMServiceBusNamespace_importBasic(t *testing.T) {
 	resourceName := "azurerm_servicebus_namespace.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusNamespace_basic(ri)
+	config := testAccAzureRMServiceBusNamespace_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_servicebus_queue_test.go
+++ b/azurerm/import_arm_servicebus_queue_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMServiceBusQueue_importBasic(t *testing.T) {
 	resourceName := "azurerm_servicebus_queue.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusQueue_basic(ri)
+	config := testAccAzureRMServiceBusQueue_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_servicebus_subscription_test.go
+++ b/azurerm/import_arm_servicebus_subscription_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMServiceBusSubscription_importBasic(t *testing.T) {
 	resourceName := "azurerm_servicebus_subscription.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusSubscription_basic, ri, ri, ri, ri)
+	config := testAccAzureRMServiceBusSubscription_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusSubscriptionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_servicebus_topic_test.go
+++ b/azurerm/import_arm_servicebus_topic_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMServiceBusTopic_importBasic(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusTopic_basic(ri)
+	config := testAccAzureRMServiceBusTopic_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMServiceBusTopic_importBasicDisabled(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusTopic_basicDisabled(ri)
+	config := testAccAzureRMServiceBusTopic_basicDisabled(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_sql_elasticpool_test.go
+++ b/azurerm/import_arm_sql_elasticpool_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMSqlElasticPool_importBasic(t *testing.T) {
 	resourceName := "azurerm_sql_elasticpool.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlElasticPool_basic, ri)
+	config := testAccAzureRMSqlElasticPool_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlElasticPoolDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_sql_firewall_rule_test.go
+++ b/azurerm/import_arm_sql_firewall_rule_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMSqlFirewallRule_importBasic(t *testing.T) {
 	resourceName := "azurerm_sql_firewall_rule.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlFirewallRule_basic, ri, ri, ri)
+	config := testAccAzureRMSqlFirewallRule_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlFirewallRuleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_sql_server_test.go
+++ b/azurerm/import_arm_sql_server_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMSqlServer_importBasic(t *testing.T) {
 	resourceName := "azurerm_sql_server.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlServer_basic, ri, ri)
+	config := testAccAzureRMSqlServer_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlServerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/azurerm/import_arm_storage_account_test.go
+++ b/azurerm/import_arm_storage_account_test.go
@@ -12,7 +12,7 @@ func TestAccAzureRMStorageAccount_importBasic(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	config := testAccAzureRMStorageAccount_basic(ri, rs)
+	config := testAccAzureRMStorageAccount_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/resource_arm_search_service.go
+++ b/azurerm/resource_arm_search_service.go
@@ -117,7 +117,7 @@ func resourceArmSearchServiceCreate(d *schema.ResourceData, meta interface{}) er
 		Pending:    []string{"provisioning"},
 		Target:     []string{"succeeded"},
 		Refresh:    azureStateRefreshFunc(*resp.ID, client, getSearchServiceCommand),
-		Timeout:    30 * time.Minute,
+		Timeout:    60 * time.Minute,
 		MinTimeout: 15 * time.Second,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMSearchService_basic(t *testing.T) {
 	resourceName := "azurerm_search_service.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMSearchService_basic(ri)
+	config := testAccAzureRMSearchService_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,9 @@ func TestAccAzureRMSearchService_basic(t *testing.T) {
 func TestAccAzureRMSearchService_updateReplicaCountAndTags(t *testing.T) {
 	resourceName := "azurerm_search_service.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMSearchService_basic(ri)
-	postConfig := testAccAzureRMSearchService_updated(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMSearchService_basic(ri, location)
+	postConfig := testAccAzureRMSearchService_updated(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -112,11 +113,11 @@ func testCheckAzureRMSearchServiceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMSearchService_basic(rInt int) string {
+func testAccAzureRMSearchService_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_search_service" "test" {
@@ -130,14 +131,14 @@ resource "azurerm_search_service" "test" {
     	database = "test"
     }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMSearchService_updated(rInt int) string {
+func testAccAzureRMSearchService_updated(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 resource "azurerm_search_service" "test" {
     name = "acctestsearchservice%d"
@@ -150,5 +151,5 @@ resource "azurerm_search_service" "test" {
     	environment = "production"
     }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_test.go
@@ -46,7 +46,7 @@ func TestAccAzureRMServiceBusNamespaceCapacity_validation(t *testing.T) {
 func TestAccAzureRMServiceBusNamespace_basic(t *testing.T) {
 	resourceName := "azurerm_servicebus_namespace.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusNamespace_basic(ri)
+	config := testAccAzureRMServiceBusNamespace_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -66,7 +66,7 @@ func TestAccAzureRMServiceBusNamespace_basic(t *testing.T) {
 func TestAccAzureRMServiceBusNamespace_readDefaultKeys(t *testing.T) {
 	resourceName := "azurerm_servicebus_namespace.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusNamespace_basic(ri)
+	config := testAccAzureRMServiceBusNamespace_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -95,7 +95,7 @@ func TestAccAzureRMServiceBusNamespace_NonStandardCasing(t *testing.T) {
 	resourceName := "azurerm_servicebus_namespace.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusNamespaceNonStandardCasing(ri)
+	config := testAccAzureRMServiceBusNamespaceNonStandardCasing(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -171,11 +171,11 @@ func testCheckAzureRMServiceBusNamespaceExists(name string) resource.TestCheckFu
 	}
 }
 
-func testAccAzureRMServiceBusNamespace_basic(rInt int) string {
+func testAccAzureRMServiceBusNamespace_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
@@ -183,14 +183,14 @@ resource "azurerm_servicebus_namespace" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "basic"
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMServiceBusNamespaceNonStandardCasing(ri int) string {
+func testAccAzureRMServiceBusNamespaceNonStandardCasing(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
@@ -198,5 +198,5 @@ resource "azurerm_servicebus_namespace" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "Basic"
 }
-`, ri, ri)
+`, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMServiceBusQueue_basic(t *testing.T) {
 	resourceName := "azurerm_servicebus_queue.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusQueue_basic(ri)
+	config := testAccAzureRMServiceBusQueue_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -36,8 +36,9 @@ func TestAccAzureRMServiceBusQueue_basic(t *testing.T) {
 func TestAccAzureRMServiceBusQueue_update(t *testing.T) {
 	resourceName := "azurerm_servicebus_queue.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMServiceBusQueue_basic(ri)
-	postConfig := testAccAzureRMServiceBusQueue_update(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusQueue_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusQueue_update(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,8 +68,9 @@ func TestAccAzureRMServiceBusQueue_update(t *testing.T) {
 func TestAccAzureRMServiceBusQueue_enablePartitioningStandard(t *testing.T) {
 	resourceName := "azurerm_servicebus_queue.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMServiceBusQueue_basic(ri)
-	postConfig := testAccAzureRMServiceBusQueue_enablePartitioningStandard(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusQueue_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusQueue_enablePartitioningStandard(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,7 +99,7 @@ func TestAccAzureRMServiceBusQueue_enablePartitioningStandard(t *testing.T) {
 func TestAccAzureRMServiceBusQueue_defaultEnablePartitioningPremium(t *testing.T) {
 	resourceName := "azurerm_servicebus_queue.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusQueue_Premium(ri)
+	config := testAccAzureRMServiceBusQueue_Premium(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -119,8 +121,9 @@ func TestAccAzureRMServiceBusQueue_defaultEnablePartitioningPremium(t *testing.T
 func TestAccAzureRMServiceBusQueue_enableDuplicateDetection(t *testing.T) {
 	resourceName := "azurerm_servicebus_queue.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMServiceBusQueue_basic(ri)
-	postConfig := testAccAzureRMServiceBusQueue_enableDuplicateDetection(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusQueue_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusQueue_enableDuplicateDetection(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -202,11 +205,11 @@ func testCheckAzureRMServiceBusQueueExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAzureRMServiceBusQueue_basic(rInt int) string {
+func testAccAzureRMServiceBusQueue_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -222,14 +225,14 @@ resource "azurerm_servicebus_queue" "test" {
     location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusQueue_Premium(rInt int) string {
+func testAccAzureRMServiceBusQueue_Premium(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -247,14 +250,14 @@ resource "azurerm_servicebus_queue" "test" {
     enable_partitioning = true
     enable_express = false
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusQueue_update(rInt int) string {
+func testAccAzureRMServiceBusQueue_update(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -273,14 +276,14 @@ resource "azurerm_servicebus_queue" "test" {
     enable_express = true
     max_size_in_megabytes = 2048
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusQueue_enablePartitioningStandard(rInt int) string {
+func testAccAzureRMServiceBusQueue_enablePartitioningStandard(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -298,14 +301,14 @@ resource "azurerm_servicebus_queue" "test" {
     enable_partitioning = true
     max_size_in_megabytes = 5120
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusQueue_enableDuplicateDetection(rInt int) string {
+func testAccAzureRMServiceBusQueue_enableDuplicateDetection(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
@@ -322,5 +325,5 @@ resource "azurerm_servicebus_queue" "test" {
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     requires_duplicate_detection = true
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestAccAzureRMServiceBusSubscription_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMServiceBusSubscription_basic, ri, ri, ri, ri)
+	config := testAccAzureRMServiceBusSubscription_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceBusSubscriptionExists("azurerm_servicebus_subscription.test"),
@@ -30,26 +30,27 @@ func TestAccAzureRMServiceBusSubscription_basic(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusSubscription_update(t *testing.T) {
+	resourceName := "azurerm_servicebus_subscription.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMServiceBusSubscription_basic, ri, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMServiceBusSubscription_update, ri, ri, ri, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusSubscription_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusSubscription_update(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusSubscriptionExists("azurerm_servicebus_subscription.test"),
+					testCheckAzureRMServiceBusSubscriptionExists(resourceName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_subscription.test", "enable_batched_operations", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_batched_operations", "true"),
 				),
 			},
 		},
@@ -57,26 +58,27 @@ func TestAccAzureRMServiceBusSubscription_update(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusSubscription_updateRequiresSession(t *testing.T) {
+	resourceName := "azurerm_servicebus_subscription.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMServiceBusSubscription_basic, ri, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMServiceBusSubscription_updateRequiresSession, ri, ri, ri, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusSubscription_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusSubscription_updateRequiresSession(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusSubscriptionExists("azurerm_servicebus_subscription.test"),
+					testCheckAzureRMServiceBusSubscriptionExists(resourceName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_subscription.test", "requires_session", "true"),
+					resource.TestCheckResourceAttr(resourceName, "requires_session", "true"),
 				),
 			},
 		},
@@ -143,94 +145,100 @@ func testCheckAzureRMServiceBusSubscriptionExists(name string) resource.TestChec
 	}
 }
 
-var testAccAzureRMServiceBusSubscription_basic = `
+func testAccAzureRMServiceBusSubscription_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_servicebus_subscription" "test" {
     name = "acctestservicebussubscription-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     topic_name = "${azurerm_servicebus_topic.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     max_delivery_count = 10
 }
-`
+`, rInt, location, rInt, rInt, rInt)
+}
 
-var testAccAzureRMServiceBusSubscription_update = `
+func testAccAzureRMServiceBusSubscription_update(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_servicebus_subscription" "test" {
     name = "acctestservicebussubscription-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     topic_name = "${azurerm_servicebus_topic.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     max_delivery_count = 10
     enable_batched_operations = true
 }
-`
+`, rInt, location, rInt, rInt, rInt)
+}
 
-var testAccAzureRMServiceBusSubscription_updateRequiresSession = `
+func testAccAzureRMServiceBusSubscription_updateRequiresSession(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_servicebus_subscription" "test" {
     name = "acctestservicebussubscription-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     topic_name = "${azurerm_servicebus_topic.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     max_delivery_count = 10
     requires_session = true
 }
-`
+`, rInt, location, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusTopic_basic(ri)
+	config := testAccAzureRMServiceBusTopic_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,7 +33,7 @@ func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
 func TestAccAzureRMServiceBusTopic_basicDisabled(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMServiceBusTopic_basicDisabled(ri)
+	config := testAccAzureRMServiceBusTopic_basicDisabled(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -53,8 +53,9 @@ func TestAccAzureRMServiceBusTopic_basicDisabled(t *testing.T) {
 func TestAccAzureRMServiceBusTopic_basicDisableEnable(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	enabledConfig := testAccAzureRMServiceBusTopic_basic(ri)
-	disabledConfig := testAccAzureRMServiceBusTopic_basicDisabled(ri)
+	location := testLocation()
+	enabledConfig := testAccAzureRMServiceBusTopic_basic(ri, location)
+	disabledConfig := testAccAzureRMServiceBusTopic_basicDisabled(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -84,9 +85,11 @@ func TestAccAzureRMServiceBusTopic_basicDisableEnable(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
+	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
-	postConfig := testAccAzureRMServiceBusTopic_update(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusTopic_update(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -96,16 +99,14 @@ func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+					testCheckAzureRMServiceBusTopicExists(resourceName),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "enable_batched_operations", "true"),
-					resource.TestCheckResourceAttr(
-						"azurerm_servicebus_topic.test", "enable_express", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_batched_operations", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_express", "true"),
 				),
 			},
 		},
@@ -115,8 +116,9 @@ func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
 func TestAccAzureRMServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
-	postConfig := testAccAzureRMServiceBusTopic_enablePartitioningStandard(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusTopic_enablePartitioningStandard(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -144,8 +146,9 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 func TestAccAzureRMServiceBusTopic_enablePartitioningPremium(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
-	postConfig := testAccAzureRMServiceBusTopic_enablePartitioningPremium(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusTopic_enablePartitioningPremium(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -172,8 +175,9 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningPremium(t *testing.T) {
 func TestAccAzureRMServiceBusTopic_enableDuplicateDetection(t *testing.T) {
 	resourceName := "azurerm_servicebus_topic.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMServiceBusTopic_basic(ri)
-	postConfig := testAccAzureRMServiceBusTopic_enableDuplicateDetection(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusTopic_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusTopic_enableDuplicateDetection(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -254,148 +258,148 @@ func testCheckAzureRMServiceBusTopicExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAzureRMServiceBusTopic_basic(rInt int) string {
+func testAccAzureRMServiceBusTopic_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusTopic_basicDisabled(rInt int) string {
+func testAccAzureRMServiceBusTopic_basicDisabled(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     status = "disabled"
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusTopic_update(rInt int) string {
+func testAccAzureRMServiceBusTopic_update(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_batched_operations = true
     enable_express = true
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusTopic_enablePartitioningStandard(rInt int) string {
+func testAccAzureRMServiceBusTopic_enablePartitioningStandard(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
     max_size_in_megabytes = 5120
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusTopic_enablePartitioningPremium(rInt int) string {
+func testAccAzureRMServiceBusTopic_enablePartitioningPremium(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "premium"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
     max_size_in_megabytes = 81920
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMServiceBusTopic_enableDuplicateDetection(rInt int) string {
+func testAccAzureRMServiceBusTopic_enableDuplicateDetection(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "West US"
+    location = "${azurerm_servicebus_namespace.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     requires_duplicate_detection = true
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -267,14 +267,14 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
@@ -290,14 +290,14 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     status = "disabled"
@@ -314,14 +314,14 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_batched_operations = true
@@ -339,14 +339,14 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
@@ -364,14 +364,14 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "premium"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
@@ -389,14 +389,14 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_servicebus_namespace" "test" {
     name = "acctestservicebusnamespace-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
-    location = "${azurerm_servicebus_namespace.test.location}"
+    location = "${azurerm_resource_group.test.location}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     requires_duplicate_detection = true

--- a/azurerm/resource_arm_sql_database_test.go
+++ b/azurerm/resource_arm_sql_database_test.go
@@ -49,7 +49,7 @@ func TestResourceAzureRMSqlDatabaseEdition_validation(t *testing.T) {
 
 func TestAccAzureRMSqlDatabase_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlDatabase_basic, ri, ri, ri)
+	config := testAccAzureRMSqlDatabase_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,7 +68,7 @@ func TestAccAzureRMSqlDatabase_basic(t *testing.T) {
 
 func TestAccAzureRMSqlDatabase_elasticPool(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlDatabase_elasticPool, ri, ri, ri, ri)
+	config := testAccAzureRMSqlDatabase_elasticPool(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -88,8 +88,9 @@ func TestAccAzureRMSqlDatabase_elasticPool(t *testing.T) {
 
 func TestAccAzureRMSqlDatabase_withTags(t *testing.T) {
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMSqlDatabase_withTags, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMSqlDatabase_withTagsUpdate, ri, ri, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMSqlDatabase_withTags(ri, location)
+	postConfig := testAccAzureRMSqlDatabase_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -116,9 +117,9 @@ func TestAccAzureRMSqlDatabase_withTags(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMSqlDatabase_datawarehouse(t *testing.T) {
+func TestAccAzureRMSqlDatabase_dataWarehouse(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlDatabase_datawarehouse, ri, ri, ri)
+	config := testAccAzureRMSqlDatabase_dataWarehouse(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -137,9 +138,11 @@ func TestAccAzureRMSqlDatabase_datawarehouse(t *testing.T) {
 
 func TestAccAzureRMSqlDatabase_restorePointInTime(t *testing.T) {
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMSqlDatabase_basic, ri, ri, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMSqlDatabase_basic(ri, location)
 	timeToRestore := time.Now().Add(15 * time.Minute)
-	postCongif := fmt.Sprintf(testAccAzureRMSqlDatabase_restorePointInTime, ri, ri, ri, ri, string(timeToRestore.UTC().Format(time.RFC3339)))
+	formattedTime := string(timeToRestore.UTC().Format(time.RFC3339))
+	postCongif := testAccAzureRMSqlDatabase_restorePointInTime(ri, formattedTime, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -214,53 +217,17 @@ func testCheckAzureRMSqlDatabaseDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMSqlDatabase_elasticPool = `
+func testAccAzureRMSqlDatabase_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
-    version = "12.0"
-    administrator_login = "mradministrator"
-    administrator_login_password = "thisIsDog11"
-}
-
-resource "azurerm_sql_elasticpool" "test" {
-    name = "acctestep%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
-    server_name = "${azurerm_sql_server.test.name}"
-    edition = "Basic"
-    dtu = 50
-    pool_size = 5000
-}
-
-resource "azurerm_sql_database" "test" {
-    name = "acctestdb%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    server_name = "${azurerm_sql_server.test.name}"
-    location = "West US"
-    edition = "${azurerm_sql_elasticpool.test.edition}"
-    collation = "SQL_Latin1_General_CP1_CI_AS"
-    max_size_bytes = "1073741824"
-    elastic_pool_name = "${azurerm_sql_elasticpool.test.name}"
-    requested_service_objective_name = "ElasticPool"
-}
-`
-
-var testAccAzureRMSqlDatabase_basic = `
-resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
-}
-resource "azurerm_sql_server" "test" {
-    name = "acctestsqlserver%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -270,23 +237,26 @@ resource "azurerm_sql_database" "test" {
     name = "acctestdb%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     server_name = "${azurerm_sql_server.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     edition = "Standard"
     collation = "SQL_Latin1_General_CP1_CI_AS"
     max_size_bytes = "1073741824"
     requested_service_objective_name = "S0"
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMSqlDatabase_withTags = `
+func testAccAzureRMSqlDatabase_withTags(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -296,7 +266,7 @@ resource "azurerm_sql_database" "test" {
     name = "acctestdb%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     server_name = "${azurerm_sql_server.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     edition = "Standard"
     collation = "SQL_Latin1_General_CP1_CI_AS"
     max_size_bytes = "1073741824"
@@ -307,17 +277,20 @@ resource "azurerm_sql_database" "test" {
     	database = "test"
     }
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMSqlDatabase_withTagsUpdate = `
+func testAccAzureRMSqlDatabase_withTagsUpdate(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -327,7 +300,7 @@ resource "azurerm_sql_database" "test" {
     name = "acctestdb%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     server_name = "${azurerm_sql_server.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     edition = "Standard"
     collation = "SQL_Latin1_General_CP1_CI_AS"
     max_size_bytes = "1073741824"
@@ -337,17 +310,20 @@ resource "azurerm_sql_database" "test" {
     	environment = "production"
     }
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMSqlDatabase_datawarehouse = `
+func testAccAzureRMSqlDatabase_dataWarehouse(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctest_rg_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -357,22 +333,25 @@ resource "azurerm_sql_database" "test" {
     name = "acctestdb%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     server_name = "${azurerm_sql_server.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     edition = "DataWarehouse"
     collation = "SQL_Latin1_General_CP1_CI_AS"
     requested_service_objective_name = "DW400"
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMSqlDatabase_restorePointInTime = `
+func testAccAzureRMSqlDatabase_restorePointInTime(rInt int, formattedTime string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -382,7 +361,7 @@ resource "azurerm_sql_database" "test" {
     name = "acctestdb%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     server_name = "${azurerm_sql_server.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     edition = "Standard"
     collation = "SQL_Latin1_General_CP1_CI_AS"
     max_size_bytes = "1073741824"
@@ -393,9 +372,50 @@ resource "azurerm_sql_database" "test_restore" {
     name = "acctestdb_restore%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     server_name = "${azurerm_sql_server.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     create_mode = "PointInTimeRestore"
     source_database_id = "${azurerm_sql_database.test.id}"
     restore_point_in_time = "%s"
 }
-`
+`, rInt, location, rInt, rInt, rInt, formattedTime)
+}
+
+func testAccAzureRMSqlDatabase_elasticPool(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG_%d"
+    location = "%s"
+}
+
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "${azurerm_resource_group.test.location}"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_sql_elasticpool" "test" {
+    name = "acctestep%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "${azurerm_resource_group.test.location}"
+    server_name = "${azurerm_sql_server.test.name}"
+    edition = "Basic"
+    dtu = 50
+    pool_size = 5000
+}
+
+resource "azurerm_sql_database" "test" {
+    name = "acctestdb%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    server_name = "${azurerm_sql_server.test.name}"
+    location = "${azurerm_resource_group.test.location}"
+    edition = "${azurerm_sql_elasticpool.test.edition}"
+    collation = "SQL_Latin1_General_CP1_CI_AS"
+    max_size_bytes = "1073741824"
+    elastic_pool_name = "${azurerm_sql_elasticpool.test.name}"
+    requested_service_objective_name = "ElasticPool"
+}
+`, rInt, location, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_sql_elasticpool_test.go
+++ b/azurerm/resource_arm_sql_elasticpool_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccAzureRMSqlElasticPool_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlElasticPool_basic, ri)
+	config := testAccAzureRMSqlElasticPool_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -30,9 +30,11 @@ func TestAccAzureRMSqlElasticPool_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSqlElasticPool_resizeDtu(t *testing.T) {
+	resourceName := "azurerm_sql_elasticpool.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMSqlElasticPool_basic, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMSqlElasticPool_resizedDtu, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMSqlElasticPool_basic(ri, location)
+	postConfig := testAccAzureRMSqlElasticPool_resizedDtu(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,21 +44,17 @@ func TestAccAzureRMSqlElasticPool_resizeDtu(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSqlElasticPoolExists("azurerm_sql_elasticpool.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_sql_elasticpool.test", "dtu", "50"),
-					resource.TestCheckResourceAttr(
-						"azurerm_sql_elasticpool.test", "pool_size", "5000"),
+					testCheckAzureRMSqlElasticPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dtu", "50"),
+					resource.TestCheckResourceAttr(resourceName, "pool_size", "5000"),
 				),
 			},
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSqlElasticPoolExists("azurerm_sql_elasticpool.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_sql_elasticpool.test", "dtu", "100"),
-					resource.TestCheckResourceAttr(
-						"azurerm_sql_elasticpool.test", "pool_size", "10000"),
+					testCheckAzureRMSqlElasticPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dtu", "100"),
+					resource.TestCheckResourceAttr(resourceName, "pool_size", "10000"),
 				),
 			},
 		},
@@ -79,7 +77,7 @@ func testCheckAzureRMSqlElasticPoolExists(name string) resource.TestCheckFunc {
 
 		resp, err := conn.Get(resourceGroup, serverName, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on sqlElasticPoolsClient: %s", err)
+			return fmt.Errorf("Bad: Get on sqlElasticPoolsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -116,16 +114,17 @@ func testCheckAzureRMSqlElasticPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMSqlElasticPool_basic = `
+func testAccAzureRMSqlElasticPool_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctest-%[1]d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_sql_server" "test" {
     name = "acctest%[1]d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "4dm1n157r470r"
     administrator_login_password = "4-v3ry-53cr37-p455w0rd"
@@ -134,24 +133,26 @@ resource "azurerm_sql_server" "test" {
 resource "azurerm_sql_elasticpool" "test" {
     name = "acctest-pool-%[1]d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     server_name = "${azurerm_sql_server.test.name}"
     edition = "Basic"
     dtu = 50
     pool_size = 5000
 }
-`
+`, rInt, location)
+}
 
-var testAccAzureRMSqlElasticPool_resizedDtu = `
+func testAccAzureRMSqlElasticPool_resizedDtu(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctest-%[1]d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_sql_server" "test" {
     name = "acctest%[1]d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "4dm1n157r470r"
     administrator_login_password = "4-v3ry-53cr37-p455w0rd"
@@ -160,10 +161,11 @@ resource "azurerm_sql_server" "test" {
 resource "azurerm_sql_elasticpool" "test" {
     name = "acctest-pool-%[1]d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     server_name = "${azurerm_sql_server.test.name}"
     edition = "Basic"
     dtu = 100
     pool_size = 10000
 }
-`
+`, rInt, location)
+}

--- a/azurerm/resource_arm_sql_firewall_rule_test.go
+++ b/azurerm/resource_arm_sql_firewall_rule_test.go
@@ -11,30 +11,30 @@ import (
 )
 
 func TestAccAzureRMSqlFirewallRule_basic(t *testing.T) {
+	resourceName := "azurerm_sql_firewall_rule.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMSqlFirewallRule_basic, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMSqlFirewallRule_withUpdates, ri, ri, ri)
+	preConfig := testAccAzureRMSqlFirewallRule_basic(ri, testLocation())
+	postConfig := testAccAzureRMSqlFirewallRule_withUpdates(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlFirewallRuleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSqlFirewallRuleExists("azurerm_sql_firewall_rule.test"),
-					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "start_ip_address", "0.0.0.0"),
-					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "end_ip_address", "255.255.255.255"),
+					testCheckAzureRMSqlFirewallRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "start_ip_address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "end_ip_address", "255.255.255.255"),
 				),
 			},
-
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSqlFirewallRuleExists("azurerm_sql_firewall_rule.test"),
-					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "start_ip_address", "10.0.17.62"),
-					resource.TestCheckResourceAttr("azurerm_sql_firewall_rule.test", "end_ip_address", "10.0.17.62"),
+					testCheckAzureRMSqlFirewallRuleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "start_ip_address", "10.0.17.62"),
+					resource.TestCheckResourceAttr(resourceName, "end_ip_address", "10.0.17.62"),
 				),
 			},
 		},
@@ -56,10 +56,10 @@ func testCheckAzureRMSqlFirewallRuleExists(name string) resource.TestCheckFunc {
 
 		readResponse, err := readRequest.Execute()
 		if err != nil {
-			return fmt.Errorf("Bad: GetFirewallRule: %s", err)
+			return fmt.Errorf("Bad: GetFirewallRule: %+v", err)
 		}
 		if !readResponse.IsSuccessful() {
-			return fmt.Errorf("Bad: GetFirewallRule: %s", readResponse.Error)
+			return fmt.Errorf("Bad: GetFirewallRule: %+v", readResponse.Error)
 		}
 
 		return nil
@@ -79,26 +79,28 @@ func testCheckAzureRMSqlFirewallRuleDestroy(s *terraform.State) error {
 
 		readResponse, err := readRequest.Execute()
 		if err != nil {
-			return fmt.Errorf("Bad: GetFirewallRule: %s", err)
+			return fmt.Errorf("Bad: GetFirewallRule: %+v", err)
 		}
 
 		if readResponse.IsSuccessful() {
-			return fmt.Errorf("Bad: SQL Server Firewall Rule still exists: %s", readResponse.Error)
+			return fmt.Errorf("Bad: SQL Server Firewall Rule still exists: %+v", readResponse.Error)
 		}
 	}
 
 	return nil
 }
 
-var testAccAzureRMSqlFirewallRule_basic = `
+func testAccAzureRMSqlFirewallRule_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -111,17 +113,20 @@ resource "azurerm_sql_firewall_rule" "test" {
     start_ip_address = "0.0.0.0"
     end_ip_address = "255.255.255.255"
 }
-`
+`, rInt, location, rInt, rInt)
+}
 
-var testAccAzureRMSqlFirewallRule_withUpdates = `
+func testAccAzureRMSqlFirewallRule_withUpdates(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -134,4 +139,5 @@ resource "azurerm_sql_firewall_rule" "test" {
     start_ip_address = "10.0.17.62"
     end_ip_address = "10.0.17.62"
 }
-`
+`, rInt, location, rInt, rInt)
+}

--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -12,14 +12,14 @@ import (
 
 func TestAccAzureRMSqlServer_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlServer_basic, ri, ri)
+	config := testAccAzureRMSqlServer_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlServerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
@@ -30,30 +30,29 @@ func TestAccAzureRMSqlServer_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSqlServer_withTags(t *testing.T) {
+	resourceName := "azurerm_sql_server.test"
 	ri := acctest.RandInt()
-	preConfig := fmt.Sprintf(testAccAzureRMSqlServer_withTags, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMSqlServer_withTagsUpdated, ri, ri)
+	location := testLocation()
+	preConfig := testAccAzureRMSqlServer_withTags(ri, location)
+	postConfig := testAccAzureRMSqlServer_withTagsUpdated(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMSqlServerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_sql_server.test", "tags.%", "2"),
+					testCheckAzureRMSqlServerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 				),
 			},
-
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSqlServerExists("azurerm_sql_server.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_sql_server.test", "tags.%", "1"),
+					testCheckAzureRMSqlServerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
 		},
@@ -75,10 +74,10 @@ func testCheckAzureRMSqlServerExists(name string) resource.TestCheckFunc {
 
 		readResponse, err := readRequest.Execute()
 		if err != nil {
-			return fmt.Errorf("Bad: GetServer: %s", err)
+			return fmt.Errorf("Bad: GetServer: %+v", err)
 		}
 		if !readResponse.IsSuccessful() {
-			return fmt.Errorf("Bad: GetServer: %s", readResponse.Error)
+			return fmt.Errorf("Bad: GetServer: %+v", readResponse.Error)
 		}
 
 		return nil
@@ -98,41 +97,46 @@ func testCheckAzureRMSqlServerDestroy(s *terraform.State) error {
 
 		readResponse, err := readRequest.Execute()
 		if err != nil {
-			return fmt.Errorf("Bad: GetServer: %s", err)
+			return fmt.Errorf("Bad: GetServer: % +v", err)
 		}
 
 		if readResponse.IsSuccessful() {
-			return fmt.Errorf("Bad: SQL Server still exists: %s", readResponse.Error)
+			return fmt.Errorf("Bad: SQL Server still exists: %+v", readResponse.Error)
 		}
 	}
 
 	return nil
 }
 
-var testAccAzureRMSqlServer_basic = `
+func testAccAzureRMSqlServer_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
 }
-`
+`, rInt, location, rInt)
+}
 
-var testAccAzureRMSqlServer_withTags = `
+func testAccAzureRMSqlServer_withTags(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -142,17 +146,20 @@ resource "azurerm_sql_server" "test" {
     	database = "test"
     }
 }
-`
+`, rInt, location, rInt)
+}
 
-var testAccAzureRMSqlServer_withTagsUpdated = `
+func testAccAzureRMSqlServer_withTagsUpdated(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
+
 resource "azurerm_sql_server" "test" {
     name = "acctestsqlserver%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     version = "12.0"
     administrator_login = "mradministrator"
     administrator_login_password = "thisIsDog11"
@@ -161,4 +168,5 @@ resource "azurerm_sql_server" "test" {
     	environment = "production"
     }
 }
-`
+`, rInt, location, rInt)
+}

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -51,10 +51,12 @@ func TestValidateArmStorageAccountName(t *testing.T) {
 }
 
 func TestAccAzureRMStorageAccount_basic(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := testAccAzureRMStorageAccount_basic(ri, rs)
-	postConfig := testAccAzureRMStorageAccount_update(ri, rs)
+	location := testLocation()
+	preConfig := testAccAzureRMStorageAccount_basic(ri, rs, location)
+	postConfig := testAccAzureRMStorageAccount_update(ri, rs, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -64,20 +66,20 @@ func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_type", "Standard_LRS"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "tags.%", "1"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "tags.environment", "production"),
+					testCheckAzureRMStorageAccountExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_type", "Standard_LRS"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
 				),
 			},
 
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_type", "Standard_GRS"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "tags.%", "1"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "tags.environment", "staging"),
+					testCheckAzureRMStorageAccountExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_type", "Standard_GRS"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),
 			},
 		},
@@ -85,9 +87,10 @@ func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStorageAccount_disappears(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := testAccAzureRMStorageAccount_basic(ri, rs)
+	preConfig := testAccAzureRMStorageAccount_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,11 +100,11 @@ func TestAccAzureRMStorageAccount_disappears(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageAccountExists("azurerm_storage_account.testsa"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_type", "Standard_LRS"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "tags.%", "1"),
-					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "tags.environment", "production"),
-					testCheckAzureRMStorageAccountDisappears("azurerm_storage_account.testsa"),
+					testCheckAzureRMStorageAccountExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_type", "Standard_LRS"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
+					testCheckAzureRMStorageAccountDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -112,7 +115,7 @@ func TestAccAzureRMStorageAccount_disappears(t *testing.T) {
 func TestAccAzureRMStorageAccount_blobConnectionString(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := testAccAzureRMStorageAccount_basic(ri, rs)
+	preConfig := testAccAzureRMStorageAccount_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -133,8 +136,9 @@ func TestAccAzureRMStorageAccount_blobConnectionString(t *testing.T) {
 func TestAccAzureRMStorageAccount_blobEncryption(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := testAccAzureRMStorageAccount_blobEncryption(ri, rs)
-	postConfig := testAccAzureRMStorageAccount_blobEncryptionDisabled(ri, rs)
+	location := testLocation()
+	preConfig := testAccAzureRMStorageAccount_blobEncryption(ri, rs, location)
+	postConfig := testAccAzureRMStorageAccount_blobEncryptionDisabled(ri, rs, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -163,8 +167,9 @@ func TestAccAzureRMStorageAccount_blobEncryption(t *testing.T) {
 func TestAccAzureRMStorageAccount_enableHttpsTrafficOnly(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := testAccAzureRMStorageAccount_enableHttpsTrafficOnly(ri, rs)
-	postConfig := testAccAzureRMStorageAccount_enableHttpsTrafficOnlyDisabled(ri, rs)
+	location := testLocation()
+	preConfig := testAccAzureRMStorageAccount_enableHttpsTrafficOnly(ri, rs, location)
+	postConfig := testAccAzureRMStorageAccount_enableHttpsTrafficOnlyDisabled(ri, rs, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -193,8 +198,9 @@ func TestAccAzureRMStorageAccount_enableHttpsTrafficOnly(t *testing.T) {
 func TestAccAzureRMStorageAccount_blobStorageWithUpdate(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := testAccAzureRMStorageAccount_blobStorage(ri, rs)
-	postConfig := testAccAzureRMStorageAccount_blobStorageUpdate(ri, rs)
+	location := testLocation()
+	preConfig := testAccAzureRMStorageAccount_blobStorage(ri, rs, location)
+	postConfig := testAccAzureRMStorageAccount_blobStorageUpdate(ri, rs, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -224,7 +230,7 @@ func TestAccAzureRMStorageAccount_blobStorageWithUpdate(t *testing.T) {
 func TestAccAzureRMStorageAccount_NonStandardCasing(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	preConfig := testAccAzureRMStorageAccountNonStandardCasing(ri, rs)
+	preConfig := testAccAzureRMStorageAccountNonStandardCasing(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -263,7 +269,7 @@ func testCheckAzureRMStorageAccountExists(name string) resource.TestCheckFunc {
 
 		resp, err := conn.GetProperties(resourceGroup, storageAccount)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on storageServiceClient: %s", err)
+			return fmt.Errorf("Bad: Get on storageServiceClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -290,7 +296,7 @@ func testCheckAzureRMStorageAccountDisappears(name string) resource.TestCheckFun
 
 		_, err := conn.Delete(resourceGroup, storageAccount)
 		if err != nil {
-			return fmt.Errorf("Bad: Delete on storageServiceClient: %s", err)
+			return fmt.Errorf("Bad: Delete on storageServiceClient: %+v", err)
 		}
 
 		return nil
@@ -321,189 +327,188 @@ func testCheckAzureRMStorageAccountDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMStorageAccount_basic(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_basic(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "westus"
+    location = "${azurerm_resource_group.testrg.location}"
     account_type = "Standard_LRS"
 
     tags {
         environment = "production"
     }
-}`, rInt, rString)
+}`, rInt, location, rString)
 }
 
-func testAccAzureRMStorageAccount_update(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_update(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "westus"
+    location = "${azurerm_resource_group.testrg.location}"
     account_type = "Standard_GRS"
 
     tags {
         environment = "staging"
     }
-}`, rInt, rString)
+}`, rInt, location, rString)
 }
 
-func testAccAzureRMStorageAccount_blobEncryption(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_blobEncryption(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "westus"
+    location = "${azurerm_resource_group.testrg.location}"
     account_type = "Standard_LRS"
     enable_blob_encryption = true
 
     tags {
         environment = "production"
     }
-}`, rInt, rString)
+}`, rInt, location, rString)
 }
 
-func testAccAzureRMStorageAccount_blobEncryptionDisabled(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_blobEncryptionDisabled(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "westus"
+    location = "${azurerm_resource_group.testrg.location}"
     account_type = "Standard_LRS"
     enable_blob_encryption = false
 
     tags {
         environment = "production"
     }
-}`, rInt, rString)
+}`, rInt, location, rString)
 }
 
-func testAccAzureRMStorageAccount_enableHttpsTrafficOnly(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_enableHttpsTrafficOnly(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "westus"
+    location = "${azurerm_resource_group.testrg.location}"
     account_type = "Standard_LRS"
     enable_https_traffic_only = true
 
     tags {
         environment = "production"
     }
-}`, rInt, rString)
+}`, rInt, location, rString)
 }
 
-func testAccAzureRMStorageAccount_enableHttpsTrafficOnlyDisabled(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_enableHttpsTrafficOnlyDisabled(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "westus"
+    location = "${azurerm_resource_group.testrg.location}"
     account_type = "Standard_LRS"
     enable_https_traffic_only = false
 
     tags {
         environment = "production"
     }
-}`, rInt, rString)
+}`, rInt, location, rString)
 }
 
-// BlobStorage accounts are not available in WestUS
-func testAccAzureRMStorageAccount_blobStorage(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_blobStorage(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "northeurope"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "northeurope"
-	account_kind = "BlobStorage"
+    location = "${azurerm_resource_group.testrg.location}"
+    account_kind = "BlobStorage"
     account_type = "Standard_LRS"
 
     tags {
         environment = "production"
     }
 }
-`, rInt, rString)
+`, rInt, location, rString)
 }
 
-func testAccAzureRMStorageAccount_blobStorageUpdate(rInt int, rString string) string {
+func testAccAzureRMStorageAccount_blobStorageUpdate(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "northeurope"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
 
-    location = "northeurope"
-	account_kind = "BlobStorage"
+    location = "${azurerm_resource_group.testrg.location}"
+    account_kind = "BlobStorage"
     account_type = "Standard_LRS"
-	access_tier = "Cool"
+    access_tier = "Cool"
 
     tags {
         environment = "production"
     }
 }
-`, rInt, rString)
+`, rInt, location, rString)
 }
 
-func testAccAzureRMStorageAccountNonStandardCasing(ri int, rs string) string {
+func testAccAzureRMStorageAccountNonStandardCasing(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "testrg" {
     name = "testAccAzureRMSA-%d"
-    location = "westus"
+    location = "%s"
 }
 resource "azurerm_storage_account" "testsa" {
     name = "unlikely23exst2acct%s"
     resource_group_name = "${azurerm_resource_group.testrg.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.testrg.location}"
     account_type = "standard_LRS"
     tags {
         environment = "production"
     }
-}`, ri, rs)
+}`, rInt, location, rString)
 }

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -493,7 +493,7 @@ func testCheckAzureRMStorageBlobDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMStorageBlob_basic(rInt int, location string, rString string) string {
+func testAccAzureRMStorageBlob_basic(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -146,14 +146,14 @@ func TestResourceAzureRMStorageBlobAttempts_validation(t *testing.T) {
 func TestAccAzureRMStorageBlob_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageBlob_basic, ri, rs)
+	config := testAccAzureRMStorageBlob_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists("azurerm_storage_blob.test"),
@@ -166,14 +166,14 @@ func TestAccAzureRMStorageBlob_basic(t *testing.T) {
 func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageBlob_basic, ri, rs)
+	config := testAccAzureRMStorageBlob_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists("azurerm_storage_blob.test"),
@@ -203,14 +203,14 @@ func TestAccAzureRMStorageBlobBlock_source(t *testing.T) {
 		t.Fatalf("Failed to close source blob")
 	}
 
-	config := fmt.Sprintf(testAccAzureRMStorageBlobBlock_source, ri, rs1, sourceBlob.Name())
+	config := testAccAzureRMStorageBlobBlock_source(ri, rs1, sourceBlob.Name(), testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobMatchesFile("azurerm_storage_blob.source", storage.BlobTypeBlock, sourceBlob.Name()),
@@ -222,7 +222,7 @@ func TestAccAzureRMStorageBlobBlock_source(t *testing.T) {
 
 func TestAccAzureRMStorageBlobPage_source(t *testing.T) {
 	ri := acctest.RandInt()
-	rs1 := strings.ToLower(acctest.RandString(11))
+	rs := strings.ToLower(acctest.RandString(11))
 	sourceBlob, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
@@ -262,14 +262,14 @@ func TestAccAzureRMStorageBlobPage_source(t *testing.T) {
 		t.Fatalf("Failed to close source blob")
 	}
 
-	config := fmt.Sprintf(testAccAzureRMStorageBlobPage_source, ri, rs1, sourceBlob.Name())
+	config := testAccAzureRMStorageBlobPage_source(ri, rs, sourceBlob.Name(), testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobMatchesFile("azurerm_storage_blob.source", storage.BlobTypePage, sourceBlob.Name()),
@@ -281,7 +281,7 @@ func TestAccAzureRMStorageBlobPage_source(t *testing.T) {
 
 func TestAccAzureRMStorageBlob_source_uri(t *testing.T) {
 	ri := acctest.RandInt()
-	rs1 := strings.ToLower(acctest.RandString(11))
+	rs := strings.ToLower(acctest.RandString(11))
 	sourceBlob, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
@@ -297,14 +297,14 @@ func TestAccAzureRMStorageBlob_source_uri(t *testing.T) {
 		t.Fatalf("Failed to close source blob")
 	}
 
-	config := fmt.Sprintf(testAccAzureRMStorageBlob_source_uri, ri, rs1, sourceBlob.Name())
+	config := testAccAzureRMStorageBlob_source_uri(ri, rs, sourceBlob.Name(), testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobMatchesFile("azurerm_storage_blob.destination", storage.BlobTypeBlock, sourceBlob.Name()),
@@ -493,16 +493,17 @@ func testCheckAzureRMStorageBlobDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMStorageBlob_basic = `
+func testAccAzureRMStorageBlob_basic(rInt int, location string, rString string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -527,18 +528,20 @@ resource "azurerm_storage_blob" "test" {
     type = "page"
     size = 5120
 }
-`
+`, rInt, location, rString)
+}
 
-var testAccAzureRMStorageBlobBlock_source = `
+func testAccAzureRMStorageBlobBlock_source(rInt int, rString string, sourceBlobName string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "source" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -561,22 +564,24 @@ resource "azurerm_storage_blob" "source" {
     storage_container_name = "${azurerm_storage_container.source.name}"
 
     type = "block"
-		source = "%s"
-		parallelism = 4
-		attempts = 2
+    source = "%s"
+    parallelism = 4
+    attempts = 2
 }
-`
+`, rInt, location, rString, sourceBlobName)
+}
 
-var testAccAzureRMStorageBlobPage_source = `
+func testAccAzureRMStorageBlobPage_source(rInt int, rString string, sourceBlobName string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "source" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -599,22 +604,24 @@ resource "azurerm_storage_blob" "source" {
     storage_container_name = "${azurerm_storage_container.source.name}"
 
     type = "page"
-		source = "%s"
-		parallelism = 3
-		attempts = 3
+    source = "%s"
+    parallelism = 3
+    attempts = 3
 }
-`
+`, rInt, location, rString, sourceBlobName)
+}
 
-var testAccAzureRMStorageBlob_source_uri = `
+func testAccAzureRMStorageBlob_source_uri(rInt int, rString string, sourceBlobName string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "source" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -637,18 +644,17 @@ resource "azurerm_storage_blob" "source" {
     storage_container_name = "${azurerm_storage_container.source.name}"
 
     type = "block"
-		source = "%s"
-		parallelism = 4
-		attempts = 2
+    source = "%s"
+    parallelism = 4
+    attempts = 2
 }
 
 resource "azurerm_storage_blob" "destination" {
     name = "destination.vhd"
-
     resource_group_name = "${azurerm_resource_group.test.name}"
     storage_account_name = "${azurerm_storage_account.source.name}"
     storage_container_name = "${azurerm_storage_container.source.name}"
-
-		source_uri = "${azurerm_storage_blob.source.url}"
+    source_uri = "${azurerm_storage_blob.source.url}"
 }
-`
+`, rInt, location, rString, sourceBlobName)
+}

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -17,7 +17,7 @@ func TestAccAzureRMStorageContainer_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageContainer_basic, ri, rs)
+	config := testAccAzureRMStorageContainer_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,7 +39,7 @@ func TestAccAzureRMStorageContainer_disappears(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageContainer_basic, ri, rs)
+	config := testAccAzureRMStorageContainer_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,7 +63,7 @@ func TestAccAzureRMStorageContainer_root(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageContainer_root, ri, rs)
+	config := testAccAzureRMStorageContainer_root(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -242,16 +242,17 @@ func TestValidateArmStorageContainerName(t *testing.T) {
 	}
 }
 
-var testAccAzureRMStorageContainer_basic = `
+func testAccAzureRMStorageContainer_basic(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -265,18 +266,20 @@ resource "azurerm_storage_container" "test" {
     storage_account_name = "${azurerm_storage_account.test.name}"
     container_access_type = "private"
 }
-`
+`, rInt, location, rString)
+}
 
-var testAccAzureRMStorageContainer_root = `
+func testAccAzureRMStorageContainer_root(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -290,4 +293,5 @@ resource "azurerm_storage_container" "test" {
     storage_account_name = "${azurerm_storage_account.test.name}"
     container_access_type = "private"
 }
-`
+`, rInt, location, rString)
+}

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -2,9 +2,8 @@ package azurerm
 
 import (
 	"fmt"
-	"testing"
-
 	"strings"
+	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -54,14 +53,14 @@ func TestResourceAzureRMStorageQueueName_Validation(t *testing.T) {
 func TestAccAzureRMStorageQueue_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageQueue_basic, ri, rs, ri)
+	config := testAccAzureRMStorageQueue_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMStorageQueueDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageQueueExists("azurerm_storage_queue.test"),
@@ -145,16 +144,17 @@ func testCheckAzureRMStorageQueueDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMStorageQueue_basic = `
+func testAccAzureRMStorageQueue_basic(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -167,4 +167,5 @@ resource "azurerm_storage_queue" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     storage_account_name = "${azurerm_storage_account.test.name}"
 }
-`
+`, rInt, location, rString, rInt)
+}

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -17,7 +17,7 @@ func TestAccAzureRMStorageShare_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageShare_basic, ri, rs)
+	config := testAccAzureRMStorageShare_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,7 +39,7 @@ func TestAccAzureRMStorageShare_disappears(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageShare_basic, ri, rs)
+	config := testAccAzureRMStorageShare_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -219,16 +219,17 @@ func TestValidateArmStorageShareName(t *testing.T) {
 	}
 }
 
-var testAccAzureRMStorageShare_basic = `
+func testAccAzureRMStorageShare_basic(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -240,5 +241,5 @@ resource "azurerm_storage_share" "test" {
     name = "testshare"
     resource_group_name = "${azurerm_resource_group.test.name}"
     storage_account_name = "${azurerm_storage_account.test.name}"
+}`, rInt, location, rString)
 }
-`

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -17,7 +17,7 @@ func TestAccAzureRMStorageTable_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageTable_basic, ri, rs, ri)
+	config := testAccAzureRMStorageTable_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,7 +39,7 @@ func TestAccAzureRMStorageTable_disappears(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	config := fmt.Sprintf(testAccAzureRMStorageTable_basic, ri, rs, ri)
+	config := testAccAzureRMStorageTable_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -218,16 +218,17 @@ func TestValidateArmStorageTableName(t *testing.T) {
 	}
 }
 
-var testAccAzureRMStorageTable_basic = `
+func testAccAzureRMStorageTable_basic(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
-    location = "westus"
+    location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
     name = "acctestacc%s"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
+    location = "${azurerm_resource_group.test.location}"
     account_type = "Standard_LRS"
 
     tags {
@@ -236,8 +237,9 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_table" "test" {
-    name = "tfacceptancetest%d"
+    name = "acctestst%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     storage_account_name = "${azurerm_storage_account.test.name}"
 }
-`
+`, rInt, location, rString, rInt)
+}


### PR DESCRIPTION
Continuing on #216

So that we're able to run the AzureRM Acceptance Tests against different clouds, we need to make the `Location` field, used to specify where to deploy the resource configurable through some means. This is simplest as an environment variable - as such I've hooked it up as such - but this needs to be added to every resource.

Resources:

- [x] Search Service
- [x] ServiceBus Namespace
- [x] ServiceBus Queue
- [x] ServiceBus Subscription
- [x] ServiceBus Topic
- [x] SQL Database
- [x] SQL ElasticPool
- [x] SQL Firewall Rule
- [x] SQL Server
- [x] Storage Account
- [x] Storage Blob
- [x] Storage Container
- [x] Storage Queue
- [x] Storage Share
- [x] Storage Tables
