### PR TITLE
`azurerm_eventhub_namespace` - support for AutoInflating/MaximumThroughputCapacity

### DIFF
--- a/azurerm/resource_arm_eventhub_namespace.go
+++ b/azurerm/resource_arm_eventhub_namespace.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/arm/eventhub"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -51,6 +52,19 @@ func resourceArmEventHubNamespace() *schema.Resource {
 				ValidateFunc: validateEventHubNamespaceCapacity,
 			},
 
+			"auto_inflate_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"maximum_throughput_units": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(1, 20),
+			},
+
 			"default_primary_connection_string": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -88,6 +102,8 @@ func resourceArmEventHubNamespaceCreate(d *schema.ResourceData, meta interface{}
 	capacity := int32(d.Get("capacity").(int))
 	tags := d.Get("tags").(map[string]interface{})
 
+	autoInflateEnabled := d.Get("auto_inflate_enabled").(bool)
+
 	parameters := eventhub.EHNamespace{
 		Location: &location,
 		Sku: &eventhub.Sku{
@@ -95,7 +111,15 @@ func resourceArmEventHubNamespaceCreate(d *schema.ResourceData, meta interface{}
 			Tier:     eventhub.SkuTier(sku),
 			Capacity: &capacity,
 		},
+		EHNamespaceProperties: &eventhub.EHNamespaceProperties{
+			IsAutoInflateEnabled: utils.Bool(autoInflateEnabled),
+		},
 		Tags: expandTags(tags),
+	}
+
+	if v, ok := d.GetOk("maximum_throughput_units"); ok {
+		maximumThroughputUnits := v.(int)
+		parameters.EHNamespaceProperties.MaximumThroughputUnits = utils.Int32(int32(maximumThroughputUnits))
 	}
 
 	_, error := namespaceClient.CreateOrUpdate(resGroup, name, parameters, make(chan struct{}))
@@ -151,6 +175,11 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
 		d.Set("default_primary_key", keys.PrimaryKey)
 		d.Set("default_secondary_key", keys.SecondaryKey)
+	}
+
+	if props := resp.EHNamespaceProperties; props != nil {
+		d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
+		d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
 	}
 
 	flattenAndSetTags(d, resp.Tags)

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -147,6 +147,26 @@ func TestAccAzureRMEventHubNamespace_readDefaultKeys(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMEventHubNamespace_maximumThroughputUnits(t *testing.T) {
+	resourceName := "azurerm_eventhub_namespace.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMEventHubNamespace_maximumThroughputUnits(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMEventHubNamespaceExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMEventHubNamespace_NonStandardCasing(t *testing.T) {
 
 	ri := acctest.RandInt()
@@ -270,6 +290,26 @@ resource "azurerm_eventhub_namespace" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "basic"
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMEventHubNamespace_maximumThroughputUnits(rInt int, location string) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                     = "acctesteventhubnamespace-%d"
+  location                 = "${azurerm_resource_group.test.location}"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  sku                      = "Standard"
+  capacity                 = "2"
+  auto_inflate_enabled     = true
+  maximum_throughput_units = 20
 }
 `, rInt, location, rInt)
 }

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_eventhub_namespace" "test" {
   name                = "acceptanceTestEventHubNamespace"
-  location            = "West US"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
   capacity            = 2
@@ -35,17 +35,19 @@ resource "azurerm_eventhub_namespace" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the EventHub Namespace resource . Changing this forces a
-    new resource to be created.
+* `name` - (Required) Specifies the name of the EventHub Namespace resource. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the namespace. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the namespace. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Defines which tier to use. Options are Basic or Standard.
+* `sku` - (Required) Defines which tier to use. Valid options are `Basic` and `Standard`.
 
-* `capacity` - (Optional) Specifies the capacity of a Standard namespace. Can be 1, 2 or 4
+* `capacity` - (Optional) Specifies the Capacity / Throughput Units for a `Standard` SKU namespace. Valid values range from 1 - 20.
+
+* `auto_inflate_enabled` - (Optional) Is Auto Inflate enabled for the EventHub Namespace?
+
+* `maximum_throughput_units` - (Optional) Specifies the maximum number of throughput units when Auto Inflate is Enabled. Valid values range from 1 - 20.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Noticed this was missing when going through checking the docs