### PR TITLE
Eventhub Throughput Unit Increase

### DIFF
--- a/azurerm/resource_arm_eventhub_namespace.go
+++ b/azurerm/resource_arm_eventhub_namespace.go
@@ -198,14 +198,10 @@ func validateEventHubNamespaceSku(v interface{}, k string) (ws []string, errors 
 
 func validateEventHubNamespaceCapacity(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(int)
-	capacities := map[int]bool{
-		1: true,
-		2: true,
-		4: true,
-	}
+	maxCapacity := 20
 
-	if !capacities[value] {
-		errors = append(errors, fmt.Errorf("EventHub Namespace Capacity can only be 1, 2 or 4"))
+	if value > maxCapacity || value < 1 {
+		errors = append(errors, fmt.Errorf("EventHub Namespace Capacity must be 20 or fewer Throughput Units for Basic or Standard SKU"))
 	}
 	return
 }

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -30,7 +30,7 @@ func TestAccAzureRMEventHubNamespaceCapacity_validation(t *testing.T) {
 		},
 		{
 			Value:    3,
-			ErrCount: 1,
+			ErrCount: 0,
 		},
 		{
 			Value:    4,

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -17,7 +17,7 @@ func TestAccAzureRMEventHubNamespaceCapacity_validation(t *testing.T) {
 		ErrCount int
 	}{
 		{
-			Value:    17,
+			Value:    21,
 			ErrCount: 1,
 		},
 		{
@@ -35,6 +35,10 @@ func TestAccAzureRMEventHubNamespaceCapacity_validation(t *testing.T) {
 		{
 			Value:    4,
 			ErrCount: 0,
+		},
+		{
+			Value:    0,
+			ErrCount: 1,
 		},
 	}
 

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -23,7 +23,7 @@ resource "azurerm_storage_account" "aci-sa" {
   resource_group_name = "${azurerm_resource_group.aci-rg.name}"
   location            = "${azurerm_resource_group.aci-rg.location}"
   account_tier        = "Standard"
-  account_replicatoin_type = "LRS"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_share" "aci-share" {

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -22,7 +22,8 @@ resource "azurerm_storage_account" "aci-sa" {
   name                = "acistorageacct"
   resource_group_name = "${azurerm_resource_group.aci-rg.name}"
   location            = "${azurerm_resource_group.aci-rg.location}"
-  account_type        = "Standard_LRS"
+  account_tier        = "Standard"
+  account_replicatoin_type = "LRS"
 }
 
 resource "azurerm_storage_share" "aci-share" {
@@ -47,13 +48,13 @@ resource "azurerm_container_group" "aci-helloworld" {
     cpu ="0.5"
     memory =  "1.5"
     port = "80"
-    
+
     environment_variables {
         "NODE_ENV"="testing"
     }
 
     command = "/bin/bash -c '/path to/myscript.sh'"
-    
+
     volume {
       name = "logs"
       mount_path = "/aci/logs"
@@ -63,7 +64,7 @@ resource "azurerm_container_group" "aci-helloworld" {
       storage_account_key = "${azurerm_storage_account.aci-sa.primary_access_key}"
     }
   }
-  
+
   container {
     name   = "sidecar"
     image  = "microsoft/aci-tutorial-sidecar"


### PR DESCRIPTION
Pull request for enhancement to match validation with the documentation for Event Hub Capacity (Throughput Units). 

Official Request:
azurerm_eventhub_namespace resource #361 

Old Values: 1,2,4 for Basic and Standard SKUs.
New Values: 1-20 inclusive for Basic and Standard SKUs.

Azure Documentation:
https://azure.microsoft.com/en-us/pricing/details/event-hubs/
