### PR TITLE
Tackling various vmss issues

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -628,14 +628,6 @@ func resourceArmVirtualMachineScaleSetCreate(d *schema.ResourceData, meta interf
 		scaleSetProps.VirtualMachineProfile.DiagnosticsProfile = &diagnosticProfile
 	}
 
-	/* TODO remove this
-	networkConfigurations := scaleSetProps.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-	for _, netConfig := range *networkConfigurations {
-		for _, ipConfig := range *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.IPConfigurations {
-			return fmt.Errorf("Here: %+v", *ipConfig.VirtualMachineScaleSetIPConfigurationProperties.Primary)
-		}
-	}*/
-
 	scaleSetParams := compute.VirtualMachineScaleSet{
 		Name:     &name,
 		Location: &location,

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -253,7 +253,6 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 						"accelerated_networking": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
 						},
 
 						"network_security_group_id": {
@@ -1307,10 +1306,9 @@ func expandAzureRmVirtualMachineScaleSetNetworkProfile(d *schema.ResourceData) *
 			},
 		}
 
-		if v := config["network_security_group_id"]; v != nil {
-			id := v.(string)
+		if v := config["network_security_group_id"].(string); v != "" {
 			networkSecurityGroupId := compute.SubResource{
-				ID: &id,
+				ID: &v,
 			}
 			nProfile.VirtualMachineScaleSetNetworkConfigurationProperties.NetworkSecurityGroup = &networkSecurityGroupId
 		}

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -250,6 +250,17 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 							Required: true,
 						},
 
+						"accelerated_networking": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
+						"network_security_group_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
 						"ip_configuration": {
 							Type:     schema.TypeList,
 							Required: true,
@@ -279,12 +290,61 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 										Elem:     &schema.Schema{Type: schema.TypeString},
 										Set:      schema.HashString,
 									},
+
+									"primary": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+
+									"public_ip_address_configuration": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+
+												"idle_timeout": {
+													Type:         schema.TypeInt,
+													Required:     true,
+													ValidateFunc: validation.IntBetween(4, 32),
+												},
+
+												"domain_name_label": {
+													Type:     schema.TypeString,
+													Required: true,
+												},
+											},
+										},
+									},
 								},
 							},
 						},
 					},
 				},
 				Set: resourceArmVirtualMachineScaleSetNetworkConfigurationHash,
