### PR TITLE
Edit the sample parameter for EventHub

### DIFF
--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -23,7 +23,7 @@ resource "azurerm_eventhub_namespace" "test" {
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Basic"
-  capacity            = 2
+  capacity            = 1
 
   tags {
     environment = "Production"
@@ -36,7 +36,7 @@ resource "azurerm_eventhub" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   partition_count     = 2
-  message_retention   = 2
+  message_retention   = 1
 }
 ```
 


### PR DESCRIPTION
Event Hub sku=BASIC model doesn't allow  message_retention = 1. If you try to keep message_retention = 1, it throws error.  Or you should change sku = "Standard" to avoid the error. 

 I don'tremember however, capacity = 1 might cause an error as well.

At least this sample works at least.