### PR TITLE
Fixing the Resource Group Sweeper

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -198,8 +198,6 @@ func setUserAgent(client *autorest.Client) {
 	if azureAgent := os.Getenv("AZURE_HTTP_USER_AGENT"); azureAgent != "" {
 		client.UserAgent = fmt.Sprintf("%s;%s", client.UserAgent, azureAgent)
 	}
-
-	log.Printf("[DEBUG] User Agent: %s", client.UserAgent)
 }
 
 func (c *Config) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {

--- a/azurerm/resource_arm_resource_group_test.go
+++ b/azurerm/resource_arm_resource_group_test.go
@@ -28,7 +28,7 @@ func testSweepResourceGroups(region string) error {
 	client := (*armClient).resourceGroupClient
 
 	log.Printf("Retrieving the Resource Groups..")
-	results, err := client.List("", nil)
+	results, err := client.List("", utils.Int32(int32(1000)))
 	if err != nil {
 		return fmt.Errorf("Error Listing on Resource Groups: %+v", err)
 	}
@@ -46,12 +46,12 @@ func testSweepResourceGroups(region string) error {
 		name := resourceId.ResourceGroup
 
 		log.Printf("Deleting Resource Group %q", name)
-		deleteResponse, error := client.Delete(name, make(chan struct{}))
-		err = <-error
+		deleteResponse, deleteErr := client.Delete(name, make(chan struct{}))
 		resp := <-deleteResponse
+		err = <-deleteErr
 		if err != nil {
 			if utils.ResponseWasNotFound(resp) {
-				return nil
+				continue
 			}
 
 			return err


### PR DESCRIPTION
I'd opened the Azure Portal and noticed a whole bunch of `accost` resource groups - upon further investigation I'd noticed we were returning rather than continuing inside the loop, and thus the sweeper wasn't doing a whole bunch.

I've run the one-off clean up job again to remove any pending items from the subscription - but this should help us going forward.