### PR TITLE
Fix invalid parameter

### DIFF
--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_cdn_profile" "test" {
   name                = "acceptanceTestCdnProfile1"
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Standard"
+  sku                 = "Standard_Verizon"
 }
 
 resource "azurerm_cdn_endpoint" "test" {
@@ -32,8 +32,10 @@ resource "azurerm_cdn_endpoint" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   origin {
-    name      = "acceptanceTestCdnOrigin1"
-    host_name = "www.example.com"
+    name       = "acceptanceTestCdnOrigin1"
+    host_name  = "www.example.com"
+    http_port  = "80"
+    https_port = "443"
   }
 }
 ```
@@ -77,9 +79,9 @@ The `origin` block supports:
 
 * `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string can be a domain name, Storage Account endpoint, Web App endpoint, IPv4 address or IPv6 address.
 
-* `http_port` - (Optional) The HTTP port of the origin. Defaults to null. When null, 80 will be used for HTTP.
+* `http_port` - (Required) The HTTP port of the origin.
 
-* `https_port` - (Optional) The HTTPS port of the origin. Defaults to null. When null, 443 will be used for HTTPS.
+* `https_port` - (Required) The HTTPS port of the origin.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The Azure CDN Profile SKU can only be Premium_Verizon, Standard_Verizon or Standard_Akamai.

If you try to keep sku = "Standard" and `terraform plan` run, it throws following error.

```
1 error(s) occurred:

* azurerm_cdn_profile.test: CDN Profile SKU can only be Premium_Verizon, Standard_Verizon or Standard_Akamai
```

`http_port` and` https_port` are written as `Optional`, and no error occurs in `terraform plan`, but `terraform apply` run, it throws following error.

```
1 error(s) occurred:

* azurerm_cdn_endpoint.test: 1 error(s) occurred:

* azurerm_cdn_endpoint.test: cdn.EndpointsClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="Invalid port \"0\". Port value must be a number between 1 and 65535."
```

As a result of Try and Error, at least this sample works.