### PR TITLE
Making the Test Location an Environment Variable: Part 7/7

### DIFF
--- a/azurerm/data_source_arm_client_config_test.go
+++ b/azurerm/data_source_arm_client_config_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAzureRMClientConfig_basic(t *testing.T) {
+func TestAccDataSourceAzureRMClientConfig_basic(t *testing.T) {
 	dataSourceName := "data.azurerm_client_config.current"
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	tenantId := os.Getenv("ARM_TENANT_ID")

--- a/azurerm/data_source_arm_client_config_test.go
+++ b/azurerm/data_source_arm_client_config_test.go
@@ -2,15 +2,15 @@ package azurerm
 
 import (
 	"os"
-	"testing"
-
 	"regexp"
+	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAzureRMClientConfig_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_client_config.current"
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	tenantId := os.Getenv("ARM_TENANT_ID")
 	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
@@ -22,10 +22,10 @@ func TestAccAzureRMClientConfig_basic(t *testing.T) {
 			{
 				Config: testAccCheckArmClientConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAzureRMClientConfigAttr("data.azurerm_client_config.current", "client_id", clientId),
-					testAzureRMClientConfigAttr("data.azurerm_client_config.current", "tenant_id", tenantId),
-					testAzureRMClientConfigAttr("data.azurerm_client_config.current", "subscription_id", subscriptionId),
-					testAzureRMClientConfigGUIDAttr("data.azurerm_client_config.current", "service_principal_object_id"),
+					testAzureRMClientConfigAttr(dataSourceName, "client_id", clientId),
+					testAzureRMClientConfigAttr(dataSourceName, "tenant_id", tenantId),
+					testAzureRMClientConfigAttr(dataSourceName, "subscription_id", subscriptionId),
+					testAzureRMClientConfigGUIDAttr(dataSourceName, "service_principal_object_id"),
 				),
 			},
 		},

--- a/azurerm/data_source_arm_public_ip_test.go
+++ b/azurerm/data_source_arm_public_ip_test.go
@@ -9,57 +9,59 @@ import (
 )
 
 func TestAccDataSourceAzureRMPublicIP_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_public_ip.test"
 	ri := acctest.RandInt()
 
 	name := fmt.Sprintf("acctestpublicip-%d", ri)
 	resourceGroupName := fmt.Sprintf("acctestRG-%d", ri)
 
-	config := testAccDatSourceAzureRMPublicIPBasic(name, resourceGroupName, ri)
+	config := testAccDatSourceAzureRMPublicIPBasic(name, resourceGroupName, ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "name", name),
-					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "resource_group_name", resourceGroupName),
-					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "domain_name_label", fmt.Sprintf("acctest-%d", ri)),
-					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "idle_timeout_in_minutes", "30"),
-					resource.TestCheckResourceAttrSet("data.azurerm_public_ip.test", "fqdn"),
-					resource.TestCheckResourceAttrSet("data.azurerm_public_ip.test", "ip_address"),
-					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("data.azurerm_public_ip.test", "tags.environment", "test"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "resource_group_name", resourceGroupName),
+					resource.TestCheckResourceAttr(dataSourceName, "domain_name_label", fmt.Sprintf("acctest-%d", ri)),
+					resource.TestCheckResourceAttr(dataSourceName, "idle_timeout_in_minutes", "30"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fqdn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ip_address"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.environment", "test"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatSourceAzureRMPublicIPBasic(name string, resourceGroupName string, rInt int) string {
+func testAccDatSourceAzureRMPublicIPBasic(name string, resourceGroupName string, rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "%s"
-    location = "West US"
+  name     = "%s"
+  location = "%s"
 }
+
 resource "azurerm_public_ip" "test" {
-    name = "%s"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    public_ip_address_allocation = "static"
-    domain_name_label = "acctest-%d"
-    idle_timeout_in_minutes = 30
-	
-    tags {
-	environment = "test"
-    }
+  name                         = "%s"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
+  domain_name_label            = "acctest-%d"
+  idle_timeout_in_minutes      = 30
+
+  tags {
+    environment = "test"
+  }
 }
 
 data "azurerm_public_ip" "test" {
-    name = "${azurerm_public_ip.test.name}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "${azurerm_public_ip.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, resourceGroupName, name, rInt)
+`, resourceGroupName, location, name, rInt)
 }

--- a/azurerm/data_source_arm_public_ip_test.go
+++ b/azurerm/data_source_arm_public_ip_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceAzureRMPublicIP_basic(t *testing.T) {
 	name := fmt.Sprintf("acctestpublicip-%d", ri)
 	resourceGroupName := fmt.Sprintf("acctestRG-%d", ri)
 
-	config := testAccDatSourceAzureRMPublicIPBasic(name, resourceGroupName, ri, testLocation())
+	config := testAccDataSourceAzureRMPublicIPBasic(name, resourceGroupName, ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,7 +39,7 @@ func TestAccDataSourceAzureRMPublicIP_basic(t *testing.T) {
 	})
 }
 
-func testAccDatSourceAzureRMPublicIPBasic(name string, resourceGroupName string, rInt int, location string) string {
+func testAccDataSourceAzureRMPublicIPBasic(name string, resourceGroupName string, rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "%s"

--- a/azurerm/data_source_arm_resource_group_test.go
+++ b/azurerm/data_source_arm_resource_group_test.go
@@ -12,16 +12,17 @@ import (
 func TestAccDataSourceAzureRMResourceGroup_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	name := fmt.Sprintf("acctestRg_%d", ri)
+	location := testLocation()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAzureRMResourceGroupBasic(name),
+				Config: testAccDataSourceAzureRMResourceGroupBasic(name, location),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.azurerm_resource_group.test", "name", name),
-					resource.TestCheckResourceAttr("data.azurerm_resource_group.test", "location", "westus2"),
+					resource.TestCheckResourceAttr("data.azurerm_resource_group.test", "location", azureRMNormalizeLocation(location)),
 					resource.TestCheckResourceAttr("data.azurerm_resource_group.test", "tags.%", "1"),
 					resource.TestCheckResourceAttr("data.azurerm_resource_group.test", "tags.env", "test"),
 				),
@@ -30,17 +31,19 @@ func TestAccDataSourceAzureRMResourceGroup_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceAzureRMResourceGroupBasic(name string) string {
-	return fmt.Sprintf(`resource "azurerm_resource_group" "test" {
-		name     = "%s"
-		location = "West US 2"
-		tags {
-			env = "test"
-		}
-	}
+func testAccDataSourceAzureRMResourceGroupBasic(name string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "%s"
+  location = "%s"
 
-	data "azurerm_resource_group" "test" {
-		name = "${azurerm_resource_group.test.name}"
-	}
-	`, name)
+  tags {
+    env = "test"
+  }
+}
+
+data "azurerm_resource_group" "test" {
+  name = "${azurerm_resource_group.test.name}"
+}
+`, name, location)
 }

--- a/azurerm/data_source_managed_disk_test.go
+++ b/azurerm/data_source_managed_disk_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceAzureRMManagedDisk_basic(t *testing.T) {
 	name := fmt.Sprintf("acctestmanageddisk-%d", ri)
 	resourceGroupName := fmt.Sprintf("acctestRG-%d", ri)
 
-	config := testAccDatSourceAzureRMManagedDiskBasic(name, resourceGroupName, testLocation())
+	config := testAccDataSourceAzureRMManagedDiskBasic(name, resourceGroupName, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -37,7 +37,7 @@ func TestAccDataSourceAzureRMManagedDisk_basic(t *testing.T) {
 	})
 }
 
-func testAccDatSourceAzureRMManagedDiskBasic(name string, resourceGroupName string, location string) string {
+func testAccDataSourceAzureRMManagedDiskBasic(name string, resourceGroupName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "%s"

--- a/azurerm/data_source_managed_disk_test.go
+++ b/azurerm/data_source_managed_disk_test.go
@@ -9,56 +9,57 @@ import (
 )
 
 func TestAccDataSourceAzureRMManagedDisk_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_managed_disk.test"
 	ri := acctest.RandInt()
 
 	name := fmt.Sprintf("acctestmanageddisk-%d", ri)
 	resourceGroupName := fmt.Sprintf("acctestRG-%d", ri)
 
-	config := testAccDatSourceAzureRMManagedDiskBasic(name, resourceGroupName)
+	config := testAccDatSourceAzureRMManagedDiskBasic(name, resourceGroupName, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.azurerm_managed_disk.test", "name", name),
-					resource.TestCheckResourceAttr("data.azurerm_managed_disk.test", "resource_group_name", resourceGroupName),
-					resource.TestCheckResourceAttr("data.azurerm_managed_disk.test", "storage_account_type", "Premium_LRS"),
-					resource.TestCheckResourceAttr("data.azurerm_managed_disk.test", "disk_size_gb", "10"),
-					resource.TestCheckResourceAttr("data.azurerm_managed_disk.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr("data.azurerm_managed_disk.test", "tags.environment", "acctest"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttr(dataSourceName, "resource_group_name", resourceGroupName),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_account_type", "Premium_LRS"),
+					resource.TestCheckResourceAttr(dataSourceName, "disk_size_gb", "10"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.environment", "acctest"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatSourceAzureRMManagedDiskBasic(name string, resourceGroupName string) string {
+func testAccDatSourceAzureRMManagedDiskBasic(name string, resourceGroupName string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "%s"
-    location = "West US"
+  name     = "%s"
+  location = "%s"
 }
 
 resource "azurerm_managed_disk" "test" {
-    name = "%s"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_type = "Premium_LRS"
-    create_option = "Empty"
-    disk_size_gb = "10"
+  name                 = "%s"
+  location             = "${azurerm_resource_group.test.location}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  storage_account_type = "Premium_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = "10"
 
-    tags {
-        environment = "acctest"
-    }
+  tags {
+    environment = "acctest"
+  }
 }
 
 data "azurerm_managed_disk" "test" {
-    name = "${azurerm_managed_disk.test.name}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "${azurerm_managed_disk.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, resourceGroupName, name)
+`, resourceGroupName, location, name)
 }

--- a/azurerm/import_arm_application_insights_test.go
+++ b/azurerm/import_arm_application_insights_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMApplicationInsights_importBasicWeb(t *testing.T) {
 	resourceName := "azurerm_application_insights.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicWeb(ri)
+	config := testAccAzureRMApplicationInsights_basicWeb(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccAzureRMApplicationInsights_importBasicOther(t *testing.T) {
 	resourceName := "azurerm_application_insights.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicWeb(ri)
+	config := testAccAzureRMApplicationInsights_basicWeb(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_availability_set_test.go
+++ b/azurerm/import_arm_availability_set_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMAvailabilitySet_importBasic(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_basic(ri)
+	config := testAccAzureRMAvailabilitySet_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccAzureRMAvailabilitySet_importWithTags(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_withTags(ri)
+	config := testAccAzureRMAvailabilitySet_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -59,7 +59,7 @@ func TestAccAzureRMAvailabilitySet_importWithDomainCounts(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_withDomainCounts(ri)
+	config := testAccAzureRMAvailabilitySet_withDomainCounts(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,7 +83,7 @@ func TestAccAzureRMAvailabilitySet_importManaged(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_managed(ri)
+	config := testAccAzureRMAvailabilitySet_managed(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_cdn_endpoint_test.go
+++ b/azurerm/import_arm_cdn_endpoint_test.go
@@ -11,18 +11,17 @@ func TestAccAzureRMCdnEndpoint_importWithTags(t *testing.T) {
 	resourceName := "azurerm_cdn_endpoint.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCdnEndpoint_withTags(ri)
+	config := testAccAzureRMCdnEndpoint_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_cdn_profile_test.go
+++ b/azurerm/import_arm_cdn_profile_test.go
@@ -11,18 +11,17 @@ func TestAccAzureRMCdnProfile_importWithTags(t *testing.T) {
 	resourceName := "azurerm_cdn_profile.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCdnProfile_withTags(ri)
+	config := testAccAzureRMCdnProfile_withTags(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: config,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/azurerm/import_arm_container_registry_test.go
+++ b/azurerm/import_arm_container_registry_test.go
@@ -12,7 +12,7 @@ func TestAccAzureRMContainerRegistry_importBasic(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	config := testAccAzureRMContainerRegistry_basic(ri, rs)
+	config := testAccAzureRMContainerRegistry_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -38,7 +38,7 @@ func TestAccAzureRMContainerRegistry_importComplete(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	config := testAccAzureRMContainerRegistry_complete(ri, rs)
+	config := testAccAzureRMContainerRegistry_complete(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_cosmosdb_account_test.go
+++ b/azurerm/import_arm_cosmosdb_account_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMCosmosDBAccount_importBoundedStaleness(t *testing.T) {
 	resourceName := "azurerm_cosmosdb_account.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_boundedStaleness(ri)
+	config := testAccAzureRMCosmosDBAccount_boundedStaleness(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccAzureRMCosmosDBAccount_importBoundedStalenessComplete(t *testing.T) 
 	resourceName := "azurerm_cosmosdb_account.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_boundedStalenessComplete(ri)
+	config := testAccAzureRMCosmosDBAccount_boundedStalenessComplete(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -59,7 +59,7 @@ func TestAccAzureRMCosmosDBAccount_importEventualConsistency(t *testing.T) {
 	resourceName := "azurerm_cosmosdb_account.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_eventualConsistency(ri)
+	config := testAccAzureRMCosmosDBAccount_eventualConsistency(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,7 +83,7 @@ func TestAccAzureRMCosmosDBAccount_importSession(t *testing.T) {
 	resourceName := "azurerm_cosmosdb_account.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_session(ri)
+	config := testAccAzureRMCosmosDBAccount_session(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,7 +107,7 @@ func TestAccAzureRMCosmosDBAccount_importStrong(t *testing.T) {
 	resourceName := "azurerm_cosmosdb_account.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_strong(ri)
+	config := testAccAzureRMCosmosDBAccount_strong(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -131,7 +131,7 @@ func TestAccAzureRMCosmosDBAccount_importGeoReplicated(t *testing.T) {
 	resourceName := "azurerm_cosmosdb_account.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_geoReplicated(ri)
+	config := testAccAzureRMCosmosDBAccount_geoReplicated(ri, testLocation(), testAltLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -254,19 +254,20 @@ func registerAzureResourceProvidersWithSubscription(providerList []resources.Pro
 	var err error
 	providerRegistrationOnce.Do(func() {
 		providers := map[string]struct{}{
-			"Microsoft.Compute":           struct{}{},
 			"Microsoft.Cache":             struct{}{},
+			"Microsoft.Cdn":               struct{}{},
+			"Microsoft.Compute":           struct{}{},
 			"Microsoft.ContainerRegistry": struct{}{},
 			"Microsoft.ContainerService":  struct{}{},
-			"Microsoft.Network":           struct{}{},
-			"Microsoft.Cdn":               struct{}{},
-			"Microsoft.Storage":           struct{}{},
-			"Microsoft.Sql":               struct{}{},
-			"Microsoft.Search":            struct{}{},
-			"Microsoft.Resources":         struct{}{},
-			"Microsoft.ServiceBus":        struct{}{},
-			"Microsoft.KeyVault":          struct{}{},
 			"Microsoft.EventHub":          struct{}{},
+			"Microsoft.KeyVault":          struct{}{},
+			"Microsoft.Insights":          struct{}{},
+			"Microsoft.Network":           struct{}{},
+			"Microsoft.Resources":         struct{}{},
+			"Microsoft.Search":            struct{}{},
+			"Microsoft.ServiceBus":        struct{}{},
+			"Microsoft.Sql":               struct{}{},
+			"Microsoft.Storage":           struct{}{},
 		}
 
 		// filter out any providers already registered

--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -29,17 +29,27 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
-	clientID := os.Getenv("ARM_CLIENT_ID")
-	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	tenantID := os.Getenv("ARM_TENANT_ID")
-	testLocation := os.Getenv("ARM_TEST_LOCATION")
+	variables := []string{
+		"ARM_SUBSCRIPTION_ID",
+		"ARM_CLIENT_ID",
+		"ARM_CLIENT_SECRET",
+		"ARM_TENANT_ID",
+		"ARM_TEST_LOCATION",
+		"ARM_TEST_LOCATION_ALT",
+	}
 
-	if subscriptionID == "" || clientID == "" || clientSecret == "" || tenantID == "" || testLocation == "" {
-		t.Fatal("ARM_SUBSCRIPTION_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_TENANT_ID and ARM_TEST_LOCATION must be set for acceptance tests")
+	for _, variable := range variables {
+		value := os.Getenv(variable)
+		if value == "" {
+			t.Fatalf("`%s` must be set for acceptance tests!", variable)
+		}
 	}
 }
 
 func testLocation() string {
 	return os.Getenv("ARM_TEST_LOCATION")
+}
+
+func testAltLocation() string {
+	return os.Getenv("ARM_TEST_LOCATION_ALT")
 }

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMApplicationInsights_basicWeb(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicWeb(ri)
+	config := testAccAzureRMApplicationInsights_basicWeb(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -33,7 +33,7 @@ func TestAccAzureRMApplicationInsights_basicWeb(t *testing.T) {
 func TestAccAzureRMApplicationInsights_basicOther(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicOther(ri)
+	config := testAccAzureRMApplicationInsights_basicOther(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -93,7 +93,7 @@ func testCheckAzureRMApplicationInsightsExists(name string) resource.TestCheckFu
 
 		resp, err := conn.Get(resourceGroup, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on appInsightsClient: %s", err)
+			return fmt.Errorf("Bad: Get on appInsightsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -104,34 +104,34 @@ func testCheckAzureRMApplicationInsightsExists(name string) resource.TestCheckFu
 	}
 }
 
-func testAccAzureRMApplicationInsights_basicWeb(rInt int) string {
+func testAccAzureRMApplicationInsights_basicWeb(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "West Europe"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_application_insights" "test" {
-  name = "acctestappinsights-%d"
-  location = "West Europe"
+  name                = "acctestappinsights-%d"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  application_type = "web"
+  application_type    = "web"
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMApplicationInsights_basicOther(rInt int) string {
+func testAccAzureRMApplicationInsights_basicOther(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "West Europe"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_application_insights" "test" {
-  name = "acctestappinsights-%d"
-  location = "West Europe"
+  name                = "acctestappinsights-%d"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  application_type = "other"
+  application_type    = "other"
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_availability_set_test.go
+++ b/azurerm/resource_arm_availability_set_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_basic(ri)
+	config := testAccAzureRMAvailabilitySet_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 func TestAccAzureRMAvailabilitySet_disappears(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_basic(ri)
+	config := testAccAzureRMAvailabilitySet_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -59,8 +59,9 @@ func TestAccAzureRMAvailabilitySet_disappears(t *testing.T) {
 func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMAvailabilitySet_withTags(ri)
-	postConfig := testAccAzureRMAvailabilitySet_withUpdatedTags(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMAvailabilitySet_withTags(ri, location)
+	postConfig := testAccAzureRMAvailabilitySet_withUpdatedTags(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -91,7 +92,7 @@ func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
 func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_withDomainCounts(ri)
+	config := testAccAzureRMAvailabilitySet_withDomainCounts(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,7 +114,7 @@ func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
 func TestAccAzureRMAvailabilitySet_managed(t *testing.T) {
 	resourceName := "azurerm_availability_set.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAvailabilitySet_managed(ri)
+	config := testAccAzureRMAvailabilitySet_managed(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -149,7 +150,7 @@ func testCheckAzureRMAvailabilitySetExists(name string) resource.TestCheckFunc {
 
 		resp, err := conn.Get(resourceGroup, availSetName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on availSetClient: %s", err)
+			return fmt.Errorf("Bad: Get on availSetClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -210,91 +211,91 @@ func testCheckAzureRMAvailabilitySetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMAvailabilitySet_basic(rInt int) string {
+func testAccAzureRMAvailabilitySet_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_availability_set" "test" {
-    name = "acctestavset-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestavset-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMAvailabilitySet_withTags(rInt int) string {
+func testAccAzureRMAvailabilitySet_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_availability_set" "test" {
-    name = "acctestavset-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestavset-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    tags {
-       environment = "Production"
-       cost_center = "MSFT"
-    }
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMAvailabilitySet_withUpdatedTags(rInt int) string {
+func testAccAzureRMAvailabilitySet_withUpdatedTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_availability_set" "test" {
-    name = "acctestavset-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestavset-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    tags {
-       environment = "staging"
-    }
+  tags {
+    environment = "staging"
+  }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMAvailabilitySet_withDomainCounts(rInt int) string {
+func testAccAzureRMAvailabilitySet_withDomainCounts(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_availability_set" "test" {
-    name = "acctestavset-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    platform_update_domain_count = 10
-    platform_fault_domain_count = 1
+  name                         = "acctestavset-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  platform_update_domain_count = 10
+  platform_fault_domain_count  = 1
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMAvailabilitySet_managed(rInt int) string {
+func testAccAzureRMAvailabilitySet_managed(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_availability_set" "test" {
-    name = "acctestavset-%d"
-    location = "${azurerm_resource_group.test.location}"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    platform_update_domain_count = 10
-    platform_fault_domain_count = 1
-    managed = true
+  name                         = "acctestavset-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  platform_update_domain_count = 10
+  platform_fault_domain_count  = 1
+  managed                      = true
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_cdn_profile_test.go
+++ b/azurerm/resource_arm_cdn_profile_test.go
@@ -91,14 +91,14 @@ func TestResourceAzureRMCdnProfileSKU_validation(t *testing.T) {
 		_, errors := validateCdnProfileSku(tc.Value, "azurerm_cdn_profile")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM CDN Profile SKU to trigger a validation error")
+			t.Fatalf("Expected the Azure RM CDN Profile SKU to trigger a validation error for '%s'", tc.Value)
 		}
 	}
 }
 
 func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMCdnProfile_basic(ri)
+	config := testAccAzureRMCdnProfile_basic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -116,10 +116,11 @@ func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 }
 
 func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
-
+	resourceName := "azurerm_cdn_profile.test"
 	ri := acctest.RandInt()
-	preConfig := testAccAzureRMCdnProfile_withTags(ri)
-	postConfig := testAccAzureRMCdnProfile_withTagsUpdate(ri)
+	location := testLocation()
+	preConfig := testAccAzureRMCdnProfile_withTags(ri, location)
+	postConfig := testAccAzureRMCdnProfile_withTagsUpdate(ri, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -129,24 +130,19 @@ func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
 			{
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMCdnProfileExists("azurerm_cdn_profile.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_profile.test", "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_profile.test", "tags.environment", "Production"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_profile.test", "tags.cost_center", "MSFT"),
+					testCheckAzureRMCdnProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
 				),
 			},
 
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMCdnProfileExists("azurerm_cdn_profile.test"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_profile.test", "tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						"azurerm_cdn_profile.test", "tags.environment", "staging"),
+					testCheckAzureRMCdnProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),
 			},
 		},
@@ -155,7 +151,7 @@ func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
 
 func TestAccAzureRMCdnProfile_NonStandardCasing(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMCdnProfileNonStandardCasing(ri)
+	config := testAccAzureRMCdnProfileNonStandardCasing(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -195,7 +191,7 @@ func testCheckAzureRMCdnProfileExists(name string) resource.TestCheckFunc {
 
 		resp, err := conn.Get(resourceGroup, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on cdnProfilesClient: %s", err)
+			return fmt.Errorf("Bad: Get on cdnProfilesClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -231,71 +227,75 @@ func testCheckAzureRMCdnProfileDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMCdnProfile_basic(ri int) string {
+func testAccAzureRMCdnProfile_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
-}
-resource "azurerm_cdn_profile" "test" {
-    name = "acctestcdnprof%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "Standard_Verizon"
-}
-`, ri, ri)
-}
-
-func testAccAzureRMCdnProfile_withTags(ri int) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
 
 resource "azurerm_cdn_profile" "test" {
-    name = "acctestcdnprof%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "Standard_Verizon"
+  name                = "acctestcdnprof%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard_Verizon"
+}
+`, rInt, location, rInt)
+}
 
-    tags {
-	environment = "Production"
-	cost_center = "MSFT"
-    }
-}
-`, ri, ri)
-}
-func testAccAzureRMCdnProfile_withTagsUpdate(ri int) string {
+func testAccAzureRMCdnProfile_withTags(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cdn_profile" "test" {
-    name = "acctestcdnprof%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "Standard_Verizon"
+  name                = "acctestcdnprof%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard_Verizon"
 
-    tags {
-	environment = "staging"
-    }
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
 }
-`, ri, ri)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMCdnProfileNonStandardCasing(ri int) string {
+func testAccAzureRMCdnProfile_withTagsUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cdn_profile" "test" {
-    name = "acctestcdnprof%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    sku = "standard_verizon"
+  name                = "acctestcdnprof%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard_Verizon"
+
+  tags {
+    environment = "staging"
+  }
 }
-`, ri, ri)
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMCdnProfileNonStandardCasing(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "standard_verizon"
+}
+`, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_container_registry_test.go
+++ b/azurerm/resource_arm_container_registry_test.go
@@ -69,7 +69,7 @@ func TestAccAzureRMContainerRegistryName_validation(t *testing.T) {
 func TestAccAzureRMContainerRegistry_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	config := testAccAzureRMContainerRegistry_basic(ri, rs)
+	config := testAccAzureRMContainerRegistry_basic(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -89,7 +89,7 @@ func TestAccAzureRMContainerRegistry_basic(t *testing.T) {
 func TestAccAzureRMContainerRegistry_complete(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	config := testAccAzureRMContainerRegistry_complete(ri, rs)
+	config := testAccAzureRMContainerRegistry_complete(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -109,8 +109,9 @@ func TestAccAzureRMContainerRegistry_complete(t *testing.T) {
 func TestAccAzureRMContainerRegistry_update(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)
-	config := testAccAzureRMContainerRegistry_complete(ri, rs)
-	updatedConfig := testAccAzureRMContainerRegistry_completeUpdated(ri, rs)
+	location := testLocation()
+	config := testAccAzureRMContainerRegistry_complete(ri, rs, location)
+	updatedConfig := testAccAzureRMContainerRegistry_completeUpdated(ri, rs, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -176,7 +177,7 @@ func testCheckAzureRMContainerRegistryExists(name string) resource.TestCheckFunc
 
 		resp, err := conn.Get(resourceGroup, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on containerRegistryClient: %s", err)
+			return fmt.Errorf("Bad: Get on containerRegistryClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -187,11 +188,11 @@ func testCheckAzureRMContainerRegistryExists(name string) resource.TestCheckFunc
 	}
 }
 
-func testAccAzureRMContainerRegistry_basic(rInt int, rStr string) string {
+func testAccAzureRMContainerRegistry_basic(rInt int, rStr string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "testAccRg-%d"
-  location = "West US"
+  location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
@@ -212,14 +213,14 @@ resource "azurerm_container_registry" "test" {
     access_key = "${azurerm_storage_account.test.primary_access_key}"
   }
 }
-`, rInt, rStr, rInt)
+`, rInt, location, rStr, rInt)
 }
 
-func testAccAzureRMContainerRegistry_complete(rInt int, rStr string) string {
+func testAccAzureRMContainerRegistry_complete(rInt int, rStr string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "testAccRg-%d"
-  location = "West US"
+  location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
@@ -245,14 +246,14 @@ resource "azurerm_container_registry" "test" {
     environment = "production"
   }
 }
-`, rInt, rStr, rInt)
+`, rInt, location, rStr, rInt)
 }
 
-func testAccAzureRMContainerRegistry_completeUpdated(rInt int, rStr string) string {
+func testAccAzureRMContainerRegistry_completeUpdated(rInt int, rStr string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "testAccRg-%d"
-  location = "West US"
+  location = "%s"
 }
 
 resource "azurerm_storage_account" "test" {
@@ -278,5 +279,5 @@ resource "azurerm_container_registry" "test" {
     environment = "production"
   }
 }
-`, rInt, rStr, rInt)
+`, rInt, location, rStr, rInt)
 }

--- a/azurerm/resource_arm_container_service_test.go
+++ b/azurerm/resource_arm_container_service_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMContainerService_orchestrationPlatformValidation(t *testing.T
 		_, errors := validateArmContainerServiceOrchestrationPlatform(tc.Value, "azurerm_container_service")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Container Service Orchestration Platform to trigger a validation error")
+			t.Fatalf("Expected the Azure RM Container Service Orchestration Platform to trigger a validation error for '%s'", tc.Value)
 		}
 	}
 }
@@ -49,7 +49,7 @@ func TestAccAzureRMContainerService_masterProfileCountValidation(t *testing.T) {
 		_, errors := validateArmContainerServiceMasterProfileCount(tc.Value, "azurerm_container_service")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Container Service Master Profile Count to trigger a validation error")
+			t.Fatalf("Expected the Azure RM Container Service Master Profile Count to trigger a validation error for '%d'", tc.Value)
 		}
 	}
 }
@@ -71,14 +71,14 @@ func TestAccAzureRMContainerService_agentProfilePoolCountValidation(t *testing.T
 		_, errors := validateArmContainerServiceAgentPoolProfileCount(tc.Value, "azurerm_container_service")
 
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM Container Service Agent Pool Profile Count to trigger a validation error")
+			t.Fatalf("Expected the Azure RM Container Service Agent Pool Profile Count to trigger a validation error for '%d'", tc.Value)
 		}
 	}
 }
 
 func TestAccAzureRMContainerService_dcosBasic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMContainerService_dcosBasic, ri, ri, ri, ri, ri)
+	config := testAccAzureRMContainerService_dcosBasic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -99,7 +99,7 @@ func TestAccAzureRMContainerService_kubernetesBasic(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMContainerService_kubernetesBasic(ri, clientId, clientSecret)
+	config := testAccAzureRMContainerService_kubernetesBasic(ri, clientId, clientSecret, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -120,7 +120,7 @@ func TestAccAzureRMContainerService_kubernetesComplete(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMContainerService_kubernetesComplete(ri, clientId, clientSecret)
+	config := testAccAzureRMContainerService_kubernetesComplete(ri, clientId, clientSecret, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -139,7 +139,7 @@ func TestAccAzureRMContainerService_kubernetesComplete(t *testing.T) {
 
 func TestAccAzureRMContainerService_swarmBasic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMContainerService_swarmBasic, ri, ri, ri, ri, ri)
+	config := testAccAzureRMContainerService_swarmBasic(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -156,10 +156,11 @@ func TestAccAzureRMContainerService_swarmBasic(t *testing.T) {
 	})
 }
 
-var testAccAzureRMContainerService_dcosBasic = `
+func testAccAzureRMContainerService_dcosBasic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "East US"
+  location = "%s"
 }
 
 resource "azurerm_container_service" "test" {
@@ -192,13 +193,14 @@ resource "azurerm_container_service" "test" {
     enabled = false
   }
 }
