### PR TITLE
remove illegal character from names

### DIFF
--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -14,12 +14,12 @@ Create an Azure Storage File Share.
 
 ```hcl
 resource "azurerm_resource_group" "test" {
-  name     = "acctestrg-%d"
+  name     = "azuretest"
   location = "westus"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
+  name                     = "azureteststorage"
   resource_group_name      = "${azurerm_resource_group.test.name}"
   location                 = "westus"
   account_tier             = "Standard"

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -14,12 +14,12 @@ Create an Azure Storage Table.
 
 ```hcl
 resource "azurerm_resource_group" "test" {
-  name     = "acctestrg-%d"
+  name     = "azuretest"
   location = "westus"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
+  name                     = "azureteststorage1"
   resource_group_name      = "${azurerm_resource_group.test.name}"
   location                 = "westus"
   account_tier             = "Standard"


### PR DESCRIPTION
`%s` and `%d` were included in name strings, but these are not acceptable by Azure