### PR TITLE
Fixed the load balancer rule name.

### DIFF
--- a/website/docs/r/loadbalancer_nat_rule.html.markdown
+++ b/website/docs/r/loadbalancer_nat_rule.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_lb" "test" {
 resource "azurerm_lb_nat_rule" "test" {
   resource_group_name            = "${azurerm_resource_group.test.name}"
   loadbalancer_id                = "${azurerm_lb.test.id}"
-  name                           = "RDP Access"
+  name                           = "RDPAccess"
   protocol                       = "Tcp"
   frontend_port                  = 3389
   backend_port                   = 3389


### PR DESCRIPTION
The azurerm_lb_nat_rule script has an error. The load balancer rule name is RDP Access. This fails. I modified the script to remove the space and have the name be RDPAccess. This works. 