### PR TITLE
Update virtual_network.html.markdown

### DIFF
--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -18,6 +18,17 @@ At this time you cannot use a Virtual Network with in-line Subnets in conjunctio
 ## Example Usage
 
 ```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "acceptanceTestResourceGroup1"
+  location = "West US"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acceptanceTestSecurityGroup1"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
 resource "azurerm_virtual_network" "test" {
   name                = "virtualNetwork1"
   resource_group_name = "${azurerm_resource_group.test.name}"


### PR DESCRIPTION
The example for **azurerm_virtual_network** was missing the creation of the **azurerm_resource_group** and **azurerm_network_security_group** resources needed to make this example fully work. Without this, users trying to learn from the sample would have to figure out which resources and its values needed to make the sample work.