### PR TITLE
`azurerm_management_lock`: fixing the name validation

### DIFF
--- a/azurerm/resource_arm_management_lock.go
+++ b/azurerm/resource_arm_management_lock.go
@@ -161,8 +161,12 @@ func parseAzureRMLockId(id string) (*AzureManagementLockId, error) {
 func validateArmManagementLockName(v interface{}, k string) (ws []string, es []error) {
 	input := v.(string)
 
-	if !regexp.MustCompile(`\A([A-Za-z0-9\-_]{1, 260})\z`).MatchString(input) {
-		es = append(es, fmt.Errorf("%s can only consist of alphanumeric characters, dashes and underscores - and must be a maxiumum of 260 characters", k))
+	if !regexp.MustCompile(`[A-Za-z0-9-_]`).MatchString(input) {
+		es = append(es, fmt.Errorf("%s can only consist of alphanumeric characters, dashes and underscores", k))
+	}
+
+	if len(input) >= 260 {
+		es = append(es, fmt.Errorf("%s can only be a maximum of 260 characters", k))
 	}
 
 	return

--- a/azurerm/resource_arm_management_lock_test.go
+++ b/azurerm/resource_arm_management_lock_test.go
@@ -31,7 +31,7 @@ func TestValidateManagementLockName(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		_, es := validateArmStorageAccountName(test.input, "name")
+		_, es := validateArmManagementLockName(test.input, "name")
 
 		if test.shouldError && len(es) == 0 {
 			t.Fatalf("Expected validating name %q to fail", test.input)


### PR DESCRIPTION
Noticed the validation & it's test was incorrect - this fixes it

Tests pass:

<img width="509" alt="screen shot 2017-12-04 at 10 41 10" src="https://user-images.githubusercontent.com/666005/33548723-126c9aa8-d8e0-11e7-9c45-5c9ebbfc1117.png">
