### PR TITLE
EnableAcceleratedNetworking is not always returned by the Azure virtual-machine-scale-set API

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -898,9 +898,12 @@ func flattenAzureRmVirtualMachineScaleSetNetworkProfile(profile *compute.Virtual
 	result := make([]map[string]interface{}, 0, len(*networkConfigurations))
 	for _, netConfig := range *networkConfigurations {
 		s := map[string]interface{}{
-			"name":                   *netConfig.Name,
-			"primary":                *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.Primary,
-			"accelerated_networking": *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.EnableAcceleratedNetworking,
+			"name":    *netConfig.Name,
+			"primary": *netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.Primary,
+		}
+
+		if v := netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.EnableAcceleratedNetworking; v != nil {
+			s["accelerated_networking"] = *v
 		}
 
 		if v := netConfig.VirtualMachineScaleSetNetworkConfigurationProperties.NetworkSecurityGroup; v != nil {


### PR DESCRIPTION
Using Terraform 0.10.8 and AzureRM 0.3.2, I was getting a crash when running terraform apply. 

Unfortunately I can't attach the crash.log as my client is concerned about privacy, but I can send it privately if someone wants it. I've included some relevant sections in this PR which I hope will be enough to explain the problem.

I've taken a look at where the AzureRM provider is crashing in the crash.log:

```
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4: panic: runtime error: invalid memory address or nil pointer dereference
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ed879f]
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4:
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4: goroutine 962 [running]:
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4: github.com/terraform-providers/terraform-provider-azurerm/azurerm.flattenAzureRmVirtualMachineS
caleSetNetworkProfile(0xc42186b960, 0x220101a, 0x17, 0x1fbe440)
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4:   /opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_machine_scale_set.go:903 +0x27f
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4: github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmVirtualMachineScaleSetRead(0xc42238d110, 0x21220c0, 0xc423d2a000, 0x0, 0x2bea4c0)
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4:   /opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_machine_scale_set.go:733 +0xcc3
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc423cb84e0, 0xc42216e870, 0x21220c0, 0xc423d2a000, 0xc422ebd598, 0xc420bc7b01, 0x1080001125eab)
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4:   /opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:321 +0x199
2017-11-01T11:59:53.509Z [DEBUG] plugin.terraform-provider-azurerm_v0.3.2_x4: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc42227ad20, 0xc42216e820, 0xc42216e870, 0x30d8458, 0x0, 0xc420bc7b98)
```

It looks like the provider fails in line 903 of resource_arm_virtual_machine_scale_set.go, where the code is trying to access a field called `accelerated_networking`, however... it looks like this doesn't always get returned by the Azure API (also taken from the crash.log just above where the crash happens)...

```
{
  "networkProfile": {
    "networkInterfaceConfigurations": [
      {
        "name": "retail-bastion-eth0",
        "properties": {
          "primary": true,
          "ipConfigurations": [
            {
              "name": "retail-dev-management-bastion-frontend-ip-configuration",
              "properties": {
                "subnet": {
                  "id": "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeeee/resourceGroups/retail-dev-management-rg/providers/Microsoft.Network/virtualNetworks/retail-dev-management-vnet/subnets/retail-bastion-subnet"
                },
                "loadBalancerBackendAddressPools": [
                  {
                    "id": "/subscriptions/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeeee/resourceGroups/retail-dev-management-rg/providers/Microsoft.Network/loadBalancers/retail-dev-management-bastion-lb/backendAddressPools/retail"
                  }
                ]
              }
            }
          ]
        }
      }
    ]
  }
}
```

This change makes the response optional (or at least that is the intention... this is my first contribution to a Go project - I've run tests and the seem to pass, and it solves the problem I was having, but I'd very much appreciate any feedback).