### PR TITLE
Add Support for Accelerated Networking (SR-IOV)

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -154,12 +154,9 @@ func resourceArmNetworkInterface() *schema.Resource {
 			},
 
 			/**
-			 * As of 2018-01-05: AN (aka. SR-IOV) on Azure is GA on Windows
-			 * and public preview on Linux.
-			 * Refer to: https://azure.microsoft.com/en-us/updates/accelerated-networking-in-expanded-preview/
+			 * As of 2018-01-06: AN (aka. SR-IOV) on Azure is GA on Windows and Linux.
 			 *
-			 * Your subscription must be whitelisted and provisioned
-			 * to enable AN support.
+			 * Refer to: https://azure.microsoft.com/en-us/blog/maximize-your-vm-s-performance-with-accelerated-networking-now-generally-available-for-both-windows-and-linux/
 			 *
 			 * Refer to: https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli
 			 * For details, VM configuration and caveats.

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -140,6 +140,23 @@ func resourceArmNetworkInterface() *schema.Resource {
 				Computed: true,
 			},
 
+			/**
+			 * As of 2018-01-05: AN (aka. SR-IOV) on Azure is GA on Windows
+			 * and public preview on Linux.
+			 * Refer to: https://azure.microsoft.com/en-us/updates/accelerated-networking-in-expanded-preview/
+			 *
+			 * Your subscription must be whitelisted and provisioned
+			 * to enable AN support.
+			 *
+			 * Refer to: https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli
+			 * For details, VM configuration and caveats.
+			 */
+			"enable_accelerated_networking": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"enable_ip_forwarding": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -173,10 +190,12 @@ func resourceArmNetworkInterfaceCreateUpdate(d *schema.ResourceData, meta interf
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	enableIpForwarding := d.Get("enable_ip_forwarding").(bool)
+	enableAcceleratedNetworking := d.Get("enable_accelerated_networking").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
 	properties := network.InterfacePropertiesFormat{
-		EnableIPForwarding: &enableIpForwarding,
+		EnableIPForwarding:          &enableIpForwarding,
+		EnableAcceleratedNetworking: &enableAcceleratedNetworking,
 	}
 
 	if v, ok := d.GetOk("network_security_group_id"); ok {

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -20,6 +21,18 @@ func resourceArmNetworkInterface() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		/**
+		 * Adding accelerated networking changes the schema, and as such
+		 * we want the migration function to handle the change.
+		 *
+		 * Schema Version Changes:
+		 * 0: Initial
+		 * 1: Add enable_accelerated_networking
+		 */
+		SchemaVersion: 1,
+
+		MigrateState: resourceNetworkInterfaceMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -578,6 +591,33 @@ func expandAzureRmNetworkInterfaceIpConfigurations(d *schema.ResourceData) ([]ne
 	}
 
 	return ipConfigs, &subnetNamesToLock, &virtualNetworkNamesToLock, nil
+}
+
+func resourceNetworkInterfaceMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AzureRM Network Interface State v0; migrating to v1")
+		return migrateNetworkInterfaceStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("unexpected schema version: %d", v)
+	}
+}
+
+func migrateNetworkInterfaceStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] ARM Network Interface Attributes before Migration: %#v", is.Attributes)
+
+	// All we do is add a "enable_accelerated_networking = false" migration
+	is.Attributes["enable_accelerated_networking"] = "false"
+
+	log.Printf("[DEBUG] ARM Network Interface Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
 }
 
 func sliceContainsValue(input []string, value string) bool {

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -201,25 +201,6 @@ func TestAccAzureRMNetworkInterface_enableAcceleratedNetworking(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMNetworkInterface_enableAnWithVM(t *testing.T) {
-	resourceName := "azurerm_network_interface.test"
-	rInt := acctest.RandInt()
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMNetworkInterface_anWithVM(rInt, testLocation()),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMNetworkInterfaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "enable_accelerated_networking", "true"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAzureRMNetworkInterface_multipleLoadBalancers(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
@@ -597,80 +578,6 @@ resource "azurerm_network_interface" "test" {
   }
 }
 `, rInt, location, rInt, rInt)
-}
-
-func testAccAzureRMNetworkInterface_anWithVM(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-rg-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "testsubnet"
-  resource_group_name  = "${azurerm_resource_group.test.name}"
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
-  address_prefix       = "10.0.2.0/24"
-}
-
-resource "azurerm_network_interface" "test" {
-  name                          = "acctestni-%d"
-  location                      = "${azurerm_resource_group.test.location}"
-  resource_group_name           = "${azurerm_resource_group.test.name}"
-  enable_ip_forwarding          = false
-  enable_accelerated_networking = true
-
-  ip_configuration {
-    name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.test.id}"
-    private_ip_address_allocation = "dynamic"
-  }
-}
-
-resource "azurerm_virtual_machine" "test" {
-    name                          = "acctestvm-%d"
-    location                      = "${azurerm_resource_group.test.location}"
-    resource_group_name           = "${azurerm_resource_group.test.name}"
-    primary_network_interface_id  = "${azurerm_network_interface.test.id}"
-    network_interface_ids         = [ "${azurerm_network_interface.test.id}" ]
-    // Only large VMs allow AN
-    vm_size                       = "Standard_D8_v3"
-    delete_os_disk_on_termination = true
-
-    storage_image_reference {
-        publisher = "${var.image["publisher"]}"
-        offer     = "${var.image["offer"]}"
-        sku       = "${var.image["sku"]}"
-        version   = "${var.image["version"]}"
-    }
-
-    storage_os_disk {
-        name              = "antest-%d-OSDisk"
-        caching           = "ReadWrite"
-        create_option     = "FromImage"
-        managed_disk_type = "Standard_LRS"
-        disk_size_gb      = 32
-    }
-
-    os_profile {
-        computer_name  = "antestMachine-%d"
-        admin_username = "antestuser"
-        admin_password = "antestpassword"
-    }
-
-    os_profile_linux_config {
-        disable_password_authentication = false
-    }
-
-}
-`, rInt, location, rInt, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_withTags(rInt int, location string) string {

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -182,6 +182,25 @@ func TestAccAzureRMNetworkInterface_enableIPForwarding(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterface_enableAcceleratedNetworking(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterface_acceleratedNetworking(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_accelerated_networking", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterface_multipleLoadBalancers(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
@@ -514,6 +533,43 @@ resource "azurerm_network_interface" "test" {
   location             = "${azurerm_resource_group.test.location}"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   enable_ip_forwarding = true
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMNetworkInterface_acceleratedNetworking(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "testsubnet"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                          = "acctestni-%d"
+  location                      = "${azurerm_resource_group.test.location}"
+  resource_group_name           = "${azurerm_resource_group.test.name}"
+  enable_ip_forwarding          = false
+  enable_accelerated_networking = true
 
   ip_configuration {
     name                          = "testconfiguration1"

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -1644,12 +1644,12 @@ resource "azurerm_virtual_machine" "test" {
     vm_size                       = "Standard_D8_v3"
     delete_os_disk_on_termination = true
 
-    storage_image_reference {
-        publisher = "${var.image["publisher"]}"
-        offer     = "${var.image["offer"]}"
-        sku       = "${var.image["sku"]}"
-        version   = "${var.image["version"]}"
-    }
+	storage_image_reference {
+		publisher = "Canonical"
+		offer     = "UbuntuServer"
+		sku       = "16.04-LTS"
+		version   = "latest"
+	}
 
     storage_os_disk {
         name              = "antest-%d-OSDisk"
@@ -1662,7 +1662,7 @@ resource "azurerm_virtual_machine" "test" {
     os_profile {
         computer_name  = "antestMachine-%d"
         admin_username = "antestuser"
-        admin_password = "antestpassword"
+        admin_password = "Password1234!"
     }
 
     os_profile_linux_config {

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -356,7 +356,6 @@ func TestAccAzureRMVirtualMachine_enableAnWithVM(t *testing.T) {
 				Config: testAccAzureRMVirtualMachine_anWithVM(rInt, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualMachineExists(resourceName, &vm),
-					resource.TestCheckResourceAttr(resourceName, "enable_accelerated_networking", "true"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+// NOTE: Test `TestAccAzureRMVirtualMachine_enableAnWithVM` requires a machine of size `D8_v3` which is large/expensive - you may wish to ignore this test"
+
 func TestAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_explicit(t *testing.T) {
 	var vm compute.VirtualMachine
 	ri := acctest.RandInt()
@@ -335,6 +337,26 @@ func TestAccAzureRMVirtualMachine_managedServiceIdentity(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "identity.0.type", "SystemAssigned"),
 					resource.TestMatchResourceAttr(resourceName, "identity.0.principal_id", match),
 					resource.TestMatchOutput("principal_id", match),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachine_enableAnWithVM(t *testing.T) {
+	var vm compute.VirtualMachine
+	resourceName := "azurerm_virtual_machine.test"
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachine_anWithVM(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists(resourceName, &vm),
+					resource.TestCheckResourceAttr(resourceName, "enable_accelerated_networking", "true"),
 				),
 			},
 		},
@@ -1575,4 +1597,78 @@ resource "azurerm_virtual_machine" "test" {
 	os_profile_windows_config {}
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rString, rString)
+}
+
+func testAccAzureRMVirtualMachine_anWithVM(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "testsubnet"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                          = "acctestni-%d"
+  location                      = "${azurerm_resource_group.test.location}"
+  resource_group_name           = "${azurerm_resource_group.test.name}"
+  enable_ip_forwarding          = false
+  enable_accelerated_networking = true
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+
+resource "azurerm_virtual_machine" "test" {
+    name                          = "acctestvm-%d"
+    location                      = "${azurerm_resource_group.test.location}"
+    resource_group_name           = "${azurerm_resource_group.test.name}"
+    primary_network_interface_id  = "${azurerm_network_interface.test.id}"
+    network_interface_ids         = [ "${azurerm_network_interface.test.id}" ]
+    // Only large VMs allow AN
+    vm_size                       = "Standard_D8_v3"
+    delete_os_disk_on_termination = true
+
+    storage_image_reference {
+        publisher = "${var.image["publisher"]}"
+        offer     = "${var.image["offer"]}"
+        sku       = "${var.image["sku"]}"
+        version   = "${var.image["version"]}"
+    }
+
+    storage_os_disk {
+        name              = "antest-%d-OSDisk"
+        caching           = "ReadWrite"
+        create_option     = "FromImage"
+        managed_disk_type = "Standard_LRS"
+        disk_size_gb      = 32
+    }
+
+    os_profile {
+        computer_name  = "antestMachine-%d"
+        admin_username = "antestuser"
+        admin_password = "antestpassword"
+    }
+
+    os_profile_linux_config {
+        disable_password_authentication = false
+    }
+
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt)
 }

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `enable_ip_forwarding` - (Optional) Enables IP Forwarding on the NIC. Defaults to `false`.
 
+* `enable_accelerated_networking` - (Optional) Enables Azure Accelerated Networking (AN) using SR-IOV. Only certain VM instance sizes support AN. Refer to [Create VM AN](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli). Defaults to `false`.
+
 * `dns_servers` - (Optional) List of DNS servers IP addresses to use for this NIC, overrides the VNet-level server list
 
 * `ip_configuration` - (Required) One or more `ip_configuration` associated with this NIC as documented below.

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `enable_ip_forwarding` - (Optional) Enables IP Forwarding on the NIC. Defaults to `false`.
 
-* `enable_accelerated_networking` - (Optional) Enables Azure Accelerated Networking (AN) using SR-IOV. Only certain VM instance sizes support AN. Refer to [Create VM AN](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli). Defaults to `false`.
+* `enable_accelerated_networking` - (Optional) Enables Azure Accelerated Networking using SR-IOV. Only certain VM instance sizes are supported. Refer to [Create a Virtual Machine with Accelerated Networking](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli). Defaults to `false`.
 
 * `dns_servers` - (Optional) List of DNS servers IP addresses to use for this NIC, overrides the VNet-level server list
 


### PR DESCRIPTION
This PR addresses #272 by providing support for AN (SR-IOV) as a flag to the network interfaces.

Your subscription needs to be enabled for AN.

Note that a schema version bump for `azurerm_network_interface` and associated migration function are included.