### PR TITLE
Making the Test Location an Environment Variable: Part 6

### DIFF
--- a/azurerm/import_arm_dns_a_record_test.go
+++ b/azurerm/import_arm_dns_a_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsARecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_a_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsARecord_basic(ri)
+	config := testAccAzureRMDnsARecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,7 +33,7 @@ func TestAccAzureRMDnsARecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_a_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsARecord_withTags(ri)
+	config := testAccAzureRMDnsARecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_aaaa_record_test.go
+++ b/azurerm/import_arm_dns_aaaa_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsAAAARecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_aaaa_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsAAAARecord_basic(ri)
+	config := testAccAzureRMDnsAAAARecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsAAAARecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_aaaa_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsAAAARecord_withTags(ri)
+	config := testAccAzureRMDnsAAAARecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_cname_record_test.go
+++ b/azurerm/import_arm_dns_cname_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsCNameRecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_cname_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsCNameRecord_basic(ri)
+	config := testAccAzureRMDnsCNameRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsCNameRecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_cname_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsCNameRecord_withTags(ri)
+	config := testAccAzureRMDnsCNameRecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_mx_record_test.go
+++ b/azurerm/import_arm_dns_mx_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsMxRecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_mx_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsMxRecord_basic(ri)
+	config := testAccAzureRMDnsMxRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccAzureRMDnsMxRecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_mx_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsMxRecord_withTags(ri)
+	config := testAccAzureRMDnsMxRecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_ns_record_test.go
+++ b/azurerm/import_arm_dns_ns_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsNsRecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_ns_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsNsRecord_basic(ri)
+	config := testAccAzureRMDnsNsRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsNsRecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_ns_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsNsRecord_withTags(ri)
+	config := testAccAzureRMDnsNsRecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_ptr_record_test.go
+++ b/azurerm/import_arm_dns_ptr_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsPtrRecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_ptr_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsPtrRecord_basic(ri)
+	config := testAccAzureRMDnsPtrRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsPtrRecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_ptr_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsPtrRecord_withTags(ri)
+	config := testAccAzureRMDnsPtrRecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_srv_record_test.go
+++ b/azurerm/import_arm_dns_srv_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsSrvRecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_srv_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsSrvRecord_basic(ri)
+	config := testAccAzureRMDnsSrvRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsSrvRecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_srv_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsSrvRecord_withTags(ri)
+	config := testAccAzureRMDnsSrvRecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_txt_record_test.go
+++ b/azurerm/import_arm_dns_txt_record_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsTxtRecord_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_txt_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsTxtRecord_basic(ri)
+	config := testAccAzureRMDnsTxtRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsTxtRecord_importWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_txt_record.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsTxtRecord_withTags(ri)
+	config := testAccAzureRMDnsTxtRecord_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_dns_zone_test.go
+++ b/azurerm/import_arm_dns_zone_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMDnsZone_importBasic(t *testing.T) {
 	resourceName := "azurerm_dns_zone.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsZone_basic(ri)
+	config := testAccAzureRMDnsZone_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsZone_importBasicWithTags(t *testing.T) {
 	resourceName := "azurerm_dns_zone.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsZone_withTags(ri)
+	config := testAccAzureRMDnsZone_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/import_arm_eventhub_authorization_rule_test.go
@@ -3,8 +3,6 @@ package azurerm
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -13,7 +11,7 @@ func TestAccAzureRMEventHubAuthorizationRule_importListen(t *testing.T) {
 	resourceName := "azurerm_eventhub_authorization_rule.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_listen, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_listen(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +35,7 @@ func TestAccAzureRMEventHubAuthorizationRule_importSend(t *testing.T) {
 	resourceName := "azurerm_eventhub_authorization_rule.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_send, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_send(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,7 +59,7 @@ func TestAccAzureRMEventHubAuthorizationRule_importReadWrite(t *testing.T) {
 	resourceName := "azurerm_eventhub_authorization_rule.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_readwrite, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_readWrite(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,7 +83,7 @@ func TestAccAzureRMEventHubAuthorizationRule_importManage(t *testing.T) {
 	resourceName := "azurerm_eventhub_authorization_rule.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_manage, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_manage(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_eventhub_consumer_group_test.go
+++ b/azurerm/import_arm_eventhub_consumer_group_test.go
@@ -3,8 +3,6 @@ package azurerm
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -13,7 +11,7 @@ func TestAccAzureRMEventHubConsumerGroup_importBasic(t *testing.T) {
 	resourceName := "azurerm_eventhub_consumer_group.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_basic, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubConsumerGroup_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +35,7 @@ func TestAccAzureRMEventHubConsumerGroup_importComplete(t *testing.T) {
 	resourceName := "azurerm_eventhub_consumer_group.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_complete, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubConsumerGroup_complete(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_eventhub_namespace_test.go
+++ b/azurerm/import_arm_eventhub_namespace_test.go
@@ -3,8 +3,6 @@ package azurerm
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -13,18 +11,17 @@ func TestAccAzureRMEventHubNamespace_importBasic(t *testing.T) {
 	resourceName := "azurerm_eventhub_namespace.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubNamespace_basic, ri, ri)
+	config := testAccAzureRMEventHubNamespace_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_eventhub_test.go
+++ b/azurerm/import_arm_eventhub_test.go
@@ -3,8 +3,6 @@ package azurerm
 import (
 	"testing"
 
-	"fmt"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -13,7 +11,7 @@ func TestAccAzureRMEventHub_importBasic(t *testing.T) {
 	resourceName := "azurerm_eventhub.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHub_basic, ri, ri, ri)
+	config := testAccAzureRMEventHub_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_express_route_circuit_test.go
+++ b/azurerm/import_arm_express_route_circuit_test.go
@@ -10,16 +10,18 @@ import (
 func TestAccAzureRMExpressRouteCircuit_importBasic(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit.test"
 
+	ri := acctest.RandInt()
+	config := testAccAzureRMExpressRouteCircuit_basic(ri, testLocation())
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMExpressRouteCircuitDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAzureRMExpressRouteCircuit_basic(acctest.RandInt()),
+			{
+				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/resource_arm_dns_a_record_test.go
+++ b/azurerm/resource_arm_dns_a_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAzureRMDnsARecord_basic(t *testing.T) {
 	resourceName := "azurerm_dns_a_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsARecord_basic(ri)
+	config := testAccAzureRMDnsARecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,9 @@ func TestAccAzureRMDnsARecord_basic(t *testing.T) {
 func TestAccAzureRMDnsARecord_updateRecords(t *testing.T) {
 	resourceName := "azurerm_dns_a_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsARecord_basic(ri)
-	postConfig := testAccAzureRMDnsARecord_updateRecords(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsARecord_basic(ri, location)
+	postConfig := testAccAzureRMDnsARecord_updateRecords(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,8 +64,9 @@ func TestAccAzureRMDnsARecord_updateRecords(t *testing.T) {
 func TestAccAzureRMDnsARecord_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_a_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsARecord_withTags(ri)
-	postConfig := testAccAzureRMDnsARecord_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsARecord_withTags(ri, location)
+	postConfig := testAccAzureRMDnsARecord_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -146,99 +148,99 @@ func testCheckAzureRMDnsARecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsARecord_basic(rInt int) string {
+func testAccAzureRMDnsARecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_a_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["1.2.3.4", "1.2.4.5"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["1.2.3.4", "1.2.4.5"]
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsARecord_updateRecords(rInt int) string {
+func testAccAzureRMDnsARecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_a_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["1.2.3.4", "1.2.4.5", "1.2.3.7"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["1.2.3.4", "1.2.4.5", "1.2.3.7"]
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsARecord_withTags(rInt int) string {
+func testAccAzureRMDnsARecord_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_a_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["1.2.3.4", "1.2.4.5"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["1.2.3.4", "1.2.4.5"]
 
-    tags {
-	environment = "Production"
-	cost_center = "MSFT"
-    }
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsARecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsARecord_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_a_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["1.2.3.4", "1.2.4.5"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["1.2.3.4", "1.2.4.5"]
 
-    tags {
-	environment = "staging"
-    }
+  tags {
+    environment = "staging"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_aaaa_record_test.go
+++ b/azurerm/resource_arm_dns_aaaa_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAzureRMDnsAAAARecord_basic(t *testing.T) {
 	resourceName := "azurerm_dns_aaaa_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsAAAARecord_basic(ri)
+	config := testAccAzureRMDnsAAAARecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,9 @@ func TestAccAzureRMDnsAAAARecord_basic(t *testing.T) {
 func TestAccAzureRMDnsAAAARecord_updateRecords(t *testing.T) {
 	resourceName := "azurerm_dns_aaaa_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsAAAARecord_basic(ri)
-	postConfig := testAccAzureRMDnsAAAARecord_updateRecords(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsAAAARecord_basic(ri, location)
+	postConfig := testAccAzureRMDnsAAAARecord_updateRecords(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,8 +64,9 @@ func TestAccAzureRMDnsAAAARecord_updateRecords(t *testing.T) {
 func TestAccAzureRMDnsAAAARecord_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_aaaa_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsAAAARecord_withTags(ri)
-	postConfig := testAccAzureRMDnsAAAARecord_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsAAAARecord_withTags(ri, location)
+	postConfig := testAccAzureRMDnsAAAARecord_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,7 +109,7 @@ func testCheckAzureRMDnsAaaaRecordExists(name string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*ArmClient).dnsClient
 		resp, err := conn.Get(resourceGroup, zoneName, aaaaName, dns.AAAA)
 		if err != nil {
-			return fmt.Errorf("Bad: Get AAAA RecordSet: %v", err)
+			return fmt.Errorf("Bad: Get AAAA RecordSet: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -146,99 +148,99 @@ func testCheckAzureRMDnsAaaaRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsAAAARecord_basic(rInt int) string {
+func testAccAzureRMDnsAAAARecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_aaaa_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006"]
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsAAAARecord_updateRecords(rInt int) string {
+func testAccAzureRMDnsAAAARecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_aaaa_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006", "::1"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006", "::1"]
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsAAAARecord_withTags(rInt int) string {
+func testAccAzureRMDnsAAAARecord_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_aaaa_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006"]
 
-    tags {
-	environment = "Production"
-	cost_center = "MSFT"
-    }
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsAAAARecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsAAAARecord_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_aaaa_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006"]
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["2607:f8b0:4009:1803::1005", "2607:f8b0:4009:1803::1006"]
 
-    tags {
-	environment = "staging"
-    }
+  tags {
+    environment = "staging"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_cname_record_test.go
+++ b/azurerm/resource_arm_dns_cname_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAzureRMDnsCNameRecord_basic(t *testing.T) {
 	resourceName := "azurerm_dns_cname_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsCNameRecord_basic(ri)
+	config := testAccAzureRMDnsCNameRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMDnsCNameRecord_basic(t *testing.T) {
 func TestAccAzureRMDnsCNameRecord_subdomain(t *testing.T) {
 	resourceName := "azurerm_dns_cname_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsCNameRecord_subdomain(ri)
+	config := testAccAzureRMDnsCNameRecord_subdomain(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -55,8 +55,9 @@ func TestAccAzureRMDnsCNameRecord_subdomain(t *testing.T) {
 func TestAccAzureRMDnsCNameRecord_updateRecords(t *testing.T) {
 	resourceName := "azurerm_dns_cname_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsCNameRecord_basic(ri)
-	postConfig := testAccAzureRMDnsCNameRecord_updateRecords(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsCNameRecord_basic(ri, location)
+	postConfig := testAccAzureRMDnsCNameRecord_updateRecords(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,8 +83,9 @@ func TestAccAzureRMDnsCNameRecord_updateRecords(t *testing.T) {
 func TestAccAzureRMDnsCNameRecord_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_cname_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsCNameRecord_withTags(ri)
-	postConfig := testAccAzureRMDnsCNameRecord_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsCNameRecord_withTags(ri, location)
+	postConfig := testAccAzureRMDnsCNameRecord_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -165,121 +167,121 @@ func testCheckAzureRMDnsCNameRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsCNameRecord_basic(rInt int) string {
+func testAccAzureRMDnsCNameRecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_cname_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    record = "contoso.com"
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  record              = "contoso.com"
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsCNameRecord_subdomain(rInt int) string {
+func testAccAzureRMDnsCNameRecord_subdomain(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_cname_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    record = "test.contoso.com"
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  record              = "test.contoso.com"
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsCNameRecord_updateRecords(rInt int) string {
+func testAccAzureRMDnsCNameRecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_cname_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    record = "contoso.co.uk"
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  record              = "contoso.co.uk"
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsCNameRecord_withTags(rInt int) string {
+func testAccAzureRMDnsCNameRecord_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_cname_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    record = "contoso.com"
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  record              = "contoso.com"
 
-    tags {
-	environment = "Production"
-	cost_center = "MSFT"
-    }
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsCNameRecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsCNameRecord_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_cname_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    record = "contoso.com"
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  record              = "contoso.com"
 
-    tags {
-	environment = "staging"
-    }
+  tags {
+    environment = "staging"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_mx_record_test.go
+++ b/azurerm/resource_arm_dns_mx_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAzureRMDnsMxRecord_basic(t *testing.T) {
 	resourceName := "azurerm_dns_mx_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsMxRecord_basic(ri)
+	config := testAccAzureRMDnsMxRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,9 @@ func TestAccAzureRMDnsMxRecord_basic(t *testing.T) {
 func TestAccAzureRMDnsMxRecord_updateRecords(t *testing.T) {
 	resourceName := "azurerm_dns_mx_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsMxRecord_basic(ri)
-	postConfig := testAccAzureRMDnsMxRecord_updateRecords(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsMxRecord_basic(ri, location)
+	postConfig := testAccAzureRMDnsMxRecord_updateRecords(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,8 +64,9 @@ func TestAccAzureRMDnsMxRecord_updateRecords(t *testing.T) {
 func TestAccAzureRMDnsMxRecord_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_mx_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsMxRecord_withTags(ri)
-	postConfig := testAccAzureRMDnsMxRecord_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsMxRecord_withTags(ri, location)
+	postConfig := testAccAzureRMDnsMxRecord_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -146,140 +148,140 @@ func testCheckAzureRMDnsMxRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsMxRecord_basic(rInt int) string {
+func testAccAzureRMDnsMxRecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_mx_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-	preference = "10"
-	exchange = "mail1.contoso.com"
-    }
+  record {
+    preference = "10"
+    exchange   = "mail1.contoso.com"
+  }
 
-    record {
-	preference = "20"
-	exchange = "mail2.contoso.com"
-    }
+  record {
+    preference = "20"
+    exchange   = "mail2.contoso.com"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsMxRecord_updateRecords(rInt int) string {
+func testAccAzureRMDnsMxRecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_mx_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-	preference = "10"
-	exchange = "mail1.contoso.com"
-    }
+  record {
+    preference = "10"
+    exchange   = "mail1.contoso.com"
+  }
 
-    record {
-	preference = "20"
-	exchange = "mail2.contoso.com"
-    }
+  record {
+    preference = "20"
+    exchange   = "mail2.contoso.com"
+  }
 
-    record {
-	preference = "50"
-	exchange = "mail3.contoso.com"
-    }
+  record {
+    preference = "50"
+    exchange   = "mail3.contoso.com"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsMxRecord_withTags(rInt int) string {
+func testAccAzureRMDnsMxRecord_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_mx_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-	preference = "10"
-	exchange = "mail1.contoso.com"
-    }
+  record {
+    preference = "10"
+    exchange   = "mail1.contoso.com"
+  }
 
-    record {
-	preference = "20"
-	exchange = "mail2.contoso.com"
-    }
+  record {
+    preference = "20"
+    exchange   = "mail2.contoso.com"
+  }
 
-    tags {
-	environment = "Production"
-	cost_center = "MSFT"
-    }
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsMxRecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsMxRecord_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_mx_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-	preference = "10"
-	exchange = "mail1.contoso.com"
-    }
+  record {
+    preference = "10"
+    exchange   = "mail1.contoso.com"
+  }
 
-    record {
-	preference = "20"
-	exchange = "mail2.contoso.com"
-    }
+  record {
+    preference = "20"
+    exchange   = "mail2.contoso.com"
+  }
 
-    tags {
-	environment = "staging"
-    }
+  tags {
+    environment = "staging"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_ns_record_test.go
+++ b/azurerm/resource_arm_dns_ns_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAzureRMDnsNsRecord_basic(t *testing.T) {
 	resourceName := "azurerm_dns_ns_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsNsRecord_basic(ri)
+	config := testAccAzureRMDnsNsRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,9 @@ func TestAccAzureRMDnsNsRecord_basic(t *testing.T) {
 func TestAccAzureRMDnsNsRecord_updateRecords(t *testing.T) {
 	resourceName := "azurerm_dns_ns_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsNsRecord_basic(ri)
-	postConfig := testAccAzureRMDnsNsRecord_updateRecords(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsNsRecord_basic(ri, location)
+	postConfig := testAccAzureRMDnsNsRecord_updateRecords(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,8 +64,9 @@ func TestAccAzureRMDnsNsRecord_updateRecords(t *testing.T) {
 func TestAccAzureRMDnsNsRecord_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_ns_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsNsRecord_withTags(ri)
-	postConfig := testAccAzureRMDnsNsRecord_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsNsRecord_withTags(ri, location)
+	postConfig := testAccAzureRMDnsNsRecord_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,7 +109,7 @@ func testCheckAzureRMDnsNsRecordExists(name string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*ArmClient).dnsClient
 		resp, err := conn.Get(resourceGroup, zoneName, nsName, dns.NS)
 		if err != nil {
-			return fmt.Errorf("Bad: Get DNS NS Record: %v", err)
+			return fmt.Errorf("Bad: Get DNS NS Record: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -145,130 +147,131 @@ func testCheckAzureRMDnsNsRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsNsRecord_basic(rInt int) string {
+func testAccAzureRMDnsNsRecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ns_record" "test" {
-    name = "mynsrecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "mynsrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-    	nsdname = "ns1.contoso.com"
-    }
+  record {
+    nsdname = "ns1.contoso.com"
+  }
 
-    record {
-    	nsdname = "ns2.contoso.com"
-    }
+  record {
+    nsdname = "ns2.contoso.com"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsNsRecord_updateRecords(rInt int) string {
+func testAccAzureRMDnsNsRecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ns_record" "test" {
-    name = "mynsrecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "mynsrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-    	nsdname = "ns1.contoso.com"
-    }
+  record {
+    nsdname = "ns1.contoso.com"
+  }
 
-    record {
-    	nsdname = "ns2.contoso.com"
-    }
+  record {
+    nsdname = "ns2.contoso.com"
+  }
 
-    record {
-    	nsdname = "ns3.contoso.com"
-    }
+  record {
+    nsdname = "ns3.contoso.com"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsNsRecord_withTags(rInt int) string {
+func testAccAzureRMDnsNsRecord_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ns_record" "test" {
-    name = "mynsrecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "mynsrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-    	nsdname = "ns1.contoso.com"
-    }
+  record {
+    nsdname = "ns1.contoso.com"
+  }
 
-    record {
-    	nsdname = "ns2.contoso.com"
-    }
+  record {
+    nsdname = "ns2.contoso.com"
+  }
 
-    tags {
-	environment = "Production"
-	cost_center = "MSFT"
-    }
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsNsRecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsNsRecord_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ns_record" "test" {
-    name = "mynsrecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    record {
-    	nsdname = "ns1.contoso.com"
-    }
+  name                = "mynsrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-    	nsdname = "ns2.contoso.com"
-    }
+  record {
+    nsdname = "ns1.contoso.com"
+  }
 
-    tags {
-	environment = "staging"
-    }
+  record {
+    nsdname = "ns2.contoso.com"
+  }
+
+  tags {
+    environment = "staging"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_ptr_record_test.go
+++ b/azurerm/resource_arm_dns_ptr_record_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccAzureRMDnsPtrRecord_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsPtrRecord_basic(ri)
+	config := testAccAzureRMDnsPtrRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -32,8 +32,9 @@ func TestAccAzureRMDnsPtrRecord_basic(t *testing.T) {
 
 func TestAccAzureRMDnsPtrRecord_updateRecords(t *testing.T) {
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsPtrRecord_basic(ri)
-	postConfig := testAccAzureRMDnsPtrRecord_updateRecords(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsPtrRecord_basic(ri, location)
+	postConfig := testAccAzureRMDnsPtrRecord_updateRecords(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,8 +62,9 @@ func TestAccAzureRMDnsPtrRecord_updateRecords(t *testing.T) {
 
 func TestAccAzureRMDnsPtrRecord_withTags(t *testing.T) {
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsPtrRecord_withTags(ri)
-	postConfig := testAccAzureRMDnsPtrRecord_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsPtrRecord_withTags(ri, location)
+	postConfig := testAccAzureRMDnsPtrRecord_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,7 +109,7 @@ func testCheckAzureRMDnsPtrRecordExists(name string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*ArmClient).dnsClient
 		resp, err := conn.Get(resourceGroup, zoneName, ptrName, dns.PTR)
 		if err != nil {
-			return fmt.Errorf("Bad: Get PTR RecordSet: %v", err)
+			return fmt.Errorf("Bad: Get PTR RecordSet: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -146,99 +148,99 @@ func testCheckAzureRMDnsPtrRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsPtrRecord_basic(rInt int) string {
+func testAccAzureRMDnsPtrRecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%[1]d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%[1]d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ptr_record" "test" {
-    name = "testptrrecord%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["hashicorp.com", "microsoft.com"]
+  name                = "testptrrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["hashicorp.com", "microsoft.com"]
 }
-`, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsPtrRecord_updateRecords(rInt int) string {
+func testAccAzureRMDnsPtrRecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%[1]d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%[1]d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ptr_record" "test" {
-    name = "testptrrecord%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["hashicorp.com", "microsoft.com", "reddit.com"]
+  name                = "testptrrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["hashicorp.com", "microsoft.com", "reddit.com"]
 }
-`, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsPtrRecord_withTags(rInt int) string {
+func testAccAzureRMDnsPtrRecord_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%[1]d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%[1]d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ptr_record" "test" {
-    name = "testptrrecord%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["hashicorp.com", "microsoft.com"]
+  name                = "testptrrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["hashicorp.com", "microsoft.com"]
 
-    tags {
-	environment = "Dev"
-	cost_center = "Ops"
-    }
+  tags {
+    environment = "Dev"
+    cost_center = "Ops"
+  }
 }
-`, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsPtrRecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsPtrRecord_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%[1]d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%[1]d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_ptr_record" "test" {
-    name = "testptrrecord%[1]d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-    records = ["hashicorp.com", "microsoft.com"]
+  name                = "testptrrecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+  records             = ["hashicorp.com", "microsoft.com"]
 
-    tags {
-	environment = "Stage"
-    }
+  tags {
+    environment = "Stage"
+  }
 }
-`, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_srv_record_test.go
+++ b/azurerm/resource_arm_dns_srv_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAzureRMDnsSrvRecord_basic(t *testing.T) {
 	resourceName := "azurerm_dns_srv_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsSrvRecord_basic(ri)
+	config := testAccAzureRMDnsSrvRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,9 @@ func TestAccAzureRMDnsSrvRecord_basic(t *testing.T) {
 func TestAccAzureRMDnsSrvRecord_updateRecords(t *testing.T) {
 	resourceName := "azurerm_dns_srv_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsSrvRecord_basic(ri)
-	postConfig := testAccAzureRMDnsSrvRecord_updateRecords(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsSrvRecord_basic(ri, location)
+	postConfig := testAccAzureRMDnsSrvRecord_updateRecords(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,8 +64,9 @@ func TestAccAzureRMDnsSrvRecord_updateRecords(t *testing.T) {
 func TestAccAzureRMDnsSrvRecord_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_srv_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsSrvRecord_withTags(ri)
-	postConfig := testAccAzureRMDnsSrvRecord_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsSrvRecord_withTags(ri, location)
+	postConfig := testAccAzureRMDnsSrvRecord_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,7 +109,7 @@ func testCheckAzureRMDnsSrvRecordExists(name string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*ArmClient).dnsClient
 		resp, err := conn.Get(resourceGroup, zoneName, srvName, dns.SRV)
 		if err != nil {
-			return fmt.Errorf("Bad: Get SRV RecordSet: %v", err)
+			return fmt.Errorf("Bad: Get SRV RecordSet: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -146,156 +148,158 @@ func testCheckAzureRMDnsSrvRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsSrvRecord_basic(rInt int) string {
+func testAccAzureRMDnsSrvRecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
-}
-resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-}
-
-resource "azurerm_dns_srv_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-
-    record {
-	priority = 1
-	weight = 5
-	port = 8080
-	target = "target1.contoso.com"
-    }
-
-    record {
-	priority = 2
-	weight = 25
-	port = 8080
-	target = "target2.contoso.com"
-    }
-}
-`, rInt, rInt, rInt)
-}
-
-func testAccAzureRMDnsSrvRecord_updateRecords(rInt int) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
-}
-resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-}
-
-resource "azurerm_dns_srv_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
-
-    record {
-	priority = 1
-	weight = 5
-	port = 8080
-	target = "target1.contoso.com"
-    }
-
-    record {
-	priority = 2
-	weight = 25
-	port = 8080
-	target = "target2.contoso.com"
-    }
-
-    record {
-	priority = 3
-	weight = 100
-	port = 8080
-	target = "target3.contoso.com"
-    }
-}
-`, rInt, rInt, rInt)
-}
-
-func testAccAzureRMDnsSrvRecord_withTags(rInt int) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_srv_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-	priority = 1
-	weight = 5
-	port = 8080
-	target = "target1.contoso.com"
-    }
+  record {
+    priority = 1
+    weight   = 5
+    port     = 8080
+    target   = "target1.contoso.com"
+  }
 
-    record {
-	priority = 2
-	weight = 25
-	port = 8080
-	target = "target2.contoso.com"
-    }
-
-    tags {
-	environment = "Production"
-	cost_center = "MSFT"
-    }
+  record {
+    priority = 2
+    weight   = 25
+    port     = 8080
+    target   = "target2.contoso.com"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsSrvRecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsSrvRecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG_%d"
-    location = "West US"
+  name     = "acctestRG_%d"
+  location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
-    name = "acctestzone%d.com"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_dns_srv_record" "test" {
-    name = "myarecord%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    zone_name = "${azurerm_dns_zone.test.name}"
-    ttl = 300
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
 
-    record {
-	priority = 1
-	weight = 5
-	port = 8080
-	target = "target1.contoso.com"
-    }
+  record {
+    priority = 1
+    weight   = 5
+    port     = 8080
+    target   = "target1.contoso.com"
+  }
 
-    record {
-	priority = 2
-	weight = 25
-	port = 8080
-	target = "target2.contoso.com"
-    }
+  record {
+    priority = 2
+    weight   = 25
+    port     = 8080
+    target   = "target2.contoso.com"
+  }
 
-    tags {
-	environment = "staging"
-    }
+  record {
+    priority = 3
+    weight   = 100
+    port     = 8080
+    target   = "target3.contoso.com"
+  }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMDnsSrvRecord_withTags(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG_%d"
+  location = "%s"
+}
+
+resource "azurerm_dns_zone" "test" {
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_dns_srv_record" "test" {
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+
+  record {
+    priority = 1
+    weight   = 5
+    port     = 8080
+    target   = "target1.contoso.com"
+  }
+
+  record {
+    priority = 2
+    weight   = 25
+    port     = 8080
+    target   = "target2.contoso.com"
+  }
+
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMDnsSrvRecord_withTagsUpdate(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG_%d"
+  location = "%s"
+}
+
+resource "azurerm_dns_zone" "test" {
+  name                = "acctestzone%d.com"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_dns_srv_record" "test" {
+  name                = "myarecord%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_name           = "${azurerm_dns_zone.test.name}"
+  ttl                 = 300
+
+  record {
+    priority = 1
+    weight   = 5
+    port     = 8080
+    target   = "target1.contoso.com"
+  }
+
+  record {
+    priority = 2
+    weight   = 25
+    port     = 8080
+    target   = "target2.contoso.com"
+  }
+
+  tags {
+    environment = "staging"
+  }
+}
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_txt_record_test.go
+++ b/azurerm/resource_arm_dns_txt_record_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccAzureRMDnsTxtRecord_basic(t *testing.T) {
 	resourceName := "azurerm_dns_txt_record.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsTxtRecord_basic(ri)
+	config := testAccAzureRMDnsTxtRecord_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,8 +34,8 @@ func TestAccAzureRMDnsTxtRecord_basic(t *testing.T) {
 func TestAccAzureRMDnsTxtRecord_updateRecords(t *testing.T) {
 	resourceName := "azurerm_dns_txt_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsTxtRecord_basic(ri)
-	postConfig := testAccAzureRMDnsTxtRecord_updateRecords(ri)
+	preConfig := testAccAzureRMDnsTxtRecord_basic(ri, testLocation())
+	postConfig := testAccAzureRMDnsTxtRecord_updateRecords(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,8 +63,8 @@ func TestAccAzureRMDnsTxtRecord_updateRecords(t *testing.T) {
 func TestAccAzureRMDnsTxtRecord_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_txt_record.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsTxtRecord_withTags(ri)
-	postConfig := testAccAzureRMDnsTxtRecord_withTagsUpdate(ri)
+	preConfig := testAccAzureRMDnsTxtRecord_withTags(ri, testLocation())
+	postConfig := testAccAzureRMDnsTxtRecord_withTagsUpdate(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,7 +107,7 @@ func testCheckAzureRMDnsTxtRecordExists(name string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*ArmClient).dnsClient
 		resp, err := conn.Get(resourceGroup, zoneName, txtName, dns.TXT)
 		if err != nil {
-			return fmt.Errorf("Bad: Get TXT RecordSet: %v", err)
+			return fmt.Errorf("Bad: Get TXT RecordSet: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -146,11 +146,11 @@ func testCheckAzureRMDnsTxtRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsTxtRecord_basic(rInt int) string {
+func testAccAzureRMDnsTxtRecord_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
@@ -172,14 +172,14 @@ resource "azurerm_dns_txt_record" "test" {
     	value = "Another test txt string"
     }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsTxtRecord_updateRecords(rInt int) string {
+func testAccAzureRMDnsTxtRecord_updateRecords(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
@@ -205,14 +205,14 @@ resource "azurerm_dns_txt_record" "test" {
     	value = "A wild 3rd record appears"
     }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsTxtRecord_withTags(rInt int) string {
+func testAccAzureRMDnsTxtRecord_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
@@ -239,14 +239,14 @@ resource "azurerm_dns_txt_record" "test" {
 	cost_center = "MSFT"
     }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDnsTxtRecord_withTagsUpdate(rInt int) string {
+func testAccAzureRMDnsTxtRecord_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
@@ -271,5 +271,5 @@ resource "azurerm_dns_txt_record" "test" {
 	environment = "staging"
     }
 }
-`, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_dns_zone_test.go
+++ b/azurerm/resource_arm_dns_zone_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMDnsZone_basic(t *testing.T) {
 	resourceName := "azurerm_dns_zone.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMDnsZone_basic(ri)
+	config := testAccAzureRMDnsZone_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,8 +33,9 @@ func TestAccAzureRMDnsZone_basic(t *testing.T) {
 func TestAccAzureRMDnsZone_withTags(t *testing.T) {
 	resourceName := "azurerm_dns_zone.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMDnsZone_withTags(ri)
-	postConfig := testAccAzureRMDnsZone_withTagsUupdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMDnsZone_withTags(ri, location)
+	postConfig := testAccAzureRMDnsZone_withTagsUupdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,25 +114,25 @@ func testCheckAzureRMDnsZoneDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMDnsZone_basic(rInt int) string {
+func testAccAzureRMDnsZone_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
     name = "acctestzone%d.com"
     resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMDnsZone_withTags(rInt int) string {
+func testAccAzureRMDnsZone_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
@@ -142,14 +143,14 @@ resource "azurerm_dns_zone" "test" {
 	cost_center = "MSFT"
     }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMDnsZone_withTagsUupdate(rInt int) string {
+func testAccAzureRMDnsZone_withTagsUupdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG_%d"
-    location = "West US"
+    location = "%s"
 }
 
 resource "azurerm_dns_zone" "test" {
@@ -159,5 +160,5 @@ resource "azurerm_dns_zone" "test" {
 	environment = "staging"
     }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/resource_arm_eventhub_authorization_rule_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccAzureRMEventHubAuthorizationRule_listen(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_listen, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_listen(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -31,7 +31,7 @@ func TestAccAzureRMEventHubAuthorizationRule_listen(t *testing.T) {
 
 func TestAccAzureRMEventHubAuthorizationRule_send(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_send, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_send(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,7 +50,7 @@ func TestAccAzureRMEventHubAuthorizationRule_send(t *testing.T) {
 
 func TestAccAzureRMEventHubAuthorizationRule_readwrite(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_readwrite, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_readWrite(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -69,7 +69,7 @@ func TestAccAzureRMEventHubAuthorizationRule_readwrite(t *testing.T) {
 
 func TestAccAzureRMEventHubAuthorizationRule_manage(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_manage, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubAuthorizationRule_manage(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -142,17 +142,20 @@ func testCheckAzureRMEventHubAuthorizationRuleExists(name string) resource.TestC
 	}
 }
 
-var testAccAzureRMEventHubAuthorizationRule_listen = `
+func testAccAzureRMEventHubAuthorizationRule_listen(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_eventhub_namespace" "test" {
-  name = "acctesteventhubnamespace-%d"
-  location = "${azurerm_resource_group.test.location}"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku = "Standard"
+  sku                 = "Standard"
 }
+
 resource "azurerm_eventhub" "test" {
   name                = "acctesteventhub-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -161,6 +164,7 @@ resource "azurerm_eventhub" "test" {
   partition_count     = 2
   message_retention   = 7
 }
+
 resource "azurerm_eventhub_authorization_rule" "test" {
   name                = "acctesteventhubrule-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -170,19 +174,24 @@ resource "azurerm_eventhub_authorization_rule" "test" {
   listen              = true
   send                = false
   manage              = false
-}`
+}
+`, rInt, location, rInt, rInt, rInt)
+}
 
-var testAccAzureRMEventHubAuthorizationRule_send = `
+func testAccAzureRMEventHubAuthorizationRule_send(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_eventhub_namespace" "test" {
-  name = "acctesteventhubnamespace-%d"
-  location = "${azurerm_resource_group.test.location}"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku = "Standard"
+  sku                 = "Standard"
 }
+
 resource "azurerm_eventhub" "test" {
   name                = "acctesteventhub-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -191,6 +200,7 @@ resource "azurerm_eventhub" "test" {
   partition_count     = 2
   message_retention   = 7
 }
+
 resource "azurerm_eventhub_authorization_rule" "test" {
   name                = "acctesteventhubrule-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -200,19 +210,24 @@ resource "azurerm_eventhub_authorization_rule" "test" {
   listen              = false
   send                = true
   manage              = false
-}`
+}
+`, rInt, location, rInt, rInt, rInt)
+}
 
-var testAccAzureRMEventHubAuthorizationRule_readwrite = `
+func testAccAzureRMEventHubAuthorizationRule_readWrite(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_eventhub_namespace" "test" {
-  name = "acctesteventhubnamespace-%d"
-  location = "${azurerm_resource_group.test.location}"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku = "Standard"
+  sku                 = "Standard"
 }
+
 resource "azurerm_eventhub" "test" {
   name                = "acctesteventhub-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -221,6 +236,7 @@ resource "azurerm_eventhub" "test" {
   partition_count     = 2
   message_retention   = 7
 }
+
 resource "azurerm_eventhub_authorization_rule" "test" {
   name                = "acctesteventhubrule-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -230,19 +246,24 @@ resource "azurerm_eventhub_authorization_rule" "test" {
   listen              = true
   send                = true
   manage              = false
-}`
+}
+`, rInt, location, rInt, rInt, rInt)
+}
 
-var testAccAzureRMEventHubAuthorizationRule_manage = `
+func testAccAzureRMEventHubAuthorizationRule_manage(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_eventhub_namespace" "test" {
-  name = "acctesteventhubnamespace-%d"
-  location = "${azurerm_resource_group.test.location}"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku = "Standard"
+  sku                 = "Standard"
 }
+
 resource "azurerm_eventhub" "test" {
   name                = "acctesteventhub-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -251,6 +272,7 @@ resource "azurerm_eventhub" "test" {
   partition_count     = 2
   message_retention   = 7
 }
+
 resource "azurerm_eventhub_authorization_rule" "test" {
   name                = "acctesteventhubrule-%d"
   namespace_name      = "${azurerm_eventhub_namespace.test.name}"
@@ -260,4 +282,6 @@ resource "azurerm_eventhub_authorization_rule" "test" {
   listen              = true
   send                = true
   manage              = true
-}`
+}
+`, rInt, location, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_eventhub_consumer_group_test.go
+++ b/azurerm/resource_arm_eventhub_consumer_group_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMEventHubConsumerGroup_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_basic, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubConsumerGroup_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,7 +33,7 @@ func TestAccAzureRMEventHubConsumerGroup_basic(t *testing.T) {
 func TestAccAzureRMEventHubConsumerGroup_complete(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_complete, ri, ri, ri, ri)
+	config := testAccAzureRMEventHubConsumerGroup_complete(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -98,7 +98,7 @@ func testCheckAzureRMEventHubConsumerGroupExists(name string) resource.TestCheck
 
 		resp, err := conn.Get(resourceGroup, namespaceName, eventHubName, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on eventHubConsumerGroupClient: %s", err)
+			return fmt.Errorf("Bad: Get on eventHubConsumerGroupClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -109,63 +109,69 @@ func testCheckAzureRMEventHubConsumerGroupExists(name string) resource.TestCheck
 	}
 }
 
-var testAccAzureRMEventHubConsumerGroup_basic = `
+func testAccAzureRMEventHubConsumerGroup_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_eventhub_namespace" "test" {
-    name = "acctesteventhubnamespace-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "Standard"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
 }
 
 resource "azurerm_eventhub" "test" {
-    name                = "acctesteventhub-%d"
-    namespace_name      = "${azurerm_eventhub_namespace.test.name}"
-    location            = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    partition_count     = 2
-    message_retention   = 7
+  name                = "acctesteventhub-%d"
+  namespace_name      = "${azurerm_eventhub_namespace.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  partition_count     = 2
+  message_retention   = 7
 }
 
 resource "azurerm_eventhub_consumer_group" "test" {
-    name = "acctesteventhubcg-%d"
-    namespace_name      = "${azurerm_eventhub_namespace.test.name}"
-    eventhub_name       = "${azurerm_eventhub.test.name}"
-    location            = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctesteventhubcg-%d"
+  namespace_name      = "${azurerm_eventhub_namespace.test.name}"
+  eventhub_name       = "${azurerm_eventhub.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`
+`, rInt, location, rInt, rInt, rInt)
+}
 
-var testAccAzureRMEventHubConsumerGroup_complete = `
+func testAccAzureRMEventHubConsumerGroup_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_eventhub_namespace" "test" {
-    name = "acctesteventhubnamespace-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "Standard"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
 }
 
 resource "azurerm_eventhub" "test" {
-    name                = "acctesteventhub-%d"
-    namespace_name      = "${azurerm_eventhub_namespace.test.name}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location            = "${azurerm_resource_group.test.location}"
-    partition_count     = 2
-    message_retention   = 7
+  name                = "acctesteventhub-%d"
+  namespace_name      = "${azurerm_eventhub_namespace.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  partition_count     = 2
+  message_retention   = 7
 }
 
 resource "azurerm_eventhub_consumer_group" "test" {
-    name                = "acctesteventhubcg-%d"
-    namespace_name      = "${azurerm_eventhub_namespace.test.name}"
-    eventhub_name       = "${azurerm_eventhub.test.name}"
-    location            = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    user_metadata       = "some-meta-data"
+  name                = "acctesteventhubcg-%d"
+  namespace_name      = "${azurerm_eventhub_namespace.test.name}"
+  eventhub_name       = "${azurerm_eventhub.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  user_metadata       = "some-meta-data"
 }
-`
+`, rInt, location, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -97,7 +97,7 @@ func TestAccAzureRMEventHubMessageRetentionCount_validation(t *testing.T) {
 func TestAccAzureRMEventHub_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHub_basic, ri, ri, ri)
+	config := testAccAzureRMEventHub_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -117,7 +117,7 @@ func TestAccAzureRMEventHub_basic(t *testing.T) {
 func TestAccAzureRMEventHub_standard(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMEventHub_standard, ri, ri, ri)
+	config := testAccAzureRMEventHub_standard(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -179,7 +179,7 @@ func testCheckAzureRMEventHubExists(name string) resource.TestCheckFunc {
 
 		resp, err := conn.Get(resourceGroup, namespaceName, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on eventHubClient: %s", err)
+			return fmt.Errorf("Bad: Get on eventHubClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -190,16 +190,18 @@ func testCheckAzureRMEventHubExists(name string) resource.TestCheckFunc {
 	}
 }
 
-var testAccAzureRMEventHub_basic = `
+func testAccAzureRMEventHub_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_eventhub_namespace" "test" {
-    name = "acctesteventhubnamespace-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "Basic"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Basic"
 }
 
 resource "azurerm_eventhub" "test" {
@@ -210,18 +212,21 @@ resource "azurerm_eventhub" "test" {
   partition_count     = 2
   message_retention   = 1
 }
-`
-
-var testAccAzureRMEventHub_standard = `
-resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+`, rInt, location, rInt, rInt)
 }
+
+func testAccAzureRMEventHub_standard(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
 resource "azurerm_eventhub_namespace" "test" {
-    name = "acctesteventhubnamespace-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "Standard"
+  name                = "acctesteventhubnamespace-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
 }
 
 resource "azurerm_eventhub" "test" {
@@ -232,4 +237,5 @@ resource "azurerm_eventhub" "test" {
   partition_count     = 2
   message_retention   = 7
 }
-`
+`, rInt, location, rInt, rInt)
+}

--- a/azurerm/resource_arm_express_route_circuit_test.go
+++ b/azurerm/resource_arm_express_route_circuit_test.go
@@ -21,7 +21,7 @@ func TestAccAzureRMExpressRouteCircuit_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMExpressRouteCircuitDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMExpressRouteCircuit_basic(ri),
+				Config: testAccAzureRMExpressRouteCircuit_basic(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMExpressRouteCircuitExists("azurerm_express_route_circuit.test", &erc),
 				),
@@ -51,7 +51,7 @@ func testCheckAzureRMExpressRouteCircuitExists(name string, erc *network.Express
 				return fmt.Errorf("Bad: Express Route Circuit %q (resource group: %q) does not exist", expressRouteCircuitName, resourceGroup)
 			}
 
-			return fmt.Errorf("Bad: Get on expressRouteCircuitClient: %s", err)
+			return fmt.Errorf("Bad: Get on expressRouteCircuitClient: %+v", err)
 		}
 
 		*erc = resp
@@ -85,29 +85,32 @@ func testCheckAzureRMExpressRouteCircuitDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
+func testAccAzureRMExpressRouteCircuit_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
-		resource "azurerm_resource_group" "test" {
-			name = "acctestrg-%d"
-			location = "West US"
-		}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
 
-		resource "azurerm_express_route_circuit" "test" {
-			name = "acctest-erc-%[1]d"
-			location = "West US"
-			resource_group_name = "${azurerm_resource_group.test.name}"
-			service_provider_name = "Equinix"
-			peering_location = "Silicon Valley"
-			bandwidth_in_mbps = 50
-			sku {
-			    tier = "Standard"
-			    family = "MeteredData"
-		    }
-			allow_classic_operations = false
+resource "azurerm_express_route_circuit" "test" {
+  name                  = "acctest-erc-%d"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  service_provider_name = "Equinix"
+  peering_location      = "Silicon Valley"
+  bandwidth_in_mbps     = 50
 
-			tags {
-				Environment = "production"
-				Purpose = "AcceptanceTests"
-			}
-		}`, rInt)
+  sku {
+    tier   = "Standard"
+    family = "MeteredData"
+  }
+
+  allow_classic_operations = false
+
+  tags {
+    Environment = "production"
+    Purpose     = "AcceptanceTests"
+  }
+}
+`, rInt, location, rInt)
 }


### PR DESCRIPTION
Continuing on #216

So that we're able to run the AzureRM Acceptance Tests against different clouds, we need to make the `Location` field, used to specify where to deploy the resource configurable through some means. This is simplest as an environment variable - as such I've hooked it up as such - but this needs to be added to every resource.

Resources:

- [x] DNS A Record
- [x] DNS AAAA Record
- [x] DNS CNAME Record
- [x] DNS MX Record
- [x] DNS PTR Record
- [x] DNS SRV Record
- [x] DNS TXT Record
- [x] DNS Zone
- [x] EventHub
- [x] EventHub Authorization Rule
- [x] EventHub Consumer Group
- [x] EventHub Namespace
- [x] Express Route Circuit