### PR TITLE
Upgrading to v12.2.0-beta of the Azure SDK for Go

### DIFF
--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/appinsights/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/appinsights/client.go
@@ -1,6 +1,8 @@
 // Package appinsights implements the Azure ARM Appinsights service API version 2015-05-01.
 //
 // Composite Swagger for Application Insights Management Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights
 package appinsights
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/appinsights/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/appinsights/version.go
@@ -19,10 +19,10 @@ package appinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-appinsights/2015-05-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-appinsights/2015-05-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/authorization/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/authorization/client.go
@@ -4,6 +4,8 @@
 // resources or resource groups. These operations enable you to manage role definitions and role assignments. A role
 // definition describes the set of actions that can be performed on resources. A role assignment grants access to Azure
 // Active Directory users.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization
 package authorization
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/authorization/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/authorization/version.go
@@ -19,10 +19,10 @@ package authorization
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-authorization/2015-07-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-authorization/2015-07-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/automation/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/automation/client.go
@@ -1,6 +1,8 @@
 // Package automation implements the Azure ARM Automation service API version 2015-10-31.
 //
 // Automation Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation
 package automation
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/automation/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/automation/version.go
@@ -19,10 +19,10 @@ package automation
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-automation/2015-10-31"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-automation/2015-10-31"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/cdn/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/cdn/client.go
@@ -2,6 +2,8 @@
 //
 // Use these APIs to manage Azure CDN resources through the Azure Resource Manager. You must make sure that requests
 // made to these resources are secure.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn
 package cdn
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/cdn/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/cdn/version.go
@@ -19,10 +19,10 @@ package cdn
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-cdn/2017-04-02"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-cdn/2017-04-02"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/client.go
@@ -1,6 +1,8 @@
 // Package compute implements the Azure ARM Compute service API version .
 //
 // Compute Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-03-30/compute
 package compute
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/compute/version.go
@@ -19,10 +19,10 @@ package compute
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-compute/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-compute/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/containerinstance/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/containerinstance/client.go
@@ -1,6 +1,6 @@
 // Package containerinstance implements the Azure ARM Containerinstance service API version 2017-08-01-preview.
 //
-//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2017-08-01-preview/containerinstance
 package containerinstance
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/containerinstance/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/containerinstance/version.go
@@ -19,10 +19,10 @@ package containerinstance
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-containerinstance/2017-08-01-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-containerinstance/2017-08-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/containerregistry/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/containerregistry/client.go
@@ -1,6 +1,6 @@
 // Package containerregistry implements the Azure ARM Containerregistry service API version 2017-10-01.
 //
-//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2017-10-01/containerregistry
 package containerregistry
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/containerregistry/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/containerregistry/version.go
@@ -19,10 +19,10 @@ package containerregistry
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-containerregistry/2017-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-containerregistry/2017-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/containerservice/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/containerservice/client.go
@@ -1,6 +1,6 @@
 // Package containerservice implements the Azure ARM Containerservice service API version 2017-01-31.
 //
