### PR TITLE
Fixing the Resource Group Sweepers

### DIFF
--- a/azurerm/azurerm_sweeper_test.go
+++ b/azurerm/azurerm_sweeper_test.go
@@ -45,20 +45,16 @@ func buildConfigForSweepers() (*ArmClient, error) {
 func shouldSweepAcceptanceTestResource(name string, resourceLocation string, region string) bool {
 	loweredName := strings.ToLower(name)
 
-	prefixesToIgnore := []string{"acctest"}
-
-	for _, prefix := range prefixesToIgnore {
-		if !strings.HasPrefix(loweredName, prefix) {
-			log.Printf("Ignoring Resource '%s' due to prefix '%s'", name, prefix)
-			return false
-		}
+	if !strings.HasPrefix(loweredName, "acctest") {
+		log.Printf("Ignoring Resource %q as it doesn't start with `acctest`", name)
+		return false
 	}
 
 	normalisedResourceLocation := azureRMNormalizeLocation(resourceLocation)
 	normalisedRegion := azureRMNormalizeLocation(region)
 
 	if normalisedResourceLocation != normalisedRegion {
-		log.Printf("Region '%s' isn't '%s' - skipping", normalisedResourceLocation, normalisedRegion)
+		log.Printf("Region %q isn't %q - skipping", normalisedResourceLocation, normalisedRegion)
 		return false
 	}
 

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -24,7 +24,7 @@ func TestAccAzureRMContainerRegistryMigrateState(t *testing.T) {
 	}
 
 	rs := acctest.RandString(4)
-	resourceGroupName := fmt.Sprintf("acctesrg%s", rs)
+	resourceGroupName := fmt.Sprintf("acctestrg%s", rs)
 	storageAccountName := fmt.Sprintf("acctestsa%s", rs)
 	location := azureRMNormalizeLocation(testLocation())
 

--- a/azurerm/resource_arm_resource_group_test.go
+++ b/azurerm/resource_arm_resource_group_test.go
@@ -33,18 +33,12 @@ func testSweepResourceGroups(region string) error {
 		return fmt.Errorf("Error Listing on Resource Groups: %+v", err)
 	}
 
-	for _, profile := range *results.Value {
-		if !shouldSweepAcceptanceTestResource(*profile.Name, *profile.Location, region) {
+	for _, resourceGroup := range *results.Value {
+		if !shouldSweepAcceptanceTestResource(*resourceGroup.Name, *resourceGroup.Location, region) {
 			continue
 		}
 
-		resourceId, err := parseAzureResourceID(*profile.ID)
-		if err != nil {
-			return err
-		}
-
-		name := resourceId.ResourceGroup
-
+		name := *resourceGroup.Name
 		log.Printf("Deleting Resource Group %q", name)
 		deleteResponse, deleteErr := client.Delete(name, make(chan struct{}))
 		resp := <-deleteResponse


### PR DESCRIPTION
Stops unnecessarily parsing the Resource Group ID to obtain the name we already had. Also updates the container registry test to create resource groups matching `acctest` so they'll be detected via the sweepers