### PR TITLE
Storage_image_reference is updated to storage_profile_image_reference

### DIFF
--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -402,7 +402,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
 	name = "test"
   ...
 
-	storage_image_reference {
+	storage_profile_image_reference {
 		id = "${azurerm_image.test.id}"
 	}
 


### PR DESCRIPTION
Updating the documentation to reflect the right variable name for storage_image_reference.