### PR TITLE
Add a cache to store storage account keys.

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -869,10 +869,11 @@ func (armClient *ArmClient) getKeyForStorageAccount(resourceGroupName, storageAc
 			return "", true, fmt.Errorf("Error retrieving keys for storage account %q: %s", storageAccountName, err)
 		}
 
-		keys := *accountKeys.Keys
 		if accountKeys.Keys == nil {
 			return "", false, fmt.Errorf("Nil key returned for storage account %q", storageAccountName)
 		}
+
+		keys := *accountKeys.Keys
 		if len(keys) <= 0 {
 			return "", false, fmt.Errorf("No keys returned for storage account %q", storageAccountName)
 		}


### PR DESCRIPTION
Each time we refresh/create a Queue/Table/Blob, a new client is retrieved through `listKeys` call to a specific storage account, even they are within one storage account. That is not necessary, the keys should not be changed during one Terraform session.

Creating **two storage accounts** with **four resources** each (one queue, one blob, one table and one container) only takes **8 `listKeys`** calls instead of the original 40 `listKeys` calls.

This will also resolve the Azure throttling issue (#202) with ~100 storage accounts and ~1000 storage resources in total.
  