### PR TITLE
`azurerm_load_balancer` - extra tests for frontend_ip_configuration

### DIFF
--- a/azurerm/import_arm_loadbalancer_test.go
+++ b/azurerm/import_arm_loadbalancer_test.go
@@ -28,3 +28,28 @@ func TestAccAzureRMLoadBalancer_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMLoadBalancer_importFrontEnd(t *testing.T) {
+	resourceName := "azurerm_lb.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMLoadBalancer_frontEndConfig(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "frontend_ip_configuration.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -193,7 +193,6 @@ func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient)
 	loadBalancerClient := meta.(*ArmClient).loadBalancerClient
 
 	id, err := parseAzureResourceID(d.Id())
@@ -202,42 +201,6 @@ func resourceArmLoadBalancerDelete(d *schema.ResourceData, meta interface{}) err
 	}
 	resGroup := id.ResourceGroup
 	name := id.Path["loadBalancers"]
-	location := d.Get("location").(string)
-
-	// We need to remove front end ip addresses before deleting the load balancer.
-	if _, ok := d.GetOk("frontend_ip_configuration"); ok {
-		loadbalancer := network.LoadBalancer{
-			Name:     utils.String(name),
-			Location: utils.String(location),
-		}
-		_, error := loadBalancerClient.CreateOrUpdate(resGroup, name, loadbalancer, make(chan struct{}))
-		err := <-error
-		if err != nil {
-			return errwrap.Wrapf("Error Creating/Updating LoadBalancer {{err}}", err)
-		}
-
-		read, err := loadBalancerClient.Get(resGroup, name, "")
-		if err != nil {
-			return errwrap.Wrapf("Error Getting LoadBalancer {{err}", err)
-		}
-		if read.ID == nil {
-			return fmt.Errorf("Cannot read LoadBalancer %s (resource group %s) ID", name, resGroup)
-		}
-
-		d.SetId(*read.ID)
-
-		log.Printf("[DEBUG] Waiting for LoadBalancer (%s) to become available", name)
-		stateConf := &resource.StateChangeConf{
-			Pending: []string{"Accepted", "Updating"},
-			Target:  []string{"Succeeded"},
-			Refresh: loadbalancerStateRefreshFunc(client, resGroup, name),
-			Timeout: 10 * time.Minute,
-		}
-		if _, err := stateConf.WaitForState(); err != nil {
-			return fmt.Errorf("Error waiting for LoadBalancer (%s) to become available: %s", name, err)
-		}
-
-	}
 
 	_, error := loadBalancerClient.Delete(resGroup, name, make(chan struct{}))
 	err = <-error

