### PR TITLE
[WIP, Question] add name_prefix to storage_account

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -30,8 +30,16 @@ func resourceArmStorageAccount() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateArmStorageAccountName,
+			},
+			"name_prefix": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateArmStorageAccountName,
 			},
@@ -228,7 +236,18 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*ArmClient).storageServiceClient
 
 	resourceGroupName := d.Get("resource_group_name").(string)
-	storageAccountName := d.Get("name").(string)
+
+	var storageAccountName string
+	if v, ok := d.GetOk("name"); ok {
+		storageAccountName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		storageAccountName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		storageAccountName = resource.UniqueId()
+	}
+	storageAccountName = storageAccountName[:23]
+	d.Set("name", storageAccountName)
+
 	accountKind := d.Get("account_kind").(string)
 
 	location := d.Get("location").(string)


### PR DESCRIPTION
this should solve #724

this uses the pattern from aws_s3_bucket to easily create unique storage_account names. This could be also implemented for sql_server or cdn_endpoint.

My current question / problem is that the name can only be 24 chars long and the generated Id from the PrefixedUniqueId function is quite long. I could cut the generated name after 24 chars but then most of the randomness would get lost.

A possible solution could be a random hash generator function in this repo or in the terraform main repo. What do you think?

Todo:
* Tests
* Docs