### PR TITLE
Making the Test Location an Environment Variable: Part 5

### DIFF
--- a/azurerm/import_arm_key_vault_test.go
+++ b/azurerm/import_arm_key_vault_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,18 +11,17 @@ func TestAccAzureRMKeyVault_importBasic(t *testing.T) {
 	resourceName := "azurerm_key_vault.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMKeyVault_basic, ri, ri)
+	config := testAccAzureRMKeyVault_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMKeyVaultDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_loadbalancer_backend_address_pool_test.go
+++ b/azurerm/import_arm_loadbalancer_backend_address_pool_test.go
@@ -19,11 +19,10 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName),
+			{
+				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName, testLocation()),
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_loadbalancer_nat_pool_test.go
+++ b/azurerm/import_arm_loadbalancer_nat_pool_test.go
@@ -19,11 +19,10 @@ func TestAccAzureRMLoadBalancerNatPool_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
+			{
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName, testLocation()),
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_loadbalancer_nat_rule_test.go
+++ b/azurerm/import_arm_loadbalancer_nat_rule_test.go
@@ -19,11 +19,10 @@ func TestAccAzureRMLoadBalancerNatRule_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
+			{
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName, testLocation()),
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_loadbalancer_probe_test.go
+++ b/azurerm/import_arm_loadbalancer_probe_test.go
@@ -19,11 +19,10 @@ func TestAccAzureRMLoadBalancerProbe_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
+			{
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName, testLocation()),
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_loadbalancer_rule_test.go
+++ b/azurerm/import_arm_loadbalancer_rule_test.go
@@ -19,11 +19,10 @@ func TestAccAzureRMLoadBalancerRule_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
+			{
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName, testLocation()),
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_loadbalancer_test.go
+++ b/azurerm/import_arm_loadbalancer_test.go
@@ -9,17 +9,18 @@ import (
 
 func TestAccAzureRMLoadBalancer_importBasic(t *testing.T) {
 	resourceName := "azurerm_lb.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMLoadBalancer_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAzureRMLoadBalancer_basic(acctest.RandInt()),
+			{
+				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_local_network_gateway_test.go
+++ b/azurerm/import_arm_local_network_gateway_test.go
@@ -17,7 +17,7 @@ func TestAccAzureRMLocalNetworkGateway_importBasic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt),
+				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt, testLocation()),
 			},
 
 			{

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -8,38 +8,38 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestAccAzureRMImage_standaloneImage(t *testing.T) {
 	ri := acctest.RandInt()
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
 	userName := "testadmin"
 	password := "Password1234!"
-	hostName := fmt.Sprintf("tftestcustomimagesrc%[1]d", ri)
+	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
 	sshPort := "22"
-	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName)
-	postConfig := testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName)
+	location := testLocation()
+	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, location)
+	postConfig := testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMImageDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				//need to create a vm and then reference it in the image creation
 				Config:  preConfig,
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMExists("azurerm_virtual_machine.testsource", true),
-					testGeneralizeVMImage(fmt.Sprintf("acctestRG-%d", ri), "testsource",
-						userName, password, hostName, sshPort),
+					testGeneralizeVMImage(resourceGroup, "testsource", userName, password, hostName, sshPort, location),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMImageExists("azurerm_image.test", true),
@@ -51,29 +51,30 @@ func TestAccAzureRMImage_standaloneImage(t *testing.T) {
 
 func TestAccAzureRMImage_customImageVMFromVHD(t *testing.T) {
 	ri := acctest.RandInt()
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
 	userName := "testadmin"
 	password := "Password1234!"
-	hostName := fmt.Sprintf("tftestcustomimagesrc%[1]d", ri)
+	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
 	sshPort := "22"
-	preConfig := testAccAzureRMImage_customImage_fromVHD_setup(ri, userName, password, hostName)
-	postConfig := testAccAzureRMImage_customImage_fromVHD_provision(ri, userName, password, hostName)
+	location := testLocation()
+	preConfig := testAccAzureRMImage_customImage_fromVHD_setup(ri, userName, password, hostName, location)
+	postConfig := testAccAzureRMImage_customImage_fromVHD_provision(ri, userName, password, hostName, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMImageDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				//need to create a vm and then reference it in the image creation
 				Config:  preConfig,
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMExists("azurerm_virtual_machine.testsource", true),
-					testGeneralizeVMImage(fmt.Sprintf("acctestRG-%[1]d", ri), "testsource",
-						userName, password, hostName, sshPort),
+					testGeneralizeVMImage(resourceGroup, "testsource", userName, password, hostName, sshPort, location),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMExists("azurerm_virtual_machine.testdestination", true),
@@ -85,29 +86,30 @@ func TestAccAzureRMImage_customImageVMFromVHD(t *testing.T) {
 
 func TestAccAzureRMImage_customImageVMFromVM(t *testing.T) {
 	ri := acctest.RandInt()
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
 	userName := "testadmin"
 	password := "Password1234!"
-	hostName := fmt.Sprintf("tftestcustomimagesrc%[1]d", ri)
+	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
 	sshPort := "22"
-	preConfig := testAccAzureRMImage_customImage_fromVM_sourceVM(ri, userName, password, hostName)
-	postConfig := testAccAzureRMImage_customImage_fromVM_destinationVM(ri, userName, password, hostName)
+	location := testLocation()
+	preConfig := testAccAzureRMImage_customImage_fromVM_sourceVM(ri, userName, password, hostName, location)
+	postConfig := testAccAzureRMImage_customImage_fromVM_destinationVM(ri, userName, password, hostName, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMImageDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				//need to create a vm and then reference it in the image creation
 				Config:  preConfig,
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMExists("azurerm_virtual_machine.testsource", true),
-					testGeneralizeVMImage(fmt.Sprintf("acctestRG-%[1]d", ri), "testsource",
-						userName, password, hostName, sshPort),
+					testGeneralizeVMImage(resourceGroup, "testsource", userName, password, hostName, sshPort, location),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMExists("azurerm_virtual_machine.testdestination", true),
@@ -119,29 +121,30 @@ func TestAccAzureRMImage_customImageVMFromVM(t *testing.T) {
 
 func TestAccAzureRMImageVMSS_customImageVMSSFromVHD(t *testing.T) {
 	ri := acctest.RandInt()
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
 	userName := "testadmin"
 	password := "Password1234!"
-	hostName := fmt.Sprintf("tftestcustomimagesrc%[1]d", ri)
+	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
 	sshPort := "22"
-	preConfig := testAccAzureRMImageVMSS_customImage_fromVHD_setup(ri, userName, password, hostName)
-	postConfig := testAccAzureRMImageVMSS_customImage_fromVHD_provision(ri, userName, password, hostName)
+	location := testLocation()
+	preConfig := testAccAzureRMImageVMSS_customImage_fromVHD_setup(ri, userName, password, hostName, location)
+	postConfig := testAccAzureRMImageVMSS_customImage_fromVHD_provision(ri, userName, password, hostName, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMImageDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				//need to create a vm and then reference it in the image creation
 				Config:  preConfig,
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMExists("azurerm_virtual_machine.testsource", true),
-					testGeneralizeVMImage(fmt.Sprintf("acctestRG-%[1]d", ri), "testsource",
-						userName, password, hostName, sshPort),
+					testGeneralizeVMImage(resourceGroup, "testsource", userName, password, hostName, sshPort, location),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMSSExists("azurerm_virtual_machine_scale_set.testdestination", true),
@@ -151,25 +154,29 @@ func TestAccAzureRMImageVMSS_customImageVMSSFromVHD(t *testing.T) {
 	})
 }
 
-func testGeneralizeVMImage(groupName string, vmName string, userName string, password string, hostName string, port string) resource.TestCheckFunc {
+func testGeneralizeVMImage(resourceGroup string, vmName string, userName string, password string, hostName string, port string, location string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		vmClient := testAccProvider.Meta().(*ArmClient).vmClient
-		dnsName := fmt.Sprintf("%[1]s.westus.cloudapp.azure.com", hostName)
+		armClient := testAccProvider.Meta().(*ArmClient)
+		vmClient := armClient.vmClient
 
-		deprovisionErr := deprovisionVM(userName, password, dnsName, port)
-		if deprovisionErr != nil {
-			return fmt.Errorf("Bad: Deprovisioning error %s", deprovisionErr)
-		}
+		normalizedLocation := azureRMNormalizeLocation(location)
+		suffix := armClient.environment.ResourceManagerVMDNSSuffix
+		dnsName := fmt.Sprintf("%s.%s.%s", hostName, normalizedLocation, suffix)
 
-		_, deallocateErr := vmClient.Deallocate(groupName, vmName, nil)
-		err := <-deallocateErr
+		err := deprovisionVM(userName, password, dnsName, port)
 		if err != nil {
-			return fmt.Errorf("Bad: Deallocating error %s", err)
+			return fmt.Errorf("Bad: Deprovisioning error %+v", err)
 		}
 
-		_, generalizeErr := vmClient.Generalize(groupName, vmName)
-		if generalizeErr != nil {
-			return fmt.Errorf("Bad: Generalizing error %s", generalizeErr)
+		_, deallocateErr := vmClient.Deallocate(resourceGroup, vmName, nil)
+		err = <-deallocateErr
+		if err != nil {
+			return fmt.Errorf("Bad: Deallocating error %+v", err)
+		}
+
+		_, err = vmClient.Generalize(resourceGroup, vmName)
+		if err != nil {
+			return fmt.Errorf("Bad: Generalizing error %+v", err)
 		}
 
 		return nil
@@ -192,18 +199,18 @@ func deprovisionVM(userName string, password string, hostName string, port strin
 	hostAddress := strings.Join([]string{hostName, port}, ":")
 	client, err := ssh.Dial("tcp", hostAddress, config)
 	if err != nil {
-		return fmt.Errorf("Bad: deprovisioning error %s", err.Error())
+		return fmt.Errorf("Bad: deprovisioning error %+v", err)
 	}
 
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("Bad: deprovisioning error, failure creating session %s", err.Error())
+		return fmt.Errorf("Bad: deprovisioning error, failure creating session %+v", err)
 	}
 	defer session.Close()
 
 	session.Stdout = &b
 	if err := session.Run(cmd); err != nil {
-		return fmt.Errorf("Bad: deprovisioning error, failure running command %s", err.Error())
+		return fmt.Errorf("Bad: deprovisioning error, failure running command %+v", err)
 	}
 
 	return nil
@@ -229,7 +236,7 @@ func testCheckAzureRMImageExists(name string, shouldExist bool) resource.TestChe
 
 		resp, err := conn.Get(resourceGroup, dName, "")
 		if err != nil {
-			return fmt.Errorf("Bad: Get on imageClient: %s", err)
+			return fmt.Errorf("Bad: Get on imageClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound && shouldExist {
@@ -261,7 +268,7 @@ func testCheckAzureVMExists(sourceVM string, shouldExist bool) resource.TestChec
 
 		resp, err := vmClient.Get(resourceGroup, vmName, "")
 		if err != nil {
-			return fmt.Errorf("Bad: Get on vmClient: %s", err)
+			return fmt.Errorf("Bad: Get on vmClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound && shouldExist {
@@ -336,569 +343,570 @@ func testCheckAzureRMImageDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMImage_standaloneImage_setup(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImage_standaloneImage_setup(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%[1]d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acctvn-%[1]d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name = "acctsub-%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_public_ip" "test" {
-  name                         = "acctpip-%[1]d"
-  location                     = "West US"
+  name                         = "acctpip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "Dynamic"
-  domain_name_label            = "%[4]s"
+  domain_name_label            = "%s"
 }
 
 resource "azurerm_network_interface" "testsource" {
-    name = "acctnicsource-%[1]d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctnicsource-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    ip_configuration {
-    	name = "testconfigurationsource"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-	    public_ip_address_id          = "${azurerm_public_ip.test.id}"
-    }
+  ip_configuration {
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
-    name = "accsa%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
-    account_type = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  account_type        = "Standard_LRS"
 
-    tags {
-        environment = "Dev"
-    }
+  tags {
+    environment = "Dev"
+  }
 }
 
 resource "azurerm_storage_container" "test" {
-    name = "vhds"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_name = "${azurerm_storage_account.test.name}"
-    container_access_type = "blob"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "blob"
 }
 
 resource "azurerm_virtual_machine" "testsource" {
-    name = "testsource"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
-    vm_size = "Standard_D1_v2"
+  name                  = "testsource"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
+  vm_size               = "Standard_D1_v2"
 
-    storage_image_reference {
-		publisher = "Canonical"
-		offer = "UbuntuServer"
-		sku = "16.04-LTS"
-		version = "latest"
-    }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
 
-    storage_os_disk {
-        name = "myosdisk1"
-        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
-        caching = "ReadWrite"
-        create_option = "FromImage"
-        disk_size_gb = "30"
-    }
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    disk_size_gb  = "30"
+  }
 
-    os_profile {
-		computer_name = "mdimagetestsource"
-		admin_username = "%[2]s"
-		admin_password = "%[3]s"
-    }
+  os_profile {
+    computer_name  = "mdimagetestsource"
+    admin_username = "%s"
+    admin_password = "%s"
+  }
 
-    os_profile_linux_config {
-		disable_password_authentication = false
-    }
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 
-    tags {
-    	environment = "Dev"
-    	cost-center = "Ops"
-    }
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
-`, rInt, userName, password, hostName)
+`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password)
 }
 
-func testAccAzureRMImage_standaloneImage_provision(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImage_standaloneImage_provision(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%[1]d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acctvn-%[1]d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name = "acctsub-%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_public_ip" "test" {
-  name                         = "acctpip-%[1]d"
-  location                     = "West US"
+  name                         = "acctpip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "Dynamic"
-  domain_name_label            = "%[4]s"
+  domain_name_label            = "%s"
 }
 
 resource "azurerm_network_interface" "testsource" {
-    name = "acctnicsource-%[1]d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctnicsource-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    ip_configuration {
-    	name = "testconfigurationsource"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-	    public_ip_address_id          = "${azurerm_public_ip.test.id}"
-    }
+  ip_configuration {
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
-    name = "accsa%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
-    account_type = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  account_type        = "Standard_LRS"
 
-    tags {
-        environment = "Dev"
-    }
+  tags {
+    environment = "Dev"
+  }
 }
 
 resource "azurerm_storage_container" "test" {
-    name = "vhds"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_name = "${azurerm_storage_account.test.name}"
-    container_access_type = "blob"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "blob"
 }
 
 resource "azurerm_virtual_machine" "testsource" {
-    name = "testsource"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
-    vm_size = "Standard_D1_v2"
+  name                  = "testsource"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
+  vm_size               = "Standard_D1_v2"
 
-    storage_image_reference {
-		publisher = "Canonical"
-		offer = "UbuntuServer"
-		sku = "16.04-LTS"
-		version = "latest"
-    }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
 
-    storage_os_disk {
-        name = "myosdisk1"
-        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
-        caching = "ReadWrite"
-        create_option = "FromImage"
-        disk_size_gb = "30"
-    }
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    disk_size_gb  = "30"
+  }
 
-    os_profile {
-		computer_name = "mdimagetestsource"
-		admin_username = "%[2]s"
-		admin_password = "%[3]s"
-    }
+  os_profile {
+    computer_name  = "mdimagetestsource"
+    admin_username = "%s"
+    admin_password = "%s"
+  }
 
-    os_profile_linux_config {
-		disable_password_authentication = false
-    }
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 
-    tags {
-    	environment = "Dev"
-    	cost-center = "Ops"
-    }
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
 
 resource "azurerm_image" "test" {
-	name = "accteste"
-	location = "West US"
-	resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "accteste"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-	os_disk {
-		os_type = "Linux"
-		os_state = "Generalized"
-		blob_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
-		size_gb = 30
-		caching = "None"
-	}
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    size_gb  = 30
+    caching  = "None"
+  }
 
-	tags {
-		environment = "Dev"
-		cost-center = "Ops"
-	}
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
-`, rInt, userName, password, hostName)
+`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password)
 }
 
-func testAccAzureRMImage_customImage_fromVHD_setup(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImage_customImage_fromVHD_setup(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%[1]d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acctvn-%[1]d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name = "acctsub-%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_public_ip" "test" {
-  name                         = "acctpip-%[1]d"
-  location                     = "West US"
+  name                         = "acctpip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "Dynamic"
-  domain_name_label            = "%[4]s"
+  domain_name_label            = "%s"
 }
 
 resource "azurerm_network_interface" "testsource" {
-    name = "acctnicsource-%[1]d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctnicsource-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    ip_configuration {
-    	name = "testconfigurationsource"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-	    public_ip_address_id          = "${azurerm_public_ip.test.id}"
-    }
+  ip_configuration {
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
-    name = "accsa%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "West US"
-    account_type = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  account_type        = "Standard_LRS"
 
-    tags {
-        environment = "Dev"
-    }
+  tags {
+    environment = "Dev"
+  }
 }
 
 resource "azurerm_storage_container" "test" {
-    name = "vhds"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_name = "${azurerm_storage_account.test.name}"
-    container_access_type = "blob"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "blob"
 }
 
 resource "azurerm_virtual_machine" "testsource" {
-    name = "testsource"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
-    vm_size = "Standard_D1_v2"
+  name                  = "testsource"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
+  vm_size               = "Standard_D1_v2"
 
-    storage_image_reference {
-		publisher = "Canonical"
-		offer = "UbuntuServer"
-		sku = "16.04-LTS"
-		version = "latest"
-    }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
 
-    storage_os_disk {
-        name = "myosdisk1"
-        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
-        caching = "ReadWrite"
-        create_option = "FromImage"
-        disk_size_gb = "30"
-    }
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    disk_size_gb  = "30"
+  }
 
-    os_profile {
-		computer_name = "mdimagetestsource"
-		admin_username = "%[2]s"
-		admin_password = "%[3]s"
-    }
+  os_profile {
+    computer_name  = "mdimagetestsource"
+    admin_username = "%s"
+    admin_password = "%s"
+  }
 
-    os_profile_linux_config {
-		disable_password_authentication = false
-    }
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 
-    tags {
-    	environment = "Dev"
-    	cost-center = "Ops"
-    }
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
-`, rInt, userName, password, hostName)
+`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password)
 }
 
-func testAccAzureRMImage_customImage_fromVHD_provision(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImage_customImage_fromVHD_provision(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-	name = "acctestRG-%[1]d"
-	location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-	name = "acctvn-%[1]d"
-	address_space = ["10.0.0.0/16"]
-	location = "West US"
-	resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-	name = "acctsub-%[1]d"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	virtual_network_name = "${azurerm_virtual_network.test.name}"
-	address_prefix = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_public_ip" "test" {
-	name                         = "acctpip-%[1]d"
-	location                     = "West US"
-	resource_group_name          = "${azurerm_resource_group.test.name}"
-	public_ip_address_allocation = "Dynamic"
-	domain_name_label            = "%[4]s"
+  name                         = "acctpip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "Dynamic"
+  domain_name_label            = "%s"
 }
 
 resource "azurerm_network_interface" "testsource" {
-	name = "acctnicsource-%[1]d"
-	location = "West US"
-	resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctnicsource-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-	ip_configuration {
-		name = "testconfigurationsource"
-		subnet_id = "${azurerm_subnet.test.id}"
-		private_ip_address_allocation = "dynamic"
-		public_ip_address_id          = "${azurerm_public_ip.test.id}"
-	}
+  ip_configuration {
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
-	name = "accsa%[1]d"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	location = "West US"
-	account_type = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  account_type        = "Standard_LRS"
 
-	tags {
-		environment = "Dev"
-	}
+  tags {
+    environment = "Dev"
+  }
 }
 
 resource "azurerm_storage_container" "test" {
-	name = "vhds"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	storage_account_name = "${azurerm_storage_account.test.name}"
-	container_access_type = "blob"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "blob"
 }
 
 resource "azurerm_virtual_machine" "testsource" {
-	name = "testsource"
-	location = "West US"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
-	vm_size = "Standard_D1_v2"
+  name                  = "testsource"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
+  vm_size               = "Standard_D1_v2"
 
-	storage_image_reference {
-		publisher = "Canonical"
-		offer = "UbuntuServer"
-		sku = "16.04-LTS"
-		version = "latest"
-	}
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
 
-	storage_os_disk {
-		name = "myosdisk1"
-		vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
-		caching = "ReadWrite"
-		create_option = "FromImage"
-		disk_size_gb = "45"
-	}
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    disk_size_gb  = "45"
+  }
 
-	os_profile {
-		computer_name = "mdimagetestsource"
-		admin_username = "%[2]s"
-		admin_password = "%[3]s"
-	}
+  os_profile {
+    computer_name  = "mdimagetestsource"
+    admin_username = "%s"
+    admin_password = "%s"
+  }
 
-	os_profile_linux_config {
-		disable_password_authentication = false
-	}
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 
-	tags {
-		environment = "Dev"
-		cost-center = "Ops"
-	}
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
 
 resource "azurerm_image" "testdestination" {
-	name = "accteste"
-	location = "West US"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	os_disk {
-		os_type = "Linux"
-		os_state = "Generalized"
-		blob_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
-		size_gb = 30
-		caching = "None"
-	}
+  name                = "accteste"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-	tags {
-		environment = "Dev"
-		cost-center = "Ops"
-	}
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    size_gb  = 30
+    caching  = "None"
+  }
+
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
 
 resource "azurerm_network_interface" "testdestination" {
-    name = "acctnicdest-%[1]d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctnicdest-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    ip_configuration {
-    	name = "testconfiguration2"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-    }
+  ip_configuration {
+    name                          = "testconfiguration2"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
 }
 
 resource "azurerm_virtual_machine" "testdestination" {
-	name = "acctvm"
-	location = "West US"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	network_interface_ids = ["${azurerm_network_interface.testdestination.id}"]
-	vm_size = "Standard_D1_v2"
+  name                  = "acctvm"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.testdestination.id}"]
+  vm_size               = "Standard_D1_v2"
 
-	storage_image_reference {
-		id = "${azurerm_image.testdestination.id}"
-	}
+  storage_image_reference {
+    id = "${azurerm_image.testdestination.id}"
+  }
 
-	storage_os_disk {
-		name = "myosdisk1"
-		caching = "ReadWrite"
-		create_option = "FromImage"
-	}
+  storage_os_disk {
+    name          = "myosdisk1"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
 
-	os_profile {
-		computer_name = "mdimagetestsource"
-		admin_username = "%[2]s"
-		admin_password = "%[3]s"
-	}
+  os_profile {
+    computer_name  = "mdimagetestsource"
+    admin_username = "%s"
+    admin_password = "%s"
+  }
 
-	os_profile_linux_config {
-		disable_password_authentication = false
-	}
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 
-	tags {
-		environment = "Dev"
-		cost-center = "Ops"
-	}
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
-`, rInt, userName, password, hostName)
+`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password, rInt, userName, password)
 }
 
-func testAccAzureRMImage_customImage_fromVM_sourceVM(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImage_customImage_fromVM_sourceVM(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%[1]d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acctvn-%[1]d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name = "acctsub-%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_public_ip" "test" {
-  name                         = "acctpip-%[1]d"
-  location                     = "West US"
+  name                         = "acctpip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "Dynamic"
-  domain_name_label            = "%[4]s"
+  domain_name_label            = "%s"
 }
 
 resource "azurerm_network_interface" "testsource" {
-    name = "acctnicsource-%[1]d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctnicsource-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    ip_configuration {
-    	name = "testconfigurationsource"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-	    public_ip_address_id          = "${azurerm_public_ip.test.id}"
-    }
+  ip_configuration {
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_virtual_machine" "testsource" {
-    name = "testsource"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
-    vm_size = "Standard_D1_v2"
+  name                  = "testsource"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.testsource.id}"]
+  vm_size               = "Standard_D1_v2"
 
-    storage_image_reference {
-		publisher = "Canonical"
-		offer = "UbuntuServer"
-		sku = "16.04-LTS"
-		version = "latest"
-    }
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
 
-    storage_os_disk {
-        name = "myosdisk1"
-        caching = "ReadWrite"
-        create_option = "FromImage"
-    }
+  storage_os_disk {
+    name          = "myosdisk1"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
 
-    os_profile {
-		computer_name = "mdimagetestsource"
-		admin_username = "%[2]s"
-		admin_password = "%[3]s"
-    }
+  os_profile {
+    computer_name  = "mdimagetestsource"
+    admin_username = "%s"
+    admin_password = "%s"
+  }
 
-    os_profile_linux_config {
-		disable_password_authentication = false
-    }
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
 
-    tags {
-    	environment = "Dev"
-    	cost-center = "Ops"
-    }
+  tags {
+    environment = "Dev"
+    cost-center = "Ops"
+  }
 }
-`, rInt, userName, password, hostName)
+`, rInt, location, rInt, rInt, rInt, hostName, rInt, userName, password)
 }
 
-func testAccAzureRMImage_customImage_fromVM_destinationVM(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImage_customImage_fromVM_destinationVM(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%[1]d"
@@ -1034,7 +1042,7 @@ resource "azurerm_virtual_machine" "testdestination" {
 `, rInt, userName, password, hostName)
 }
 
-func testAccAzureRMImageVMSS_customImage_fromVHD_setup(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImageVMSS_customImage_fromVHD_setup(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%[1]d"
@@ -1134,7 +1142,7 @@ resource "azurerm_virtual_machine" "testsource" {
 `, rInt, userName, password, hostName)
 }
 
-func testAccAzureRMImageVMSS_customImage_fromVHD_provision(rInt int, userName string, password string, hostName string) string {
+func testAccAzureRMImageVMSS_customImage_fromVHD_provision(rInt int, userName string, password string, hostName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
 	name = "acctestRG-%[1]d"

--- a/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -27,7 +27,7 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
@@ -50,14 +50,14 @@ func TestAccAzureRMLoadBalancerNatPool_removal(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_removal(ri),
+				Config: testAccAzureRMLoadBalancerNatPool_removal(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolNotExists(natPoolName, &lb),
@@ -79,7 +79,7 @@ func TestAccAzureRMLoadBalancerNatPool_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_multiplePools(ri, natPoolName, natPool2Name),
+				Config: testAccAzureRMLoadBalancerNatPool_multiplePools(ri, natPoolName, natPool2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
@@ -88,7 +88,7 @@ func TestAccAzureRMLoadBalancerNatPool_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_multiplePoolsUpdate(ri, natPoolName, natPool2Name),
+				Config: testAccAzureRMLoadBalancerNatPool_multiplePoolsUpdate(ri, natPoolName, natPool2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
@@ -115,7 +115,7 @@ func TestAccAzureRMLoadBalancerNatPool_reapply(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
@@ -124,7 +124,7 @@ func TestAccAzureRMLoadBalancerNatPool_reapply(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
@@ -145,7 +145,7 @@ func TestAccAzureRMLoadBalancerNatPool_disappears(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
@@ -200,7 +200,7 @@ func testCheckAzureRMLoadBalancerNatPoolDisappears(natPoolName string, lb *netwo
 		_, error := conn.CreateOrUpdate(id.ResourceGroup, *lb.Name, *lb, make(chan struct{}))
 		err = <-error
 		if err != nil {
-			return fmt.Errorf("Error Creating/Updating LoadBalancer %s", err)
+			return fmt.Errorf("Error Creating/Updating LoadBalancer %+v", err)
 		}
 
 		_, err = conn.Get(id.ResourceGroup, *lb.Name, "")
@@ -208,90 +208,90 @@ func testCheckAzureRMLoadBalancerNatPoolDisappears(natPoolName string, lb *netwo
 	}
 }
 
-func testAccAzureRMLoadBalancerNatPool_basic(rInt int, natPoolName string) string {
+func testAccAzureRMLoadBalancerNatPool_basic(rInt int, natPoolName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_nat_pool" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port_start = 80
-  frontend_port_end = 81
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port_start            = 80
+  frontend_port_end              = 81
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
-
-`, rInt, rInt, rInt, rInt, natPoolName, rInt)
+`, rInt, location, rInt, rInt, rInt, natPoolName, rInt)
 }
 
-func testAccAzureRMLoadBalancerNatPool_removal(rInt int) string {
+func testAccAzureRMLoadBalancerNatPool_removal(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMLoadBalancerNatPool_multiplePools(rInt int, natPoolName, natPool2Name string, location string) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
     name = "acctestrg-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
     name = "test-ip-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
     name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
-}
-`, rInt, rInt, rInt, rInt)
-}
-
-func testAccAzureRMLoadBalancerNatPool_multiplePools(rInt int, natPoolName, natPool2Name string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
-}
-
-resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
-}
-
-resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
+    location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
     frontend_ip_configuration {
@@ -301,7 +301,7 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_nat_pool" "test" {
-  location = "West US"
+  location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id = "${azurerm_lb.test.id}"
   name = "%s"
@@ -313,7 +313,7 @@ resource "azurerm_lb_nat_pool" "test" {
 }
 
 resource "azurerm_lb_nat_pool" "test2" {
-  location = "West US"
+  location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id = "${azurerm_lb.test.id}"
   name = "%s"
@@ -323,58 +323,56 @@ resource "azurerm_lb_nat_pool" "test2" {
   backend_port = 3390
   frontend_ip_configuration_name = "one-%d"
 }
-
-`, rInt, rInt, rInt, rInt, natPoolName, rInt, natPool2Name, rInt)
+`, rInt, location, rInt, rInt, rInt, natPoolName, rInt, natPool2Name, rInt)
 }
 
-func testAccAzureRMLoadBalancerNatPool_multiplePoolsUpdate(rInt int, natPoolName, natPool2Name string) string {
+func testAccAzureRMLoadBalancerNatPool_multiplePoolsUpdate(rInt int, natPoolName, natPool2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_nat_pool" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port_start = 80
-  frontend_port_end = 81
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port_start            = 80
+  frontend_port_end              = 81
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
 
 resource "azurerm_lb_nat_pool" "test2" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port_start = 82
-  frontend_port_end = 83
-  backend_port = 3391
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port_start            = 82
+  frontend_port_end              = 83
+  backend_port                   = 3391
   frontend_ip_configuration_name = "one-%d"
 }
-
-`, rInt, rInt, rInt, rInt, natPoolName, rInt, natPool2Name, rInt)
+`, rInt, location, rInt, rInt, rInt, natPoolName, rInt, natPool2Name, rInt)
 }

--- a/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -27,7 +27,7 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
@@ -50,14 +50,14 @@ func TestAccAzureRMLoadBalancerNatRule_removal(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_removal(ri),
+				Config: testAccAzureRMLoadBalancerNatRule_removal(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleNotExists(natRuleName, &lb),
@@ -79,7 +79,7 @@ func TestAccAzureRMLoadBalancerNatRule_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_multipleRules(ri, natRuleName, natRule2Name),
+				Config: testAccAzureRMLoadBalancerNatRule_multipleRules(ri, natRuleName, natRule2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
@@ -89,7 +89,7 @@ func TestAccAzureRMLoadBalancerNatRule_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_multipleRulesUpdate(ri, natRuleName, natRule2Name),
+				Config: testAccAzureRMLoadBalancerNatRule_multipleRulesUpdate(ri, natRuleName, natRule2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
@@ -117,7 +117,7 @@ func TestAccAzureRMLoadBalancerNatRule_reapply(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
@@ -126,7 +126,7 @@ func TestAccAzureRMLoadBalancerNatRule_reapply(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
@@ -147,7 +147,7 @@ func TestAccAzureRMLoadBalancerNatRule_disappears(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
@@ -202,7 +202,7 @@ func testCheckAzureRMLoadBalancerNatRuleDisappears(natRuleName string, lb *netwo
 		_, error := conn.CreateOrUpdate(id.ResourceGroup, *lb.Name, *lb, make(chan struct{}))
 		err = <-error
 		if err != nil {
-			return fmt.Errorf("Error Creating/Updating LoadBalancer %s", err)
+			return fmt.Errorf("Error Creating/Updating LoadBalancer %+v", err)
 		}
 
 		_, err = conn.Get(id.ResourceGroup, *lb.Name, "")
@@ -210,168 +210,165 @@ func testCheckAzureRMLoadBalancerNatRuleDisappears(natRuleName string, lb *netwo
 	}
 }
 
-func testAccAzureRMLoadBalancerNatRule_basic(rInt int, natRuleName string) string {
+func testAccAzureRMLoadBalancerNatRule_basic(rInt int, natRuleName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_nat_rule" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port = 3389
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
-
-`, rInt, rInt, rInt, rInt, natRuleName, rInt)
+`, rInt, location, rInt, rInt, rInt, natRuleName, rInt)
 }
 
-func testAccAzureRMLoadBalancerNatRule_removal(rInt int) string {
+func testAccAzureRMLoadBalancerNatRule_removal(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt)
 }
 
-func testAccAzureRMLoadBalancerNatRule_multipleRules(rInt int, natRuleName, natRule2Name string) string {
+func testAccAzureRMLoadBalancerNatRule_multipleRules(rInt int, natRuleName, natRule2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_nat_rule" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port = 3389
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
 
 resource "azurerm_lb_nat_rule" "test2" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port = 3390
-  backend_port = 3390
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port                  = 3390
+  backend_port                   = 3390
   frontend_ip_configuration_name = "one-%d"
 }
-
-`, rInt, rInt, rInt, rInt, natRuleName, rInt, natRule2Name, rInt)
+`, rInt, location, rInt, rInt, rInt, natRuleName, rInt, natRule2Name, rInt)
 }
 
-func testAccAzureRMLoadBalancerNatRule_multipleRulesUpdate(rInt int, natRuleName, natRule2Name string) string {
+func testAccAzureRMLoadBalancerNatRule_multipleRulesUpdate(rInt int, natRuleName, natRule2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_nat_rule" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port = 3389
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
 
 resource "azurerm_lb_nat_rule" "test2" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port = 3391
-  backend_port = 3391
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port                  = 3391
+  backend_port                   = 3391
   frontend_ip_configuration_name = "one-%d"
 }
-
-`, rInt, rInt, rInt, rInt, natRuleName, rInt, natRule2Name, rInt)
+`, rInt, location, rInt, rInt, rInt, natRuleName, rInt, natRule2Name, rInt)
 }

--- a/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -27,7 +27,7 @@ func TestAccAzureRMLoadBalancerProbe_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -43,6 +43,7 @@ func TestAccAzureRMLoadBalancerProbe_removal(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := acctest.RandInt()
 	probeName := fmt.Sprintf("probe-%d", ri)
+	location := testLocation()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,14 +51,14 @@ func TestAccAzureRMLoadBalancerProbe_removal(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerProbe_removal(ri),
+				Config: testAccAzureRMLoadBalancerProbe_removal(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeNotExists(probeName, &lb),
@@ -79,7 +80,7 @@ func TestAccAzureRMLoadBalancerProbe_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerProbe_multipleProbes(ri, probeName, probe2Name),
+				Config: testAccAzureRMLoadBalancerProbe_multipleProbes(ri, probeName, probe2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -88,7 +89,7 @@ func TestAccAzureRMLoadBalancerProbe_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerProbe_multipleProbesUpdate(ri, probeName, probe2Name),
+				Config: testAccAzureRMLoadBalancerProbe_multipleProbesUpdate(ri, probeName, probe2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -111,7 +112,7 @@ func TestAccAzureRMLoadBalancerProbe_updateProtocol(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerProbe_updateProtocolBefore(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_updateProtocolBefore(ri, probeName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -119,7 +120,7 @@ func TestAccAzureRMLoadBalancerProbe_updateProtocol(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerProbe_updateProtocolAfter(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_updateProtocolAfter(ri, probeName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -145,7 +146,7 @@ func TestAccAzureRMLoadBalancerProbe_reapply(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -154,7 +155,7 @@ func TestAccAzureRMLoadBalancerProbe_reapply(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -175,7 +176,7 @@ func TestAccAzureRMLoadBalancerProbe_disappears(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
@@ -238,223 +239,224 @@ func testCheckAzureRMLoadBalancerProbeDisappears(addressPoolName string, lb *net
 	}
 }
 
-func testAccAzureRMLoadBalancerProbe_basic(rInt int, probeName string) string {
+func testAccAzureRMLoadBalancerProbe_basic(rInt int, probeName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_probe" "test" {
-  location = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  port = 22
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "%s"
+  port                = 22
 }
-`, rInt, rInt, rInt, rInt, probeName)
+`, rInt, location, rInt, rInt, rInt, probeName)
 }
 
-func testAccAzureRMLoadBalancerProbe_removal(rInt int) string {
+func testAccAzureRMLoadBalancerProbe_removal(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
-`, rInt, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt)
 }
 
-func testAccAzureRMLoadBalancerProbe_multipleProbes(rInt int, probeName, probe2Name string) string {
+func testAccAzureRMLoadBalancerProbe_multipleProbes(rInt int, probeName, probe2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_probe" "test" {
-  location = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  port = 22
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "%s"
+  port                = 22
 }
 
 resource "azurerm_lb_probe" "test2" {
-  location = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  port = 80
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "%s"
+  port                = 80
 }
-`, rInt, rInt, rInt, rInt, probeName, probe2Name)
+`, rInt, location, rInt, rInt, rInt, probeName, probe2Name)
 }
 
-func testAccAzureRMLoadBalancerProbe_multipleProbesUpdate(rInt int, probeName, probe2Name string) string {
+func testAccAzureRMLoadBalancerProbe_multipleProbesUpdate(rInt int, probeName, probe2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_probe" "test" {
-  location = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  port = 22
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "%s"
+  port                = 22
 }
 
 resource "azurerm_lb_probe" "test2" {
-  location = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  port = 8080
-}
-`, rInt, rInt, rInt, rInt, probeName, probe2Name)
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "%s"
+  port                = 8080
 }
 
-func testAccAzureRMLoadBalancerProbe_updateProtocolBefore(rInt int, probeName string) string {
+`, rInt, location, rInt, rInt, rInt, probeName, probe2Name)
+}
+
+func testAccAzureRMLoadBalancerProbe_updateProtocolBefore(rInt int, probeName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_probe" "test" {
-  location = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Http"
-  request_path = "/"
-  port = 80
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "%s"
+  protocol            = "Http"
+  request_path        = "/"
+  port                = 80
 }
-`, rInt, rInt, rInt, rInt, probeName)
+`, rInt, location, rInt, rInt, rInt, probeName)
 }
 
-func testAccAzureRMLoadBalancerProbe_updateProtocolAfter(rInt int, probeName string) string {
+func testAccAzureRMLoadBalancerProbe_updateProtocolAfter(rInt int, probeName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_probe" "test" {
-  location = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  port = 80
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "%s"
+  protocol            = "Tcp"
+  port                = 80
 }
-`, rInt, rInt, rInt, rInt, probeName)
+`, rInt, location, rInt, rInt, rInt, probeName)
 }

--- a/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -523,5 +523,5 @@ resource "azurerm_lb_rule" "test2" {
   backend_port                   = 3391
   frontend_ip_configuration_name = "one-%d"
 }
-`, rInt, location, rInt, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
+`, rInt, location, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
 }

--- a/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -480,27 +480,8 @@ resource "azurerm_lb_rule" "test2" {
 func testAccAzureRMLoadBalancerRule_multipleRulesUpdate(rInt int, lbRuleName, lbRule2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctest-rg-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acceptanceTestVirtualNetwork1"
-  address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "testsubnet"
-  resource_group_name  = "${azurerm_resource_group.test.name}"
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
-  address_prefix       = "10.0.2.0/24"
-}
-
-resource "azurerm_resource_group" "test" {
   name     = "acctestrg-%d"
-  location = "${azurerm_resource_group.test.location}"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
@@ -541,16 +522,6 @@ resource "azurerm_lb_rule" "test2" {
   frontend_port                  = 3391
   backend_port                   = 3391
   frontend_ip_configuration_name = "one-%d"
-
-  name                = "acceptanceTestNetworkInterface1"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  ip_configuration {
-    name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.test.id}"
-    private_ip_address_allocation = "dynamic"
-  }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
 }

--- a/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -83,7 +83,7 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
@@ -106,14 +106,14 @@ func TestAccAzureRMLoadBalancerRule_removal(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerRule_removal(ri),
+				Config: testAccAzureRMLoadBalancerRule_removal(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleNotExists(lbRuleName, &lb),
@@ -137,7 +137,7 @@ func TestAccAzureRMLoadBalancerRule_inconsistentReads(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerRule_inconsistentRead(ri, backendPoolName, probeName, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_inconsistentRead(ri, backendPoolName, probeName, lbRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerBackEndAddressPoolExists(backendPoolName, &lb),
@@ -170,7 +170,7 @@ func TestAccAzureRMLoadBalancerRule_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerRule_multipleRules(ri, lbRuleName, lbRule2Name),
+				Config: testAccAzureRMLoadBalancerRule_multipleRules(ri, lbRuleName, lbRule2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
@@ -182,7 +182,7 @@ func TestAccAzureRMLoadBalancerRule_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMLoadBalancerRule_multipleRulesUpdate(ri, lbRuleName, lbRule2Name),
+				Config: testAccAzureRMLoadBalancerRule_multipleRulesUpdate(ri, lbRuleName, lbRule2Name, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
@@ -212,7 +212,7 @@ func TestAccAzureRMLoadBalancerRule_reapply(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
@@ -221,7 +221,7 @@ func TestAccAzureRMLoadBalancerRule_reapply(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
@@ -242,7 +242,7 @@ func TestAccAzureRMLoadBalancerRule_disappears(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
@@ -297,7 +297,7 @@ func testCheckAzureRMLoadBalancerRuleDisappears(ruleName string, lb *network.Loa
 		_, error := conn.CreateOrUpdate(id.ResourceGroup, *lb.Name, *lb, make(chan struct{}))
 		err = <-error
 		if err != nil {
-			return fmt.Errorf("Error Creating/Updating LoadBalancer %s", err)
+			return fmt.Errorf("Error Creating/Updating LoadBalancer %+v", err)
 		}
 
 		_, err = conn.Get(id.ResourceGroup, *lb.Name, "")
@@ -305,108 +305,108 @@ func testCheckAzureRMLoadBalancerRuleDisappears(ruleName string, lb *network.Loa
 	}
 }
 
-func testAccAzureRMLoadBalancerRule_basic(rInt int, lbRuleName string) string {
+func testAccAzureRMLoadBalancerRule_basic(rInt int, lbRuleName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_rule" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Tcp"
-  frontend_port = 3389
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
-
-`, rInt, rInt, rInt, rInt, lbRuleName, rInt)
+`, rInt, location, rInt, rInt, rInt, lbRuleName, rInt)
 }
 
-func testAccAzureRMLoadBalancerRule_removal(rInt int) string {
+func testAccAzureRMLoadBalancerRule_removal(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
-`, rInt, rInt, rInt, rInt)
+
+`, rInt, location, rInt, rInt, rInt)
 }
 
 // https://github.com/hashicorp/terraform/issues/9424
-func testAccAzureRMLoadBalancerRule_inconsistentRead(rInt int, backendPoolName, probeName, lbRuleName string) string {
+func testAccAzureRMLoadBalancerRule_inconsistentRead(rInt int, backendPoolName, probeName, lbRuleName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_backend_address_pool" "teset" {
   name                = "%s"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id     = "${azurerm_lb.test.id}"
 }
 
 resource "azurerm_lb_probe" "test" {
   name                = "%s"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id     = "${azurerm_lb.test.id}"
   protocol            = "Tcp"
@@ -414,114 +414,143 @@ resource "azurerm_lb_probe" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  name = "%s"
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  protocol = "Tcp"
-  frontend_port = 3389
-  backend_port = 3389
+  name                           = "%s"
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  protocol                       = "Tcp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
-`, rInt, rInt, rInt, rInt, backendPoolName, probeName, lbRuleName, rInt)
+
+`, rInt, location, rInt, rInt, rInt, backendPoolName, probeName, lbRuleName, rInt)
 }
 
-func testAccAzureRMLoadBalancerRule_multipleRules(rInt int, lbRuleName, lbRule2Name string) string {
+func testAccAzureRMLoadBalancerRule_multipleRules(rInt int, lbRuleName, lbRule2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctestrg-%d"
+  location = "%s"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_rule" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Udp"
-  frontend_port = 3389
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Udp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
 
 resource "azurerm_lb_rule" "test2" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Udp"
-  frontend_port = 3390
-  backend_port = 3390
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Udp"
+  frontend_port                  = 3390
+  backend_port                   = 3390
   frontend_ip_configuration_name = "one-%d"
 }
 
-`, rInt, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
+`, rInt, location, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
 }
 
-func testAccAzureRMLoadBalancerRule_multipleRulesUpdate(rInt int, lbRuleName, lbRule2Name string) string {
+func testAccAzureRMLoadBalancerRule_multipleRulesUpdate(rInt int, lbRuleName, lbRule2Name string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestrg-%d"
-    location = "West US"
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acceptanceTestVirtualNetwork1"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "testsubnet"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "${azurerm_resource_group.test.location}"
 }
 
 resource "azurerm_public_ip" "test" {
-    name = "test-ip-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
+  name                         = "test-ip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name = "arm-test-loadbalancer-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    frontend_ip_configuration {
-      name = "one-%d"
-      public_ip_address_id = "${azurerm_public_ip.test.id}"
-    }
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_rule" "test" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Udp"
-  frontend_port = 3389
-  backend_port = 3389
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Udp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
   frontend_ip_configuration_name = "one-%d"
 }
 
 resource "azurerm_lb_rule" "test2" {
-  location = "West US"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  loadbalancer_id = "${azurerm_lb.test.id}"
-  name = "%s"
-  protocol = "Udp"
-  frontend_port = 3391
-  backend_port = 3391
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Udp"
+  frontend_port                  = 3391
+  backend_port                   = 3391
   frontend_ip_configuration_name = "one-%d"
-}
 
-`, rInt, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
+  name                = "acceptanceTestNetworkInterface1"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
 }

--- a/azurerm/resource_arm_local_network_gateway_test.go
+++ b/azurerm/resource_arm_local_network_gateway_test.go
@@ -20,7 +20,7 @@ func TestAccAzureRMLocalNetworkGateway_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt),
+				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLocalNetworkGatewayExists(name),
 					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
@@ -41,7 +41,7 @@ func TestAccAzureRMLocalNetworkGateway_disappears(t *testing.T) {
 		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt),
+				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLocalNetworkGatewayExists(name),
 					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
@@ -81,7 +81,7 @@ func testCheckAzureRMLocalNetworkGatewayExists(name string) resource.TestCheckFu
 			if resp.StatusCode == http.StatusNotFound {
 				return fmt.Errorf("Local network gateway '%s' (resource group '%s') does not exist on Azure.", localNetName, resGrp)
 			}
-			return fmt.Errorf("Error reading the state of local network gateway '%s'.", localNetName)
+			return fmt.Errorf("Error reading the state of local network gateway '%s': %+v", localNetName, err)
 		}
 
 		return nil
@@ -114,7 +114,7 @@ func testCheckAzureRMLocalNetworkGatewayDisappears(name string) resource.TestChe
 			if resp.StatusCode == http.StatusNotFound {
 				return fmt.Errorf("Local network gateway '%s' (resource group '%s') does not exist on Azure.", localNetName, resGrp)
 			}
-			return fmt.Errorf("Error deleting the state of local network gateway '%s'.", localNetName)
+			return fmt.Errorf("Error deleting the state of local network gateway '%s': %+v", localNetName, err)
 		}
 
 		return nil
@@ -149,11 +149,11 @@ func testCheckAzureRMLocalNetworkGatewayDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMLocalNetworkGatewayConfig_basic(rInt int) string {
+func testAccAzureRMLocalNetworkGatewayConfig_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctest-%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_local_network_gateway" "test" {
@@ -163,5 +163,5 @@ resource "azurerm_local_network_gateway" "test" {
 	gateway_address = "127.0.0.1"
 	address_space = ["127.0.0.0/8"]
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }


### PR DESCRIPTION
Continuing on #216

So that we're able to run the AzureRM Acceptance Tests against different clouds, we need to make the `Location` field, used to specify where to deploy the resource configurable through some means. This is simplest as an environment variable - as such I've hooked it up as such - but this needs to be added to every resource.

Resources:

- [x] Image
- [x] Key Vault
- [x] Load Balancer
- [x] Load Balancer Backend Address Pool
- [x] Load Balancer NAT Pool
- [x] Load Balancer NAT Rule
- [x] Load Balancer Probe
- [x] Load Balancer Rule
- [x] Local Network Gateway