### PR TITLE
Missing reference to azurerm_virtual_network data source in sidebar

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -75,6 +75,10 @@
                     <a href="/docs/providers/azurerm/d/subscription.html">azurerm_subscription</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-virtual-network") %>>
+                    <a href="/docs/providers/azurerm/d/virtual_network.html">azurerm_virtual_network</a>
+		</li>
+
               </ul>
             </li>
 


### PR DESCRIPTION
Noticed that the terraform website includes a page for the azurerm_virtual_network datasource 

  https://www.terraform.io/docs/providers/azurerm/d/virtual_network.html

but there is no link to this page on the website sidebar. 

This pull request should add it.