### PR TITLE
Documentation Updates

### DIFF
--- a/website/docs/authenticating_via_azure_cli.html.markdown
+++ b/website/docs/authenticating_via_azure_cli.html.markdown
@@ -13,6 +13,8 @@ Terraform supports authenticating to Azure through a couple of different means -
 
 We recommend [using a Service Principal when running in a Shared Environment](authenticating_via_service_principal.html) (such as within a CI server/automation) - and authenticating via the Azure CLI when you're running Terraform locally.
 
+When authenticating via the Azure CLI, Terraform will automatically connect to the Default Subscription - this can be changed by using the Azure CLI - and is documented below.
+
 ## Configuring the Azure CLI
 
 ~> **Note:** There are multiple versions of the Azure CLI's - the latest version is known as [the Azure CLI 2.0 (Python)](https://github.com/Azure/azure-cli) and [the older Azure CLI (Node.JS)](https://github.com/Azure/azure-xplat-cli). Whilst Terraform currently supports both - we highly recommend users upgrade to the Azure CLI 2.0 (Python) if possible.
@@ -45,7 +47,7 @@ Once logged in - it's possible to list the Subscriptions associated with the acc
 $ az account list
 ```
 
-The output (similar to below) will display one or more Subscriptions - with the `ID` field being the `subscription_id` field referenced above.
+The output (similar to below) will display one or more Subscriptions - with the `ID` field being the Subscription ID.
 
 ```json
 [

--- a/website/docs/authenticating_via_service_principal.html.markdown
+++ b/website/docs/authenticating_via_service_principal.html.markdown
@@ -142,4 +142,4 @@ Secondly, search for and select the name of the Application created in Azure Act
 
 ## Creating a Service Principal through the Legacy CLI's
 
-It's also possible to create credentials via [the legacy cross-platform CLI](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/) and the [legacy PowerShell Commandlets](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal/) - however we would highly recommend using the Azure CLI above.
+It's also possible to create credentials via [the legacy cross-platform CLI](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/) and the [legacy PowerShell Cmdlets](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal/) - however we would highly recommend using the Azure CLI above.

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create as an Azure Container Group instance.
 
-## Example Usage (Linux)
+## Example Usage
 
 ```hcl
 resource "azurerm_resource_group" "aci-rg" {
@@ -19,30 +19,32 @@ resource "azurerm_resource_group" "aci-rg" {
 }
 
 resource "azurerm_container_group" "aci-helloworld" {
-  
-  name = "aci-hw"
-  location = "${azurerm_resource_group.aci-rg.location}"
+  name                = "aci-hw"
+  location            = "${azurerm_resource_group.aci-rg.location}"
   resource_group_name = "${azurerm_resource_group.aci-rg.name}"
-  ip_address_type="public"
-  os_type = "linux"
+  ip_address_type     = "public"
+  os_type             = "linux"
 
   container {
-        name = "hw"
-        image = "microsoft/aci-helloworld:latest"
-        cpu ="0.5"
-        memory =  "1.5"
-        port = "80"
-        environment_variables {
-            "NODE_ENV"="Staging"
-        }
-        command = "/bin/bash -c '/path to/myscript.sh'"
+    name   = "hw"
+    image  = "microsoft/aci-helloworld:latest"
+    cpu    = "0.5"
+    memory = "1.5"
+    port   = "80"
+
+    environment_variables {
+      "NODE_ENV" = "Staging"
     }
-    container {
-        name = "sidecar"
-        image = "microsoft/aci-tutorial-sidecar"
-        cpu="0.5"
-        memory="1.5"
-    }
+
+    command = "/bin/bash -c '/path to/myscript.sh'"
+  }
+
+  container {
+    name   = "sidecar"
+    image  = "microsoft/aci-tutorial-sidecar"
+    cpu    = "0.5"
+    memory = "1.5"
+  }
 
   tags {
     environment = "testing"
@@ -62,7 +64,7 @@ The following arguments are supported:
 
 * `ip_address_type` - (Optional) Specifies the ip address type of the container. `Public` is the only acceptable value at this time. Changing this forces a new resource to be created.
 
-* `os_type` - (Required) The OS for the container group. Allowed values are `linux` and `windows` Changing this forces a new resource to be created.
+* `os_type` - (Required) The OS for the container group. Allowed values are `Linux` and `Windows` Changing this forces a new resource to be created.
 
 * `container` - (Required) The definition of a container that is part of the group. Changing this forces a new resource to be created.
 

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 * `storage_account_name` - (Required) Specifies the storage account in which to create the storage container.
  Changing this forces a new resource to be created.
 
-* `container_access_type` - (Required) The 'interface' for access the container provides. Can be either `blob`, `container` or `private`.
+* `container_access_type` - (Optional) The 'interface' for access the container provides. Can be either `blob`, `container` or `private`. Defaults to `private`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -144,6 +144,11 @@ The following arguments are supported:
 * `type` - (Required) The type of extension, available types for a publisher can
     be found using the Azure CLI.
 
+~> **Note:** The `Publisher` and `Type` of Virtual Machine Extensions can be found using the Azure CLI, via:
+```
+$ az vm extension image list --location westus -o table
+```
+
 * `type_handler_version` - (Required) Specifies the version of the extension to
     use, available versions can be found using the Azure CLI.
 


### PR DESCRIPTION
Includes:

- [x] Updating the Azure CLI guide to remove a bad reference
- [x] Running `terraform fmt` on the Container Group example
- [x] `azurerm_storage_container` `container_access_type` is not required - #337
- [x] How to get extension publisher and type with Azure CLI  #335