+			},
+
+			"boot_diagnostics": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"storage_uri": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
 			},
 
 			"storage_profile_os_disk": {
@@ -563,6 +623,19 @@ func resourceArmVirtualMachineScaleSetCreate(d *schema.ResourceData, meta interf
 		SinglePlacementGroup: &singlePlacementGroup,
 	}
 
+	if _, ok := d.GetOk("boot_diagnostics"); ok {
+		diagnosticProfile := expandAzureRMVirtualMachineScaleSetsDiagnosticProfile(d)
+		scaleSetProps.VirtualMachineProfile.DiagnosticsProfile = &diagnosticProfile
+	}
+
+	/* TODO remove this
+	networkConfigurations := scaleSetProps.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+	for _, netConfig := range *networkConfigurations {
+		for _, ipConfig := range *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.IPConfigurations {
+			return fmt.Errorf("Here: %+v", *ipConfig.VirtualMachineScaleSetIPConfigurationProperties.Primary)
+		}
+	}*/
+
 	scaleSetParams := compute.VirtualMachineScaleSet{
 		Name:     &name,
 		Location: &location,
@@ -645,6 +718,12 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 	if properties.VirtualMachineProfile.OsProfile.Secrets != nil {
 		if err := d.Set("os_profile_secrets", flattenAzureRmVirtualMachineScaleSetOsProfileSecrets(properties.VirtualMachineProfile.OsProfile.Secrets)); err != nil {
 			return fmt.Errorf("[DEBUG] Error setting Virtual Machine Scale Set OS Profile Secrets error: %#v", err)
+		}
+	}
+
+	if properties.VirtualMachineProfile.DiagnosticsProfile != nil {
+		if err := d.Set("boot_diagnostics", flattenAzureRmVirtualMachineScaleSetBootDiagnostics(properties.VirtualMachineProfile.DiagnosticsProfile.BootDiagnostics)); err != nil {
+			return fmt.Errorf("[DEBUG] Error setting Virutal Machine Scale Set Boot Diagnostics: %#v", err)
 		}
 	}
 
@@ -814,13 +893,27 @@ func flattenAzureRmVirtualMachineScaleSetOsProfileSecrets(secrets *[]compute.Vau
 	return result
 }
 
+func flattenAzureRmVirtualMachineScaleSetBootDiagnostics(bootDiagnostic *compute.BootDiagnostics) []interface{} {
+	b := map[string]interface{}{
+		"enabled":     *bootDiagnostic.Enabled,
+		"storage_uri": *bootDiagnostic.StorageURI,
+	}
+
+	return []interface{}{b}
+}
+
 func flattenAzureRmVirtualMachineScaleSetNetworkProfile(profile *compute.VirtualMachineScaleSetNetworkProfile) []map[string]interface{} {
 	networkConfigurations := profile.NetworkInterfaceConfigurations
 	result := make([]map[string]interface{}, 0, len(*networkConfigurations))
 	for _, netConfig := range *networkConfigurations {
 		s := map[string]interface{}{
-			"name":    *netConfig.Name,
-			"primary": *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.Primary,
+			"name":                   *netConfig.Name,
+			"primary":                *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.Primary,
+			"accelerated_networking": *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.EnableAcceleratedNetworking,
+		}
+
+		if v := netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.NetworkSecurityGroup; v != nil {
+			s["network_security_group_id"] = *v.ID
 		}
 
 		if netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.IPConfigurations != nil {
@@ -849,6 +942,20 @@ func flattenAzureRmVirtualMachineScaleSetNetworkProfile(profile *compute.Virtual
 						inboundNatPools = append(inboundNatPools, *rule.ID)
 					}
 					config["load_balancer_inbound_nat_rules_ids"] = schema.NewSet(schema.HashString, inboundNatPools)
+				}
+
+				if properties.Primary != nil {
+					config["primary"] = *properties.Primary
+				}
+
+				if properties.PublicIPAddressConfiguration != nil {
+					publicIpInfo := properties.PublicIPAddressConfiguration
+					publicIpConfigs := make([]map[string]interface{}, 0, 1)
+					publicIpConfig := make(map[string]interface{})
+					publicIpConfig["name"] = *publicIpInfo.Name
+					publicIpConfig["domain_name_label"] = *publicIpInfo.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.DNSSettings
+					publicIpConfig["idle_timeout"] = *publicIpInfo.VirtualMachineScaleSetPublicIPAddressConfigurationProperties.IdleTimeoutInMinutes
+					config["public_ip_address_configuration"] = publicIpConfigs
 				}
 
 				ipConfigs = append(ipConfigs, config)
@@ -1124,6 +1231,7 @@ func expandAzureRmVirtualMachineScaleSetNetworkProfile(d *schema.ResourceData) *
 
 		name := config["name"].(string)
 		primary := config["primary"].(bool)
+		acceleratedNetworking := config["accelerated_networking"].(bool)
 
 		ipConfigurationConfigs := config["ip_configuration"].([]interface{})
 		ipConfigurations := make([]compute.VirtualMachineScaleSetIPConfiguration, 0, len(ipConfigurationConfigs))
@@ -1165,15 +1273,54 @@ func expandAzureRmVirtualMachineScaleSetNetworkProfile(d *schema.ResourceData) *
 				ipConfiguration.LoadBalancerInboundNatPools = &rulesResources
 			}
 
+			if v := ipconfig["primary"]; v != nil {
+				primary := v.(bool)
+				ipConfiguration.Primary = &primary
+			}
+
+			if v := ipconfig["public_ip_address_configuration"]; v != nil {
+				publicIpConfigs := v.([]interface{})
+				for _, publicIpConfigConfig := range publicIpConfigs {
+					publicIpConfig := publicIpConfigConfig.(map[string]interface{})
+
+					domainNameLabel := publicIpConfig["domain_name_label"].(string)
+					dnsSettings := compute.VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings{
+						DomainNameLabel: &domainNameLabel,
+					}
+
+					idleTimeout := int32(publicIpConfig["idle_timeout"].(int))
+					prop := compute.VirtualMachineScaleSetPublicIPAddressConfigurationProperties{
+						DNSSettings:          &dnsSettings,
+						IdleTimeoutInMinutes: &idleTimeout,
+					}
+
+					publicIPConfigName := publicIpConfig["name"].(string)
+					config := compute.VirtualMachineScaleSetPublicIPAddressConfiguration{
+						Name: &publicIPConfigName,
+						VirtualMachineScaleSetPublicIPAddressConfigurationProperties: &prop,
+					}
+					ipConfiguration.PublicIPAddressConfiguration = &config
+				}
+			}
+
 			ipConfigurations = append(ipConfigurations, ipConfiguration)
 		}
 
 		nProfile := compute.VirtualMachineScaleSetNetworkConfiguration{
 			Name: &name,
 			VirtualMachineScaleSetNetworkConfigurationProperties: &compute.VirtualMachineScaleSetNetworkConfigurationProperties{
-				Primary:          &primary,
-				IPConfigurations: &ipConfigurations,
+				Primary:                     &primary,
+				IPConfigurations:            &ipConfigurations,
+				EnableAcceleratedNetworking: &acceleratedNetworking,
 			},
+		}
+
+		if v := config["network_security_group_id"]; v != nil {
+			id := v.(string)
+			networkSecurityGroupId := compute.SubResource{
+				ID: &id,
+			}
+			nProfile.VirtualMachineScaleSetNetworkConfigurationProperties.NetworkSecurityGroup = &networkSecurityGroupId
 		}
 
 		networkProfileConfig = append(networkProfileConfig, nProfile)
@@ -1233,6 +1380,25 @@ func expandAzureRMVirtualMachineScaleSetsOsProfile(d *schema.ResourceData) (*com
 	}
 
 	return osProfile, nil
+}
+
+func expandAzureRMVirtualMachineScaleSetsDiagnosticProfile(d *schema.ResourceData) compute.DiagnosticsProfile {
+	bootDiagnosticConfigs := d.Get("boot_diagnostics").([]interface{})
+	bootDiagnosticConfig := bootDiagnosticConfigs[0].(map[string]interface{})
+
+	enabled := bootDiagnosticConfig["enabled"].(bool)
+	storageURI := bootDiagnosticConfig["storage_uri"].(string)
+
+	bootDiagnostic := &compute.BootDiagnostics{
+		Enabled:    &enabled,
+		StorageURI: &storageURI,
+	}
+
+	diagnosticsProfile := compute.DiagnosticsProfile{
+		BootDiagnostics: bootDiagnostic,
+	}
+
+	return diagnosticsProfile
 }
 
 func expandAzureRMVirtualMachineScaleSetsStorageProfileOsDisk(d *schema.ResourceData) (*compute.VirtualMachineScaleSetOSDisk, error) {

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -257,6 +257,7 @@ The following arguments are supported:
 * `storage_profile_data_disk` - (Optional) A storage profile data disk block as documented below
 * `storage_profile_image_reference` - (Optional) A storage profile image reference block as documented below.
 * `extension` - (Optional) Can be specified multiple times to add extension profiles to the scale set. Each `extension` block supports the fields documented below.
+* `boot_diagnostics` - (Optional) A boot diagnostics profile block as referenced below.
 * `plan` - (Optional) A plan block as documented below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -317,6 +318,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the network interface configuration.
 * `primary` - (Required) Indicates whether network interfaces created from the network interface configuration will be the primary NIC of the VM.
 * `ip_configuration` - (Required) An ip_configuration block as documented below
+* `network_security_group_id` - (Optional) Specifies the identifier for the network security group.
 
 `ip_configuration` supports the following:
 
@@ -324,6 +326,17 @@ The following arguments are supported:
 * `subnet_id` - (Required) Specifies the identifier of the subnet.
 * `load_balancer_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of load balancers. A scale set can reference backend address pools of one public and one internal load balancer. Multiple scale sets cannot use the same load balancer.
 * `load_balancer_inbound_nat_rules_ids` - (Optional) Specifies an array of references to inbound NAT rules for load balancers.
+* `primary` - (Optional) Specifies if this ip_configuration is the primary one.
+* `accelerated_networking` - (Optional) Specifies whether to enable accelerated networking or not. Defaults to
+false.
+* `public_ip_address_configuration` - (Optional) describes a virtual machines scale set IP Configuration's
+ PublicIPAddress configuration. The public_ip_address_configuration is documented below.
+
+`public_ip_address_configuration` supports the following:
+
+* `name` - (Required) The name of the public ip address configuration
+* `idle_timeout` - (Required) The idle timeout in minutes. This value must be between 4 and 32.
+* `domain_name_label` - (Required) The domain name label for the dns settings.
 
 `storage_profile_os_disk` supports the following:
 
@@ -353,6 +366,12 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 * `offer` - (Optional) Specifies the offer of the image used to create the virtual machines.
 * `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
 * `version` - (Optional) Specifies the version of the image used to create the virtual machines.
+
+`boot_diagnostics` supports the following:
+
+* `enabled`: (Required) Whether to enable boot diagnostics for the virtual machine.
+* `storage_uri`: (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
+
 
 `extension` supports the following:
 


### PR DESCRIPTION
This PR adds the new sdk features to virtual machine scale sets and fixes #160, #339, and #340 

```
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicPublicIP
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicPublicIP (402.10s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_bootDiagnostic
--- PASS: TestAccAzureRMVirtualMachineScaleSet_bootDiagnostic (400.54s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_networkSecurityGroup
--- PASS: TestAccAzureRMVirtualMachineScaleSet_networkSecurityGroup (400.65s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicAcceleratedNetworking
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicAcceleratedNetworking (339.38s)
```