### PR TITLE
`azurerm_subnet` - add support for Service Endpoints

### DIFF
--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -325,6 +325,26 @@ func testCheckAzureRMSubnetDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccAzureRMSubnet_serviceEndpoints(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMSubnet_serviceEndpoints(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAzureRMSubnet_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -344,6 +364,7 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.2.0/24"
+	service_endpoints    = ["Microsoft.Sql","Microsoft.Storage"]
 }
 `, rInt, location, rInt, rInt)
 }
@@ -666,4 +687,28 @@ resource "azurerm_subnet" "test" {
   network_security_group_id = "${azurerm_network_security_group.test.id}"
 }
 `, rInt, location, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMSubnet_serviceEndpoints(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+	service_endpoints    = ["Microsoft.Sql","Microsoft.Storage"]
+}
+`, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -364,7 +364,6 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.2.0/24"
-	service_endpoints    = ["Microsoft.Sql","Microsoft.Storage"]
 }
 `, rInt, location, rInt, rInt)
 }
@@ -708,7 +707,7 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.2.0/24"
-	service_endpoints    = ["Microsoft.Sql","Microsoft.Storage"]
+  service_endpoints    = ["Microsoft.Sql","Microsoft.Storage"]
 }
 `, rInt, location, rInt, rInt)
 }

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `route_table_id` - (Optional) The ID of the Route Table to associate with the subnet.
 
-* `service_endpoints` - (Optional) The list of Service endpoint to associate with the subnet. E.g. Microsoft.Storage.
+* `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.Storage`, `Microsoft.Sql`.
 
 ## Attributes Reference
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -54,6 +54,8 @@ The following arguments are supported:
 
 * `route_table_id` - (Optional) The ID of the Route Table to associate with the subnet.
 
+* `service_endpoints` - (Optional) The list of Service endpoint to associate with the subnet. E.g. Microsoft.Storage.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Hey @tombuildsstuff,

Since Virtual Network Service Endpoints for Storage Accounts are now GA (https://azure.microsoft.com/en-us/blog/virtual-network-service-endpoints-and-firewalls-for-azure-storage-now-generally-available/), I have started a pull request for subnets to support multiple endpoints, in a view that SQL endpoints will be made GA too.

Tests are passing:
```
$ make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMSubnet_serviceEndpoints'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMSubnet_serviceEndpoints -timeout 180m
=== RUN   TestAccAzureRMSubnet_serviceEndpoints
--- PASS: TestAccAzureRMSubnet_serviceEndpoints (102.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	102.671s
``` 

Storage account changes to follow in another PR.

