### PR TITLE
Traffic Manager Profile: Adding support for setting `protocol` to tcp`

### DIFF
--- a/azurerm/resource_arm_traffic_manager_profile.go
+++ b/azurerm/resource_arm_traffic_manager_profile.go
@@ -88,9 +88,11 @@ func resourceArmTrafficManagerProfile() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								"http",
-								"https",
-							}, false),
+								string(trafficmanager.HTTP),
+								string(trafficmanager.HTTPS),
+								string(trafficmanager.TCP),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 						"port": {
 							Type:         schema.TypeInt,
@@ -99,7 +101,7 @@ func resourceArmTrafficManagerProfile() *schema.Resource {
 						},
 						"path": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 					},
 				},
@@ -269,7 +271,10 @@ func flattenAzureRMTrafficManagerProfileMonitorConfig(cfg *trafficmanager.Monito
 
 	result["protocol"] = string(cfg.Protocol)
 	result["port"] = int(*cfg.Port)
-	result["path"] = *cfg.Path
+
+	if cfg.Path != nil {
+		result["path"] = *cfg.Path
+	}
 
 	return []interface{}{result}
 }
@@ -290,7 +295,10 @@ func resourceAzureRMTrafficManagerMonitorConfigHash(v interface{}) int {
 
 	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["protocol"].(string))))
 	buf.WriteString(fmt.Sprintf("%d-", m["port"].(int)))
-	buf.WriteString(fmt.Sprintf("%s-", m["path"].(string)))
+
+	if m["path"] != "" {
+		buf.WriteString(fmt.Sprintf("%s-", m["path"].(string)))
+	}
 
 	return hashcode.String(buf.String())
 }

--- a/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -47,6 +47,33 @@ func TestAccAzureRMTrafficManagerProfile_weighted(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMTrafficManagerProfile_weightedTCP(t *testing.T) {
+	resourceName := "azurerm_traffic_manager_profile.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMTrafficManagerProfile_weightedTCP(ri, testLocation())
+
+	fqdn, err := getTrafficManagerFQDN(fmt.Sprintf("acctesttmp%d", ri))
+	if err != nil {
+		t.Fatalf("Error obtaining Azure Region: %+v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMTrafficManagerProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "traffic_routing_method", "Weighted"),
+					resource.TestCheckResourceAttr(resourceName, "fqdn", fqdn),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMTrafficManagerProfile_performance(t *testing.T) {
 	resourceName := "azurerm_traffic_manager_profile.test"
 	ri := acctest.RandInt()
@@ -210,6 +237,31 @@ resource "azurerm_traffic_manager_profile" "test" {
         protocol = "https"
         port = 443
         path = "/"
+    }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMTrafficManagerProfile_weightedTCP(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_traffic_manager_profile" "test" {
+    name = "acctesttmp%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    traffic_routing_method = "Weighted"
+
+    dns_config {
+        relative_name = "acctesttmp%d"
+        ttl = 30
+    }
+
+    monitor_config {
+        protocol = "tcp"
+        port = 443
     }
 }
 `, rInt, location, rInt, rInt)

--- a/website/docs/r/traffic_manager_profile.html.markdown
+++ b/website/docs/r/traffic_manager_profile.html.markdown
@@ -89,11 +89,11 @@ The `dns_config` block supports:
 The `monitor_config` block supports:
 
 * `protocol` - (Required) The protocol used by the monitoring checks, supported
-    values are `http` or `https`.
+    values are `HTTP`, `HTTPS` and `TCP``.
 
 * `port` - (Required) The port number used by the monitoring checks.
 
-* `path` - (Required) The path used by the monitoring checks.
+* `path` - (Optional) The path used by the monitoring checks. Required when `protocol` is set to `HTTP` or `HTTPS` - cannot be set when `protocol` is set to `TCP`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #717

New test:

```
$ acctests azurerm TestAccAzureRMTrafficManagerProfile_weightedTCP
=== RUN   TestAccAzureRMTrafficManagerProfile_weightedTCP
--- PASS: TestAccAzureRMTrafficManagerProfile_weightedTCP (73.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	73.527s
```