### PR TITLE
`azurerm_template_deployment` - support for specifying parameters via `parameters_body`

### DIFF
--- a/azurerm/resource_arm_template_deployment.go
+++ b/azurerm/resource_arm_template_deployment.go
@@ -43,6 +43,11 @@ func resourceArmTemplateDeployment() *schema.Resource {
 				Optional: true,
 			},
 
+			"parameters_body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"outputs": {
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -83,6 +88,15 @@ func resourceArmTemplateDeploymentCreate(d *schema.ResourceData, meta interface{
 		}
 
 		properties.Parameters = &newParams
+	}
+
+	if v, ok := d.GetOk("parameters_body"); ok {
+		params, err := expandParametersBody(v.(string))
+		if err != nil {
+			return err
+		}
+
+		properties.Parameters = &params
 	}
 
 	if v, ok := d.GetOk("template_body"); ok {
@@ -209,6 +223,15 @@ func resourceArmTemplateDeploymentDelete(d *schema.ResourceData, meta interface{
 }
 
 // TODO: move this out into the new `helpers` structure
+func expandParametersBody(body string) (map[string]interface{}, error) {
+	var parametersBody map[string]interface{}
+	err := json.Unmarshal([]byte(body), &parametersBody)
+	if err != nil {
+		return nil, fmt.Errorf("Error Expanding the parameters_body for Azure RM Template Deployment")
+	}
+	return parametersBody, nil
+}
+
 func expandTemplateBody(template string) (map[string]interface{}, error) {
 	var templateBody map[string]interface{}
 	err := json.Unmarshal([]byte(template), &templateBody)

--- a/azurerm/resource_arm_template_deployment_test.go
+++ b/azurerm/resource_arm_template_deployment_test.go
@@ -68,6 +68,26 @@ func TestAccAzureRMTemplateDeployment_withParams(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMTemplateDeployment_withParamsBody(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testaccAzureRMTemplateDeployment_withParamsBody(ri, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMTemplateDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMTemplateDeploymentExists("azurerm_template_deployment.test"),
+					resource.TestCheckResourceAttr("azurerm_template_deployment.test", "outputs.testOutput", "Output Value"),
+				),
+			},
+		},
+	})
+
+}
+
 func TestAccAzureRMTemplateDeployment_withOutputs(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMTemplateDeployment_withOutputs(ri, testLocation())
@@ -299,6 +319,153 @@ DEPLOY
     deployment_mode = "Complete"
   }
 `, rInt, location, rInt)
+}
+
+func testaccAzureRMTemplateDeployment_withParamsBody(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+output "test" {
+  value = "${azurerm_template_deployment.test.outputs["testOutput"]}"
+}
+
+resource "azurerm_storage_container" "using-outputs" {
+  name = "vhds"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  storage_account_name = "${azurerm_template_deployment.test.outputs["accountName"]}"
+  container_access_type = "private"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test-kv" {
+  location = "%s"
+  name = "acctestKv-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  "sku" {
+    name = "standard"
+  }
+  tenant_id = "${data.azurerm_client_config.current.tenant_id}"
+  enabled_for_template_deployment = true
+
+  access_policy {
+    key_permissions = []
+    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    secret_permissions = [
+      "all"]
+    tenant_id = "${data.azurerm_client_config.current.tenant_id}"
+  }
+}
+
+resource "azurerm_key_vault_secret" "test-secret" {
+  name = "acctestsecret-%d"
+  value = "terraform-test-%d"
+  vault_uri = "${azurerm_key_vault.test-kv.vault_uri}"
+}
+
+data "template_file" "test-template" {
+  template = <<TPL
+{
+"dnsLabelPrefix": {
+    "reference": {
+      "keyvault": {
+        "id": "/subscriptions/$${subscription_id}/resourceGroups/$${vault_resource_group_name}/providers/Microsoft.KeyVault/vaults/$${vault_name}"
+      },
+      "secretName": "$${secret_name}"
+    }
+  },
+"storageAccountType": {
+   "value": "Standard_GRS"
+  }
+}
+TPL
+  vars {
+    "subscription_id" = "${data.azurerm_client_config.current.subscription_id}"
+    "vault_resource_group_name" = "${azurerm_resource_group.test.name}"
+    "vault_name" = "${azurerm_key_vault.test-kv.name}"
+    "secret_name" = "${azurerm_key_vault_secret.test-secret.name}"
+  }
+}
+
+resource "azurerm_template_deployment" "test" {
+  name = "acctesttemplate-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  template_body = <<DEPLOY
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type"
+      }
+    },
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'storage')]",
+    "publicIPAddressName": "[concat('myPublicIp', uniquestring(resourceGroup().id))]",
+    "publicIPAddressType": "Dynamic",
+    "apiVersion": "2015-06-15"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "[variables('apiVersion')]",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsLabelPrefix')]"
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "testOutput": {
+      "type": "string",
+      "value": "Output Value"
+    },
+    "accountName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    }
+  }
+}
+DEPLOY
+
+  parameters_body = "${data.template_file.test-template.rendered}"
+  deployment_mode = "Complete"
+  depends_on = ["azurerm_key_vault_secret.test-secret"]
+}
+`, rInt, location, location, rInt, rInt, rInt, rInt)
+
 }
 
 func testAccAzureRMTemplateDeployment_withParams(rInt int, location string) string {

--- a/website/docs/r/template_deployment.html.markdown
+++ b/website/docs/r/template_deployment.html.markdown
@@ -116,6 +116,10 @@ The following arguments are supported:
 
 * `parameters` - (Optional) Specifies the name and value pairs that define the deployment parameters for the template.
 
+* `parameters_body` - (Optional) Specifies a valid Azure JSON parameters file that define the deployment parameters. It can contain KeyVault references
+
+~> **Note:** There's an [`file` interpolation function available](https://www.terraform.io/docs/configuration/interpolation.html#file-path-) which allows you to read this from an external file, which helps makes this more resource more readable.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Currently, the resource azurerm_template_deployment only supports passing in parameters as a key, value pair. This does not allow the use of parameters that reference a KeyVault that is enabled for template deployment, which is desired in some use-cases. 

One such use-case is executing a bootstrap script when a virtual machine (or scale set) comes online - via the Azure extension mechanism - and inject secrets into the script being executed, without the operator that runs terraform to know their value upfront.

This is enabled similar to the template_body parameter, and it passes the JSON string to the Azure Rest API.