-// Compute Client
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-01-31/containerservice
 package containerservice
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/containerservice/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/containerservice/version.go
@@ -19,10 +19,10 @@ package containerservice
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-containerservice/2017-01-31"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-containerservice/2017-01-31"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/cosmos-db/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/cosmos-db/client.go
@@ -1,6 +1,8 @@
 // Package cosmosdb implements the Azure ARM Cosmosdb service API version 2015-04-08.
 //
 // Azure Cosmos DB Database Service Resource Provider REST API
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb
 package cosmosdb
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/cosmos-db/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/cosmos-db/version.go
@@ -19,10 +19,10 @@ package cosmosdb
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-cosmosdb/2015-04-08"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-cosmosdb/2015-04-08"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/disk/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/disk/client.go
@@ -2,6 +2,8 @@
 // 2016-04-30-preview.
 //
 // The Disk Resource Provider Client.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2016-04-30-preview/compute
 package disk
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/disk/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/disk/version.go
@@ -19,10 +19,10 @@ package disk
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v10.2.0-beta arm-disk/2016-04-30-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-disk/2016-04-30-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v10.2.0-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/dns/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/dns/client.go
@@ -1,6 +1,8 @@
 // Package dns implements the Azure ARM Dns service API version 2016-04-01.
 //
 // The DNS Management Client.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2016-04-01/dns
 package dns
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/dns/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/dns/version.go
@@ -19,10 +19,10 @@ package dns
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-dns/2016-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-dns/2016-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/eventgrid/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/eventgrid/client.go
@@ -1,6 +1,8 @@
 // Package eventgrid implements the Azure ARM Eventgrid service API version 2017-09-15-preview.
 //
 // Azure EventGrid Management Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/eventgrid/mgmt/2017-09-15-preview/eventgrid
 package eventgrid
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/eventgrid/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/eventgrid/version.go
@@ -19,10 +19,10 @@ package eventgrid
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-eventgrid/2017-09-15-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-eventgrid/2017-09-15-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/eventhub/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/eventhub/client.go
@@ -1,6 +1,8 @@
 // Package eventhub implements the Azure ARM Eventhub service API version 2017-04-01.
 //
 // Azure Event Hubs client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/event
 package eventhub
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/eventhub/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/eventhub/version.go
@@ -19,10 +19,10 @@ package eventhub
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-eventhub/2017-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-eventhub/2017-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/graphrbac/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/graphrbac/client.go
@@ -1,6 +1,8 @@
 // Package graphrbac implements the Azure ARM Graphrbac service API version 1.6.
 //
 // The Graph RBAC Management Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac
 package graphrbac
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/graphrbac/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/graphrbac/version.go
@@ -19,10 +19,10 @@ package graphrbac
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-graphrbac/1.6"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-graphrbac/1.6"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/keyvault/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/keyvault/client.go
@@ -1,6 +1,8 @@
 // Package keyvault implements the Azure ARM Keyvault service API version 2016-10-01.
 //
 // The Azure management API provides a RESTful set of web services that interact with Azure Key Vault.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault
 package keyvault
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/keyvault/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-keyvault/2016-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-keyvault/2016-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/mysql/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/mysql/client.go
@@ -2,6 +2,8 @@
 //
 // The Microsoft Azure management API provides create, read, update, and delete functionality for Azure MySQL resources
 // including servers, databases, firewall rules, log files and configurations.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-04-30-preview/mysql
 package mysql
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/mysql/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/mysql/version.go
@@ -19,10 +19,10 @@ package mysql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-mysql/2017-04-30-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-mysql/2017-04-30-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/client.go
@@ -1,6 +1,8 @@
 // Package network implements the Azure ARM Network service API version .
 //
 // Network Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network
 package network
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/network/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/network/version.go
@@ -19,10 +19,10 @@ package network
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-network/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-network/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/operationalinsights/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/operationalinsights/client.go
@@ -1,6 +1,8 @@
 // Package operationalinsights implements the Azure ARM Operationalinsights service API version .
 //
 // Operational Insights Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/operationalinsights/mgmt/2015-11-01-preview/operationalinsights
 package operationalinsights
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/operationalinsights/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/operationalinsights/version.go
@@ -19,10 +19,10 @@ package operationalinsights
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-operationalinsights/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-operationalinsights/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/postgresql/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/postgresql/client.go
@@ -2,6 +2,8 @@
 //
 // The Microsoft Azure management API provides create, read, update, and delete functionality for Azure PostgreSQL
 // resources including servers, databases, firewall rules, log files and configurations.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-04-30-preview/postgresql
 package postgresql
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/postgresql/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/postgresql/version.go
@@ -19,10 +19,10 @@ package postgresql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-postgresql/2017-04-30-preview"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-postgresql/2017-04-30-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/redis/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/redis/client.go
@@ -1,6 +1,8 @@
 // Package redis implements the Azure ARM Redis service API version 2016-04-01.
 //
 // REST API for Azure Redis Cache Service.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2016-04-01/redis
 package redis
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/redis/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/redis/version.go
@@ -19,10 +19,10 @@ package redis
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-redis/2016-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-redis/2016-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/locks/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/locks/client.go
@@ -1,6 +1,8 @@
 // Package locks implements the Azure ARM Locks service API version 2016-09-01.
 //
 // Azure resources can be locked to prevent other users in your organization from deleting or modifying resources.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-09-01/locks
 package locks
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/locks/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/locks/version.go
@@ -19,10 +19,10 @@ package locks
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-locks/2016-09-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-locks/2016-09-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/client.go
@@ -1,6 +1,8 @@
 // Package resources implements the Azure ARM Resources service API version 2017-05-10.
 //
 // Provides operations for working with resources and resource groups.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2017-05-10/resources
 package resources
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/resources/version.go
@@ -19,10 +19,10 @@ package resources
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-resources/2017-05-10"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-resources/2017-05-10"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/client.go
@@ -3,6 +3,8 @@
 // All resource groups and resources exist within subscriptions. These operation enable you get information about your
 // subscriptions and tenants. A tenant is a dedicated instance of Azure Active Directory (Azure AD) for your
 // organization.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-06-01/subscriptions
 package subscriptions
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions/version.go
@@ -19,10 +19,10 @@ package subscriptions
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-subscriptions/2016-06-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-subscriptions/2016-06-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/scheduler/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/scheduler/client.go
@@ -1,6 +1,6 @@
 // Package scheduler implements the Azure ARM Scheduler service API version 2016-03-01.
 //
-//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/scheduler/2016-03-01/scheduler
 package scheduler
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/scheduler/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/scheduler/version.go
@@ -19,10 +19,10 @@ package scheduler
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-scheduler/2016-03-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-scheduler/2016-03-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/search/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/search/client.go
@@ -1,6 +1,8 @@
 // Package search implements the Azure ARM Search service API version 2015-08-19.
 //
 // Client that can be used to manage Azure Search services and API keys.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/search/2015-08-19/search
 package search
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/search/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/search/version.go
@@ -19,10 +19,10 @@ package search
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-search/2015-08-19"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-search/2015-08-19"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/servicebus/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/servicebus/client.go
@@ -1,6 +1,8 @@
 // Package servicebus implements the Azure ARM Servicebus service API version 2017-04-01.
 //
 // Azure Service Bus client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/servicebus/mgmt/2017-04-01/servicebus
 package servicebus
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/servicebus/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/servicebus/version.go
@@ -19,10 +19,10 @@ package servicebus
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-servicebus/2017-04-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-servicebus/2017-04-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/sql/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/sql/client.go
@@ -2,6 +2,8 @@
 //
 // The Azure SQL Database management API provides a RESTful set of web services that interact with Azure SQL Database
 // services to manage your databases. The API enables you to create, retrieve, update, and delete databases.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/sql/mgmt/2017-03-01-preview/sql
 package sql
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/sql/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/sql/version.go
@@ -19,10 +19,10 @@ package sql
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-sql/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-sql/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/client.go
@@ -1,6 +1,8 @@
 // Package storage implements the Azure ARM Storage service API version 2017-06-01.
 //
 // The Azure Storage Management API.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-06-01/storage
 package storage
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/storage/version.go
@@ -19,10 +19,10 @@ package storage
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-storage/2017-06-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-storage/2017-06-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/trafficmanager/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/trafficmanager/client.go
@@ -1,6 +1,6 @@
 // Package trafficmanager implements the Azure ARM Trafficmanager service API version .
 //
