### PR TITLE
Documentation: specifying the syntax for code where needed

### DIFF
--- a/website/docs/authenticating_via_azure_cli.html.markdown
+++ b/website/docs/authenticating_via_azure_cli.html.markdown
@@ -23,7 +23,7 @@ This guide assumes that you have [the Azure CLI 2.0 (Python)](https://github.com
 
 ~> **Note:** if you're using the **China**, **German** or **Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
 
-```
+```shell
 $ az cloud set --name AzureChinaCloud|AzureGermanCloud|AzureUSGovernment
 ```
 

--- a/website/docs/authenticating_via_service_principal.html.markdown
+++ b/website/docs/authenticating_via_service_principal.html.markdown
@@ -23,7 +23,7 @@ It's possible to complete this task in either the [Azure CLI](#creating-a-servic
 
 ~> **Note**: if you're using the **China**, **German** or **Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
 
-```
+```shell
 $ az cloud set --name AzureChinaCloud|AzureGermanCloud|AzureUSGovernment
 ```
 
@@ -107,7 +107,7 @@ $ az vm list-sizes --location westus
 
 ~> **Note**: If you're using the **China**, **German** or **Government** Azure Clouds - you will need to switch `westus` out for another region. You can find which regions are available by running:
 
-```
+```shell
 $ az account list-locations
 ```
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -150,6 +150,6 @@ The following attributes are exported:
 
 App Services can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_app_service.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/instance1
 ```

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -75,6 +75,6 @@ The following attributes are exported:
 
 App Service Plan instances can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_app_service_plan.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/serverfarms/instance1
 ```

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -3,7 +3,7 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azure_application_gateway"
 sidebar_current: "docs-azurerm-resource-application-gateway"
 description: |-
-  Creates a new application gateway based on a previously created virtual network with configured subnets. 
+  Creates a new application gateway based on a previously created virtual network with configured subnets.
 ---
 
 # azurerm\_application\_gateway
@@ -18,7 +18,7 @@ resource "azurerm_resource_group" "rg" {
   name     = "my-rg-application-gateway-12345"
   location = "West US"
 }
- 
+
 # Create a application gateway in the web_servers resource group
 resource "azurerm_virtual_network" "vnet" {
   name                = "my-vnet-12345"
@@ -53,23 +53,23 @@ resource "azurerm_application_gateway" "network" {
   name                = "my-application-gateway-12345"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   location            = "West US"
- 
+
   sku {
     name           = "Standard_Small"
     tier           = "Standard"
     capacity       = 2
   }
- 
+
   gateway_ip_configuration {
       name         = "my-gateway-ip-configuration"
       subnet_id    = "${azurerm_virtual_network.vnet.id}/subnets/${azurerm_subnet.sub1.name}"
   }
- 
+
   frontend_port {
       name         = "${azurerm_virtual_network.vnet.name}-feport"
       port         = 80
   }
- 
+
   frontend_ip_configuration {
       name         = "${azurerm_virtual_network.vnet.name}-feip"  
       public_ip_address_id = "${azurerm_public_ip.pip.id}"
@@ -78,7 +78,7 @@ resource "azurerm_application_gateway" "network" {
   backend_address_pool {
       name = "${azurerm_virtual_network.vnet.name}-beap"
   }
- 
+
   backend_http_settings {
       name                  = "${azurerm_virtual_network.vnet.name}-be-htst"
       cookie_based_affinity = "Disabled"
@@ -86,14 +86,14 @@ resource "azurerm_application_gateway" "network" {
       protocol              = "Http"
      request_timeout        = 1
   }
- 
+
   http_listener {
         name                                  = "${azurerm_virtual_network.vnet.name}-httplstn"
         frontend_ip_configuration_name        = "${azurerm_virtual_network.vnet.name}-feip"
         frontend_port_name                    = "${azurerm_virtual_network.vnet.name}-feport"
         protocol                              = "Http"
   }
- 
+
   request_routing_rule {
           name                       = "${azurerm_virtual_network.vnet.name}-rqrt"
           rule_type                  = "Basic"
@@ -176,7 +176,7 @@ The `frontend_ip_configuration` block supports:
 
 * `name` - (Required) User defined name for a frontend IP configuration.
 
-* `subnet_id` - (Optional) Reference to a Subnet. 
+* `subnet_id` - (Optional) Reference to a Subnet.
 
 * `private_ip_address` - (Optional) Private IP Address.
 
@@ -220,7 +220,7 @@ The `http_listener` block supports:
 
 * `frontend_ip_configuration_name` - (Required) Reference to frontend Ip configuration.
 
-* `frontend_port_name` - (Required) Reference to frontend port. 
+* `frontend_port_name` - (Required) Reference to frontend port.
 
 * `protocol` - (Required) Valid values are:
   * `Http`
@@ -230,7 +230,7 @@ The `http_listener` block supports:
 
 * `ssl_certificate_name` - (Optional) Reference to ssl certificate. Valid only if protocol is https.
 
-* `require_sni` - (Optional) Applicable only if protocol is https. Enables SNI for multi-hosting. 
+* `require_sni` - (Optional) Applicable only if protocol is https. Enables SNI for multi-hosting.
 Valid values are:
 * true
 * false
@@ -286,7 +286,7 @@ The `path_rule` block supports:
 
 * `paths` - (Required) The list of path patterns to match. Each must start with / and the only place a * is allowed is at the end following a /. The string fed to the path matcher does not include any text after the first ? or #, and those chars are not allowed here.
 
-* `backend_address_pool_name` - (Required) Reference to `backend_address_pool_name`. 
+* `backend_address_pool_name` - (Required) Reference to `backend_address_pool_name`.
 
 * `backend_http_settings_name` - (Required) Reference to `backend_http_settings`.
 
@@ -311,10 +311,10 @@ The `waf_configuration` block supports:
 * `firewall_mode` - (Required) Firewall mode.  Valid values are:
   * `Detection`
   * `Prevention`
-  
+
 * `rule_set_type` - (Required) Rule set type.  Must be set to `OWASP`
 
-* `rule_set_version` - (Required) Ruleset version. Supported values: 
+* `rule_set_version` - (Required) Ruleset version. Supported values:
   * `2.2.9`
   * `3.0`
 
@@ -337,8 +337,7 @@ The following attributes are exported:
 
 application gateways can be imported using the `resource id`, e.g.
 
-```
- 
+```shell 
 terraform import azurerm_application_gateway.testApplicationGateway /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/applicationGateways/myGateway1
- 
+
 ```

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -57,6 +57,6 @@ The following attributes are exported:
 
 Application Insights instances can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_application_insights.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.insights/components/instance1
 ```

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -12,7 +12,7 @@ Creates a new Automation Account.
 
 ## Example Usage
 
-```
+```hcl
 resource "azurerm_resource_group" "example" {
  name = "resourceGroup1"
  location = "West Europe"
@@ -61,6 +61,6 @@ The following attributes are exported:
 
 Automation Accounts can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_automation_account.account1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1
 ```

--- a/website/docs/r/automation_credential.html.markdown
+++ b/website/docs/r/automation_credential.html.markdown
@@ -12,7 +12,7 @@ Creates a new Automation Credential.
 
 ## Example Usage
 
-```
+```hcl
 resource "azurerm_resource_group" "example" {
  name = "resourceGroup1"
  location = "West Europe"
@@ -63,6 +63,6 @@ The following attributes are exported:
 
 Automation Credentials can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_automation_credential.credential1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1/credentials/credential1
 ```

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -12,7 +12,7 @@ Creates a new Automation Runbook.
 
 ## Example Usage
 
-```
+```hcl
 resource "azurerm_resource_group" "example" {
  name = "resourceGroup1"
  location = "West Europe"
@@ -78,6 +78,6 @@ The following attributes are exported:
 
 Automation Runbooks can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_automation_runbook.Get-AzureVMTutorial /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1/runbooks/Get-AzureVMTutorial
 ```

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -12,7 +12,7 @@ Creates a new Automation Schedule.
 
 ## Example Usage
 
-```
+```hcl
 resource "azurerm_resource_group" "example" {
  name = "resourceGroup1"
  location = "West Europe"
@@ -68,6 +68,6 @@ The following attributes are exported:
 
 Automation Schedule can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_automation_schedule.schedule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Automation/automationAccounts/account1/schedules/schedule1
 ```

--- a/website/docs/r/availability_set.html.markdown
+++ b/website/docs/r/availability_set.html.markdown
@@ -59,6 +59,6 @@ The following attributes are exported:
 
 Availability Sets can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_availability_set.group1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/availabilitySets/webAvailSet
 ```

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -92,6 +92,6 @@ The following attributes are exported:
 
 CDN Endpoints can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_cdn_endpoint.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Cdn/profiles/myprofile1/endpoints/myendpoint1
 ```

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -57,6 +57,6 @@ The following attributes are exported:
 
 CDN Profiles can be imported using the `resource id`, e.g.
 
-```hcl
+```shell
 terraform import azurerm_cdn_profile.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Cdn/profiles/myprofile1
 ```

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -79,6 +79,6 @@ The following attributes are exported:
 
 Container Registries can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_container_registry.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/mygroup1/providers/Microsoft.ContainerRegistry/registries/myregistry1
 ```

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -97,6 +97,6 @@ The following attributes are exported:
 
 CosmosDB Accounts can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_cosmosdb_account.account1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DocumentDB/databaseAccounts/account1
 ```

--- a/website/docs/r/dns_a_record.html.markdown
+++ b/website/docs/r/dns_a_record.html.markdown
@@ -58,6 +58,6 @@ The following attributes are exported:
 
 A records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_a_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/A/myrecord1
 ```

--- a/website/docs/r/dns_aaaa_record.html.markdown
+++ b/website/docs/r/dns_aaaa_record.html.markdown
@@ -58,6 +58,6 @@ The following attributes are exported:
 
 AAAA records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_aaaa_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/AAAA/myrecord1
 ```

--- a/website/docs/r/dns_cname_record.html.markdown
+++ b/website/docs/r/dns_cname_record.html.markdown
@@ -58,6 +58,6 @@ The following attributes are exported:
 
 CNAME records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_cname_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/CNAME/myrecord1
 ```

--- a/website/docs/r/dns_mx_record.html.markdown
+++ b/website/docs/r/dns_mx_record.html.markdown
@@ -76,6 +76,6 @@ The following attributes are exported:
 
 MX records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_mx_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/MX/myrecord1
 ```

--- a/website/docs/r/dns_ns_record.html.markdown
+++ b/website/docs/r/dns_ns_record.html.markdown
@@ -72,6 +72,6 @@ The following attributes are exported:
 
 NS records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_ns_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/NS/myrecord1
 ```

--- a/website/docs/r/dns_ptr_record.html.markdown
+++ b/website/docs/r/dns_ptr_record.html.markdown
@@ -58,6 +58,6 @@ The following attributes are exported:
 
 PTR records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_ptr_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/PTR/myrecord1
 ```

--- a/website/docs/r/dns_srv_record.html.markdown
+++ b/website/docs/r/dns_srv_record.html.markdown
@@ -78,6 +78,6 @@ The following attributes are exported:
 
 SRV records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_srv_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/SRV/myrecord1
 ```

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -72,6 +72,6 @@ The following attributes are exported:
 
 TXT records can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_txt_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/TXT/myrecord1
 ```

--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -47,6 +47,6 @@ The following attributes are exported:
 
 DNS Zones can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_dns_zone.zone1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1
 ```

--- a/website/docs/r/eventgrid_topic.html.markdown
+++ b/website/docs/r/eventgrid_topic.html.markdown
@@ -60,6 +60,6 @@ The following attributes are exported:
 
 EventGrid Topic's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_eventgrid_topic.topic1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventGrid/topics/topic1
 ```

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -65,6 +65,6 @@ The following attributes are exported:
 
 EventHubs can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_eventhub.eventhub1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1
 ```

--- a/website/docs/r/eventhub_authorization_rule.html.markdown
+++ b/website/docs/r/eventhub_authorization_rule.html.markdown
@@ -87,6 +87,6 @@ The following attributes are exported:
 
 EventHubs can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_eventhub_authorization_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/authorizationRules/rule1
 ```

--- a/website/docs/r/eventhub_consumer_group.html.markdown
+++ b/website/docs/r/eventhub_consumer_group.html.markdown
@@ -71,6 +71,6 @@ The following attributes are exported:
 
 EventHub Consumer Groups can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_eventhub_consumer_group.consumerGroup1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/eventhubs/eventhub1/consumergroups/consumerGroup1
 ```

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -72,6 +72,6 @@ The following attributes are exported only if there is an authorization rule nam
 
 EventHub Namespaces can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_eventhub_namespace.namespace1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1
 ```

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -84,6 +84,6 @@ The following attributes are exported:
 
 ExpressRoute circuits can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_express_route_circuit.myExpressRoute /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/expressRouteCircuits/myExpressRoute
 ```

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -89,6 +89,6 @@ The following attributes are exported:
 
 Image can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_image.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.compute/images/image1
 ```

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -122,6 +122,6 @@ The following attributes are exported:
 
 Key Vault's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_key_vault.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.KeyVault/vaults/vault1
 ```

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -251,6 +251,6 @@ The following attributes are exported:
 
 Key Vault Certificates can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_key_vault_certificate.test https://example-keyvault.vault.azure.net/certificates/example/fdf067c93bbb4b22bff4d8b7a9a56217
 ```

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -98,6 +98,6 @@ The following attributes are exported:
 
 Key Vault Key which is Enabled can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_key_vault_key.test https://example-keyvault.vault.azure.net/keys/example/fdf067c93bbb4b22bff4d8b7a9a56217
 ```

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -87,6 +87,6 @@ The following attributes are exported:
 
 Key Vault Secrets which are Enabled can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_key_vault_secret.test https://example-keyvault.vault.azure.net/secrets/example/fdf067c93bbb4b22bff4d8b7a9a56217
 ```

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -66,7 +66,6 @@ The following attributes are exported:
 
 Load Balancers can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_lb.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1
 ```
-

--- a/website/docs/r/loadbalancer_backend_address_pool.html.markdown
+++ b/website/docs/r/loadbalancer_backend_address_pool.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create a LoadBalancer Backend Address Pool.
 
-~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+~> **NOTE:** When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
 
 ## Example Usage
 
@@ -63,6 +63,6 @@ The following attributes are exported:
 
 Load Balancer Backend Address Pools can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_lb_backend_address_pool.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/pool1
 ```

--- a/website/docs/r/loadbalancer_nat_pool.html.markdown
+++ b/website/docs/r/loadbalancer_nat_pool.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create a LoadBalancer NAT pool.
 
-~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+~> **NOTE** When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
 
 ## Example Usage
 
@@ -73,6 +73,6 @@ The following attributes are exported:
 
 Load Balancer NAT Pools can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_lb_nat_pool.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatPools/pool1
 ```

--- a/website/docs/r/loadbalancer_nat_rule.html.markdown
+++ b/website/docs/r/loadbalancer_nat_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create a LoadBalancer NAT Rule.
 
-~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+~> **NOTE** When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
 
 ## Example Usage
 
@@ -71,6 +71,6 @@ The following attributes are exported:
 
 Load Balancer NAT Rules can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_lb_nat_rule.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/rule1
 ```

--- a/website/docs/r/loadbalancer_probe.html.markdown
+++ b/website/docs/r/loadbalancer_probe.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create a LoadBalancer Probe Resource.
 
-~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+~> **NOTE** When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
 
 ## Example Usage
 
@@ -70,6 +70,6 @@ The following attributes are exported:
 
 Load Balancer Probes can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_lb_probe.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/probes/probe1
 ```

--- a/website/docs/r/loadbalancer_rule.html.markdown
+++ b/website/docs/r/loadbalancer_rule.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create a LoadBalancer Rule.
 
-~> **NOTE When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
+~> **NOTE** When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
 
 ## Example Usage
 
@@ -76,6 +76,6 @@ The following attributes are exported:
 
 Load Balancer Rules can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_lb_rule.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/loadBalancingRules/rule1
 ```

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -51,6 +51,6 @@ The following attributes are exported:
 
 Local Network Gateways can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_local_network_gateway.lng1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/localNetworkGateways/lng1
 ```

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -136,6 +136,6 @@ The following attributes are exported:
 
 Managed Disks can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_managed_disk.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.compute/disks/manageddisk1
 ```

--- a/website/docs/r/mysql_configuration.html.markdown
+++ b/website/docs/r/mysql_configuration.html.markdown
@@ -66,6 +66,6 @@ The following attributes are exported:
 
 MySQL Configurations can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_mysql_configuration.interactive_timeout /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforMySQL/servers/server1/configurations/interactive_timeout
 ```

--- a/website/docs/r/mysql_database.html.markdown
+++ b/website/docs/r/mysql_database.html.markdown
@@ -69,6 +69,6 @@ The following attributes are exported:
 
 MySQL Database's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_mysql_database.database1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforMySQL/servers/server1/databases/database1
 ```

--- a/website/docs/r/mysql_firewall_rule.html.markdown
+++ b/website/docs/r/mysql_firewall_rule.html.markdown
@@ -76,6 +76,6 @@ The following attributes are exported:
 
 MySQL Firewall Rule's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_mysql_firewall_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforMySQL/servers/server1/firewallRules/rule1
 ```

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -102,6 +102,6 @@ The following attributes are exported:
 
 MySQL Server's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_mysql_server.server1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforMySQL/servers/server1
 ```

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -105,6 +105,6 @@ The following attributes are exported:
 
 Network Interfaces can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_network_interface.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1
 ```

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -95,6 +95,6 @@ The following attributes are exported:
 
 Network Security Groups can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_network_security_group.group1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/networkSecurityGroups/mySecurityGroup
 ```

--- a/website/docs/r/network_security_rule.html.markdown
+++ b/website/docs/r/network_security_rule.html.markdown
@@ -83,6 +83,6 @@ The following attributes are exported:
 
 Network Security Rules can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_network_security_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/networkSecurityGroups/mySecurityGroup/securityRules/rule1
 ```

--- a/website/docs/r/postgresql_configuration.html.markdown
+++ b/website/docs/r/postgresql_configuration.html.markdown
@@ -66,6 +66,6 @@ The following attributes are exported:
 
 PostgreSQL Configurations can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_postgresql_configuration.backslash_quote /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforPostgreSQL/servers/server1/configurations/backslash_quote
 ```

--- a/website/docs/r/postgresql_database.html.markdown
+++ b/website/docs/r/postgresql_database.html.markdown
@@ -70,6 +70,6 @@ The following attributes are exported:
 
 PostgreSQL Database's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_postgresql_database.database1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforPostgreSQL/servers/server1/databases/database1
 ```

--- a/website/docs/r/postgresql_firewall_rule.html.markdown
+++ b/website/docs/r/postgresql_firewall_rule.html.markdown
@@ -77,6 +77,6 @@ The following attributes are exported:
 
 PostgreSQL Firewall Rule's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_postgresql_firewall_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforPostgreSQL/servers/server1/firewallRules/rule1
 ```

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -104,6 +104,6 @@ The following attributes are exported:
 
 PostgreSQL Server's can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_postgresql_server.server1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DBforPostgreSQL/servers/server1
 ```

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -70,6 +70,6 @@ The following attributes are exported:
 
 Public IPs can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_public_ip.myPublicIp /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/publicIPAddresses/myPublicIpAddress1
 ```

--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -46,6 +46,6 @@ The following attributes are exported:
 
 Resource Groups can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_resource_group.mygroup /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup
 ```

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_role_assignment" "test" {
 
 ## Example Usage (Custom Role & Service Principal)
 
-```
+```hcl
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}
@@ -62,7 +62,7 @@ resource "azurerm_role_assignment" "test" {
 
 ## Example Usage (Custom Role & User)
 
-```
+```hcl
 data "azurerm_subscription" "primary" {}
 
 data "azurerm_client_config" "test" {}
@@ -113,6 +113,6 @@ The following attributes are exported:
 
 Role Assignments can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_role_assignment.test /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000
 ```

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -65,6 +65,6 @@ The following attributes are exported:
 
 Role Definitions can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_role_definition.test /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/00000000-0000-0000-0000-000000000000
 ```

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -59,6 +59,6 @@ The following attributes are exported:
 
 Routes can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_route.testRoute /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/routeTables/mytable1/routes/myroute1
 ```

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -56,9 +56,9 @@ The `route` block supports:
 
 * `address_prefix` - (Required) The destination CIDR to which the route applies, such as 10.1.0.0/16
 
-* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal``, `Internet`, `VirtualAppliance` and `None`.
+* `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`.
 
-* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance``.
+* `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance`.
 
 
 ## Attributes Reference
@@ -72,6 +72,6 @@ The following attributes are exported:
 
 Route Tables can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_route_table.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/routeTables/mytable1
 ```

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -58,6 +58,6 @@ The following attributes are exported:
 
 Search Services can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_search_service.service1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Search/searchServices/service1
 ```

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -71,6 +71,6 @@ The following attributes are exported only if there is an authorization rule nam
 
 Service Bus Namespace can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_servicebus_namespace.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1
 ```

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -12,7 +12,7 @@ Create and manage a ServiceBus Queue.
 
 ## Example Usage
 
-```
+```hcl
 resource "azurerm_resource_group" "test" {
   name     = "resourceGroup1"
   location = "West US"
@@ -103,6 +103,6 @@ The following attributes are exported:
 
 Service Bus Queue can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_servicebus_queue.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1/queues/snqueue1
 ```

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -106,6 +106,6 @@ The following attributes are exported:
 
 Service Bus Subscriptions can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_servicebus_subscription.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1/topics/sntopic1/subscriptions/sbsub1
 ```

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -107,6 +107,6 @@ The following attributes are exported:
 
 Service Bus Topics can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_servicebus_topic.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1/topics/sntopic1
 ```

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -70,6 +70,6 @@ The following attributes are exported:
 
 Snapshots can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_snapshot.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/snapshots/snapshot1
 ```

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -75,7 +75,6 @@ The following attributes are exported:
 
 SQL Databases can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_sql_database.database1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver/databases/database1
 ```
-

--- a/website/docs/r/sql_firewall_rule.html.markdown
+++ b/website/docs/r/sql_firewall_rule.html.markdown
@@ -61,6 +61,6 @@ The following attributes are exported:
 
 SQL Firewall Rules can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_sql_firewall_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver/firewallRules/rule1
 ```

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -64,6 +64,6 @@ The following attributes are exported:
 
 SQL Servers can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_sql_server.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver
 ```

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -106,6 +106,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 Storage Accounts can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_storage_account.storageAcc1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Storage/storageAccounts/myaccount
 ```

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -69,6 +69,6 @@ The following attributes are exported:
 
 Subnets can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_subnet.testSubnet /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1
 ```

--- a/website/docs/r/traffic_manager_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_endpoint.html.markdown
@@ -106,6 +106,6 @@ The following attributes are exported:
 
 Traffic Manager Endpoints can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_traffic_manager_endpoint.testEndpoints /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/trafficManagerProfiles/mytrafficmanagerprofile1/azureEndpoints/mytrafficmanagerendpoint
 ```

--- a/website/docs/r/traffic_manager_profile.html.markdown
+++ b/website/docs/r/traffic_manager_profile.html.markdown
@@ -97,6 +97,6 @@ The Traffic Manager is created with the location `global`.
 
 Traffic Manager Profiles can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_traffic_manager_profile.testProfile /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/trafficManagerProfiles/mytrafficmanagerprofile1
 ```

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -146,7 +146,7 @@ The following arguments are supported:
     be found using the Azure CLI.
 
 ~> **Note:** The `Publisher` and `Type` of Virtual Machine Extensions can be found using the Azure CLI, via:
-```
+```shell
 $ az vm extension image list --location westus -o table
 ```
 
@@ -172,6 +172,6 @@ The following attributes are exported:
 
 Virtual Machine Extensions can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_virtual_machine_extension.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/virtualMachines/myVM/extensions/hostname
 ```

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -420,6 +420,6 @@ The following attributes are exported:
 
 Virtual Machine Scale Sets can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_virtual_machine_scale_set.scaleset1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleset1
 ```

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -99,6 +99,6 @@ The following attributes are exported:
 
 Virtual Networks can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_virtual_network.testNetwork /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1
 ```

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -97,6 +97,6 @@ Virtual Network peerings cannot be created, updated or deleted concurrently.
 
 Virtual Network Peerings can be imported using the `resource id`, e.g.
 
-```
+```shell
 terraform import azurerm_virtual_network_peering.testPeering /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/virtualNetworkPeerings/myvnet1peering
 ```


### PR DESCRIPTION
Noticed a ton of these were missing - added the missing syntax flag where needed