### PR TITLE
Update to azurerm_lb_nat_rule doc

### DIFF
--- a/website/docs/r/loadbalancer_nat_pool.html.markdown
+++ b/website/docs/r/loadbalancer_nat_pool.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_lb" "test" {
 resource "azurerm_lb_nat_pool" "test" {
   resource_group_name            = "${azurerm_resource_group.test.name}"
   loadbalancer_id                = "${azurerm_lb.test.id}"
-  name                           = "SampleApplication Pool"
+  name                           = "SampleApplicationPool"
   protocol                       = "Tcp"
   frontend_port_start            = 80
   frontend_port_end              = 81

--- a/website/docs/r/loadbalancer_nat_rule.html.markdown
+++ b/website/docs/r/loadbalancer_nat_rule.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_lb" "test" {
 resource "azurerm_lb_nat_rule" "test" {
   resource_group_name            = "${azurerm_resource_group.test.name}"
   loadbalancer_id                = "${azurerm_lb.test.id}"
-  name                           = "RDP Access"
+  name                           = "RDPAccess"
   protocol                       = "Tcp"
   frontend_port                  = 3389
   backend_port                   = 3389


### PR DESCRIPTION
The azurerm_lb_nat_pool doc has an error. It uses "SampleApplication Pool" as the azurerm_lb_nat_pool name. This fails. I removed the space. 