### PR TITLE
Fix invalid parameter

### DIFF
--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -19,7 +19,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_cosmosdb_account" "test" {
-  name                = "cosmosDBAccount1"
+  name                = "cosmos-db-account1"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   offer_type          = "Standard"


### PR DESCRIPTION
The CosmosDB Account name doesn't allow uppercase letters.

If you try to keep name = "cosmosDBAccount1", it throws following error.

```
* azurerm_cosmosdb_account.test: cosmosdb.DatabaseAccountsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="Unknown" Message="Unknown service error"
```

At least this sample works at least.