### PR TITLE
`azurerm_servicebus_queue`: supporting Lock Duration

### DIFF
--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -67,6 +67,12 @@ func resourceArmServiceBusQueue() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"lock_duration": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"max_size_in_megabytes": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -128,6 +134,10 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 
 	if duplicateWindow := d.Get("duplicate_detection_history_time_window").(string); duplicateWindow != "" {
 		parameters.SBQueueProperties.DuplicateDetectionHistoryTimeWindow = &duplicateWindow
+	}
+
+	if lockDuration := d.Get("lock_duration").(string); lockDuration != "" {
+		parameters.SBQueueProperties.LockDuration = &lockDuration
 	}
 
 	// We need to retrieve the namespace because Premium namespace works differently from Basic and Standard,
@@ -199,6 +209,7 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("auto_delete_on_idle", props.AutoDeleteOnIdle)
 	d.Set("default_message_ttl", props.DefaultMessageTimeToLive)
 	d.Set("duplicate_detection_history_time_window", props.DuplicateDetectionHistoryTimeWindow)
+	d.Set("lock_duration", props.LockDuration)
 
 	d.Set("enable_express", props.EnableExpress)
 	d.Set("enable_partitioning", props.EnablePartitioning)

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -88,6 +88,10 @@ The following arguments are supported:
 
 ~> **NOTE:** Service Bus Premium namespaces are always partitioned, so `enable_partitioning` MUST be set to `true`.
 
+* `lock_duration` - (Optional) The duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. The maximum value is 5 minutes. Default value is 1 minute. Provided in the [TimeSpan](#timespan-format) format.
+
+* `lock_duration` - (Optional) The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. Maximum value is 5 minutes. Defaults to 1 minute. (`PT1M`)
+
 * `max_size_in_megabytes` - (Optional) Integer value which controls the size of
     memory allocated for the queue. For supported values see the "Queue/topic size"
     section of [this document](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).


### PR DESCRIPTION
Fixes #622


New test:

```
$ acctests azurerm TestAccAzureRMServiceBusQueue_lockDuration
=== RUN   TestAccAzureRMServiceBusQueue_lockDuration
--- PASS: TestAccAzureRMServiceBusQueue_lockDuration (220.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm    220.997s
```

Tests pass:

<img width="480" alt="screen shot 2017-12-13 at 12 32 10" src="https://user-images.githubusercontent.com/666005/33939095-b7501108-e001-11e7-9965-4ff59e4f691c.png">
