### PR TITLE
Added an option to have 0 in disk_size_gb property of managed_disk

### DIFF
--- a/azurerm/resource_arm_managed_disk.go
+++ b/azurerm/resource_arm_managed_disk.go
@@ -86,6 +86,7 @@ func resourceArmManagedDisk() *schema.Resource {
 			"disk_size_gb": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validateDiskSizeGB,
 			},
 
@@ -98,9 +99,9 @@ func resourceArmManagedDisk() *schema.Resource {
 
 func validateDiskSizeGB(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(int)
-	if value < 1 || value > 4095 {
+	if value < 0 || value > 4095 {
 		errors = append(errors, fmt.Errorf(
-			"The `disk_size_gb` can only be between 1 and 4095"))
+			"The `disk_size_gb` can only be between 0 and 4095"))
 	}
 	return
 }


### PR DESCRIPTION
Added tests and changed validation to allow managed disks of size "0" (unset).