### PR TITLE
Fixing hard-coded test data failures identified against Azure Germany

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -259,6 +259,7 @@ func registerAzureResourceProvidersWithSubscription(providerList []resources.Pro
 			"Microsoft.Compute":           struct{}{},
 			"Microsoft.ContainerRegistry": struct{}{},
 			"Microsoft.ContainerService":  struct{}{},
+			"Microsoft.DocumentDB":        struct{}{},
 			"Microsoft.EventHub":          struct{}{},
 			"Microsoft.KeyVault":          struct{}{},
 			"Microsoft.Insights":          struct{}{},

--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -1,13 +1,13 @@
 package azurerm
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"fmt"
-	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider

--- a/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -11,12 +11,24 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func getTrafficManagerFQDN(hostname string) (string, error) {
+	environment, err := testArmEnvironment()
+	if err != nil {
+		return "", err
+	}
+	dnsSuffix := environment.TrafficManagerDNSSuffix
+	return fmt.Sprintf("%s.%s", hostname, dnsSuffix), nil
+}
+
 func TestAccAzureRMTrafficManagerProfile_weighted(t *testing.T) {
 	resourceName := "azurerm_traffic_manager_profile.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMTrafficManagerProfile_weighted(ri, testLocation())
 
-	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
+	fqdn, err := getTrafficManagerFQDN(fmt.Sprintf("acctesttmp%d", ri))
+	if err != nil {
+		t.Fatalf("Error obtaining Azure Region: %+v", err)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +52,10 @@ func TestAccAzureRMTrafficManagerProfile_performance(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMTrafficManagerProfile_performance(ri, testLocation())
 
-	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
+	fqdn, err := getTrafficManagerFQDN(fmt.Sprintf("acctesttmp%d", ri))
+	if err != nil {
+		t.Fatalf("Error obtaining Azure Region: %+v", err)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -63,7 +78,11 @@ func TestAccAzureRMTrafficManagerProfile_priority(t *testing.T) {
 	resourceName := "azurerm_traffic_manager_profile.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMTrafficManagerProfile_priority(ri, testLocation())
-	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
+
+	fqdn, err := getTrafficManagerFQDN(fmt.Sprintf("acctesttmp%d", ri))
+	if err != nil {
+		t.Fatalf("Error obtaining Azure Region: %+v", err)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/resource_arm_virtual_machine_extension_test.go
+++ b/azurerm/resource_arm_virtual_machine_extension_test.go
@@ -198,7 +198,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -303,7 +303,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -409,7 +409,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -526,7 +526,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -268,7 +268,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -341,7 +341,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -422,7 +422,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -503,7 +503,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -655,7 +655,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -736,7 +736,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -815,7 +815,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -898,7 +898,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -763,7 +763,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   storage_profile_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 }
@@ -862,7 +862,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   storage_profile_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
   tags {
@@ -1672,7 +1672,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   storage_profile_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 }

--- a/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
@@ -590,7 +590,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -681,7 +681,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -776,7 +776,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -871,7 +871,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -1084,7 +1084,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -1183,7 +1183,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -1272,7 +1272,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -1722,7 +1722,7 @@ resource "azurerm_resource_group" "test" {
      storage_image_reference {
  	publisher = "Canonical"
  	offer = "UbuntuServer"
- 	sku = "14.04.2-LTS"
+ 	sku = "16.04-LTS"
  	version = "latest"
      }
 
@@ -1815,7 +1815,7 @@ func testAccAzureRMVirtualMachine_updateAvailabilitySet(rInt int, location strin
      storage_image_reference {
  	publisher = "Canonical"
  	offer = "UbuntuServer"
- 	sku = "14.04.2-LTS"
+ 	sku = "16.04-LTS"
  	version = "latest"
      }
 
@@ -1901,7 +1901,7 @@ func testAccAzureRMVirtualMachine_updateMachineName(rInt int, location string) s
      storage_image_reference {
  	publisher = "Canonical"
  	offer = "UbuntuServer"
- 	sku = "14.04.2-LTS"
+ 	sku = "16.04-LTS"
  	version = "latest"
      }
 
@@ -1987,7 +1987,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -2171,7 +2171,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 
@@ -2442,7 +2442,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
         publisher = "Canonical"
         offer = "UbuntuServer"
-        sku = "14.04.2-LTS"
+        sku = "16.04-LTS"
         version = "latest"
     }
 
@@ -2528,7 +2528,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
         publisher = "Canonical"
         offer = "UbuntuServer"
-        sku = "14.04.2-LTS"
+        sku = "16.04-LTS"
         version = "latest"
     }
 
@@ -2627,7 +2627,7 @@ resource "azurerm_virtual_machine" "test" {
     storage_image_reference {
 	publisher = "Canonical"
 	offer = "UbuntuServer"
-	sku = "14.04.2-LTS"
+	sku = "16.04-LTS"
 	version = "latest"
     }
 

--- a/examples/traffic-manager-vm/variables.tf
+++ b/examples/traffic-manager-vm/variables.tf
@@ -53,7 +53,7 @@ variable "image_offer" {
 
 variable "image_sku" {
   description = "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version. Allowed values: 12.04.5-LTS, 14.04.2-LTS, 15.10."
-  default     = "14.04.2-LTS"
+  default     = "16.04-LTS"
 }
 
 variable "image_version" {

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -54,7 +54,7 @@ resource "azurerm_virtual_machine" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -69,7 +69,7 @@ resource "azurerm_virtual_machine" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 
@@ -181,7 +181,7 @@ resource "azurerm_virtual_machine" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -74,7 +74,7 @@ resource "azurerm_virtual_machine" "test" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -100,7 +100,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   storage_profile_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 }
@@ -184,7 +184,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   storage_profile_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "14.04.2-LTS"
+    sku       = "16.04-LTS"
     version   = "latest"
   }
 


### PR DESCRIPTION
- Registering the CosmosDB (DocumentDB) Resource Provider
- Upgrading the examples to Ubuntu 16.04, since 14.04.2 isn't available in Azure Germany
- Exposing the Azure Environment in order to be able to get the DNS Suffixes for tests