-//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/trafficmanager/mgmt/2017-09-01-preview/trafficmanager
 package trafficmanager
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/trafficmanager/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/trafficmanager/version.go
@@ -19,10 +19,10 @@ package trafficmanager
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-trafficmanager/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-trafficmanager/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/web/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/web/client.go
@@ -1,6 +1,8 @@
 // Package web implements the Azure ARM Web service API version .
 //
 // WebSite Management Client
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web
 package web
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/arm/web/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/arm/web/version.go
@@ -19,10 +19,10 @@ package web
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-web/"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-web/"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/dataplane/keyvault/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/dataplane/keyvault/client.go
@@ -1,6 +1,8 @@
 // Package keyvault implements the Azure ARM Keyvault service API version 2016-10-01.
 //
 // The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
+//
+// Deprecated: Please instead use github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault
 package keyvault
 
 // Copyright (c) Microsoft and contributors.  All rights reserved.

--- a/vendor/github.com/Azure/azure-sdk-for-go/dataplane/keyvault/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/dataplane/keyvault/version.go
@@ -19,10 +19,10 @@ package keyvault
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/v11.1.1-beta arm-keyvault/2016-10-01"
+	return "Azure-SDK-For-Go/v12.2.0-beta arm-keyvault/2016-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-	return "v11.1.1-beta"
+	return "v12.2.0-beta"
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/README.md
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/README.md
@@ -6,7 +6,7 @@ This package includes support for [Azure Storage Emulator](https://azure.microso
 
 # Getting Started
 
- 1. Go get the SDK `go get -u github.com/Azure/azure-sdk-for=go/storage`
+ 1. Go get the SDK `go get -u github.com/Azure/azure-sdk-for-go/storage`
  1. If you don't already have one, [create a Storage Account](https://docs.microsoft.com/en-us/azure/storage/storage-create-storage-account).
       - Take note of your Azure Storage Account Name and Azure Storage Account Key. They'll both be necessary for using this library.
       - This option is production ready, but can also be used for development.

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/container.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/container.go
@@ -301,9 +301,6 @@ func (c *Container) Exists() (bool, error) {
 		uri = newURI.String()
 
 	} else {
-		if c.bsc.client.isAccountSASClient() {
-			q = mergeParams(q, c.bsc.client.accountSASToken)
-		}
 		uri = c.bsc.client.getEndpoint(blobServiceName, c.buildPath(), q)
 	}
 	headers := c.bsc.client.getStandardHeaders()
@@ -489,9 +486,6 @@ func (c *Container) ListBlobs(params ListBlobsParameters) (BlobListResponse, err
 		newURI.RawQuery = q.Encode()
 		uri = newURI.String()
 	} else {
-		if c.bsc.client.isAccountSASClient() {
-			q = mergeParams(q, c.bsc.client.accountSASToken)
-		}
 		uri = c.bsc.client.getEndpoint(blobServiceName, c.buildPath(), q)
 	}
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/entity.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/entity.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/satori/uuid"
+	"github.com/satori/go.uuid"
 )
 
 // Annotating as secure for gas scanning

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/table_batch.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/table_batch.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/satori/uuid"
+	"github.com/marstr/guid"
 )
 
 // Operation type. Insert, Delete, Replace etc.
