### PR TITLE
Data Source: `azurerm_virtual_network` - Fixing a crash when the DhcpOptions aren't specified

### DIFF
--- a/azurerm/data_source_virtual_network.go
+++ b/azurerm/data_source_virtual_network.go
@@ -77,9 +77,11 @@ func dataSourceArmVnetRead(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
-		dnsServers := flattenVnetAddressPrefixes(props.DhcpOptions.DNSServers)
-		if err := d.Set("dns_servers", dnsServers); err != nil {
-			return err
+		if options := props.DhcpOptions; options != nil {
+			dnsServers := flattenVnetAddressPrefixes(options.DNSServers)
+			if err := d.Set("dns_servers", dnsServers); err != nil {
+				return err
+			}
 		}
 
 		subnets := flattenVnetSubnetsNames(props.Subnets)


### PR DESCRIPTION
Fixes #801