### PR TITLE
Website Page Metadata Issue

### DIFF
--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -1,4 +1,3 @@
-
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_key"


### PR DESCRIPTION
A leading line break on the `azurerm_key_vault_key` page seems to be preventing the website generator from interpreting its metadata properly.

![image](https://user-images.githubusercontent.com/908409/33780467-bc7bd630-dc05-11e7-8d58-bec3d7244582.png)

I'm not sure this will fix the issue because I'm not familiar how the "website generator" works. I'm going to say it will _probably_ fix it :)