### PR TITLE
Renaming Microsoft Azure -> Azure Provider

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -8,7 +8,7 @@
             </li>
 
             <li<%= sidebar_current("docs-azurerm-index") %>>
-              <a href="/docs/providers/azurerm/index.html">Microsoft Azure Provider</a>
+              <a href="/docs/providers/azurerm/index.html">Azure Provider</a>
               <ul class="nav nav-visible">
                 <li<%= sidebar_current("docs-azurerm-index-authentication-azure-cli") %>>
                     <a href="/docs/providers/azurerm/authenticating_via_azure_cli.html">Authenticating via the Azure CLI</a>
@@ -543,9 +543,6 @@
               </ul>
             </li>
 
-            <li>
-              <a href="/docs/providers/azure/index.html">Azure Service Management Provider &raquo;</a>
-            </li>
           </ul>
         </div>
     <% end %>

--- a/website/docs/authenticating_via_azure_cli.html.markdown
+++ b/website/docs/authenticating_via_azure_cli.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "azurerm"
-page_title: "AzureRM: Authenticating via the Azure CLI"
+page_title: "Azure Provider: Authenticating via the Azure CLI"
 sidebar_current: "docs-azurerm-index-authentication-azure-cli"
 description: |-
-  The Azure Resource Manager provider supports authenticating via multiple means. This guide will cover using the Azure CLI to authenticate to Azure Resource Manager.
+  This guide will cover how to use the Azure CLI provide authentication for the Azure Provider.
 
 ---
 
-# Authenticating to Azure Resource Manager using the Azure CLI
+# Azure Provider: Authenticating using the Azure CLI
 
 Terraform supports authenticating to Azure through a Service Principal or the Azure CLI.
 

--- a/website/docs/authenticating_via_service_principal.html.markdown
+++ b/website/docs/authenticating_via_service_principal.html.markdown
@@ -1,13 +1,13 @@
 ---
 layout: "azurerm"
-page_title: "AzureRM: Authenticating via a Service Principal"
+page_title: "Azure Provider: Authenticating via a Service Principal"
 sidebar_current: "docs-azurerm-index-authentication-service-principal"
 description: |-
-  The Azure Resource Manager provider supports authenticating via multiple means. This guide will cover creating a Service Principal which can be used to access Azure Resource Manager.
+  This guide will cover how to use a Service Principal (Shared Account) as authentication for the Azure Provider.
 
 ---
 
-# Authenticating to Azure Resource Manager using a Service Principal
+# Azure Provider: Authenticating using a Service Principal
 
 Terraform supports authenticating to Azure through a Service Principal or the Azure CLI.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,14 +1,15 @@
 ---
 layout: "azurerm"
-page_title: "Provider: Azure Resource Manager"
+page_title: "Provider: Azure"
 sidebar_current: "docs-azurerm-index"
 description: |-
-  The Microsoft AzureRM provider is used to interact with the many resources supported by Azure Resource Manager via the AzureRM API's. The provider needs to be configured with the credentials needed to generate OAuth tokens for the AzureRM API's.
+  The Azure Provider is used to interact with the many resources supported by Azure Resource Manager (also known as AzureRM) through it's API's.
+
 ---
 
-# Microsoft AzureRM Provider
+# Azure Provider
 
-The Microsoft AzureRM provider is used to interact with the many resources supported by Azure Resource Manager via the AzureRM API's. The provider needs to be configured with the credentials needed to generate OAuth tokens for the AzureRM API's.
+The Azure Provider is used to interact with the many resources supported by Azure Resource Manager (AzureRM) through it's API's.
 
 ~> **Note:** This supercedes the [legacy Azure provider](/docs/providers/azure/index.html), which interacts with Azure using the Service Management API.
 
@@ -23,26 +24,21 @@ We recommend [using a Service Principal when running in a Shared Environment](au
 ## Example Usage
 
 ```hcl
-# Configure the Microsoft Azure Provider
-provider "azurerm" {
-  subscription_id = "..."
-  client_id       = "..."
-  client_secret   = "..."
-  tenant_id       = "..."
-}
+# Configure the Azure Provider
+provider "azurerm" { }
 
 # Create a resource group
-resource "azurerm_resource_group" "production" {
+resource "azurerm_resource_group" "network" {
   name     = "production"
   location = "West US"
 }
 
-# Create a virtual network in the web_servers resource group
+# Create a virtual network within the resource group
 resource "azurerm_virtual_network" "network" {
-  name                = "productionNetwork"
+  name                = "production-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "West US"
-  resource_group_name = "${azurerm_resource_group.production.name}"
+  location            = "${azurerm_resource_group.network.location}"
+  resource_group_name = "${azurerm_resource_group.network.name}"
 
   subnet {
     name           = "subnet1"


### PR DESCRIPTION
Renaming `Microsoft AzureRM` -> `Azure Provider`

Also updating the first example to not set the credentials in-line