### PR TITLE
Acceptance Test Fixes

### DIFF
--- a/azurerm/resource_arm_route_table_test.go
+++ b/azurerm/resource_arm_route_table_test.go
@@ -52,7 +52,7 @@ func TestAccAzureRMRouteTable_removeRoute(t *testing.T) {
 	resourceName := "azurerm_route_table.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMRouteTable_singleRoute(ri, testLocation())
-	updatedConfig := testAccAzureRMRouteTable_basic(ri, testLocation())
+	updatedConfig := testAccAzureRMRouteTable_singleRouteRemoved(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -283,6 +283,22 @@ resource "azurerm_route_table" "test" {
 		address_prefix = "10.1.0.0/16"
 		next_hop_type = "vnetlocal"
     }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMRouteTable_singleRouteRemoved(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_route_table" "test" {
+    name = "acctestrt%d"
+    location = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+	route = []
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_route_test.go
+++ b/azurerm/resource_arm_route_test.go
@@ -25,7 +25,6 @@ func TestAccAzureRMRoute_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteExists("azurerm_route.test"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -68,7 +67,6 @@ func TestAccAzureRMRoute_multipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteExists("azurerm_route.test"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 
 			{
@@ -76,7 +74,6 @@ func TestAccAzureRMRoute_multipleRoutes(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteExists("azurerm_route.test1"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/azurerm/resource_arm_servicebus_namespace.go
+++ b/azurerm/resource_arm_servicebus_namespace.go
@@ -3,7 +3,6 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/servicebus"
@@ -188,8 +187,10 @@ func resourceArmServiceBusNamespaceDelete(d *schema.ResourceData, meta interface
 	resp := <-deleteResp
 	err = <-error
 
-	if resp.StatusCode != http.StatusNotFound {
-		return fmt.Errorf("Error issuing Azure ARM delete request of ServiceBus Namespace '%s': %+v", name, err)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error issuing Azure ARM delete request of ServiceBus Namespace %q: %+v", name, err)
+		}
 	}
 
 	return nil

--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -236,7 +236,12 @@ func resourceArmServiceBusQueueDelete(d *schema.ResourceData, meta interface{}) 
 	namespaceName := id.Path["namespaces"]
 	name := id.Path["queues"]
 
-	_, err = client.Delete(resGroup, namespaceName, name)
+	resp, err := client.Delete(resGroup, namespaceName, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return err
+		}
+	}
 
-	return err
+	return nil
 }

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -363,6 +363,7 @@ resource "azurerm_servicebus_namespace" "test" {
     location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     sku = "premium"
+	capacity = 1
 }
 
 resource "azurerm_servicebus_topic" "test" {


### PR DESCRIPTION
Working through the broken acceptance tests:

- Fixing some broken tests where `Route` was made `Computed` again
- Fixing an intermittent issue where the ServiceBus namespace was deleted but was returned as an error
