### PR TITLE
added a comment to the 0.0.0.0 block

### DIFF
--- a/examples/sql-database/main.tf
+++ b/examples/sql-database/main.tf
@@ -30,6 +30,8 @@ resource "azurerm_sql_server" "server" {
   administrator_login_password = "${var.sql_password}"
 }
 
+# Enables the "Allow Access to Azure services" box as described in the API docs 
+# https://docs.microsoft.com/en-us/rest/api/sql/firewallrules/createorupdate
 resource "azurerm_sql_firewall_rule" "fw" {
   name                = "firewallrules"
   resource_group_name = "${azurerm_resource_group.rg.name}"


### PR DESCRIPTION
The firewall rule for 0.0.0.0 is unclear to users unless they dig into the docs for the API.   Adding a comment there tells the user what that particular rule emulates from the portal when it's deployed.