### PR TITLE
SDKv12 migration TestAccAzureRMResourceProviderRegistration

### DIFF
--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -117,7 +117,7 @@ func TestAccAzureRMResourceProviderRegistration(t *testing.T) {
 	}
 
 	client := armClient.providersClient
-	ctx := armClient.StopContext
+	ctx := testAccProvider.StopContext()
 	providerList, err := client.List(ctx, nil, "")
 	if err != nil {
 		t.Fatalf("Unable to list provider registration status, it is possible that this is due to invalid "+


### PR DESCRIPTION
Fixing `TestAccAzureRMResourceProviderRegistration`

```
make testacc TEST=./azurerm TESTARGS="-run=TestAccAzureRMResourceProviderRegistration"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMResourceProviderRegistration -timeout 180m
=== RUN   TestAccAzureRMResourceProviderRegistration
--- PASS: TestAccAzureRMResourceProviderRegistration (1.88s)
PASS
```