### PR TITLE
[Docs] mysql_server: name needs to be globally unique

### DIFF
--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -42,7 +42,7 @@ resource "azurerm_mysql_server" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the MySQL Server. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the MySQL Server. Changing this forces a new resource to be created. This needs to be globally unique within Azure.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the MySQL Server.
 


### PR DESCRIPTION
see https://docs.microsoft.com/en-us/azure/mysql/quickstart-create-mysql-server-database-using-azure-portal

closes #751