-`
+`, rInt, location, rInt, rInt, rInt, rInt)
+}
 
-func testAccAzureRMContainerService_kubernetesBasic(rInt int, clientId string, clientSecret string) string {
+func testAccAzureRMContainerService_kubernetesBasic(rInt int, clientId string, clientSecret string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "East US"
+  location = "%s"
 }
 
 resource "azurerm_container_service" "test" {
@@ -236,14 +238,14 @@ resource "azurerm_container_service" "test" {
     enabled = false
   }
 }
-`, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
+`, rInt, location, rInt, rInt, rInt, rInt, clientId, clientSecret)
 }
 
-func testAccAzureRMContainerService_kubernetesComplete(rInt int, clientId string, clientSecret string) string {
+func testAccAzureRMContainerService_kubernetesComplete(rInt int, clientId string, clientSecret string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "East US"
+  location = "%s"
 }
 
 resource "azurerm_container_service" "test" {
@@ -285,13 +287,14 @@ resource "azurerm_container_service" "test" {
     you = "me"
   }
 }
-`, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
+`, rInt, location, rInt, rInt, rInt, rInt, clientId, clientSecret)
 }
 
-var testAccAzureRMContainerService_swarmBasic = `
+func testAccAzureRMContainerService_swarmBasic(rInt int, location string) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "East US"
+  location = "%s"
 }
 
 resource "azurerm_container_service" "test" {
@@ -324,7 +327,8 @@ resource "azurerm_container_service" "test" {
     enabled = false
   }
 }
-`
+`, rInt, location, rInt, rInt, rInt, rInt)
+}
 
 func testCheckAzureRMContainerServiceExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -344,7 +348,7 @@ func testCheckAzureRMContainerServiceExists(name string) resource.TestCheckFunc 
 
 		resp, err := conn.Get(resourceGroup, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on containerServicesClient: %s", err)
+			return fmt.Errorf("Bad: Get on containerServicesClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {

--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -46,7 +46,7 @@ func TestAccAzureRMCosmosDBAccountName_validation(t *testing.T) {
 func TestAccAzureRMCosmosDBAccount_boundedStaleness(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_boundedStaleness(ri)
+	config := testAccAzureRMCosmosDBAccount_boundedStaleness(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -66,7 +66,7 @@ func TestAccAzureRMCosmosDBAccount_boundedStaleness(t *testing.T) {
 func TestAccAzureRMCosmosDBAccount_boundedStalenessComplete(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_boundedStalenessComplete(ri)
+	config := testAccAzureRMCosmosDBAccount_boundedStalenessComplete(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -85,7 +85,7 @@ func TestAccAzureRMCosmosDBAccount_boundedStalenessComplete(t *testing.T) {
 
 func TestAccAzureRMCosmosDBAccount_eventualConsistency(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_eventualConsistency(ri)
+	config := testAccAzureRMCosmosDBAccount_eventualConsistency(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -104,7 +104,7 @@ func TestAccAzureRMCosmosDBAccount_eventualConsistency(t *testing.T) {
 
 func TestAccAzureRMCosmosDBAccount_session(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_session(ri)
+	config := testAccAzureRMCosmosDBAccount_session(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -123,7 +123,7 @@ func TestAccAzureRMCosmosDBAccount_session(t *testing.T) {
 
 func TestAccAzureRMCosmosDBAccount_strong(t *testing.T) {
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_strong(ri)
+	config := testAccAzureRMCosmosDBAccount_strong(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -143,7 +143,7 @@ func TestAccAzureRMCosmosDBAccount_strong(t *testing.T) {
 func TestAccAzureRMCosmosDBAccount_geoReplicated(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMCosmosDBAccount_geoReplicated(ri)
+	config := testAccAzureRMCosmosDBAccount_geoReplicated(ri, testLocation(), testAltLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -203,7 +203,7 @@ func testCheckAzureRMCosmosDBAccountExists(name string) resource.TestCheckFunc {
 
 		resp, err := conn.Get(resourceGroup, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on cosmosDBClient: %s", err)
+			return fmt.Errorf("Bad: Get on cosmosDBClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -214,12 +214,13 @@ func testCheckAzureRMCosmosDBAccountExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testAccAzureRMCosmosDBAccount_boundedStaleness(rInt int) string {
+func testAccAzureRMCosmosDBAccount_boundedStaleness(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -235,15 +236,16 @@ resource "azurerm_cosmosdb_account" "test" {
     priority = 0
   }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMCosmosDBAccount_boundedStalenessComplete(rInt int) string {
+func testAccAzureRMCosmosDBAccount_boundedStalenessComplete(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -261,15 +263,16 @@ resource "azurerm_cosmosdb_account" "test" {
     priority = 0
   }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMCosmosDBAccount_eventualConsistency(rInt int) string {
+func testAccAzureRMCosmosDBAccount_eventualConsistency(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -285,15 +288,16 @@ resource "azurerm_cosmosdb_account" "test" {
     priority = 0
   }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMCosmosDBAccount_session(rInt int) string {
+func testAccAzureRMCosmosDBAccount_session(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -309,15 +313,16 @@ resource "azurerm_cosmosdb_account" "test" {
     priority = 0
   }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMCosmosDBAccount_strong(rInt int) string {
+func testAccAzureRMCosmosDBAccount_strong(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -333,15 +338,16 @@ resource "azurerm_cosmosdb_account" "test" {
     priority = 0
   }
 }
-`, rInt, rInt)
+`, rInt, location, rInt)
 }
 
-func testAccAzureRMCosmosDBAccount_geoReplicated(rInt int) string {
+func testAccAzureRMCosmosDBAccount_geoReplicated(rInt int, location string, altLocation string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "%s"
 }
+
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -360,9 +366,9 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   failover_policy {
-    location = "West Europe"
+    location = "%s"
     priority = 1
   }
 }
-`, rInt, rInt)
+`, rInt, location, rInt, altLocation)
 }


### PR DESCRIPTION
So that we're able to run the AzureRM Acceptance Tests against different clouds, we need to make the `Location` field, used to specify where to deploy the resource configurable through some means. This is simplest as an environment variable - as such I've hooked it up as such - but this needs to be added to every resource.

Due to the way CosmosDB Accounts are tested, I've had to add an `alternate location` environment variable for testing creating replicated CosmosDB Accounts works, but I think we'll use this in a couple of other places too

Resources:
- [x] Data Sources
- [x] Application Insights
- [x] Availability Sets
- [x] CDN Endpoints
- [x] CDN Profile
- [x] Container Registry
- [x] Container Service
- [x] CosmosDB Account

Fixes #216