### PR TITLE
`azurerm_local_network_gateway` - support for BGP Settings

### DIFF
--- a/azurerm/import_arm_local_network_gateway_test.go
+++ b/azurerm/import_arm_local_network_gateway_test.go
@@ -28,3 +28,25 @@ func TestAccAzureRMLocalNetworkGateway_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMLocalNetworkGateway_importBGPSettingsComplete(t *testing.T) {
+	resourceName := "azurerm_local_network_gateway.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_bgpSettingsComplete(rInt, testLocation()),
+			},
+
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_local_network_gateway.go
+++ b/azurerm/resource_arm_local_network_gateway.go
@@ -45,7 +45,7 @@ func resourceArmLocalNetworkGateway() *schema.Resource {
 			"bgp_settings": {
 				Type:     schema.TypeList,
 				Optional: true,
-				MaxItems: 1, // TODO: confirm
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"asn": {
@@ -176,7 +176,7 @@ func resourceArmLocalNetworkGatewayDelete(d *schema.ResourceData, meta interface
 			return nil
 		}
 
-		return fmt.Errorf("Error issuing Azure ARM delete request of local network gateway '%s': %s", name, err)
+		return fmt.Errorf("Error issuing delete request for local network gateway %q: %+v", name, err)
 	}
 
 	return nil
@@ -191,10 +191,11 @@ func expandLocalNetworkGatewayBGPSettings(d *schema.ResourceData) (*network.BgpS
 	settings := v.([]interface{})
 	setting := settings[0].(map[string]interface{})
 
-	bgpSettings := network.BgpSettings{}
-	bgpSettings.Asn = utils.Int64(int64(setting["asn"].(int)))
-	bgpSettings.BgpPeeringAddress = utils.String(setting["bgp_peering_address"].(string))
-	bgpSettings.PeerWeight = utils.Int32(int32(setting["peer_weight"].(int)))
+	bgpSettings := network.BgpSettings{
+		Asn:               utils.Int64(int64(setting["asn"].(int))),
+		BgpPeeringAddress: utils.String(setting["bgp_peering_address"].(string)),
+		PeerWeight:        utils.Int32(int32(setting["peer_weight"].(int))),
+	}
 
 	return &bgpSettings, nil
 }

--- a/azurerm/resource_arm_local_network_gateway.go
+++ b/azurerm/resource_arm_local_network_gateway.go
@@ -2,7 +2,6 @@ package azurerm
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -42,22 +41,48 @@ func resourceArmLocalNetworkGateway() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+
+			"bgp_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1, // TODO: confirm
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"asn": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+
+						"bgp_peering_address": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"peer_weight": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
 func resourceArmLocalNetworkGatewayCreate(d *schema.ResourceData, meta interface{}) error {
-	lnetClient := meta.(*ArmClient).localNetConnClient
+	client := meta.(*ArmClient).localNetConnClient
 
 	name := d.Get("name").(string)
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	ipAddress := d.Get("gateway_address").(string)
 
-	// fetch the 'address_space_prefixes:
-	prefixes := []string{}
-	for _, pref := range d.Get("address_space").([]interface{}) {
-		prefixes = append(prefixes, pref.(string))
+	addressSpaces := expandLocalNetworkGatewayAddressSpaces(d)
+
+	bgpSettings, err := expandLocalNetworkGatewayBGPSettings(d)
+	if err != nil {
+		return err
 	}
 
 	gateway := network.LocalNetworkGateway{
@@ -65,24 +90,25 @@ func resourceArmLocalNetworkGatewayCreate(d *schema.ResourceData, meta interface
 		Location: &location,
 		LocalNetworkGatewayPropertiesFormat: &network.LocalNetworkGatewayPropertiesFormat{
 			LocalNetworkAddressSpace: &network.AddressSpace{
-				AddressPrefixes: &prefixes,
+				AddressPrefixes: &addressSpaces,
 			},
 			GatewayIPAddress: &ipAddress,
+			BgpSettings:      bgpSettings,
 		},
 	}
 
-	_, error := lnetClient.CreateOrUpdate(resGroup, name, gateway, make(chan struct{}))
-	err := <-error
+	_, createError := client.CreateOrUpdate(resGroup, name, gateway, make(chan struct{}))
+	err = <-createError
 	if err != nil {
-		return fmt.Errorf("Error creating Azure ARM Local Network Gateway '%s': %s", name, err)
+		return fmt.Errorf("Error creating Local Network Gateway %q: %+v", name, err)
 	}
 
-	read, err := lnetClient.Get(resGroup, name)
+	read, err := client.Get(resGroup, name)
 	if err != nil {
 		return err
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Virtual Network %s (resource group %s) ID", name, resGroup)
+		return fmt.Errorf("Cannot read Local Network Gateway ID %q (resource group %q) ID", name, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -90,46 +116,49 @@ func resourceArmLocalNetworkGatewayCreate(d *schema.ResourceData, meta interface
 	return resourceArmLocalNetworkGatewayRead(d, meta)
 }
 
-// resourceArmLocalNetworkGatewayRead goes ahead and reads the state of the corresponding ARM local network gateway.
 func resourceArmLocalNetworkGatewayRead(d *schema.ResourceData, meta interface{}) error {
-	lnetClient := meta.(*ArmClient).localNetConnClient
+	client := meta.(*ArmClient).localNetConnClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
 	name := id.Path["localNetworkGateways"]
-	if name == "" {
-		return fmt.Errorf("Cannot find 'localNetworkGateways' in '%s', make sure it is specified in the ID parameter", d.Id())
-	}
 	resGroup := id.ResourceGroup
 
-	resp, err := lnetClient.Get(resGroup, name)
+	resp, err := client.Get(resGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading the state of Azure ARM local network gateway '%s': %s", name, err)
+
+		return fmt.Errorf("Error reading the state of Local Network Gateway %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	d.Set("resource_group_name", resGroup)
 	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
 	d.Set("location", azureRMNormalizeLocation(*resp.Location))
-	d.Set("gateway_address", resp.LocalNetworkGatewayPropertiesFormat.GatewayIPAddress)
 
-	prefs := []string{}
-	if ps := *resp.LocalNetworkGatewayPropertiesFormat.LocalNetworkAddressSpace.AddressPrefixes; ps != nil {
-		prefs = ps
+	if props := resp.LocalNetworkGatewayPropertiesFormat; props != nil {
+		d.Set("gateway_address", props.GatewayIPAddress)
+
+		if lnas := props.LocalNetworkAddressSpace; lnas != nil {
+			if prefixes := lnas.AddressPrefixes; prefixes != nil {
+				d.Set("address_space", *prefixes)
+			}
+		}
+		flattenedSettings := flattenLocalNetworkGatewayBGPSettings(props.BgpSettings)
+		if err := d.Set("bgp_settings", flattenedSettings); err != nil {
+			return err
+		}
 	}
-	d.Set("address_space", prefs)
 
 	return nil
 }
 
-// resourceArmLocalNetworkGatewayDelete deletes the specified ARM local network gateway.
 func resourceArmLocalNetworkGatewayDelete(d *schema.ResourceData, meta interface{}) error {
-	lnetClient := meta.(*ArmClient).localNetConnClient
+	client := meta.(*ArmClient).localNetConnClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -138,17 +167,58 @@ func resourceArmLocalNetworkGatewayDelete(d *schema.ResourceData, meta interface
 	name := id.Path["localNetworkGateways"]
 	resGroup := id.ResourceGroup
 
-	deleteResp, error := lnetClient.Delete(resGroup, name, make(chan struct{}))
+	deleteResp, error := client.Delete(resGroup, name, make(chan struct{}))
 	resp := <-deleteResp
 	err = <-error
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil
-	}
-
 	if err != nil {
+		if utils.ResponseWasNotFound(resp) {
+			return nil
+		}
+
 		return fmt.Errorf("Error issuing Azure ARM delete request of local network gateway '%s': %s", name, err)
 	}
 
 	return nil
+}
+
+func expandLocalNetworkGatewayBGPSettings(d *schema.ResourceData) (*network.BgpSettings, error) {
+	v, exists := d.GetOk("bgp_settings")
+	if !exists {
+		return nil, nil
+	}
+
+	settings := v.([]interface{})
+	setting := settings[0].(map[string]interface{})
+
+	bgpSettings := network.BgpSettings{}
+	bgpSettings.Asn = utils.Int64(int64(setting["asn"].(int)))
+	bgpSettings.BgpPeeringAddress = utils.String(setting["bgp_peering_address"].(string))
+	bgpSettings.PeerWeight = utils.Int32(int32(setting["peer_weight"].(int)))
+
+	return &bgpSettings, nil
+}
+
+func expandLocalNetworkGatewayAddressSpaces(d *schema.ResourceData) []string {
+	prefixes := make([]string, 0)
+
+	for _, pref := range d.Get("address_space").([]interface{}) {
+		prefixes = append(prefixes, pref.(string))
+	}
+
+	return prefixes
+}
+
+func flattenLocalNetworkGatewayBGPSettings(input *network.BgpSettings) []interface{} {
+	output := make(map[string]interface{}, 0)
+
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output["asn"] = int(*input.Asn)
+	output["bgp_peering_address"] = *input.BgpPeeringAddress
+	output["peer_weight"] = int(*input.PeerWeight)
+
+	return []interface{}{output}
 }

--- a/azurerm/resource_arm_local_network_gateway_test.go
+++ b/azurerm/resource_arm_local_network_gateway_test.go
@@ -2,12 +2,12 @@ package azurerm
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMLocalNetworkGateway_basic(t *testing.T) {
@@ -54,6 +54,123 @@ func TestAccAzureRMLocalNetworkGateway_disappears(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLocalNetworkGateway_bgpSettings(t *testing.T) {
+	name := "azurerm_local_network_gateway.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_bgpSettings(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(name),
+					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(name, "address_space.0", "127.0.0.0/8"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLocalNetworkGateway_bgpSettingsDisable(t *testing.T) {
+	name := "azurerm_local_network_gateway.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_bgpSettings(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(name),
+					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(name, "address_space.0", "127.0.0.0/8"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.#", "1"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.0.asn", "2468"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.0.bgp_peering_address", "10.104.1.1"),
+				),
+			},
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(name),
+					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(name, "address_space.0", "127.0.0.0/8"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLocalNetworkGateway_bgpSettingsEnable(t *testing.T) {
+	name := "azurerm_local_network_gateway.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(name),
+					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(name, "address_space.0", "127.0.0.0/8"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.#", "0"),
+				),
+			},
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_bgpSettings(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(name),
+					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(name, "address_space.0", "127.0.0.0/8"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.#", "1"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.0.asn", "2468"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.0.bgp_peering_address", "10.104.1.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLocalNetworkGateway_bgpSettingsComplete(t *testing.T) {
+	name := "azurerm_local_network_gateway.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_bgpSettingsComplete(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(name),
+					resource.TestCheckResourceAttr(name, "gateway_address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(name, "address_space.0", "127.0.0.0/8"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.#", "1"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.0.asn", "2468"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.0.bgp_peering_address", "10.104.1.1"),
+					resource.TestCheckResourceAttr(name, "bgp_settings.0.peer_weight", "15"),
+				),
+			},
+		},
+	})
+}
+
 // testCheckAzureRMLocalNetworkGatewayExists returns the resurce.TestCheckFunc
 // which checks whether or not the expected local network gateway exists both
 // in the schema, and on Azure.
@@ -74,14 +191,15 @@ func testCheckAzureRMLocalNetworkGatewayExists(name string) resource.TestCheckFu
 		resGrp := id.ResourceGroup
 
 		// and finally, check that it exists on Azure:
-		lnetClient := testAccProvider.Meta().(*ArmClient).localNetConnClient
+		client := testAccProvider.Meta().(*ArmClient).localNetConnClient
 
-		resp, err := lnetClient.Get(resGrp, localNetName)
+		resp, err := client.Get(resGrp, localNetName)
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("Local network gateway '%s' (resource group '%s') does not exist on Azure.", localNetName, resGrp)
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Local network gateway %q (resource group %q) does not exist on Azure.", localNetName, resGrp)
 			}
-			return fmt.Errorf("Error reading the state of local network gateway '%s': %+v", localNetName, err)
+
+			return fmt.Errorf("Error reading the state of local network gateway %q: %+v", localNetName, err)
 		}
 
 		return nil
@@ -105,16 +223,16 @@ func testCheckAzureRMLocalNetworkGatewayDisappears(name string) resource.TestChe
 		resGrp := id.ResourceGroup
 
 		// and finally, check that it exists on Azure:
-		lnetClient := testAccProvider.Meta().(*ArmClient).localNetConnClient
+		client := testAccProvider.Meta().(*ArmClient).localNetConnClient
 
-		deleteResp, error := lnetClient.Delete(resGrp, localNetName, make(chan struct{}))
+		deleteResp, error := client.Delete(resGrp, localNetName, make(chan struct{}))
 		resp := <-deleteResp
 		err = <-error
 		if err != nil {
-			if resp.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("Local network gateway '%s' (resource group '%s') does not exist on Azure.", localNetName, resGrp)
+			if utils.ResponseWasNotFound(resp) {
+				return fmt.Errorf("Local network gateway %q (resource group %q) does not exist on Azure.", localNetName, resGrp)
 			}
-			return fmt.Errorf("Error deleting the state of local network gateway '%s': %+v", localNetName, err)
+			return fmt.Errorf("Error deleting the state of local network gateway %q: %+v", localNetName, err)
 		}
 
 		return nil
@@ -134,16 +252,18 @@ func testCheckAzureRMLocalNetworkGatewayDestroy(s *terraform.State) error {
 		localNetName := id.Path["localNetworkGateways"]
 		resGrp := id.ResourceGroup
 
-		lnetClient := testAccProvider.Meta().(*ArmClient).localNetConnClient
-		resp, err := lnetClient.Get(resGrp, localNetName)
+		client := testAccProvider.Meta().(*ArmClient).localNetConnClient
+		resp, err := client.Get(resGrp, localNetName)
 
 		if err != nil {
-			return nil
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return err
 		}
 
-		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("Local network gateway still exists:\n%#v", resp.LocalNetworkGatewayPropertiesFormat)
-		}
+		return fmt.Errorf("Local network gateway still exists:\n%#v", resp.LocalNetworkGatewayPropertiesFormat)
 	}
 
 	return nil
@@ -152,16 +272,64 @@ func testCheckAzureRMLocalNetworkGatewayDestroy(s *terraform.State) error {
 func testAccAzureRMLocalNetworkGatewayConfig_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctest-%d"
-    location = "%s"
+  name     = "acctest-%d"
+  location = "%s"
 }
 
 resource "azurerm_local_network_gateway" "test" {
-	name = "acctestlng-%d"
-	location = "${azurerm_resource_group.test.location}"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	gateway_address = "127.0.0.1"
-	address_space = ["127.0.0.0/8"]
+  name                = "acctestlng-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  gateway_address     = "127.0.0.1"
+  address_space       = ["127.0.0.0/8"]
 }
+
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMLocalNetworkGatewayConfig_bgpSettings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-%d"
+  location = "%s"
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlng-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  gateway_address     = "127.0.0.1"
+  address_space       = ["127.0.0.0/8"]
+
+  bgp_settings {
+    asn                 = 2468
+    bgp_peering_address = "10.104.1.1"
+  }
+}
+
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMLocalNetworkGatewayConfig_bgpSettingsComplete(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-%d"
+  location = "%s"
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlng-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  gateway_address     = "127.0.0.1"
+  address_space       = ["127.0.0.0/8"]
+
+  bgp_settings {
+    asn                 = 2468
+    bgp_peering_address = "10.104.1.1"
+    peer_weight         = 15
+  }
+}
+
 `, rInt, location, rInt)
 }

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -47,6 +47,21 @@ The following arguments are supported:
 * `address_space` - (Required) The list of string CIDRs representing the
     address spaces the gateway exposes.
 
+* `bgp_settings` - (Optional) A `bgp_settings` block as defined below containing the
+    Local Network Gateway's BGP speaker settings.
+
+---
+
+`bgp_settings` supports the following:
+
+* `asn` - (Required) The BGP speaker's ASN.
+
+* `bgp_peering_address` - (Required) The BGP peering address and BGP identifier
+    of this BGP speaker.
+
+* `peer_weight` - (Optional) The weight added to routes learned from this
+    BGP speaker.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
```
$ acctests azurerm TestAccAzureRMLocalNetworkGateway_
=== RUN   TestAccAzureRMLocalNetworkGateway_importBasic
--- PASS: TestAccAzureRMLocalNetworkGateway_importBasic (82.23s)
=== RUN   TestAccAzureRMLocalNetworkGateway_basic
--- PASS: TestAccAzureRMLocalNetworkGateway_basic (81.29s)
=== RUN   TestAccAzureRMLocalNetworkGateway_disappears
--- PASS: TestAccAzureRMLocalNetworkGateway_disappears (79.17s)
=== RUN   TestAccAzureRMLocalNetworkGateway_bgpSettings
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettings (78.70s)
=== RUN   TestAccAzureRMLocalNetworkGateway_bgpSettingsDisable
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettingsDisable (96.18s)
=== RUN   TestAccAzureRMLocalNetworkGateway_bgpSettingsEnable
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettingsEnable (97.39s)
=== RUN   TestAccAzureRMLocalNetworkGateway_bgpSettingsComplete
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettingsComplete (79.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm    594.680s
```

also the import BGP tests:

```
$ acctests azurerm TestAccAzureRMLocalNetworkGateway_importBGPSettingsComplete
=== RUN   TestAccAzureRMLocalNetworkGateway_importBGPSettingsComplete
--- PASS: TestAccAzureRMLocalNetworkGateway_importBGPSettingsComplete (80.96s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	80.987s
```