### PR TITLE
Documentation: fixing the sidebar highlight

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -90,7 +90,7 @@
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-app-service") %>>
+            <li<%= sidebar_current("docs-azurerm-resource-role") %>>
               <a href="#">Authorization Resources</a>
               <ul class="nav nav-visible">
 
@@ -416,7 +416,7 @@
               <ul class="nav nav-visible">
 
                 <li<%= sidebar_current("docs-azurerm-resource-network-application-gateway") %>>
-                  <a href="/docs/providers/azurerm/r/application_gateway.html">azurerm_application_gateway</a> 
+                  <a href="/docs/providers/azurerm/r/application_gateway.html">azurerm_application_gateway</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-resource-network-express-route-circuit") %>>


### PR DESCRIPTION
Noticed the highlight was broken for Role Assignments/Definitions