### PR TITLE
New Data Source: `azurerm_app_service_plan`

### DIFF
--- a/azurerm/data_source_app_service_plan.go
+++ b/azurerm/data_source_app_service_plan.go
@@ -1,0 +1,118 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceAppServicePlan() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAppServicePlanRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"location": locationForDataSourceSchema(),
+
+			"kind": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"sku": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"capacity": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"properties": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"reserved": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"per_site_scaling": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"maximum_number_of_workers": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"tags": tagsForDataSourceSchema(),
+		},
+	}
+}
+
+func dataSourceAppServicePlanRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicePlansClient
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making Read request on App Service Plan %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+	d.Set("kind", resp.Kind)
+
+	if props := resp.AppServicePlanProperties; props != nil {
+		d.Set("properties", flattenAppServiceProperties(props))
+
+		if props.MaximumNumberOfWorkers != nil {
+			d.Set("maximum_number_of_workers", int(*props.MaximumNumberOfWorkers))
+		}
+	}
+
+	if sku := resp.Sku; sku != nil {
+		d.Set("sku", flattenAppServicePlanSku(sku))
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}

--- a/azurerm/data_source_app_service_plan_test.go
+++ b/azurerm/data_source_app_service_plan_test.go
@@ -1,0 +1,119 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMAppServicePlan_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_app_service_plan.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppServicePlan_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "kind", "Windows"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.tier", "Basic"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.size", "B1"),
+					resource.TestCheckResourceAttr(dataSourceName, "properties.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "properties.0.per_site_scaling", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMAppServicePlan_complete(t *testing.T) {
+	dataSourceName := "data.azurerm_app_service_plan.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppServicePlan_complete(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "kind", "Windows"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.tier", "Standard"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.size", "S1"),
+					resource.TestCheckResourceAttr(dataSourceName, "properties.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "properties.0.per_site_scaling", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.environment", "Test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAppServicePlan_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Basic"
+    size = "B1"
+  }
+}
+
+data "azurerm_app_service_plan" "test" {
+  name                = "${azurerm_app_service_plan.test.name}"
+  resource_group_name = "${azurerm_app_service_plan.test.resource_group_name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceAppServicePlan_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "Windows"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+
+  properties {
+    per_site_scaling = true
+  }
+
+  tags {
+    environment = "Test"
+  }
+}
+
+data "azurerm_app_service_plan" "test" {
+  name                = "${azurerm_app_service_plan.test.name}"
+  resource_group_name = "${azurerm_app_service_plan.test.resource_group_name}"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -65,6 +65,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"azurerm_app_service_plan":        dataSourceAppServicePlan(),
 			"azurerm_builtin_role_definition": dataSourceArmBuiltInRoleDefinition(),
 			"azurerm_client_config":           dataSourceArmClientConfig(),
 			"azurerm_image":                   dataSourceArmImage(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -23,9 +23,14 @@
             <li<%= sidebar_current("docs-azurerm-datasource") %>>
               <a href="#">Data Sources</a>
               <ul class="nav nav-visible">
-                <li<%= sidebar_current("docs-azurerm-datasource-builtin_role_definition") %>>
-                    <a href="/docs/providers/azurerm/d/builtin_role_definition.html">azurerm_builtin_role_definition</a>
+                <li<%= sidebar_current("docs-azurerm-datasource-app-service-plan") %>>
+                    <a href="/docs/providers/azurerm/d/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
+
+                <ul class="nav nav-visible">
+                  <li<%= sidebar_current("docs-azurerm-datasource-builtin-role-definition") %>>
+                      <a href="/docs/providers/azurerm/d/builtin_role_definition.html">azurerm_builtin_role_definition</a>
+                  </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-client-config") %>>
                     <a href="/docs/providers/azurerm/d/client_config.html">azurerm_client_config</a>

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_plan"
+sidebar_current: "docs-azurerm-datasource-app-service-plan"
+description: |-
+  Get information about an App Service Plan.
+---
+
+# Data Source: azurerm_app_service_plan
+
+Use this data source to obtain information about an App Service Plan (formerly known as a `Server Farm`).
+
+## Example Usage
+
+```hcl
+data "azurerm_app_service_plan" "test" {
+  name                = "search-app-service"
+  resource_group_name = "search-service"
+}
+
+output "app_service_plan_id" {
+  value = "${data.azurerm_app_service_plan.test.id}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the App Service Plan.
+* `resource_group_name` - (Required) The Name of the Resource Group where the App Service Plan exists.
+
+## Attributes Reference
+
+* `id` - The ID of the built-in App Service Plan.
+
+* `location` - The Azure location where the App Service Plan exists
+
+* `kind` - The Operating System type of the App Service Plan
+
+* `sku` - A `sku` block as documented below.
+
+* `properties` - A `properties` block as documented below.
+
+* `tags` - A mapping of tags to assign to the resource.
+
+A `sku` block supports the following:
+
+* `tier` - Specifies the plan's pricing tier.
+
+* `size` - Specifies the plan's instance size.
+
+* `capacity` - Specifies the number of workers associated with this App Service Plan.
+
+A `properties` block supports the following:
+
+* `maximum_number_of_workers` - Maximum number of instances that can be assigned to this App Service plan.
+
+* `reserved` - Is this App Service Plan `Reserved`?
+
+* `per_site_scaling` - Can Apps assigned to this App Service Plan be scaled independently?
+
+* `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.


### PR DESCRIPTION
Whilst reviewing #647 I realised this could be a useful Data Source - as such I've added one with the same properties visible on the Resource.

Tests pass:

```
$ acctests azurerm TestAccDataSourceAzureRMAppServicePlan_
=== RUN   TestAccDataSourceAzureRMAppServicePlan_basic
--- PASS: TestAccDataSourceAzureRMAppServicePlan_basic (79.79s)
=== RUN   TestAccDataSourceAzureRMAppServicePlan_complete
--- PASS: TestAccDataSourceAzureRMAppServicePlan_complete (74.04s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	153.860s
```