@@ -131,14 +131,26 @@ func (t *TableBatch) MergeEntity(entity *Entity) {
 // the changesets.
 // As per document https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/performing-entity-group-transactions
 func (t *TableBatch) ExecuteBatch() error {
-	changesetBoundary := fmt.Sprintf("changeset_%s", uuid.NewV1())
+
+	// Using `github.com/marstr/guid` is in response to issue #947 (https://github.com/Azure/azure-sdk-for-go/issues/947).
+	id, err := guid.NewGUIDs(guid.CreationStrategyVersion1)
+	if err != nil {
+		return err
+	}
+
+	changesetBoundary := fmt.Sprintf("changeset_%s", id.String())
 	uri := t.Table.tsc.client.getEndpoint(tableServiceName, "$batch", nil)
 	changesetBody, err := t.generateChangesetBody(changesetBoundary)
 	if err != nil {
 		return err
 	}
 
-	boundary := fmt.Sprintf("batch_%s", uuid.NewV1())
+	id, err = guid.NewGUIDs(guid.CreationStrategyVersion1)
+	if err != nil {
+		return err
+	}
+
+	boundary := fmt.Sprintf("batch_%s", id.String())
 	body, err := generateBody(changesetBody, changesetBoundary, boundary)
 	if err != nil {
 		return err

--- a/vendor/github.com/Azure/azure-sdk-for-go/storage/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/storage/version.go
@@ -15,5 +15,5 @@ package storage
 //  limitations under the License.
 
 var (
-	sdkVersion = "10.0.2"
+	sdkVersion = "v12.2.0-beta"
 )

--- a/vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
@@ -159,7 +159,7 @@ func register(client autorest.Client, originalReq *http.Request, re RequestError
 		}
 		req.Cancel = originalReq.Cancel
 
-		resp, err := autorest.SendWithSender(client.Sender, req,
+		resp, err := autorest.SendWithSender(client, req,
 			autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...),
 		)
 		if err != nil {

--- a/vendor/github.com/Azure/go-autorest/autorest/utility.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/utility.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -193,30 +192,6 @@ func pathEscape(s string) string {
 
 func queryEscape(s string) string {
 	return url.QueryEscape(s)
-}
-
-// This method is same as Encode() method of "net/url" go package,
-// except it does not encode the query parameters because they
-// already come encoded. It formats values map in query format (bar=foo&a=b).
-func createQuery(v url.Values) string {
-	var buf bytes.Buffer
-	keys := make([]string, 0, len(v))
-	for k := range v {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		vs := v[k]
-		prefix := url.QueryEscape(k) + "="
-		for _, v := range vs {
-			if buf.Len() > 0 {
-				buf.WriteByte('&')
-			}
-			buf.WriteString(prefix)
-			buf.WriteString(v)
-		}
-	}
-	return buf.String()
 }
 
 // ChangeToGet turns the specified http.Request into a GET (it assumes it wasn't).

--- a/vendor/github.com/marstr/guid/LICENSE.txt
+++ b/vendor/github.com/marstr/guid/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Martin Strobel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/marstr/guid/README.md
+++ b/vendor/github.com/marstr/guid/README.md
@@ -1,0 +1,27 @@
+[![Build Status](https://travis-ci.org/marstr/guid.svg?branch=master)](https://travis-ci.org/marstr/guid)
+[![GoDoc](https://godoc.org/github.com/marstr/guid?status.svg)](https://godoc.org/github.com/marstr/guid)
+[![Go Report Card](https://goreportcard.com/badge/github.com/marstr/guid)](https://goreportcard.com/report/github.com/marstr/guid)
+
+# Guid
+Globally unique identifiers offer a quick means of generating non-colliding values across a distributed system. For this implemenation, [RFC 4122](http://ietf.org/rfc/rfc4122.txt) governs the desired behavior.
+
+## What's in a name?
+You have likely already noticed that RFC and some implementations refer to these structures as UUIDs (Universally Unique Identifiers), where as this project is annotated as  GUIDs (Globally Unique Identifiers). The name Guid was selected to make clear this project's ties to the [.NET struct Guid.](https://msdn.microsoft.com/en-us/library/system.guid(v=vs.110).aspx) The most obvious relationship is the desire to have the same format specifiers available in this library's Format and Parse methods as .NET would have in its ToString and Parse methods.
+
+# Installation
+- Ensure you have the [Go Programming Language](https://golang.org/) installed on your system.
+- Run the command: `go get -u github.com/marstr/guid`
+
+# Contribution
+Contributions are welcome! Feel free to send Pull Requests. Continuous Integration will ensure that you have conformed to Go conventions. Please remember to add tests for your changes.
+
+# Versioning
+This library will adhere to the
+[Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html) specification. It may be worth noting this should allow for tools like [glide](https://glide.readthedocs.io/en/latest/) to pull in this library with ease.
+
+The Release Notes portion of this file will be updated to reflect the most recent major/minor updates, with the option to tag particular bug-fixes as well. Updates to the Release Notes for patches should be addative, where as major/minor updates should replace the previous version. If one desires to see the release notes for an older version, checkout that version of code and open this file.
+
+# Release Notes 1.1.*
+
+## v1.1.0
+Adding support for JSON marshaling and unmarshaling.

--- a/vendor/github.com/marstr/guid/guid.go
+++ b/vendor/github.com/marstr/guid/guid.go
@@ -1,0 +1,301 @@
+package guid
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+)
+
+// GUID is a unique identifier designed to virtually guarantee non-conflict between values generated
+// across a distributed system.
+type GUID struct {
+	timeHighAndVersion      uint16
+	timeMid                 uint16
+	timeLow                 uint32
+	clockSeqHighAndReserved uint8
+	clockSeqLow             uint8
+	node                    [6]byte
+}
+
+// Format enumerates the values that are supported by Parse and Format
+type Format string
+
+// These constants define the possible string formats available via this implementation of Guid.
+const (
+	FormatB       Format = "B" // {00000000-0000-0000-0000-000000000000}
+	FormatD       Format = "D" // 00000000-0000-0000-0000-000000000000
+	FormatN       Format = "N" // 00000000000000000000000000000000
+	FormatP       Format = "P" // (00000000-0000-0000-0000-000000000000)
+	FormatX       Format = "X" // {0x00000000,0x0000,0x0000,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}}
+	FormatDefault Format = FormatD
+)
+
+// CreationStrategy enumerates the values that are supported for populating the bits of a new Guid.
+type CreationStrategy string
+
+// These constants define the possible creation strategies available via this implementation of Guid.
+const (
+	CreationStrategyVersion1 CreationStrategy = "version1"
+	CreationStrategyVersion2 CreationStrategy = "version2"
+	CreationStrategyVersion3 CreationStrategy = "version3"
+	CreationStrategyVersion4 CreationStrategy = "version4"
+	CreationStrategyVersion5 CreationStrategy = "version5"
+)
+
+var emptyGUID GUID
+
+// NewGUID generates and returns a new globally unique identifier
+func NewGUID() GUID {
+	result, err := version4()
+	if err != nil {
+		panic(err) //Version 4 (pseudo-random GUID) doesn't use anything that could fail.
+	}
+	return result
+}
+
+var knownStrategies = map[CreationStrategy]func() (GUID, error){
+	CreationStrategyVersion1: version1,
+	CreationStrategyVersion4: version4,
+}
+
+// NewGUIDs generates and returns a new globally unique identifier that conforms to the given strategy.
+func NewGUIDs(strategy CreationStrategy) (GUID, error) {
+	if creator, present := knownStrategies[strategy]; present {
+		result, err := creator()
+		return result, err
+	}
+	return emptyGUID, errors.New("Unsupported CreationStrategy")
+}
+
+// Empty returns a copy of the default and empty GUID.
+func Empty() GUID {
+	return emptyGUID
+}
+
+var knownFormats = map[Format]string{
+	FormatN: "%08x%04x%04x%02x%02x%02x%02x%02x%02x%02x%02x",
+	FormatD: "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+	FormatB: "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
+	FormatP: "(%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x)",
+	FormatX: "{0x%08x,0x%04x,0x%04x,{0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x}}",
+}
+
+// MarshalJSON writes a GUID as a JSON string.
+func (guid GUID) MarshalJSON() (marshaled []byte, err error) {
+	buf := bytes.Buffer{}
+
+	_, err = buf.WriteRune('"')
+	buf.WriteString(guid.String())
+	buf.WriteRune('"')
+
+	marshaled = buf.Bytes()
+	return
+}
+
+// Parse instantiates a GUID from a text representation of the same GUID.
+// This is the inverse of function family String()
+func Parse(value string) (GUID, error) {
+	var guid GUID
+	for _, fullFormat := range knownFormats {
+		parity, err := fmt.Sscanf(
+			value,
+			fullFormat,
+			&guid.timeLow,
+			&guid.timeMid,
+			&guid.timeHighAndVersion,
+			&guid.clockSeqHighAndReserved,
+			&guid.clockSeqLow,
+			&guid.node[0],
+			&guid.node[1],
+			&guid.node[2],
+			&guid.node[3],
+			&guid.node[4],
+			&guid.node[5])
+		if parity == 11 && err == nil {
+			return guid, err
+		}
+	}
+	return emptyGUID, fmt.Errorf("\"%s\" is not in a recognized format", value)
+}
+
+// String returns a text representation of a GUID in the default format.
+func (guid GUID) String() string {
+	return guid.Stringf(FormatDefault)
+}
+
+// Stringf returns a text representation of a GUID that conforms to the specified format.
+// If an unrecognized format is provided, the empty string is returned.
+func (guid GUID) Stringf(format Format) string {
+	if format == "" {
+		format = FormatDefault
+	}
+	fullFormat, present := knownFormats[format]
+	if !present {
+		return ""
+	}
+	return fmt.Sprintf(
+		fullFormat,
+		guid.timeLow,
+		guid.timeMid,
+		guid.timeHighAndVersion,
+		guid.clockSeqHighAndReserved,
+		guid.clockSeqLow,
+		guid.node[0],
+		guid.node[1],
+		guid.node[2],
+		guid.node[3],
+		guid.node[4],
+		guid.node[5])
+}
+
+// UnmarshalJSON parses a GUID from a JSON string token.
+func (guid *GUID) UnmarshalJSON(marshaled []byte) (err error) {
+	if len(marshaled) < 2 {
+		err = errors.New("JSON GUID must be surrounded by quotes")
+		return
+	}
+	stripped := marshaled[1 : len(marshaled)-1]
+	*guid, err = Parse(string(stripped))
+	return
+}
+
+// Version reads a GUID to parse which mechanism of generating GUIDS was employed.
+// Values returned here are documented in rfc4122.txt.
+func (guid GUID) Version() uint {
+	return uint(guid.timeHighAndVersion >> 12)
+}
+
+var unixToGregorianOffset = time.Date(1970, 01, 01, 0, 0, 00, 0, time.UTC).Sub(time.Date(1582, 10, 15, 0, 0, 0, 0, time.UTC))
+
+// getRFC4122Time returns a 60-bit count of 100-nanosecond intervals since 00:00:00.00 October 15th, 1582
+func getRFC4122Time() int64 {
+	currentTime := time.Now().UTC().Add(unixToGregorianOffset).UnixNano()
+	currentTime /= 100
+	return currentTime & 0x0FFFFFFFFFFFFFFF
+}
+
+var clockSeqVal uint16
+var clockSeqKey sync.Mutex
+
+func getClockSequence() (uint16, error) {
+	clockSeqKey.Lock()
+	defer clockSeqKey.Unlock()
+
+	if 0 == clockSeqVal {
+		var temp [2]byte
+		if parity, err := rand.Read(temp[:]); !(2 == parity && nil == err) {
+			return 0, err
+		}
+		clockSeqVal = uint16(temp[0])<<8 | uint16(temp[1])
+	}
+	clockSeqVal++
+	return clockSeqVal, nil
+}
+
+func getMACAddress() (mac [6]byte, err error) {
+	var hostNICs []net.Interface
+
+	hostNICs, err = net.Interfaces()
+	if err != nil {
+		return
+	}
+
+	for _, nic := range hostNICs {
+		var parity int
+
+		parity, err = fmt.Sscanf(
+			strings.ToLower(nic.HardwareAddr.String()),
+			"%02x:%02x:%02x:%02x:%02x:%02x",
+			&mac[0],
+			&mac[1],
+			&mac[2],
+			&mac[3],
+			&mac[4],
+			&mac[5])
+
+		if parity == len(mac) {
+			return
+		}
+	}
+
+	err = fmt.Errorf("No suitable address found")
+
+	return
+}
+
+func version1() (result GUID, err error) {
+	var localMAC [6]byte
+	var clockSeq uint16
+
+	currentTime := getRFC4122Time()
+
+	result.timeLow = uint32(currentTime)
+	result.timeMid = uint16(currentTime >> 32)
+	result.timeHighAndVersion = uint16(currentTime >> 48)
+	if err = result.setVersion(1); err != nil {
+		return emptyGUID, err
+	}
+
+	if localMAC, err = getMACAddress(); nil != err {
+		if parity, err := rand.Read(localMAC[:]); !(len(localMAC) != parity && err == nil) {
+			return emptyGUID, err
+		}
+		localMAC[0] |= 0x1
+	}
+	copy(result.node[:], localMAC[:])
+
+	if clockSeq, err = getClockSequence(); nil != err {
+		return emptyGUID, err
+	}
+
+	result.clockSeqLow = uint8(clockSeq)
+	result.clockSeqHighAndReserved = uint8(clockSeq >> 8)
+
+	result.setReservedBits()
+
+	return
+}
+
+func version4() (GUID, error) {
+	var retval GUID
+	var bits [10]byte
+
+	if parity, err := rand.Read(bits[:]); !(len(bits) == parity && err == nil) {
+		return emptyGUID, err
+	}
+	retval.timeHighAndVersion |= uint16(bits[0]) | uint16(bits[1])<<8
+	retval.timeMid |= uint16(bits[2]) | uint16(bits[3])<<8
+	retval.timeLow |= uint32(bits[4]) | uint32(bits[5])<<8 | uint32(bits[6])<<16 | uint32(bits[7])<<24
+	retval.clockSeqHighAndReserved = uint8(bits[8])
+	retval.clockSeqLow = uint8(bits[9])
+
+	//Randomly set clock-sequence, reserved, and node
+	if written, err := rand.Read(retval.node[:]); !(nil == err && written == len(retval.node)) {
+		retval = emptyGUID
+		return retval, err
+	}
+
+	if err := retval.setVersion(4); nil != err {
+		return emptyGUID, err
+	}
+	retval.setReservedBits()
+
+	return retval, nil
+}
+
+func (guid *GUID) setVersion(version uint16) error {
+	if version > 5 || version == 0 {
+		return fmt.Errorf("While setting GUID version, unsupported version: %d", version)
+	}
+	guid.timeHighAndVersion = (guid.timeHighAndVersion & 0x0fff) | version<<12
+	return nil
+}
+
+func (guid *GUID) setReservedBits() {
+	guid.clockSeqHighAndReserved = (guid.clockSeqHighAndReserved & 0x3f) | 0x80
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -259,67 +259,67 @@
 			"versionExact": "v11.2.2-beta"
 		},
 		{
-			"checksumSHA1": "tmbv8hhVXheuJk0/b5f0az1hzB0=",
-			"comment": "v9.5.2",
+			"checksumSHA1": "RzIYmvG1ReOud+kafFsZTDIZSK0=",
+			"comment": "v9.7.0",
 			"path": "github.com/Azure/go-autorest/autorest",
-			"revision": "40e67ab508b948cd6ab4b4108ea42f3793ca19e3",
-			"revisionTime": "2017-12-12T18:03:12Z",
-			"version": "v9.5.2",
-			"versionExact": "v9.5.2"
+			"revision": "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01",
+			"revisionTime": "2018-01-06T16:29:27Z",
+			"version": "v9.7.0",
+			"versionExact": "v9.7.0"
 		},
 		{
-			"checksumSHA1": "GHaYEopkom2TYCTK1yJSbyVf/VE=",
-			"comment": "v9.5.2",
+			"checksumSHA1": "OxKbGGQUfsDtM4Fz4ysBpallhOE=",
+			"comment": "v9.7.0",
 			"path": "github.com/Azure/go-autorest/autorest/adal",
-			"revision": "40e67ab508b948cd6ab4b4108ea42f3793ca19e3",
-			"revisionTime": "2017-12-12T18:03:12Z",
-			"version": "v9.5.2",
-			"versionExact": "v9.5.2"
+			"revision": "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01",
+			"revisionTime": "2018-01-06T16:29:27Z",
+			"version": "v9.7.0",
+			"versionExact": "v9.7.0"
 		},
 		{
-			"checksumSHA1": "fazJNSy32igO+x8x2wXupgNhu+c=",
-			"comment": "v9.5.2",
+			"checksumSHA1": "PwTnRhiCu8p2D1M2nsM0ADL4FM0=",
+			"comment": "v9.7.0",
 			"path": "github.com/Azure/go-autorest/autorest/azure",
-			"revision": "40e67ab508b948cd6ab4b4108ea42f3793ca19e3",
-			"revisionTime": "2017-12-12T18:03:12Z",
-			"version": "v9.5.2",
-			"versionExact": "v9.5.2"
+			"revision": "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01",
+			"revisionTime": "2018-01-06T16:29:27Z",
+			"version": "v9.7.0",
+			"versionExact": "v9.7.0"
 		},
 		{
 			"checksumSHA1": "+nXRwVB/JVEGe+oLsFhCmSkKPuI=",
-			"comment": "v9.5.2",
+			"comment": "v9.7.0",
 			"path": "github.com/Azure/go-autorest/autorest/azure/cli",
-			"revision": "40e67ab508b948cd6ab4b4108ea42f3793ca19e3",
-			"revisionTime": "2017-12-12T18:03:12Z",
-			"version": "v9.5.2",
-			"versionExact": "v9.5.2"
+			"revision": "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01",
+			"revisionTime": "2018-01-06T16:29:27Z",
+			"version": "v9.7.0",
+			"versionExact": "v9.7.0"
 		},
 		{
 			"checksumSHA1": "9nXCi9qQsYjxCeajJKWttxgEt0I=",
-			"comment": "v9.5.2",
+			"comment": "v9.7.0",
 			"path": "github.com/Azure/go-autorest/autorest/date",
-			"revision": "40e67ab508b948cd6ab4b4108ea42f3793ca19e3",
-			"revisionTime": "2017-12-12T18:03:12Z",
-			"version": "v9.5.2",
-			"versionExact": "v9.5.2"
+			"revision": "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01",
+			"revisionTime": "2018-01-06T16:29:27Z",
+			"version": "v9.7.0",
+			"versionExact": "v9.7.0"
 		},
 		{
 			"checksumSHA1": "SbBb2GcJNm5GjuPKGL2777QywR4=",
-			"comment": "v9.5.2",
+			"comment": "v9.7.0",
 			"path": "github.com/Azure/go-autorest/autorest/to",
-			"revision": "40e67ab508b948cd6ab4b4108ea42f3793ca19e3",
-			"revisionTime": "2017-12-12T18:03:12Z",
-			"version": "v9.5.2",
-			"versionExact": "v9.5.2"
+			"revision": "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01",
+			"revisionTime": "2018-01-06T16:29:27Z",
+			"version": "v9.7.0",
+			"versionExact": "v9.7.0"
 		},
 		{
 			"checksumSHA1": "HfqZyKllcHQDvTwgCaYL1jUPmW0=",
-			"comment": "v9.5.2",
+			"comment": "v9.7.0",
 			"path": "github.com/Azure/go-autorest/autorest/validation",
-			"revision": "40e67ab508b948cd6ab4b4108ea42f3793ca19e3",
-			"revisionTime": "2017-12-12T18:03:12Z",
-			"version": "v9.5.2",
-			"versionExact": "v9.5.2"
+			"revision": "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01",
+			"revisionTime": "2018-01-06T16:29:27Z",
+			"version": "v9.7.0",
+			"versionExact": "v9.7.0"
 		},
 		{
 			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -941,6 +941,12 @@
 			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
+			"checksumSHA1": "T9E+5mKBQ/BX4wlNxgaPfetxdeI=",
+			"path": "github.com/marstr/guid",
+			"revision": "8bdf7d1a087ccc975cf37dd6507da50698fd19ca",
+			"revisionTime": "2017-04-27T23:51:15Z"
+		},
+		{
 			"checksumSHA1": "y/A5iuvwjytQE2CqVuphQRXR2nI=",
 			"path": "github.com/mattn/go-isatty",
 			"revision": "a5cdd64afdee435007ee3e9f6ed4684af949d568",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,260 +3,260 @@
 	"ignore": "test github.com/hashicorp/terraform/backend",
 	"package": [
 		{
-			"checksumSHA1": "cLJryrfFsQ0kxvT26jyrRASjqyE=",
+			"checksumSHA1": "6L+lfS4jjiDIT4vBffPkpmx2PI0=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/appinsights",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "1TjThMsS9q9PFA1Ku6VpArJpwrc=",
+			"checksumSHA1": "IjNs00z0UNBU/yuPRYynmrgVGGs=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/authorization",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "dLLvvMHpeu3J7VxCLRUQKDHZWX4=",
+			"checksumSHA1": "ntRFNTvyrAmlRlpQVLJpVBwhQms=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/automation",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "Ne7TSUwMhG0j3gjU/xK+mpF8+iI=",
+			"checksumSHA1": "wgnU3Mmf/S8pUvERC4TRzoLLH5g=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/cdn",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "sgst5KZzsaGRp3Q6Qg9+EFXzloo=",
+			"checksumSHA1": "ntK9uWj6tVf/jSFsQiGezSsr9dM=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/compute",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "A1kAbUQOdO46tH0VVmib+++GxNc=",
+			"checksumSHA1": "IedxDiI9EV0mSaxf4eNtK92crZY=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/containerinstance",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "rYa0VeazE13rwuRokLQ6NjK+PKk=",
+			"checksumSHA1": "qC39cfKej1D75HsDIySK3bcXUeg=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/containerregistry",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "wt107iTLA62ppLn3KHWcCazDRhI=",
+			"checksumSHA1": "e/5MUSVCg252Ql+dQ4MUD/xdxCU=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/containerservice",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "vuYaWbUWFk+uh7YR1uCpeoXD5lM=",
+			"checksumSHA1": "bZvdO5h22oZJFrnYK5jaSyDdFAQ=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/cosmos-db",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "TZa+aR1MLk+nQVZaUWNPWCBHeBQ=",
+			"checksumSHA1": "IuOad6dkXLtlhfpz0uAXf2D/0BU=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/disk",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "s6FLUuLGdNO9o3tLucJ92BWCGKM=",
+			"checksumSHA1": "IXreuQabmzmRhjA0cCHXulObl1c=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/dns",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "aDYe656iEsKhC2MChDgin/bEOBo=",
+			"checksumSHA1": "+fxsSGqHe7t9+9sVbmBhyUeVmNU=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/eventgrid",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "qVIgSktHgjRL+m6O3YR/C3QX94w=",
+			"checksumSHA1": "NiwGn7ohqvpC1UevRLxGbiqvWMw=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/eventhub",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "InelJwKuAnbd6CGuCB6pNMhAXlI=",
+			"checksumSHA1": "ukh0GPROTDLuKagYzTAnOp0E5hk=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/graphrbac",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "7lanQDNfujqC80Pmr+h0GQH00D4=",
+			"checksumSHA1": "MTOGJVzeFd1VxLpuz+JoJ/5r8lA=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/keyvault",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "bb4XrZmhiQKz+tl2ycSykFCnyx4=",
+			"checksumSHA1": "aSAQM4LTlSAyWJTSMCJjBxUkmVI=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/mysql",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "ogmv4nD4MyLgjk0eRughDtWvSZQ=",
+			"checksumSHA1": "PDMRG1zVjFxDESUXBwR74V+zVHs=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/network",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "dV30DwwWfqE+HxqIrJDSQL6C6vU=",
+			"checksumSHA1": "k5+yVk1W5Vgt0kBB+iNsI8cEt0Y=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/operationalinsights",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "8a0hsMvOcVsHLBIsLJurLL885eQ=",
+			"checksumSHA1": "1IZMTPTijWAzodsaa1Qsn7T/wj8=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/postgresql",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "OMI3k1lMtyKXMwJKrAGE0pP5pdo=",
+			"checksumSHA1": "1vQZbJJLbYz+ocnsVsWmPrAfu4A=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/redis",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "2A4jetKtPI0BebL2+2IfZyMHFuY=",
+			"checksumSHA1": "p1TxN/VU3M0OQ31Tdy993dAiHNw=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/resources/locks",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "/c1STvJS8QAjYpbWC1taB8Jb6oY=",
+			"checksumSHA1": "TE0GnPTelRfFvMJakgRcaB2TxHg=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/resources/resources",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "+37p6Yqa/A1CC0Y2P1fX+JTftmE=",
+			"checksumSHA1": "6Csnt2xO8qZ+4gmrEqlYMpn8vvc=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/resources/subscriptions",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "iQ7v67Q37TOdd65RjezPdHkic+U=",
+			"checksumSHA1": "XSQZIQNppPwrrhrcXitEyDhGY5A=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/scheduler",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "R0z0S9aDThvTeRWz9v07mvhZM0M=",
+			"checksumSHA1": "+Z62YwWMUMqYyBGIyBRi/EBCHeU=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/search",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "w27ZgdEpmK5PMEYRoq0isCXDoP8=",
+			"checksumSHA1": "ic3iVn7qIYW1l0xKJ/0N9+wUMXs=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/servicebus",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "8ayQzyFNFa5GHy/RgLvNY0cI8lw=",
+			"checksumSHA1": "whHT4jwkYhuqG/BQ7s1Hvf7WN9M=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/sql",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "nXZ5ngUwVap9VKe+dGPNsAfN8ow=",
+			"checksumSHA1": "CmbTBUAZKv3EVjWu+xQCwzDniMQ=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/storage",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "7uh2CPPBNaws4WnaUv9D2VQ7gb0=",
+			"checksumSHA1": "d9xZegy2040SulgLJliNEpE+k50=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/trafficmanager",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "tGPwaWleaPVxYU/4G5wmKYyPhc0=",
+			"checksumSHA1": "jyn5xCr0BJgVJpZ35jAt1dIjrZ0=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/web",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "hOnaPIkeDhBG2PFf+qAJe8Rgmh4=",
+			"checksumSHA1": "z/C9jsbI3ZO3u8lJRAPXN0ZX2r0=",
 			"path": "github.com/Azure/azure-sdk-for-go/dataplane/keyvault",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
-			"checksumSHA1": "YhsdEgNxWnYrqYtlBRbwI66DVgw=",
+			"checksumSHA1": "YDEw1uWzG+8V7KAaJfr4jKs1cM0=",
 			"path": "github.com/Azure/azure-sdk-for-go/storage",
-			"revision": "7692b0cef22674113fcf71cc17ac3ccc1a7fef48",
-			"revisionTime": "2017-11-07T22:03:28Z",
-			"version": "v11.2.2-beta",
-			"versionExact": "v11.2.2-beta"
+			"revision": "eae258195456be76b2ec9ad2ee2ab63cdda365d9",
+			"revisionTime": "2018-01-09T21:59:56Z",
+			"version": "v12.2.0-beta",
+			"versionExact": "v12.2.0-beta"
 		},
 		{
 			"checksumSHA1": "RzIYmvG1ReOud+kafFsZTDIZSK0=",


### PR DESCRIPTION
This is the first phase of upgrading to the Azure SDK for Go v12.2.0-beta. Once this is merged we can start moving Data Sources and Resources off the Deprecated SDKs and over to the versioned SDKs

Upgrades to:
 - [v12.2.0-beta of the Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go/releases/tag/v12.2.0-beta)
 - [v9.7.0 of Go-AutoRest](https://github.com/Azure/go-autorest/releases/tag/v9.7.0)
 - [`8bdf7d1a087ccc975cf37dd6507da50698fd19ca` of marstr/guid](github.com/marstr/guid) (new dependency from the Go SDK)