### PR TITLE
Hotfix: update the logic to get path to access tokens.

### DIFF
--- a/vendor/github.com/Azure/go-autorest/autorest/azure/cli/token.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/cli/token.go
@@ -49,7 +49,17 @@ func (t Token) ToADALToken() (converted adal.Token, err error) {
 
 // AccessTokensPath returns the path where access tokens are stored from the Azure CLI
 func AccessTokensPath() (string, error) {
-	return homedir.Expand("~/.azure/accessTokens.json")
+	// Azure-CLI allows user to customize the path of access tokens thorugh environment variable.
+	var accessTokenPath = os.Getenv("AZURE_ACCESS_TOKEN_FILE")
+	var err error
+
+	// Fallback logic to default path on non-cloud-shell environment.
+	// TODO(sushi): remove the dependency on hard-coding path.
+	if accessTokenPath == "" {
+		accessTokenPath, err = homedir.Expand("~/.azure/accessTokens.json")
+	}
+
+	return accessTokenPath, err
 }
 
 // ParseExpirationDate parses either a Azure CLI or CloudShell date into a time object


### PR DESCRIPTION
1. Add logic to read path to access tokens through environment variable.
2. Add fallback logic to default path in the case environment variable is not set.

Notice: this is short-term fix and need users to use latest version of provider in Cloud Shell. Will provide
long-term fix later.