### PR TITLE
Prepending `Data Source: ` to the Data Source docs

### DIFF
--- a/website/docs/d/builtin_role_definition.markdown
+++ b/website/docs/d/builtin_role_definition.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about a built-in Role Definition.
 ---
 
-# azurerm_builtin_role_definition
+# Data Source: azurerm_builtin_role_definition
 
 Use this data source to access the properties of a built-in Role Definition. To access information about a custom Role Definition, [please see the `azurerm_role_definition` data source](role_definition.html) instead.
 

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the configuration of the azurerm provider.
 ---
 
-# azurerm\_client\_config
+# Data Source: azurerm_client_config
 
 Use this data source to access the configuration of the Azure Resource Manager
 provider.

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 ---
 
-# azurerm_image
+# Data Source: azurerm_image
 
 Use this data source to access information about an Image.
 

--- a/website/docs/d/key_vault_access_policy.html.markdown
+++ b/website/docs/d/key_vault_access_policy.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the templated Access Policies for Key Vault.
 ---
 
-# azurerm_key_vault_access_policy
+# Data Source: azurerm_key_vault_access_policy
 
 Use this data source to access information about the permissions from the Management Key Vault Templates.
 

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified managed disk.
 ---
 
-# azurerm\_managed\_disk
+# Data Source: azurerm_managed_disk
 
 Use this data source to access the properties of an existing Azure Managed Disk.
 

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified Network Security Group.
 ---
 
-# azurerm_network_security_group
+# Data Source: azurerm_network_security_group
 
 Use this data source to access the properties of a Network Security Group.
 

--- a/website/docs/d/platform_image.html.markdown
+++ b/website/docs/d/platform_image.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified Platform Image.
 ---
 
-# azurerm_platform_image
+# Data Source: azurerm_platform_image
 
 Use this data source to access the properties of an Azure Platform Image.
 

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 ---
 
-# azurerm_public_ip
+# Data Source: azurerm_public_ip
 
 Use this data source to access the properties of an existing Azure Public IP Address.
 

--- a/website/docs/d/resource_group.html.markdown
+++ b/website/docs/d/resource_group.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified resource group.
 ---
 
-# azurerm\_resource\_group
+# Data Source: azurerm_resource_group
 
 Use this data source to access the properties of an Azure resource group.
 

--- a/website/docs/d/role_definition.markdown
+++ b/website/docs/d/role_definition.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about a custom Role Definition.
 ---
 
-# azurerm_role_definition
+# Data Source: azurerm_role_definition
 
 Use this data source to access the properties of a custom Role Definition. To access information about a built-in Role Definition, [please see the `azurerm_builtin_role_definition` data source](builtin_role_definition.html) instead.
 

--- a/website/docs/d/snapshot.html.markdown
+++ b/website/docs/d/snapshot.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified Snapshot
 ---
 
-# azurerm_snapshot
+# Data Source: azurerm_snapshot
 
 Use this data source to access the properties of a Snapshot of an Disk.
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified Subnet located within a Virtual Network.
 ---
 
-# azurerm_subnet
+# Data Source: azurerm_subnet
 
 Use this data source to access the properties of an Azure Subnet located within a Virtual Network.
 

--- a/website/docs/d/subscription.html.markdown
+++ b/website/docs/d/subscription.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified subscription.
 ---
 
-# azurerm\_subscription
+# Data Source: azurerm_subscription
 
 Use this data source to access the properties of an Azure subscription.
 

--- a/website/docs/d/virtual_network.html.markdown
+++ b/website/docs/d/virtual_network.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Get information about the specified Virtual Network.
 ---
 
-# azurerm_virtual_network
+# Data Source: azurerm_virtual_network
 
 Use this data source to access the properties of an Azure Virtual Network.
 


### PR DESCRIPTION
Prepending `Data Source: ` to the Data Source docs for consistency with the changes made in terraform-providers/terraform-provider-aws#2713