### PR TITLE
Container Group: updating to use a Windows image

### DIFF
--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -225,8 +225,8 @@ resource "azurerm_container_group" "test" {
   os_type             = "windows"
 
   container {
-    name   = "winapp"
-    image  = "winappimage:latest"
+    name   = "windowsservercore"
+    image  = "microsoft/windowsservercore:latest"
     cpu    = "2.0"
     memory = "3.5"
     port   = "80"
@@ -254,8 +254,8 @@ resource "azurerm_container_group" "test" {
   os_type             = "windows"
 
   container {
-    name   = "winapp"
-    image  = "winappimage:latest"
+    name   = "windowsservercore"
+    image  = "microsoft/windowsservercore:latest"
     cpu    = "2.0"
     memory = "3.5"
     port   = "80"


### PR DESCRIPTION
The tests are currently failing for this since the Windows Docker container was pulled:

```
------- Stdout: -------
=== RUN   TestAccAzureRMContainerGroup_windowsBasic
--- FAIL: TestAccAzureRMContainerGroup_windowsBasic (58.02s)
    testing.go:459: Step 0 error: Error applying: 1 error(s) occurred:
        
        * azurerm_container_group.test: 1 error(s) occurred:
        
        * azurerm_container_group.test: containerinstance.ContainerGroupsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InaccessibleImage" Message="The image 'winappimage:latest' in container group 'acctestcontainergroup-4456597369366035246' is not accessible. Please check the image and registry credential."
FAIL
```

with these changes the tests now pass:

```
$ acctests azurerm TestAccAzureRMContainerGroup_
=== RUN   TestAccAzureRMContainerGroup_linuxBasic
--- PASS: TestAccAzureRMContainerGroup_linuxBasic (65.69s)
=== RUN   TestAccAzureRMContainerGroup_linuxBasicUpdate
--- PASS: TestAccAzureRMContainerGroup_linuxBasicUpdate (67.84s)
=== RUN   TestAccAzureRMContainerGroup_linuxComplete
--- PASS: TestAccAzureRMContainerGroup_linuxComplete (70.88s)
=== RUN   TestAccAzureRMContainerGroup_windowsBasic
--- PASS: TestAccAzureRMContainerGroup_windowsBasic (70.94s)
=== RUN   TestAccAzureRMContainerGroup_windowsComplete
--- PASS: TestAccAzureRMContainerGroup_windowsComplete (59.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	334.768s
```