### PR TITLE
Fix invalid parameter

### DIFF
--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -14,12 +14,12 @@ Create an Azure Storage Blob.
 
 ```hcl
 resource "azurerm_resource_group" "test" {
-  name     = "acctestrg-%d"
+  name     = "acctestrg-d"
   location = "westus"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                = "acctestacc%s"
+  name                = "acctestaccs"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "westus"
   account_type        = "Standard_LRS"


### PR DESCRIPTION
The Azure Storage Account name doesn't allow `%`.

If you try to keep name = "acctestacc%s" and `terraform plan` run, it throws following error.

```
1 error(s) occurred:

* azurerm_storage_account.test: name can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long
```

The Azure Resource Group name doesn't allow `%`.

If you try to keep name = "acctestrg-%d" and `terraform apply` run, it throws following error.

```
1 error(s) occurred:

* azurerm_resource_group.test: 1 error(s) occurred:

* azurerm_resource_group.test: Error creating resource group: InvalidDoubleEncodedRequestUri (400) - The request URI 'https://management.azure.com:443/subscriptions/2db6d261-2e79-4a72-bd34-21fe049260cc/resourceGroups/acctestrg-%25d?api-version=2015-01-01' is not valid, because it contains double encoding sequence '%25'.
```

At least this sample works at least.