### PR TITLE
`azurerm_public_ip`: Adding an acceptance test to check that the `ip_address` property is set

### DIFF
--- a/azurerm/resource_arm_public_ip_test.go
+++ b/azurerm/resource_arm_public_ip_test.go
@@ -79,7 +79,7 @@ func TestResourceAzureRMPublicIpDomainNameLabel_validation(t *testing.T) {
 }
 
 func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
-
+	resourceName := "azurerm_public_ip.test"
 	ri := acctest.RandInt()
 	config := testAccAzureRMPublicIPStatic_basic(ri, testLocation())
 
@@ -91,7 +91,9 @@ func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMPublicIpExists("azurerm_public_ip.test"),
+					testCheckAzureRMPublicIpExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip_address_allocation", "static"),
 				),
 			},
 		},
@@ -99,7 +101,6 @@ func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPublicIpStatic_standard(t *testing.T) {
-
 	ri := acctest.RandInt()
 	config := testAccAzureRMPublicIPStatic_standard(ri, testLocation())
 


### PR DESCRIPTION
This currently fails against the `master` branch:

```
$ acctests azurerm TestAccAzureRMPublicIpStatic_basic
=== RUN   TestAccAzureRMPublicIpStatic_basic
--- FAIL: TestAccAzureRMPublicIpStatic_basic (70.86s)
	testing.go:459: Step 0 error: Check failed: Check 2/3 error: azurerm_public_ip.test: Attribute 'ip_address' expected to be set
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	70.886s
```

But will pass once #772 is merged:

```
$ acctests azurerm TestAccAzureRMPublicIpStatic_basic
=== RUN   TestAccAzureRMPublicIpStatic_basic
--- PASS: TestAccAzureRMPublicIpStatic_basic (83.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	83.219s
```