### PR TITLE
`azurerm_app_service`: documentation updates

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 * `always_on` - (Optional) Should the app be loaded at all times? Defaults to `false`.
 * `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
-* `dotnet_framework_version` - (Optional) The version of the .net framework used in this App Service. Possible values are `v2.0` (which corresponds to `v3.5`) and `v4.0` (which is `v4.7` at the time of writing). Defaults to `v4.0`.
+* `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`) and `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`). [For more information on which .net CLR version to use based on the .net framework you're targetting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
 
 * `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7` and `1.8`.
 * `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.


### PR DESCRIPTION
Documenting how the CLR version corresponds to the .net framework version. This could make more sense as a table - but I've linked to Wikipedia for the moment.

Fixes #446