--- a/azurerm/resource_arm_loadbalancer_test.go
+++ b/azurerm/resource_arm_loadbalancer_test.go
@@ -85,6 +85,13 @@ func TestAccAzureRMLoadBalancer_frontEndConfig(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAzureRMLoadBalancer_frontEndConfigRemovalWithIP(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists(resourceName, &lb),
+					resource.TestCheckResourceAttr(resourceName, "frontend_ip_configuration.#", "1"),
+				),
+			},
+			{
 				Config: testAccAzureRMLoadBalancer_frontEndConfigRemoval(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists(resourceName, &lb),
@@ -258,6 +265,39 @@ resource "azurerm_lb" "test" {
       public_ip_address_id = "${azurerm_public_ip.test1.id}"
     }
 }`, rInt, location, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMLoadBalancer_frontEndConfigRemovalWithIP(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_public_ip" "test1" {
+    name = "another-test-ip-%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}`, rInt, location, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMLoadBalancer_frontEndConfigRemoval(rInt int, location string) string {


### PR DESCRIPTION
Fixs/adds front end load balancer tests.

```
make testacc TEST=./azurerm TESTARGS="-run=TestAccAzureRMLoadBalancer"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMLoadBalancer -timeout 120m
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_importBasic
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_importBasic (88.04s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_importBasic
--- PASS: TestAccAzureRMLoadBalancerNatPool_importBasic (86.58s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_importBasic
--- PASS: TestAccAzureRMLoadBalancerNatRule_importBasic (94.80s)
=== RUN   TestAccAzureRMLoadBalancerProbe_importBasic
--- PASS: TestAccAzureRMLoadBalancerProbe_importBasic (96.77s)
=== RUN   TestAccAzureRMLoadBalancerRule_importBasic
--- PASS: TestAccAzureRMLoadBalancerRule_importBasic (80.09s)
=== RUN   TestAccAzureRMLoadBalancer_importBasic
--- PASS: TestAccAzureRMLoadBalancer_importBasic (71.61s)
=== RUN   TestAccAzureRMLoadBalancer_importFrontEnd
--- PASS: TestAccAzureRMLoadBalancer_importFrontEnd (83.83s)
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_basic
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_basic (86.60s)
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_removal
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_removal (83.00s)
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_reapply
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_reapply (89.45s)
=== RUN   TestAccAzureRMLoadBalancerBackEndAddressPool_disappears
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_disappears (93.96s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_basic
--- PASS: TestAccAzureRMLoadBalancerNatPool_basic (84.12s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_removal
--- PASS: TestAccAzureRMLoadBalancerNatPool_removal (74.16s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_update
--- PASS: TestAccAzureRMLoadBalancerNatPool_update (100.98s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_reapply
--- PASS: TestAccAzureRMLoadBalancerNatPool_reapply (90.76s)
=== RUN   TestAccAzureRMLoadBalancerNatPool_disappears
--- PASS: TestAccAzureRMLoadBalancerNatPool_disappears (83.14s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_basic
--- PASS: TestAccAzureRMLoadBalancerNatRule_basic (95.44s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_removal
--- PASS: TestAccAzureRMLoadBalancerNatRule_removal (102.38s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_update
--- PASS: TestAccAzureRMLoadBalancerNatRule_update (92.15s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_reapply
--- PASS: TestAccAzureRMLoadBalancerNatRule_reapply (96.46s)
=== RUN   TestAccAzureRMLoadBalancerNatRule_disappears
--- PASS: TestAccAzureRMLoadBalancerNatRule_disappears (85.41s)
=== RUN   TestAccAzureRMLoadBalancerProbe_basic
--- PASS: TestAccAzureRMLoadBalancerProbe_basic (79.69s)
=== RUN   TestAccAzureRMLoadBalancerProbe_removal
--- PASS: TestAccAzureRMLoadBalancerProbe_removal (76.58s)
=== RUN   TestAccAzureRMLoadBalancerProbe_update
--- PASS: TestAccAzureRMLoadBalancerProbe_update (76.60s)
=== RUN   TestAccAzureRMLoadBalancerProbe_updateProtocol
--- PASS: TestAccAzureRMLoadBalancerProbe_updateProtocol (90.40s)
=== RUN   TestAccAzureRMLoadBalancerProbe_reapply
--- PASS: TestAccAzureRMLoadBalancerProbe_reapply (87.01s)
=== RUN   TestAccAzureRMLoadBalancerProbe_disappears
--- PASS: TestAccAzureRMLoadBalancerProbe_disappears (67.44s)
=== RUN   TestAccAzureRMLoadBalancerRule_basic
--- PASS: TestAccAzureRMLoadBalancerRule_basic (92.80s)
=== RUN   TestAccAzureRMLoadBalancerRule_removal
--- PASS: TestAccAzureRMLoadBalancerRule_removal (86.23s)
=== RUN   TestAccAzureRMLoadBalancerRule_inconsistentReads
--- PASS: TestAccAzureRMLoadBalancerRule_inconsistentReads (74.76s)
=== RUN   TestAccAzureRMLoadBalancerRule_update
--- PASS: TestAccAzureRMLoadBalancerRule_update (102.49s)
=== RUN   TestAccAzureRMLoadBalancerRule_reapply
--- PASS: TestAccAzureRMLoadBalancerRule_reapply (85.04s)
=== RUN   TestAccAzureRMLoadBalancerRule_disappears
--- PASS: TestAccAzureRMLoadBalancerRule_disappears (95.45s)
=== RUN   TestAccAzureRMLoadBalancer_basic
--- PASS: TestAccAzureRMLoadBalancer_basic (67.54s)
=== RUN   TestAccAzureRMLoadBalancer_frontEndConfig
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfig (101.41s)
=== RUN   TestAccAzureRMLoadBalancer_tags
--- PASS: TestAccAzureRMLoadBalancer_tags (72.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	3116.193s
```