### PR TITLE
Fixes #628 - multiple output IPs for azurerm_lb

### DIFF
--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -183,7 +183,7 @@ func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 		privateIpAddresses := make([]string, 0, len(*ipconfigs))
 		for _, config := range *ipconfigs {
 			if config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
-				append(privateIpAddresses, *config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress)
+				privateIpAddresses = append(privateIpAddresses, *config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress)
 			}
 		}
 

--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -88,9 +88,12 @@ func resourceArmLoadBalancer() *schema.Resource {
 				},
 			},
 
-			"private_ip_address": {
-				Type:     schema.TypeString,
+			"private_ip_addresses": {
+				Type:     schema.TypeList,
 				Computed: true,
+				Elem: &schema.Schema {
+					Type: schema.TypeString,
+				},
 			},
 
 			"tags": tagsSchema(),
@@ -177,14 +180,14 @@ func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 		ipconfigs := loadBalancer.LoadBalancerPropertiesFormat.FrontendIPConfigurations
 		d.Set("frontend_ip_configuration", flattenLoadBalancerFrontendIpConfiguration(ipconfigs))
 
+		privateIpAddresses := make([]string, 0, len(*ipconfigs))
 		for _, config := range *ipconfigs {
 			if config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
-				d.Set("private_ip_address", config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress)
-
-				// set the private IP address at most once
-				break
+				append(privateIpAddresses, *config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress)
 			}
 		}
+
+		d.Set("private_ip_addresses", privateIpAddresses)
 	}
 
 	flattenAndSetTags(d, loadBalancer.Tags)

--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -91,7 +91,7 @@ func resourceArmLoadBalancer() *schema.Resource {
 			"private_ip_addresses": {
 				Type:     schema.TypeList,
 				Computed: true,
-				Elem: &schema.Schema {
+				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},

--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -88,6 +88,10 @@ func resourceArmLoadBalancer() *schema.Resource {
 				},
 			},
 
+			"private_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"private_ip_addresses": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -180,13 +184,19 @@ func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 		ipconfigs := loadBalancer.LoadBalancerPropertiesFormat.FrontendIPConfigurations
 		d.Set("frontend_ip_configuration", flattenLoadBalancerFrontendIpConfiguration(ipconfigs))
 
+		privateIpAddress := ""
 		privateIpAddresses := make([]string, 0, len(*ipconfigs))
 		for _, config := range *ipconfigs {
 			if config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
+				if privateIpAddress == "" {
+					privateIpAddress = *config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress
+				}
+
 				privateIpAddresses = append(privateIpAddresses, *config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress)
 			}
 		}
 
+		d.Set("private_ip_address", privateIpAddress)
 		d.Set("private_ip_addresses", privateIpAddresses)
 	}
 

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The LoadBalancer ID.
-* `private_ip_address` - The private IP address assigned to the load balancer, if any.
+* `private_ip_addresses` - The list of private IP address assigned to the load balancer in `frontend_ip_configuration` blocks, if any.
 
 ## Import
 

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The LoadBalancer ID.
+* `private_ip_address` - The first private IP address assigned to the load balancer in `frontend_ip_configuration` blocks, if any.
 * `private_ip_addresses` - The list of private IP address assigned to the load balancer in `frontend_ip_configuration` blocks, if any.
 
 ## Import


### PR DESCRIPTION
This PR changes the `azurerm_lb` resource to output a list of private IPs instead of just the first one, to improve support for load balancers with multiple IP configurations. 