### PR TITLE
update servicebus examples

### DIFF
--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -13,19 +13,28 @@ Create a ServiceBus Namespace.
 ## Example Usage
 
 ```hcl
+variable "location" {
+  description = "Azure datacenter to deploy to."
+  default = "West US"
+}
+
+variable "servicebus_name" {
+  description = "Input your unique Azure service bus name"
+}
+
 resource "azurerm_resource_group" "test" {
-  name     = "resourceGroup1"
-  location = "West US"
+  name     = "terraform-servicebus"
+  location = "${var.location}"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
-  name                = "acceptanceTestServiceBusNamespace"
-  location            = "West US"
+  name                = "${var.servicebus_name}"
+  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "basic"
 
   tags {
-    environment = "Production"
+    source = "terraform"
   }
 }
 ```

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -13,25 +13,33 @@ Create and manage a ServiceBus Queue.
 ## Example Usage
 
 ```hcl
+variable "location" {
+  description = "Azure datacenter to deploy to."
+  default = "West US"
+}
+
+variable "servicebus_name" {
+  description = "Input your unique Azure service bus name"
+}
+
 resource "azurerm_resource_group" "test" {
-  name     = "resourceGroup1"
-  location = "West US"
+  name     = "terraform-servicebus"
+  location = "${var.location}"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
-  name                = "acceptanceTestServiceBusNamespace"
-  location            = "West US"
+  name                = "${var.servicebus_name}"
+  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "standard"
 
   tags {
-    environment = "Production"
+    source = "terraform"
   }
 }
 
 resource "azurerm_servicebus_queue" "test" {
   name                = "testQueue"
-  location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_servicebus_namespace.test.name}"
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -13,25 +13,33 @@ Create a ServiceBus Subscription.
 ## Example Usage
 
 ```hcl
+variable "location" {
+  description = "Azure datacenter to deploy to."
+  default = "West US"
+}
+
+variable "servicebus_name" {
+  description = "Input your unique Azure service bus name"
+}
+
 resource "azurerm_resource_group" "test" {
-  name     = "resourceGroup1"
-  location = "West US"
+  name     = "terraform-servicebus"
+  location = "${var.location}"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
-  name                = "acceptanceTestServiceBusNamespace"
-  location            = "West US"
+  name                = "${var.servicebus_name}"
+  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "standard"
 
   tags {
-    environment = "Production"
+    source = "terraform"
   }
 }
 
 resource "azurerm_servicebus_topic" "test" {
   name                = "testTopic"
-  location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_servicebus_namespace.test.name}"
 
@@ -40,7 +48,6 @@ resource "azurerm_servicebus_topic" "test" {
 
 resource "azurerm_servicebus_subscription" "test" {
   name                = "testSubscription"
-  location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_servicebus_namespace.test.name}"
   topic_name          = "${azurerm_servicebus_topic.test.name}"

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -15,25 +15,29 @@ Create a ServiceBus Topic.
 ## Example Usage
 
 ```hcl
+variable "location" {
+  description = "Azure datacenter to deploy to."
+  default = "West US"
+}
+
 resource "azurerm_resource_group" "test" {
-  name     = "resourceGroup1"
-  location = "West US"
+  name     = "terraform-servicebus"
+  location = "${var.location}"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
-  name                = "acceptanceTestServiceBusNamespace"
-  location            = "West US"
+  name                = "${var.servicebus_name}"
+  location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "standard"
 
   tags {
-    environment = "Production"
+    source = "terraform"
   }
 }
 
 resource "azurerm_servicebus_topic" "test" {
   name                = "testTopic"
-  location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   namespace_name      = "${azurerm_servicebus_namespace.test.name}"
 


### PR DESCRIPTION
- Updates the servicebus examples so there is a better experience (i.e. variable for the servicebus name so no deployment conflict).
- Easier to update the location via var
- Removes the deprecated `location` for topic, subscription, and queue from the example