### PR TITLE
Fixing a broken VMSS test

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -2826,7 +2826,8 @@ resource "azurerm_storage_account" "test" {
     name = "accsa%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     location = "${azurerm_resource_group.test.location}"
-    account_type = "Standard_LRS"
+    account_tier = "Standard"
+    account_replication_type = "LRS"
 
     tags {
         environment = "staging"


### PR DESCRIPTION
Updating `TestAccAzureRMVirtualMachineScaleSet_multipleNetworkProfiles` to use the split out storage account fields, added after we'd migrated