### PR TITLE
Replaced deprecated account_type

### DIFF
--- a/examples/aci-linux-volume-mount/main.tf
+++ b/examples/aci-linux-volume-mount/main.tf
@@ -7,7 +7,8 @@ resource "azurerm_storage_account" "aci-sa" {
   name                = "acistorageacct"
   resource_group_name = "${azurerm_resource_group.aci-rg.name}"
   location            = "${azurerm_resource_group.aci-rg.location}"
-  account_type        = "Standard_LRS"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_share" "aci-share" {


### PR DESCRIPTION
Replaced deprecated account_type by account_tier/account_replication_type

This corrects the following error seen during apply:

>   * azurerm_storage_account.terraform-test-aci-sa: "account_type": [DEPRECATED] This field has been split into `account_tier` and `account_replication_type`