### PR TITLE
Support build and run azure terraform provider on native Windows.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,10 +27,10 @@ fmt:
 	gofmt -w $(GOFMT_FILES)
 
 fmtcheck:
-	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+	@sh "$(CURDIR)/scripts/gofmtcheck.sh"
 
 errcheck:
-	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
+	@sh "$(CURDIR)/scripts/errcheck.sh"
 
 vendor-status:
 	@govendor status

--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@ AzureRM Terraform Provider
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-Requirements
+General Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
 -	[Go](https://golang.org/doc/install) 1.9 (to build the provider plugin)
+
+Windows Specific Requirements
+-----------------------------
+- [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm)
+- [Git Bash for Windows](https://git-scm.com/download/win)
+
+For *GNU32 Make*, make sure its bin path is added to PATH environment variable.*
+
+For *Git Bash for Windows*, at the step of "Adjusting your PATH environment", please choose "Use Git and optional Unix tools from Windows Command Prompt".*
 
 Building The Provider
 ---------------------

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -3,7 +3,7 @@
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
 gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
-if [[ -n ${gofmt_files} ]]; then
+if [ -n "${gofmt_files}" ]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"
     echo "You can use the command: \`make fmt\` to reformat code."


### PR DESCRIPTION
This PR contains below changes to support build & run on Windows:
1. Update the gofmtcheck.sh to use POSIX compatible shell style to do if-test.
2. Remove "-c"(command way) and single quotes inside double quotes while running "sh" to make it work on Git Bash on Windows.
3. Update the README.md to install required tools for Windows.

Tested platforms: Windows 10, Bash on Windows 10. 