### PR TITLE
`azurerm_postgresql_server` - supporting additional storage sizes

### DIFF
--- a/azurerm/resource_arm_postgresql_server.go
+++ b/azurerm/resource_arm_postgresql_server.go
@@ -102,7 +102,13 @@ func resourceArmPostgreSQLServer() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validateIntInSlice([]int{
 					51200,
-					102400,
+					179200,
+					307200,
+					435200,
+					563200,
+					691200,
+					819200,
+					947200,
 				}),
 			},
 

--- a/azurerm/resource_arm_postgresql_server_test.go
+++ b/azurerm/resource_arm_postgresql_server_test.go
@@ -58,6 +58,30 @@ func TestAccAzureRMPostgreSQLServer_basicNinePointSix(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPostgreSQLServer_basicMaxStorage(t *testing.T) {
+	resourceName := "azurerm_postgresql_server.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMPostgreSQLServer_basicMaxStorage(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPostgreSQLServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPostgreSQLServerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "administrator_login", "acctestun"),
+					resource.TestCheckResourceAttr(resourceName, "version", "9.6"),
+					resource.TestCheckResourceAttr(resourceName, "storage_mb", "947200"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enforcement", "Enabled"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMPostgreSQLServer_updatePassword(t *testing.T) {
 	resourceName := "azurerm_postgresql_server.test"
 	ri := acctest.RandInt()
@@ -221,5 +245,32 @@ resource "azurerm_postgresql_server" "test" {
   ssl_enforcement              = "Disabled"
 }
 
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMPostgreSQLServer_basicMaxStorage(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_postgresql_server" "test" {
+  name                = "acctestpsqlsvr-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    name     = "PGSQLB50"
+    capacity = 50
+    tier     = "Basic"
+  }
+
+  administrator_login          = "acctestun"
+  administrator_login_password = "H@Sh1CoR3!"
+  version                      = "9.6"
+  storage_mb                   = 947200
+  ssl_enforcement              = "Enabled"
+}
 `, rInt, location, rInt)
 }

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -57,7 +57,17 @@ The following arguments are supported:
 
 * `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5` and `9.6`. Changing this forces a new resource to be created.
 
-* `storage_mb` - (Required) Specifies the amount of storage for the PostgreSQL Server in Megabytes. Possible values are `51200` and `102400`. Changing this forces a new resource to be created.
+* `storage_mb` - (Required) Specifies the amount of storage for the PostgreSQL Server in Megabytes. Possible values are shown below. Changing this forces a new resource to be created.
+
+Possible values for `storage_mb` are:
+- `51200` (50GB)
+- `179200` (175GB)
+- `307200` (300GB)
+- `435200` (425GB)
+- `563200` (550GB)
+- `691200` (675GB)
+- `819200` (800GB)
+- `947200` (925GB)
 
 * `ssl_enforcement` - (Required) Specifies if SSL should be enforced on connections. Possible values are `Enforced` and `Disabled`.
 


### PR DESCRIPTION
Updating the PostgreSQL Server resource to include the latest acceptable values for Storage (MB)

- [x] Update Validation
- [x] Tests
- [x] Update documentation

Fixes #324