### PR TITLE
New Resources: `azurerm_app_service_slot` & `azurerm_app_service_active_slot`

### DIFF
--- a/azurerm/import_arm_app_service_slot_test.go
+++ b/azurerm/import_arm_app_service_slot_test.go
@@ -1,0 +1,31 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMAppServiceSlot_importBasic(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -92,6 +92,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_application_insights":               resourceArmApplicationInsights(),
 			"azurerm_app_service":                        resourceArmAppService(),
 			"azurerm_app_service_plan":                   resourceArmAppServicePlan(),
+			"azurerm_app_service_active_slot":            resourceArmAppServiceActiveSlot(),
 			"azurerm_app_service_slot":                   resourceArmAppServiceSlot(),
 			"azurerm_automation_account":                 resourceArmAutomationAccount(),
 			"azurerm_automation_credential":              resourceArmAutomationCredential(),

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -92,6 +92,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_application_insights":               resourceArmApplicationInsights(),
 			"azurerm_app_service":                        resourceArmAppService(),
 			"azurerm_app_service_plan":                   resourceArmAppServicePlan(),
+			"azurerm_app_service_slot":                   resourceArmAppServiceSlot(),
 			"azurerm_automation_account":                 resourceArmAutomationAccount(),
 			"azurerm_automation_credential":              resourceArmAutomationCredential(),
 			"azurerm_automation_runbook":                 resourceArmAutomationRunbook(),

--- a/azurerm/resource_arm_app_service_active_slot.go
+++ b/azurerm/resource_arm_app_service_active_slot.go
@@ -1,119 +1,119 @@
 package azurerm
 
 import (
-  "fmt"
-  "log"
+	"fmt"
+	"log"
 
-  "github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
-  "github.com/hashicorp/terraform/helper/schema"
-  "github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceArmAppServiceActiveSlot() *schema.Resource {
-  return &schema.Resource{
-    Create: resourceArmAppServiceActiveSlotCreate,
-    Read:   resourceArmAppServiceActiveSlotRead,
-    Update: resourceArmAppServiceActiveSlotCreate,
-    Delete: resourceArmAppServiceActiveSlotDelete,
-    Importer: &schema.ResourceImporter{
-      State: schema.ImportStatePassthrough,
-    },
-    Schema: map[string]*schema.Schema{
+	return &schema.Resource{
+		Create: resourceArmAppServiceActiveSlotCreate,
+		Read:   resourceArmAppServiceActiveSlotRead,
+		Update: resourceArmAppServiceActiveSlotCreate,
+		Delete: resourceArmAppServiceActiveSlotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
 
-      "resource_group_name": resourceGroupNameSchema(),
+			"resource_group_name": resourceGroupNameSchema(),
 
-      "app_service_name": {
-        Type:     schema.TypeString,
-        ForceNew: true,
-        Required: true,
-      },
+			"app_service_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
 
-      "app_service_slot_name": {
-        Type:     schema.TypeString,
-        Required: true,
-      },
+			"app_service_slot_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
 
-      "preserve_vnet": {
-        Type:     schema.TypeBool,
-        Required: true,
-      },
-    },
-  }
+			"preserve_vnet": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
 }
 
 func resourceArmAppServiceActiveSlotCreate(d *schema.ResourceData, meta interface{}) error {
-  client := meta.(*ArmClient).appServicesClient
-  ctx := meta.(*ArmClient).StopContext
+	client := meta.(*ArmClient).appServicesClient
+	ctx := meta.(*ArmClient).StopContext
 
-  appServiceName := d.Get("app_service_name").(string)
-  resGroup := d.Get("resource_group_name").(string)
-  targetSlot := d.Get("app_service_slot_name").(string)
-  preserveVnet := d.Get("preserve_vnet").(bool)
+	appServiceName := d.Get("app_service_name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	targetSlot := d.Get("app_service_slot_name").(string)
+	preserveVnet := d.Get("preserve_vnet").(bool)
 
-  resp, err := client.Get(ctx, resGroup, appServiceName)
-  if err != nil {
-    if utils.ResponseWasNotFound(resp.Response) {
-      return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
-    }
-    return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
-  }
+	resp, err := client.Get(ctx, resGroup, appServiceName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
+	}
 
-  _, err = client.Get(ctx, resGroup, targetSlot)
-  if err != nil {
-    if utils.ResponseWasNotFound(resp.Response) {
-      return fmt.Errorf("[DEBUG] App Service Target Active Slot %q/%q (resource group %q) was not found.", appServiceName, targetSlot, resGroup)
-    }
-    return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
-  }
+	_, err = client.Get(ctx, resGroup, targetSlot)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("[DEBUG] App Service Target Active Slot %q/%q (resource group %q) was not found.", appServiceName, targetSlot, resGroup)
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+	}
 
-  cmsSlotEntity := web.CsmSlotEntity{
-    TargetSlot:   &targetSlot,
-    PreserveVnet: &preserveVnet,
-  }
+	cmsSlotEntity := web.CsmSlotEntity{
+		TargetSlot:   &targetSlot,
+		PreserveVnet: &preserveVnet,
+	}
 
-  future, err := client.SwapSlotWithProduction(ctx, resGroup, appServiceName, cmsSlotEntity)
-  if err != nil {
-    return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
-  }
-  err = future.WaitForCompletion(ctx, client.Client)
-  if err != nil {
-    return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
-  }
-  d.SetId(*resp.ID)
-  return resourceArmAppServiceActiveSlotRead(d, meta)
+	future, err := client.SwapSlotWithProduction(ctx, resGroup, appServiceName, cmsSlotEntity)
+	if err != nil {
+		return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+	}
+	err = future.WaitForCompletion(ctx, client.Client)
+	if err != nil {
+		return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+	}
+	d.SetId(*resp.ID)
+	return resourceArmAppServiceActiveSlotRead(d, meta)
 }
 
 func resourceArmAppServiceActiveSlotRead(d *schema.ResourceData, meta interface{}) error {
-  client := meta.(*ArmClient).appServicesClient
-  ctx := meta.(*ArmClient).StopContext
+	client := meta.(*ArmClient).appServicesClient
+	ctx := meta.(*ArmClient).StopContext
 
-  id, err := parseAzureResourceID(d.Id())
-  if err != nil {
-    return err
-  }
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
 
-  resGroup := id.ResourceGroup
-  name := id.Path["sites"]
+	resGroup := id.ResourceGroup
+	name := id.Path["sites"]
 
-  resp, err := client.Get(ctx, resGroup, name)
-  if err != nil {
-    if utils.ResponseWasNotFound(resp.Response) {
-      log.Printf("[DEBUG] App Service %q (resource group %q) was not found - removing from state", name, resGroup)
-      d.SetId("")
-      return nil
-    }
-    return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", name, err)
-  }
+	resp, err := client.Get(ctx, resGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] App Service %q (resource group %q) was not found - removing from state", name, resGroup)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", name, err)
+	}
 
-  d.Set("app_service_name", resp.Name)
-  d.Set("resource_group_name", resp.ResourceGroup)
-  d.Set("app_service_slot_name", resp.SiteProperties.SlotSwapStatus.SourceSlotName)
-  // The API does not return the preserve vnet value
-  d.Set("preserve_vnet", d.Get("preserve_vnet").(bool))
-  return nil
+	d.Set("app_service_name", resp.Name)
+	d.Set("resource_group_name", resp.ResourceGroup)
+	d.Set("app_service_slot_name", resp.SiteProperties.SlotSwapStatus.SourceSlotName)
+	// The API does not return the preserve vnet value
+	d.Set("preserve_vnet", d.Get("preserve_vnet").(bool))
+	return nil
 }
 
 func resourceArmAppServiceActiveSlotDelete(d *schema.ResourceData, meta interface{}) error {
-  // There is nothing to delete so return nil
-  return nil
+	// There is nothing to delete so return nil
+	return nil
 }

--- a/azurerm/resource_arm_app_service_active_slot.go
+++ b/azurerm/resource_arm_app_service_active_slot.go
@@ -32,11 +32,6 @@ func resourceArmAppServiceActiveSlot() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
-			"preserve_vnet": {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
 		},
 	}
 }
@@ -48,7 +43,7 @@ func resourceArmAppServiceActiveSlotCreate(d *schema.ResourceData, meta interfac
 	appServiceName := d.Get("app_service_name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	targetSlot := d.Get("app_service_slot_name").(string)
-	preserveVnet := d.Get("preserve_vnet").(bool)
+	preserveVnet := true
 
 	resp, err := client.Get(ctx, resGroup, appServiceName)
 	if err != nil {
@@ -108,8 +103,6 @@ func resourceArmAppServiceActiveSlotRead(d *schema.ResourceData, meta interface{
 	d.Set("app_service_name", resp.Name)
 	d.Set("resource_group_name", resp.ResourceGroup)
 	d.Set("app_service_slot_name", resp.SiteProperties.SlotSwapStatus.SourceSlotName)
-	// The API does not return the preserve vnet value
-	d.Set("preserve_vnet", d.Get("preserve_vnet").(bool))
 	return nil
 }
 

--- a/azurerm/resource_arm_app_service_active_slot.go
+++ b/azurerm/resource_arm_app_service_active_slot.go
@@ -1,0 +1,119 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmAppServiceActiveSlot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAppServiceActiveSlotCreate,
+		Read:   resourceArmAppServiceActiveSlotRead,
+		Update: resourceArmAppServiceActiveSlotCreate,
+		Delete: resourceArmAppServiceActiveSlotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"app_service_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"source_slot_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"preserve_vnet": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceArmAppServiceActiveSlotCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	appServiceName := d.Get("app_service_name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	targetSlot := d.Get("source_slot_name").(string)
+	preserveVnet := d.Get("preserve_vnet").(bool)
+
+	resp, err := client.Get(ctx, resGroup, appServiceName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
+	}
+
+	_, err = client.Get(ctx, resGroup, targetSlot)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("[DEBUG] App Service Target Active Slot %q/%q (resource group %q) was not found.", appServiceName, targetSlot, resGroup)
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+	}
+
+	cmsSlotEntity := web.CsmSlotEntity{
+		TargetSlot:   &targetSlot,
+		PreserveVnet: &preserveVnet,
+	}
+
+	future, err := client.SwapSlotWithProduction(ctx, resGroup, appServiceName, cmsSlotEntity)
+	if err != nil {
+		return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+	}
+	err = future.WaitForCompletion(ctx, client.Client)
+	if err != nil {
+		return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+	}
+	d.SetId(*resp.ID)
+	return resourceArmAppServiceActiveSlotRead(d, meta)
+}
+
+func resourceArmAppServiceActiveSlotRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	resp, err := client.Get(ctx, resGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] App Service %q (resource group %q) was not found - removing from state", name, resGroup)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", name, err)
+	}
+
+	d.Set("app_service_name", resp.Name)
+	d.Set("resource_group_name", resp.ResourceGroup)
+	d.Set("source_slot_name", resp.SiteProperties.SlotSwapStatus.SourceSlotName)
+	// The API does not return the preserve vnet value
+	d.Set("preserve_vnet", d.Get("preserve_vnet").(bool))
+	return nil
+}
+
+func resourceArmAppServiceActiveSlotDelete(d *schema.ResourceData, meta interface{}) error {
+	// There is nothing to delete so return nil
+	return nil
+}

--- a/azurerm/resource_arm_app_service_active_slot.go
+++ b/azurerm/resource_arm_app_service_active_slot.go
@@ -1,119 +1,119 @@
 package azurerm
 
 import (
-	"fmt"
-	"log"
+  "fmt"
+  "log"
 
-	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+  "github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
+  "github.com/hashicorp/terraform/helper/schema"
+  "github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceArmAppServiceActiveSlot() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceArmAppServiceActiveSlotCreate,
-		Read:   resourceArmAppServiceActiveSlotRead,
-		Update: resourceArmAppServiceActiveSlotCreate,
-		Delete: resourceArmAppServiceActiveSlotDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
-		Schema: map[string]*schema.Schema{
+  return &schema.Resource{
+    Create: resourceArmAppServiceActiveSlotCreate,
+    Read:   resourceArmAppServiceActiveSlotRead,
+    Update: resourceArmAppServiceActiveSlotCreate,
+    Delete: resourceArmAppServiceActiveSlotDelete,
+    Importer: &schema.ResourceImporter{
+      State: schema.ImportStatePassthrough,
+    },
+    Schema: map[string]*schema.Schema{
 
-			"resource_group_name": resourceGroupNameSchema(),
+      "resource_group_name": resourceGroupNameSchema(),
 
-			"app_service_name": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
-			},
+      "app_service_name": {
+        Type:     schema.TypeString,
+        ForceNew: true,
+        Required: true,
+      },
 
-			"source_slot_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+      "app_service_slot_name": {
+        Type:     schema.TypeString,
+        Required: true,
+      },
 
-			"preserve_vnet": {
-				Type:     schema.TypeBool,
-				Required: true,
-			},
-		},
-	}
+      "preserve_vnet": {
+        Type:     schema.TypeBool,
+        Required: true,
+      },
+    },
+  }
 }
 
 func resourceArmAppServiceActiveSlotCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appServicesClient
-	ctx := meta.(*ArmClient).StopContext
+  client := meta.(*ArmClient).appServicesClient
+  ctx := meta.(*ArmClient).StopContext
 
-	appServiceName := d.Get("app_service_name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	targetSlot := d.Get("source_slot_name").(string)
-	preserveVnet := d.Get("preserve_vnet").(bool)
+  appServiceName := d.Get("app_service_name").(string)
+  resGroup := d.Get("resource_group_name").(string)
+  targetSlot := d.Get("app_service_slot_name").(string)
+  preserveVnet := d.Get("preserve_vnet").(bool)
 
-	resp, err := client.Get(ctx, resGroup, appServiceName)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
-		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
-	}
+  resp, err := client.Get(ctx, resGroup, appServiceName)
+  if err != nil {
+    if utils.ResponseWasNotFound(resp.Response) {
+      return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
+    }
+    return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
+  }
 
-	_, err = client.Get(ctx, resGroup, targetSlot)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("[DEBUG] App Service Target Active Slot %q/%q (resource group %q) was not found.", appServiceName, targetSlot, resGroup)
-		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
-	}
+  _, err = client.Get(ctx, resGroup, targetSlot)
+  if err != nil {
+    if utils.ResponseWasNotFound(resp.Response) {
+      return fmt.Errorf("[DEBUG] App Service Target Active Slot %q/%q (resource group %q) was not found.", appServiceName, targetSlot, resGroup)
+    }
+    return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+  }
 
-	cmsSlotEntity := web.CsmSlotEntity{
-		TargetSlot:   &targetSlot,
-		PreserveVnet: &preserveVnet,
-	}
+  cmsSlotEntity := web.CsmSlotEntity{
+    TargetSlot:   &targetSlot,
+    PreserveVnet: &preserveVnet,
+  }
 
-	future, err := client.SwapSlotWithProduction(ctx, resGroup, appServiceName, cmsSlotEntity)
-	if err != nil {
-		return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
-	}
-	err = future.WaitForCompletion(ctx, client.Client)
-	if err != nil {
-		return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
-	}
-	d.SetId(*resp.ID)
-	return resourceArmAppServiceActiveSlotRead(d, meta)
+  future, err := client.SwapSlotWithProduction(ctx, resGroup, appServiceName, cmsSlotEntity)
+  if err != nil {
+    return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+  }
+  err = future.WaitForCompletion(ctx, client.Client)
+  if err != nil {
+    return fmt.Errorf("Error swapping App Service Slot %q/%q: %+v", appServiceName, targetSlot, err)
+  }
+  d.SetId(*resp.ID)
+  return resourceArmAppServiceActiveSlotRead(d, meta)
 }
 
 func resourceArmAppServiceActiveSlotRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appServicesClient
-	ctx := meta.(*ArmClient).StopContext
+  client := meta.(*ArmClient).appServicesClient
+  ctx := meta.(*ArmClient).StopContext
 
-	id, err := parseAzureResourceID(d.Id())
-	if err != nil {
-		return err
-	}
+  id, err := parseAzureResourceID(d.Id())
+  if err != nil {
+    return err
+  }
 
-	resGroup := id.ResourceGroup
-	name := id.Path["sites"]
+  resGroup := id.ResourceGroup
+  name := id.Path["sites"]
 
-	resp, err := client.Get(ctx, resGroup, name)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] App Service %q (resource group %q) was not found - removing from state", name, resGroup)
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", name, err)
-	}
+  resp, err := client.Get(ctx, resGroup, name)
+  if err != nil {
+    if utils.ResponseWasNotFound(resp.Response) {
+      log.Printf("[DEBUG] App Service %q (resource group %q) was not found - removing from state", name, resGroup)
+      d.SetId("")
+      return nil
+    }
+    return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", name, err)
+  }
 
-	d.Set("app_service_name", resp.Name)
-	d.Set("resource_group_name", resp.ResourceGroup)
-	d.Set("source_slot_name", resp.SiteProperties.SlotSwapStatus.SourceSlotName)
-	// The API does not return the preserve vnet value
-	d.Set("preserve_vnet", d.Get("preserve_vnet").(bool))
-	return nil
+  d.Set("app_service_name", resp.Name)
+  d.Set("resource_group_name", resp.ResourceGroup)
+  d.Set("app_service_slot_name", resp.SiteProperties.SlotSwapStatus.SourceSlotName)
+  // The API does not return the preserve vnet value
+  d.Set("preserve_vnet", d.Get("preserve_vnet").(bool))
+  return nil
 }
 
 func resourceArmAppServiceActiveSlotDelete(d *schema.ResourceData, meta interface{}) error {
-	// There is nothing to delete so return nil
-	return nil
+  // There is nothing to delete so return nil
+  return nil
 }

--- a/azurerm/resource_arm_app_service_active_slot_test.go
+++ b/azurerm/resource_arm_app_service_active_slot_test.go
@@ -93,7 +93,6 @@ func testAccAzureRMAppServiceActiveSlot_basic(rInt int, location string) string 
   resource "azurerm_app_service_active_slot" "test" {
     resource_group_name   = "${azurerm_resource_group.test.name}"
     app_service_name      = "${azurerm_app_service.test.name}"
-    preserve_vnet         = true
     app_service_slot_name = "${azurerm_app_service_slot.test.name}"
   }
   `, rInt, location, rInt, rInt, rInt)
@@ -143,7 +142,6 @@ func testAccAzureRMAppServiceActiveSlot_update(rInt int, location string) string
   resource "azurerm_app_service_active_slot" "test" {
     resource_group_name   = "${azurerm_resource_group.test.name}"
     app_service_name      = "${azurerm_app_service.test.name}"
-    preserve_vnet         = true
     app_service_slot_name = "${azurerm_app_service_slot.test.name}"
   }
   `, rInt, location, rInt, rInt, rInt, rInt)
@@ -193,7 +191,6 @@ func testAccAzureRMAppServiceActiveSlot_updated(rInt int, location string) strin
   resource "azurerm_app_service_active_slot" "test" {
     resource_group_name   = "${azurerm_resource_group.test.name}"
     app_service_name      = "${azurerm_app_service.test.name}"
-    preserve_vnet         = true
     app_service_slot_name = "${azurerm_app_service_slot.test2.name}"
   }
   `, rInt, location, rInt, rInt, rInt, rInt)

--- a/azurerm/resource_arm_app_service_active_slot_test.go
+++ b/azurerm/resource_arm_app_service_active_slot_test.go
@@ -1,64 +1,64 @@
 package azurerm
 
 import (
-  "fmt"
-  "testing"
+	"fmt"
+	"testing"
 
-  "github.com/hashicorp/terraform/helper/acctest"
-  "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAzureRMAppServiceActiveSlot_basic(t *testing.T) {
-  resourceName := "azurerm_app_service_active_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceActiveSlot_basic(ri, testLocation())
+	resourceName := "azurerm_app_service_active_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceActiveSlot_basic(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    // Destroy actually does nothing so we just return nil
-    CheckDestroy: nil,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// Destroy actually does nothing so we just return nil
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceActiveSlot_update(t *testing.T) {
-  resourceName := "azurerm_app_service_active_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceActiveSlot_update(ri, testLocation())
-  config2 := testAccAzureRMAppServiceActiveSlot_updated(ri, testLocation())
+	resourceName := "azurerm_app_service_active_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceActiveSlot_update(ri, testLocation())
+	config2 := testAccAzureRMAppServiceActiveSlot_updated(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:  func() { testAccPreCheck(t) },
-    Providers: testAccProviders,
-    // Destroy actually does nothing so we just return nil
-    CheckDestroy: nil,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
-        ),
-      },
-      {
-        Config: config2,
-        Check: resource.ComposeTestCheckFunc(
-          resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot2-%d", ri)),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// Destroy actually does nothing so we just return nil
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
+				),
+			},
+			{
+				Config: config2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot2-%d", ri)),
+				),
+			},
+		},
+	})
 }
 
 func testAccAzureRMAppServiceActiveSlot_basic(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
   resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "%s"
@@ -100,7 +100,7 @@ func testAccAzureRMAppServiceActiveSlot_basic(rInt int, location string) string 
 }
 
 func testAccAzureRMAppServiceActiveSlot_update(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
   resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "%s"
@@ -150,7 +150,7 @@ func testAccAzureRMAppServiceActiveSlot_update(rInt int, location string) string
 }
 
 func testAccAzureRMAppServiceActiveSlot_updated(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
   resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "%s"

--- a/azurerm/resource_arm_app_service_active_slot_test.go
+++ b/azurerm/resource_arm_app_service_active_slot_test.go
@@ -1,200 +1,200 @@
 package azurerm
 
 import (
-	"fmt"
-	"testing"
+  "fmt"
+  "testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+  "github.com/hashicorp/terraform/helper/acctest"
+  "github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAzureRMAppServiceActiveSlot_basic(t *testing.T) {
-	resourceName := "azurerm_app_service_active_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceActiveSlot_basic(ri, testLocation())
+  resourceName := "azurerm_app_service_active_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceActiveSlot_basic(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		// Destroy actually does nothing so we just return nil
-		CheckDestroy: nil,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "source_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:  func() { testAccPreCheck(t) },
+    Providers: testAccProviders,
+    // Destroy actually does nothing so we just return nil
+    CheckDestroy: nil,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
+        ),
+      },
+    },
+  })
 }
 
-func TestAccAzureRMAppServiceActiveSlot_multiple(t *testing.T) {
-	resourceName := "azurerm_app_service_active_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceActiveSlot_multiple(ri, testLocation())
-	config2 := testAccAzureRMAppServiceActiveSlot_multipleUpdated(ri, testLocation())
+func TestAccAzureRMAppServiceActiveSlot_update(t *testing.T) {
+  resourceName := "azurerm_app_service_active_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceActiveSlot_update(ri, testLocation())
+  config2 := testAccAzureRMAppServiceActiveSlot_updated(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		// Destroy actually does nothing so we just return nil
-		CheckDestroy: nil,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "source_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
-				),
-			},
-			{
-				Config: config2,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "source_slot_name", fmt.Sprintf("acctestASSlot2-%d", ri)),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:  func() { testAccPreCheck(t) },
+    Providers: testAccProviders,
+    // Destroy actually does nothing so we just return nil
+    CheckDestroy: nil,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
+        ),
+      },
+      {
+        Config: config2,
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr(resourceName, "app_service_slot_name", fmt.Sprintf("acctestASSlot2-%d", ri)),
+        ),
+      },
+    },
+  })
 }
 
 func testAccAzureRMAppServiceActiveSlot_basic(rInt int, location string) string {
-	return fmt.Sprintf(`
-	resource "azurerm_resource_group" "test" {
-		name = "acctestRG-%d"
-		location = "%s"
-	}
-	
-	resource "azurerm_app_service_plan" "test" {
-		name                = "acctestASP-%d"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-	
-		sku {
-		tier = "Standard"
-		size = "S1"
-		}
-	}
-	
-	resource "azurerm_app_service" "test" {
-		name                = "acctestAS-%d"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
+  return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_app_service_plan" "test" {
+    name                = "acctestASP-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+  
+    sku {
+        tier = "Standard"
+        size = "S1"
+    }
+  }
+  
+  resource "azurerm_app_service" "test" {
+    name                = "acctestAS-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
 
-	resource "azurerm_app_service_slot" "test" {
-		name                = "acctestASSlot-%d"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
+  resource "azurerm_app_service_slot" "test" {
+    name                = "acctestASSlot-%d"
+    app_service_name    = "${azurerm_app_service.test.name}"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
 
-	resource "azurerm_app_service_active_slot" "test" {
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		preserve_vnet       = true
-		source_slot_name    = "${azurerm_app_service_slot.test.name}"
-	}
-	`, rInt, location, rInt, rInt, rInt)
+  resource "azurerm_app_service_active_slot" "test" {
+    resource_group_name   = "${azurerm_resource_group.test.name}"
+    app_service_name      = "${azurerm_app_service.test.name}"
+    preserve_vnet         = true
+    app_service_slot_name = "${azurerm_app_service_slot.test.name}"
+  }
+  `, rInt, location, rInt, rInt, rInt)
 }
 
-func testAccAzureRMAppServiceActiveSlot_multiple(rInt int, location string) string {
-	return fmt.Sprintf(`
-	resource "azurerm_resource_group" "test" {
-		name = "acctestRG-%d"
-		location = "%s"
-	}
-	
-	resource "azurerm_app_service_plan" "test" {
-		name                = "acctestASP-%d"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-	
-		sku {
-		tier = "Standard"
-		size = "S1"
-		}
-	}
-	
-	resource "azurerm_app_service" "test" {
-		name                = "acctestAS-%d"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
+func testAccAzureRMAppServiceActiveSlot_update(rInt int, location string) string {
+  return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_app_service_plan" "test" {
+    name                = "acctestASP-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+  
+    sku {
+        tier = "Standard"
+        size = "S1"
+    }
+  }
+  
+  resource "azurerm_app_service" "test" {
+    name                = "acctestAS-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
 
-	resource "azurerm_app_service_slot" "test" {
-		name                = "acctestASSlot-%d"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
-	
-	resource "azurerm_app_service_slot" "test2" {
-		name                = "acctestASSlot2-%d"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
+  resource "azurerm_app_service_slot" "test" {
+    name                = "acctestASSlot-%d"
+    app_service_name    = "${azurerm_app_service.test.name}"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
+  
+  resource "azurerm_app_service_slot" "test2" {
+    name                = "acctestASSlot2-%d"
+    app_service_name    = "${azurerm_app_service.test.name}"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
 
-	resource "azurerm_app_service_active_slot" "test" {
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		preserve_vnet       = true
-		source_slot_name    = "${azurerm_app_service_slot.test.name}"
-	}
-	`, rInt, location, rInt, rInt, rInt, rInt)
+  resource "azurerm_app_service_active_slot" "test" {
+    resource_group_name   = "${azurerm_resource_group.test.name}"
+    app_service_name      = "${azurerm_app_service.test.name}"
+    preserve_vnet         = true
+    app_service_slot_name = "${azurerm_app_service_slot.test.name}"
+  }
+  `, rInt, location, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMAppServiceActiveSlot_multipleUpdated(rInt int, location string) string {
-	return fmt.Sprintf(`
-	resource "azurerm_resource_group" "test" {
-		name = "acctestRG-%d"
-		location = "%s"
-	}
-	
-	resource "azurerm_app_service_plan" "test" {
-		name                = "acctestASP-%d"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-	
-		sku {
-		tier = "Standard"
-		size = "S1"
-		}
-	}
-	
-	resource "azurerm_app_service" "test" {
-		name                = "acctestAS-%d"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
+func testAccAzureRMAppServiceActiveSlot_updated(rInt int, location string) string {
+  return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_app_service_plan" "test" {
+    name                = "acctestASP-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+  
+    sku {
+        tier = "Standard"
+        size = "S1"
+    }
+  }
+  
+  resource "azurerm_app_service" "test" {
+    name                = "acctestAS-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
 
-	resource "azurerm_app_service_slot" "test" {
-		name                = "acctestASSlot-%d"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
-	
-	resource "azurerm_app_service_slot" "test2" {
-		name                = "acctestASSlot2-%d"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		location            = "${azurerm_resource_group.test.location}"
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	}
+  resource "azurerm_app_service_slot" "test" {
+    name                = "acctestASSlot-%d"
+    app_service_name    = "${azurerm_app_service.test.name}"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
+  
+  resource "azurerm_app_service_slot" "test2" {
+    name                = "acctestASSlot2-%d"
+    app_service_name    = "${azurerm_app_service.test.name}"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
 
-	resource "azurerm_app_service_active_slot" "test" {
-		resource_group_name = "${azurerm_resource_group.test.name}"
-		app_service_name    = "${azurerm_app_service.test.name}"
-		preserve_vnet       = true
-		source_slot_name    = "${azurerm_app_service_slot.test2.name}"
-	}
-	`, rInt, location, rInt, rInt, rInt, rInt)
+  resource "azurerm_app_service_active_slot" "test" {
+    resource_group_name   = "${azurerm_resource_group.test.name}"
+    app_service_name      = "${azurerm_app_service.test.name}"
+    preserve_vnet         = true
+    app_service_slot_name = "${azurerm_app_service_slot.test2.name}"
+  }
+  `, rInt, location, rInt, rInt, rInt, rInt)
 }

--- a/azurerm/resource_arm_app_service_active_slot_test.go
+++ b/azurerm/resource_arm_app_service_active_slot_test.go
@@ -1,0 +1,200 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMAppServiceActiveSlot_basic(t *testing.T) {
+	resourceName := "azurerm_app_service_active_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceActiveSlot_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// Destroy actually does nothing so we just return nil
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "source_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceActiveSlot_multiple(t *testing.T) {
+	resourceName := "azurerm_app_service_active_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceActiveSlot_multiple(ri, testLocation())
+	config2 := testAccAzureRMAppServiceActiveSlot_multipleUpdated(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// Destroy actually does nothing so we just return nil
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "source_slot_name", fmt.Sprintf("acctestASSlot-%d", ri)),
+				),
+			},
+			{
+				Config: config2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "source_slot_name", fmt.Sprintf("acctestASSlot2-%d", ri)),
+				),
+			},
+		},
+	})
+}
+
+func testAccAzureRMAppServiceActiveSlot_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+	resource "azurerm_resource_group" "test" {
+		name = "acctestRG-%d"
+		location = "%s"
+	}
+	
+	resource "azurerm_app_service_plan" "test" {
+		name                = "acctestASP-%d"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+	
+		sku {
+		tier = "Standard"
+		size = "S1"
+		}
+	}
+	
+	resource "azurerm_app_service" "test" {
+		name                = "acctestAS-%d"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+
+	resource "azurerm_app_service_slot" "test" {
+		name                = "acctestASSlot-%d"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+
+	resource "azurerm_app_service_active_slot" "test" {
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		preserve_vnet       = true
+		source_slot_name    = "${azurerm_app_service_slot.test.name}"
+	}
+	`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceActiveSlot_multiple(rInt int, location string) string {
+	return fmt.Sprintf(`
+	resource "azurerm_resource_group" "test" {
+		name = "acctestRG-%d"
+		location = "%s"
+	}
+	
+	resource "azurerm_app_service_plan" "test" {
+		name                = "acctestASP-%d"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+	
+		sku {
+		tier = "Standard"
+		size = "S1"
+		}
+	}
+	
+	resource "azurerm_app_service" "test" {
+		name                = "acctestAS-%d"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+
+	resource "azurerm_app_service_slot" "test" {
+		name                = "acctestASSlot-%d"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+	
+	resource "azurerm_app_service_slot" "test2" {
+		name                = "acctestASSlot2-%d"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+
+	resource "azurerm_app_service_active_slot" "test" {
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		preserve_vnet       = true
+		source_slot_name    = "${azurerm_app_service_slot.test.name}"
+	}
+	`, rInt, location, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceActiveSlot_multipleUpdated(rInt int, location string) string {
+	return fmt.Sprintf(`
+	resource "azurerm_resource_group" "test" {
+		name = "acctestRG-%d"
+		location = "%s"
+	}
+	
+	resource "azurerm_app_service_plan" "test" {
+		name                = "acctestASP-%d"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+	
+		sku {
+		tier = "Standard"
+		size = "S1"
+		}
+	}
+	
+	resource "azurerm_app_service" "test" {
+		name                = "acctestAS-%d"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+
+	resource "azurerm_app_service_slot" "test" {
+		name                = "acctestASSlot-%d"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+	
+	resource "azurerm_app_service_slot" "test2" {
+		name                = "acctestASSlot2-%d"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		location            = "${azurerm_resource_group.test.location}"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	}
+
+	resource "azurerm_app_service_active_slot" "test" {
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		app_service_name    = "${azurerm_app_service.test.name}"
+		preserve_vnet       = true
+		source_slot_name    = "${azurerm_app_service_slot.test2.name}"
+	}
+	`, rInt, location, rInt, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -1,0 +1,457 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmAppServiceSlot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAppServiceSlotCreate,
+		Read:   resourceArmAppServiceSlotRead,
+		Update: resourceArmAppServiceSlotUpdate,
+		Delete: resourceArmAppServiceSlotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAppServiceName,
+			},
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"location": locationSchema(),
+
+			"app_service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"app_service_plan_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"site_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"always_on": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
+						"default_documents": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
+						"dotnet_framework_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "v4.0",
+							ValidateFunc: validation.StringInSlice([]string{
+								"v2.0",
+								"v4.0",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+
+						"java_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"1.7",
+								"1.8",
+							}, false),
+						},
+
+						"java_container": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"JETTY",
+								"TOMCAT",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+
+						"java_container_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"local_mysql_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"managed_pipeline_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.Classic),
+								string(web.Integrated),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+
+						"php_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"5.5",
+								"5.6",
+								"7.0",
+								"7.1",
+							}, false),
+						},
+
+						"python_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"2.7",
+								"3.4",
+							}, false),
+						},
+
+						"remote_debugging_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
+						"remote_debugging_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"VS2012",
+								"VS2013",
+								"VS2015",
+								"VS2017",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+
+						"use_32_bit_worker_process": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+
+						"websockets_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"client_affinity_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
+			},
+
+			"app_settings": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+			},
+
+			"connection_string": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.APIHub),
+								string(web.Custom),
+								string(web.DocDb),
+								string(web.EventHub),
+								string(web.MySQL),
+								string(web.NotificationHub),
+								string(web.PostgreSQL),
+								string(web.RedisCache),
+								string(web.ServiceBus),
+								string(web.SQLAzure),
+								string(web.SQLServer),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+					},
+				},
+			},
+
+			// TODO: (tombuildsstuff) support Update once the API is fixed:
+			// https://github.com/Azure/azure-rest-api-specs/issues/1697
+			"tags": tagsForceNewSchema(),
+
+			"default_site_hostname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"outbound_ip_addresses": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmAppServiceSlotCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
+
+	log.Printf("[INFO] preparing arguments for AzureRM App Service Slot creation.")
+
+	slot := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	location := d.Get("location").(string)
+	appServiceName := d.Get("app_service_name").(string)
+	appServicePlanId := d.Get("app_service_plan_id").(string)
+	enabled := d.Get("enabled").(bool)
+	tags := d.Get("tags").(map[string]interface{})
+
+	siteConfig := expandAppServiceSiteConfig(d)
+
+	siteEnvelope := web.Site{
+		Location: &location,
+		Tags:     expandTags(tags),
+		SiteProperties: &web.SiteProperties{
+			ServerFarmID: utils.String(appServicePlanId),
+			Enabled:      utils.Bool(enabled),
+			SiteConfig:   &siteConfig,
+		},
+	}
+
+	if v, ok := d.GetOk("client_affinity_enabled"); ok {
+		enabled := v.(bool)
+		siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
+	}
+
+	// NOTE: these seem like sensible defaults, in lieu of any better documentation.
+	skipDNSRegistration := false
+	forceDNSRegistration := false
+	skipCustomDomainVerification := true
+	ttlInSeconds := "60"
+	ctx := meta.(*ArmClient).StopContext
+	createFuture, err := client.CreateOrUpdateSlot(ctx, resGroup, appServiceName, siteEnvelope, slot, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds)
+	if err != nil {
+		return err
+	}
+
+	err = createFuture.WaitForCompletion(ctx, client.Client)
+	if err != nil {
+		return err
+	}
+
+	read, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return err
+	}
+
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read App Service Slot %q/%q (resource group %q) ID", appServiceName, slot, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmAppServiceSlotUpdate(d, meta)
+}
+
+func resourceArmAppServiceSlotUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+	slot := id.Path["slots"]
+
+	if d.HasChange("site_config") {
+		// update the main configuration
+		siteConfig := expandAppServiceSiteConfig(d)
+		siteConfigResource := web.SiteConfigResource{
+			SiteConfig: &siteConfig,
+		}
+		_, err := client.CreateOrUpdateConfigurationSlot(ctx, resGroup, appServiceName, siteConfigResource, slot)
+		if err != nil {
+			return fmt.Errorf("Error updating Configuration for App Service Slot %q/%q: %+v", appServiceName, slot, err)
+		}
+	}
+
+	if d.HasChange("app_settings") {
+		// update the AppSettings
+		appSettings := expandAppServiceAppSettings(d)
+		settings := web.StringDictionary{
+			Properties: appSettings,
+		}
+
+		_, err := client.UpdateApplicationSettingsSlot(ctx, resGroup, appServiceName, settings, slot)
+		if err != nil {
+			return fmt.Errorf("Error updating Application Settings for App Service Slot %q/%q: %+v", appServiceName, slot, err)
+		}
+	}
+
+	if d.HasChange("connection_string") {
+		// update the ConnectionStrings
+		connectionStrings := expandAppServiceConnectionStrings(d)
+		properties := web.ConnectionStringDictionary{
+			Properties: connectionStrings,
+		}
+
+		_, err := client.UpdateConnectionStringsSlot(ctx, resGroup, appServiceName, properties, slot)
+		if err != nil {
+			return fmt.Errorf("Error updating Connection Strings for App Service %q/%q: %+v", appServiceName, slot, err)
+		}
+	}
+
+	return resourceArmAppServiceSlotRead(d, meta)
+}
+
+func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+	slot := id.Path["slots"]
+
+	ctx := meta.(*ArmClient).StopContext
+	resp, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] App Service Slot %q/%q (resource group %q) was not found - removing from state", appServiceName, slot, resGroup)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, slot, err)
+	}
+
+	configResp, err := client.GetConfigurationSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot Configuration %q/%q: %+v", appServiceName, slot, err)
+	}
+
+	appSettingsResp, err := client.ListApplicationSettingsSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot AppSettings %q/%q: %+v", appServiceName, slot, err)
+	}
+
+	connectionStringsResp, err := client.ListConnectionStringsSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot ConnectionStrings %q/%q: %+v", appServiceName, slot, err)
+	}
+
+	d.Set("name", slot)
+	d.Set("app_service_name", appServiceName)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+
+	if props := resp.SiteProperties; props != nil {
+		d.Set("app_service_plan_id", props.ServerFarmID)
+		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
+		d.Set("enabled", props.Enabled)
+		d.Set("default_site_hostname", props.DefaultHostName)
+		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
+	}
+
+	if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {
+		return err
+	}
+	if err := d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties)); err != nil {
+		return err
+	}
+
+	siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
+	if err := d.Set("site_config", siteConfig); err != nil {
+		return err
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}
+
+func resourceArmAppServiceSlotDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appServicesClient
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+	slot := id.Path["slots"]
+
+	log.Printf("[DEBUG] Deleting App Service Slot %q/%q (resource group %q)", appServiceName, slot, resGroup)
+
+	deleteMetrics := true
+	deleteEmptyServerFarm := false
+	skipDNSRegistration := true
+	ctx := meta.(*ArmClient).StopContext
+	resp, err := client.DeleteSlot(ctx, resGroup, appServiceName, slot, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -283,6 +283,15 @@ func resourceArmAppServiceSlotCreate(d *schema.ResourceData, meta interface{}) e
 	skipCustomDomainVerification := true
 	ttlInSeconds := "60"
 	ctx := meta.(*ArmClient).StopContext
+
+	resp, err := client.Get(ctx, resGroup, appServiceName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
+	}
+
 	createFuture, err := client.CreateOrUpdateSlot(ctx, resGroup, appServiceName, siteEnvelope, slot, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds)
 	if err != nil {
 		return err

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -1,466 +1,467 @@
 package azurerm
 
 import (
-	"fmt"
-	"log"
+  "fmt"
+  "log"
 
-	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+  "github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
+  "github.com/hashicorp/terraform/helper/schema"
+  "github.com/hashicorp/terraform/helper/validation"
+  "github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceArmAppServiceSlot() *schema.Resource {
-	return &schema.Resource{
-		Create: resourceArmAppServiceSlotCreate,
-		Read:   resourceArmAppServiceSlotRead,
-		Update: resourceArmAppServiceSlotUpdate,
-		Delete: resourceArmAppServiceSlotDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+  return &schema.Resource{
+    Create: resourceArmAppServiceSlotCreate,
+    Read:   resourceArmAppServiceSlotRead,
+    Update: resourceArmAppServiceSlotUpdate,
+    Delete: resourceArmAppServiceSlotDelete,
+    Importer: &schema.ResourceImporter{
+      State: schema.ImportStatePassthrough,
+    },
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateAppServiceName,
-			},
+    Schema: map[string]*schema.Schema{
+      "name": {
+        Type:         schema.TypeString,
+        Required:     true,
+        ForceNew:     true,
+        ValidateFunc: validateAppServiceName,
+      },
 
-			"resource_group_name": resourceGroupNameSchema(),
+      "resource_group_name": resourceGroupNameSchema(),
 
-			"location": locationSchema(),
+      "location": locationSchema(),
 
-			"app_service_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+      "app_service_name": {
+        Type:     schema.TypeString,
+        Required: true,
+        ForceNew: true,
+      },
 
-			"app_service_plan_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+      "app_service_plan_id": {
+        Type:     schema.TypeString,
+        Required: true,
+        ForceNew: true,
+      },
 
-			"site_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"always_on": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
+      "site_config": {
+        Type:     schema.TypeList,
+        Optional: true,
+        Computed: true,
+        MaxItems: 1,
+        Elem: &schema.Resource{
+          Schema: map[string]*schema.Schema{
+            "always_on": {
+              Type:     schema.TypeBool,
+              Optional: true,
+              Default:  false,
+            },
 
-						"default_documents": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
+            "default_documents": {
+              Type:     schema.TypeList,
+              Optional: true,
+              Elem:     &schema.Schema{Type: schema.TypeString},
+            },
 
-						"dotnet_framework_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Default:  "v4.0",
-							ValidateFunc: validation.StringInSlice([]string{
-								"v2.0",
-								"v4.0",
-							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-						},
+            "dotnet_framework_version": {
+              Type:     schema.TypeString,
+              Optional: true,
+              Default:  "v4.0",
+              ValidateFunc: validation.StringInSlice([]string{
+                "v2.0",
+                "v4.0",
+              }, true),
+              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+            },
 
-						"java_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"1.7",
-								"1.8",
-							}, false),
-						},
+            "java_version": {
+              Type:     schema.TypeString,
+              Optional: true,
+              ValidateFunc: validation.StringInSlice([]string{
+                "1.7",
+                "1.8",
+              }, false),
+            },
 
-						"java_container": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"JETTY",
-								"TOMCAT",
-							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-						},
+            "java_container": {
+              Type:     schema.TypeString,
+              Optional: true,
+              ValidateFunc: validation.StringInSlice([]string{
+                "JETTY",
+                "TOMCAT",
+              }, true),
+              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+            },
 
-						"java_container_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
+            "java_container_version": {
+              Type:     schema.TypeString,
+              Optional: true,
+            },
 
-						"local_mysql_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
+            "local_mysql_enabled": {
+              Type:     schema.TypeBool,
+              Optional: true,
+              Computed: true,
+            },
 
-						"managed_pipeline_mode": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(web.Classic),
-								string(web.Integrated),
-							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-						},
+            "managed_pipeline_mode": {
+              Type:     schema.TypeString,
+              Optional: true,
+              Computed: true,
+              ValidateFunc: validation.StringInSlice([]string{
+                string(web.Classic),
+                string(web.Integrated),
+              }, true),
+              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+            },
 
-						"php_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"5.5",
-								"5.6",
-								"7.0",
-								"7.1",
-							}, false),
-						},
+            "php_version": {
+              Type:     schema.TypeString,
+              Optional: true,
+              ValidateFunc: validation.StringInSlice([]string{
+                "5.5",
+                "5.6",
+                "7.0",
+                "7.1",
+              }, false),
+            },
 
-						"python_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"2.7",
-								"3.4",
-							}, false),
-						},
+            "python_version": {
+              Type:     schema.TypeString,
+              Optional: true,
+              ValidateFunc: validation.StringInSlice([]string{
+                "2.7",
+                "3.4",
+              }, false),
+            },
 
-						"remote_debugging_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
+            "remote_debugging_enabled": {
+              Type:     schema.TypeBool,
+              Optional: true,
+              Default:  false,
+            },
 
-						"remote_debugging_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"VS2012",
-								"VS2013",
-								"VS2015",
-								"VS2017",
-							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-						},
+            "remote_debugging_version": {
+              Type:     schema.TypeString,
+              Optional: true,
+              Computed: true,
+              ValidateFunc: validation.StringInSlice([]string{
+                "VS2012",
+                "VS2013",
+                "VS2015",
+                "VS2017",
+              }, true),
+              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+            },
 
-						"use_32_bit_worker_process": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
+            "use_32_bit_worker_process": {
+              Type:     schema.TypeBool,
+              Optional: true,
+              Computed: true,
+            },
 
-						"websockets_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Computed: true,
-						},
-					},
-				},
-			},
+            "websockets_enabled": {
+              Type:     schema.TypeBool,
+              Optional: true,
+              Computed: true,
+            },
+          },
+        },
+      },
 
-			"client_affinity_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+      "client_affinity_enabled": {
+        Type:     schema.TypeBool,
+        Optional: true,
+        Computed: true,
 
-				// TODO: (tombuildsstuff) support Update once the API is fixed:
-				// https://github.com/Azure/azure-rest-api-specs/issues/1697
-				ForceNew: true,
-			},
+        // TODO: (tombuildsstuff) support Update once the API is fixed:
+        // https://github.com/Azure/azure-rest-api-specs/issues/1697
+        ForceNew: true,
+      },
 
-			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+      "enabled": {
+        Type:     schema.TypeBool,
+        Optional: true,
+        Default:  true,
 
-				// TODO: (tombuildsstuff) support Update once the API is fixed:
-				// https://github.com/Azure/azure-rest-api-specs/issues/1697
-				ForceNew: true,
-			},
+        // TODO: (tombuildsstuff) support Update once the API is fixed:
+        // https://github.com/Azure/azure-rest-api-specs/issues/1697
+        ForceNew: true,
+      },
 
-			"app_settings": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Computed: true,
-			},
+      "app_settings": {
+        Type:     schema.TypeMap,
+        Optional: true,
+        Computed: true,
+      },
 
-			"connection_string": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"value": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(web.APIHub),
-								string(web.Custom),
-								string(web.DocDb),
-								string(web.EventHub),
-								string(web.MySQL),
-								string(web.NotificationHub),
-								string(web.PostgreSQL),
-								string(web.RedisCache),
-								string(web.ServiceBus),
-								string(web.SQLAzure),
-								string(web.SQLServer),
-							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-						},
-					},
-				},
-			},
+      "connection_string": {
+        Type:     schema.TypeList,
+        Optional: true,
+        Computed: true,
+        Elem: &schema.Resource{
+          Schema: map[string]*schema.Schema{
+            "name": {
+              Type:     schema.TypeString,
+              Required: true,
+            },
+            "value": {
+              Type:     schema.TypeString,
+              Required: true,
+            },
+            "type": {
+              Type:     schema.TypeString,
+              Required: true,
+              ValidateFunc: validation.StringInSlice([]string{
+                string(web.APIHub),
+                string(web.Custom),
+                string(web.DocDb),
+                string(web.EventHub),
+                string(web.MySQL),
+                string(web.NotificationHub),
+                string(web.PostgreSQL),
+                string(web.RedisCache),
+                string(web.ServiceBus),
+                string(web.SQLAzure),
+                string(web.SQLServer),
+              }, true),
+              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+            },
+          },
+        },
+      },
 
-			// TODO: (tombuildsstuff) support Update once the API is fixed:
-			// https://github.com/Azure/azure-rest-api-specs/issues/1697
-			"tags": tagsForceNewSchema(),
+      // TODO: (tombuildsstuff) support Update once the API is fixed:
+      // https://github.com/Azure/azure-rest-api-specs/issues/1697
+      "tags": tagsForceNewSchema(),
 
-			"default_site_hostname": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
+      "default_site_hostname": {
+        Type:     schema.TypeString,
+        Computed: true,
+      },
 
-			"outbound_ip_addresses": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-		},
-	}
+      "outbound_ip_addresses": {
+        Type:     schema.TypeString,
+        Computed: true,
+      },
+    },
+  }
 }
 
 func resourceArmAppServiceSlotCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appServicesClient
+  client := meta.(*ArmClient).appServicesClient
 
-	log.Printf("[INFO] preparing arguments for AzureRM App Service Slot creation.")
+  log.Printf("[INFO] preparing arguments for AzureRM App Service Slot creation.")
 
-	slot := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
-	location := d.Get("location").(string)
-	appServiceName := d.Get("app_service_name").(string)
-	appServicePlanId := d.Get("app_service_plan_id").(string)
-	enabled := d.Get("enabled").(bool)
-	tags := d.Get("tags").(map[string]interface{})
+  slot := d.Get("name").(string)
+  resGroup := d.Get("resource_group_name").(string)
+  location := d.Get("location").(string)
+  appServiceName := d.Get("app_service_name").(string)
+  appServicePlanId := d.Get("app_service_plan_id").(string)
+  enabled := d.Get("enabled").(bool)
+  tags := d.Get("tags").(map[string]interface{})
 
-	siteConfig := expandAppServiceSiteConfig(d)
+  siteConfig := expandAppServiceSiteConfig(d)
 
-	siteEnvelope := web.Site{
-		Location: &location,
-		Tags:     expandTags(tags),
-		SiteProperties: &web.SiteProperties{
-			ServerFarmID: utils.String(appServicePlanId),
-			Enabled:      utils.Bool(enabled),
-			SiteConfig:   &siteConfig,
-		},
-	}
+  siteEnvelope := web.Site{
+    Location: &location,
+    Tags:     expandTags(tags),
+    SiteProperties: &web.SiteProperties{
+      ServerFarmID: utils.String(appServicePlanId),
+      Enabled:      utils.Bool(enabled),
+      SiteConfig:   &siteConfig,
+    },
+  }
 
-	if v, ok := d.GetOk("client_affinity_enabled"); ok {
-		enabled := v.(bool)
-		siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
-	}
+  if v, ok := d.GetOk("client_affinity_enabled"); ok {
+    enabled := v.(bool)
+    siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
+  }
 
-	// NOTE: these seem like sensible defaults, in lieu of any better documentation.
-	skipDNSRegistration := false
-	forceDNSRegistration := false
-	skipCustomDomainVerification := true
-	ttlInSeconds := "60"
-	ctx := meta.(*ArmClient).StopContext
+  // NOTE: these seem like sensible defaults, in lieu of any better documentation.
+  skipDNSRegistration := false
+  forceDNSRegistration := false
+  skipCustomDomainVerification := true
+  ttlInSeconds := "60"
+  ctx := meta.(*ArmClient).StopContext
 
-	resp, err := client.Get(ctx, resGroup, appServiceName)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
-		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
-	}
+  resp, err := client.Get(ctx, resGroup, appServiceName)
+  if err != nil {
+    if utils.ResponseWasNotFound(resp.Response) {
+      return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
+    }
+    return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
+  }
 
-	createFuture, err := client.CreateOrUpdateSlot(ctx, resGroup, appServiceName, siteEnvelope, slot, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds)
-	if err != nil {
-		return err
-	}
+  createFuture, err := client.CreateOrUpdateSlot(ctx, resGroup, appServiceName, siteEnvelope, slot, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds)
+  if err != nil {
+    return err
+  }
 
-	err = createFuture.WaitForCompletion(ctx, client.Client)
-	if err != nil {
-		return err
-	}
+  err = createFuture.WaitForCompletion(ctx, client.Client)
+  if err != nil {
+    return err
+  }
 
-	read, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
-	if err != nil {
-		return err
-	}
+  read, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
+  if err != nil {
+    return err
+  }
 
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read App Service Slot %q/%q (resource group %q) ID", appServiceName, slot, resGroup)
-	}
+  if read.ID == nil {
+    return fmt.Errorf("Cannot read App Service Slot %q/%q (resource group %q) ID", appServiceName, slot, resGroup)
+  }
 
-	d.SetId(*read.ID)
+  d.SetId(*read.ID)
 
-	return resourceArmAppServiceSlotUpdate(d, meta)
+  return resourceArmAppServiceSlotUpdate(d, meta)
 }
 
 func resourceArmAppServiceSlotUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appServicesClient
-	ctx := meta.(*ArmClient).StopContext
+  client := meta.(*ArmClient).appServicesClient
+  ctx := meta.(*ArmClient).StopContext
 
-	id, err := parseAzureResourceID(d.Id())
-	if err != nil {
-		return err
-	}
+  id, err := parseAzureResourceID(d.Id())
+  if err != nil {
+    return err
+  }
 
-	resGroup := id.ResourceGroup
-	appServiceName := id.Path["sites"]
-	slot := id.Path["slots"]
+  resGroup := id.ResourceGroup
+  appServiceName := id.Path["sites"]
+  slot := id.Path["slots"]
 
-	if d.HasChange("site_config") {
-		// update the main configuration
-		siteConfig := expandAppServiceSiteConfig(d)
-		siteConfigResource := web.SiteConfigResource{
-			SiteConfig: &siteConfig,
-		}
-		_, err := client.CreateOrUpdateConfigurationSlot(ctx, resGroup, appServiceName, siteConfigResource, slot)
-		if err != nil {
-			return fmt.Errorf("Error updating Configuration for App Service Slot %q/%q: %+v", appServiceName, slot, err)
-		}
-	}
+  if d.HasChange("site_config") {
+    // update the main configuration
+    siteConfig := expandAppServiceSiteConfig(d)
+    siteConfigResource := web.SiteConfigResource{
+      SiteConfig: &siteConfig,
+    }
+    _, err := client.CreateOrUpdateConfigurationSlot(ctx, resGroup, appServiceName, siteConfigResource, slot)
+    if err != nil {
+      return fmt.Errorf("Error updating Configuration for App Service Slot %q/%q: %+v", appServiceName, slot, err)
+    }
+  }
 
-	if d.HasChange("app_settings") {
-		// update the AppSettings
-		appSettings := expandAppServiceAppSettings(d)
-		settings := web.StringDictionary{
-			Properties: appSettings,
-		}
+  if d.HasChange("app_settings") {
+    // update the AppSettings
+    appSettings := expandAppServiceAppSettings(d)
+    settings := web.StringDictionary{
+      Properties: appSettings,
+    }
 
-		_, err := client.UpdateApplicationSettingsSlot(ctx, resGroup, appServiceName, settings, slot)
-		if err != nil {
-			return fmt.Errorf("Error updating Application Settings for App Service Slot %q/%q: %+v", appServiceName, slot, err)
-		}
-	}
+    _, err := client.UpdateApplicationSettingsSlot(ctx, resGroup, appServiceName, settings, slot)
+    if err != nil {
+      return fmt.Errorf("Error updating Application Settings for App Service Slot %q/%q: %+v", appServiceName, slot, err)
+    }
+  }
 
-	if d.HasChange("connection_string") {
-		// update the ConnectionStrings
-		connectionStrings := expandAppServiceConnectionStrings(d)
-		properties := web.ConnectionStringDictionary{
-			Properties: connectionStrings,
-		}
+  if d.HasChange("connection_string") {
+    // update the ConnectionStrings
+    connectionStrings := expandAppServiceConnectionStrings(d)
+    properties := web.ConnectionStringDictionary{
+      Properties: connectionStrings,
+    }
 
-		_, err := client.UpdateConnectionStringsSlot(ctx, resGroup, appServiceName, properties, slot)
-		if err != nil {
-			return fmt.Errorf("Error updating Connection Strings for App Service %q/%q: %+v", appServiceName, slot, err)
-		}
-	}
+    _, err := client.UpdateConnectionStringsSlot(ctx, resGroup, appServiceName, properties, slot)
+    if err != nil {
+      return fmt.Errorf("Error updating Connection Strings for App Service %q/%q: %+v", appServiceName, slot, err)
+    }
+  }
 
-	return resourceArmAppServiceSlotRead(d, meta)
+  return resourceArmAppServiceSlotRead(d, meta)
 }
 
 func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appServicesClient
+  client := meta.(*ArmClient).appServicesClient
 
-	id, err := parseAzureResourceID(d.Id())
-	if err != nil {
-		return err
-	}
+  id, err := parseAzureResourceID(d.Id())
+  if err != nil {
+    return err
+  }
 
-	resGroup := id.ResourceGroup
-	appServiceName := id.Path["sites"]
-	slot := id.Path["slots"]
+  resGroup := id.ResourceGroup
+  appServiceName := id.Path["sites"]
+  slot := id.Path["slots"]
 
-	ctx := meta.(*ArmClient).StopContext
-	resp, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] App Service Slot %q/%q (resource group %q) was not found - removing from state", appServiceName, slot, resGroup)
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, slot, err)
-	}
+  ctx := meta.(*ArmClient).StopContext
+  resp, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
+  if err != nil {
+    if utils.ResponseWasNotFound(resp.Response) {
+      log.Printf("[DEBUG] App Service Slot %q/%q (resource group %q) was not found - removing from state", appServiceName, slot, resGroup)
+      d.SetId("")
+      return nil
+    }
+    return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, slot, err)
+  }
 
-	configResp, err := client.GetConfigurationSlot(ctx, resGroup, appServiceName, slot)
-	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service Slot Configuration %q/%q: %+v", appServiceName, slot, err)
-	}
+  configResp, err := client.GetConfigurationSlot(ctx, resGroup, appServiceName, slot)
+  if err != nil {
+    return fmt.Errorf("Error making Read request on AzureRM App Service Slot Configuration %q/%q: %+v", appServiceName, slot, err)
+  }
 
-	appSettingsResp, err := client.ListApplicationSettingsSlot(ctx, resGroup, appServiceName, slot)
-	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service Slot AppSettings %q/%q: %+v", appServiceName, slot, err)
-	}
+  appSettingsResp, err := client.ListApplicationSettingsSlot(ctx, resGroup, appServiceName, slot)
+  if err != nil {
+    return fmt.Errorf("Error making Read request on AzureRM App Service Slot AppSettings %q/%q: %+v", appServiceName, slot, err)
+  }
 
-	connectionStringsResp, err := client.ListConnectionStringsSlot(ctx, resGroup, appServiceName, slot)
-	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service Slot ConnectionStrings %q/%q: %+v", appServiceName, slot, err)
-	}
+  connectionStringsResp, err := client.ListConnectionStringsSlot(ctx, resGroup, appServiceName, slot)
+  if err != nil {
+    return fmt.Errorf("Error making Read request on AzureRM App Service Slot ConnectionStrings %q/%q: %+v", appServiceName, slot, err)
+  }
 
-	d.Set("name", slot)
-	d.Set("app_service_name", appServiceName)
-	d.Set("resource_group_name", resGroup)
-	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+  d.Set("name", slot)
+  d.Set("app_service_name", appServiceName)
+  d.Set("resource_group_name", resGroup)
+  d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
-	if props := resp.SiteProperties; props != nil {
-		d.Set("app_service_plan_id", props.ServerFarmID)
-		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
-		d.Set("enabled", props.Enabled)
-		d.Set("default_site_hostname", props.DefaultHostName)
-		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
-	}
+  if props := resp.SiteProperties; props != nil {
+    d.Set("app_service_plan_id", props.ServerFarmID)
+    d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
+    d.Set("enabled", props.Enabled)
+    d.Set("default_site_hostname", props.DefaultHostName)
+    d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
+  }
 
-	if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {
-		return err
-	}
-	if err := d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties)); err != nil {
-		return err
-	}
+  if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {
+    return err
+  }
+  if err := d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties)); err != nil {
+    return err
+  }
 
-	siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
-	if err := d.Set("site_config", siteConfig); err != nil {
-		return err
-	}
+  siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
+  if err := d.Set("site_config", siteConfig); err != nil {
+    return err
+  }
 
-	flattenAndSetTags(d, resp.Tags)
+  flattenAndSetTags(d, resp.Tags)
 
-	return nil
+  return nil
 }
 
 func resourceArmAppServiceSlotDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appServicesClient
+  client := meta.(*ArmClient).appServicesClient
 
-	id, err := parseAzureResourceID(d.Id())
-	if err != nil {
-		return err
-	}
-	resGroup := id.ResourceGroup
-	appServiceName := id.Path["sites"]
-	slot := id.Path["slots"]
+  id, err := parseAzureResourceID(d.Id())
+  if err != nil {
+    return err
+  }
+  resGroup := id.ResourceGroup
+  appServiceName := id.Path["sites"]
+  slot := id.Path["slots"]
 
-	log.Printf("[DEBUG] Deleting App Service Slot %q/%q (resource group %q)", appServiceName, slot, resGroup)
+  log.Printf("[DEBUG] Deleting App Service Slot %q/%q (resource group %q)", appServiceName, slot, resGroup)
 
-	deleteMetrics := true
-	deleteEmptyServerFarm := false
-	skipDNSRegistration := true
-	ctx := meta.(*ArmClient).StopContext
-	resp, err := client.DeleteSlot(ctx, resGroup, appServiceName, slot, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
-	if err != nil {
-		if !utils.ResponseWasNotFound(resp) {
-			return err
-		}
-	}
+  deleteMetrics := true
+  deleteEmptyServerFarm := false
+  skipDNSRegistration := true
+  ctx := meta.(*ArmClient).StopContext
+  resp, err := client.DeleteSlot(ctx, resGroup, appServiceName, slot, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
+  if err != nil {
+    if !utils.ResponseWasNotFound(resp) {
+      return err
+    }
+  }
 
-	return nil
+  return nil
 }

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -1,467 +1,467 @@
 package azurerm
 
 import (
-  "fmt"
-  "log"
+	"fmt"
+	"log"
 
-  "github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
-  "github.com/hashicorp/terraform/helper/schema"
-  "github.com/hashicorp/terraform/helper/validation"
-  "github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2016-09-01/web"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceArmAppServiceSlot() *schema.Resource {
-  return &schema.Resource{
-    Create: resourceArmAppServiceSlotCreate,
-    Read:   resourceArmAppServiceSlotRead,
-    Update: resourceArmAppServiceSlotUpdate,
-    Delete: resourceArmAppServiceSlotDelete,
-    Importer: &schema.ResourceImporter{
-      State: schema.ImportStatePassthrough,
-    },
+	return &schema.Resource{
+		Create: resourceArmAppServiceSlotCreate,
+		Read:   resourceArmAppServiceSlotRead,
+		Update: resourceArmAppServiceSlotUpdate,
+		Delete: resourceArmAppServiceSlotDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
-    Schema: map[string]*schema.Schema{
-      "name": {
-        Type:         schema.TypeString,
-        Required:     true,
-        ForceNew:     true,
-        ValidateFunc: validateAppServiceName,
-      },
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAppServiceName,
+			},
 
-      "resource_group_name": resourceGroupNameSchema(),
+			"resource_group_name": resourceGroupNameSchema(),
 
-      "location": locationSchema(),
+			"location": locationSchema(),
 
-      "app_service_name": {
-        Type:     schema.TypeString,
-        Required: true,
-        ForceNew: true,
-      },
+			"app_service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 
-      "app_service_plan_id": {
-        Type:     schema.TypeString,
-        Required: true,
-        ForceNew: true,
-      },
+			"app_service_plan_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 
-      "site_config": {
-        Type:     schema.TypeList,
-        Optional: true,
-        Computed: true,
-        MaxItems: 1,
-        Elem: &schema.Resource{
-          Schema: map[string]*schema.Schema{
-            "always_on": {
-              Type:     schema.TypeBool,
-              Optional: true,
-              Default:  false,
-            },
+			"site_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"always_on": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 
-            "default_documents": {
-              Type:     schema.TypeList,
-              Optional: true,
-              Elem:     &schema.Schema{Type: schema.TypeString},
-            },
+						"default_documents": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 
-            "dotnet_framework_version": {
-              Type:     schema.TypeString,
-              Optional: true,
-              Default:  "v4.0",
-              ValidateFunc: validation.StringInSlice([]string{
-                "v2.0",
-                "v4.0",
-              }, true),
-              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-            },
+						"dotnet_framework_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "v4.0",
+							ValidateFunc: validation.StringInSlice([]string{
+								"v2.0",
+								"v4.0",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
 
-            "java_version": {
-              Type:     schema.TypeString,
-              Optional: true,
-              ValidateFunc: validation.StringInSlice([]string{
-                "1.7",
-                "1.8",
-              }, false),
-            },
+						"java_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"1.7",
+								"1.8",
+							}, false),
+						},
 
-            "java_container": {
-              Type:     schema.TypeString,
-              Optional: true,
-              ValidateFunc: validation.StringInSlice([]string{
-                "JETTY",
-                "TOMCAT",
-              }, true),
-              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-            },
+						"java_container": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"JETTY",
+								"TOMCAT",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
 
-            "java_container_version": {
-              Type:     schema.TypeString,
-              Optional: true,
-            },
+						"java_container_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 
-            "local_mysql_enabled": {
-              Type:     schema.TypeBool,
-              Optional: true,
-              Computed: true,
-            },
+						"local_mysql_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
 
-            "managed_pipeline_mode": {
-              Type:     schema.TypeString,
-              Optional: true,
-              Computed: true,
-              ValidateFunc: validation.StringInSlice([]string{
-                string(web.Classic),
-                string(web.Integrated),
-              }, true),
-              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-            },
+						"managed_pipeline_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.Classic),
+								string(web.Integrated),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
 
-            "php_version": {
-              Type:     schema.TypeString,
-              Optional: true,
-              ValidateFunc: validation.StringInSlice([]string{
-                "5.5",
-                "5.6",
-                "7.0",
-                "7.1",
-              }, false),
-            },
+						"php_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"5.5",
+								"5.6",
+								"7.0",
+								"7.1",
+							}, false),
+						},
 
-            "python_version": {
-              Type:     schema.TypeString,
-              Optional: true,
-              ValidateFunc: validation.StringInSlice([]string{
-                "2.7",
-                "3.4",
-              }, false),
-            },
+						"python_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"2.7",
+								"3.4",
+							}, false),
+						},
 
-            "remote_debugging_enabled": {
-              Type:     schema.TypeBool,
-              Optional: true,
-              Default:  false,
-            },
+						"remote_debugging_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 
-            "remote_debugging_version": {
-              Type:     schema.TypeString,
-              Optional: true,
-              Computed: true,
-              ValidateFunc: validation.StringInSlice([]string{
-                "VS2012",
-                "VS2013",
-                "VS2015",
-                "VS2017",
-              }, true),
-              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-            },
+						"remote_debugging_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"VS2012",
+								"VS2013",
+								"VS2015",
+								"VS2017",
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
 
-            "use_32_bit_worker_process": {
-              Type:     schema.TypeBool,
-              Optional: true,
-              Computed: true,
-            },
+						"use_32_bit_worker_process": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
 
-            "websockets_enabled": {
-              Type:     schema.TypeBool,
-              Optional: true,
-              Computed: true,
-            },
-          },
-        },
-      },
+						"websockets_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
 
-      "client_affinity_enabled": {
-        Type:     schema.TypeBool,
-        Optional: true,
-        Computed: true,
+			"client_affinity_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
 
-        // TODO: (tombuildsstuff) support Update once the API is fixed:
-        // https://github.com/Azure/azure-rest-api-specs/issues/1697
-        ForceNew: true,
-      },
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
+			},
 
-      "enabled": {
-        Type:     schema.TypeBool,
-        Optional: true,
-        Default:  true,
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
 
-        // TODO: (tombuildsstuff) support Update once the API is fixed:
-        // https://github.com/Azure/azure-rest-api-specs/issues/1697
-        ForceNew: true,
-      },
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
+			},
 
-      "app_settings": {
-        Type:     schema.TypeMap,
-        Optional: true,
-        Computed: true,
-      },
+			"app_settings": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+			},
 
-      "connection_string": {
-        Type:     schema.TypeList,
-        Optional: true,
-        Computed: true,
-        Elem: &schema.Resource{
-          Schema: map[string]*schema.Schema{
-            "name": {
-              Type:     schema.TypeString,
-              Required: true,
-            },
-            "value": {
-              Type:     schema.TypeString,
-              Required: true,
-            },
-            "type": {
-              Type:     schema.TypeString,
-              Required: true,
-              ValidateFunc: validation.StringInSlice([]string{
-                string(web.APIHub),
-                string(web.Custom),
-                string(web.DocDb),
-                string(web.EventHub),
-                string(web.MySQL),
-                string(web.NotificationHub),
-                string(web.PostgreSQL),
-                string(web.RedisCache),
-                string(web.ServiceBus),
-                string(web.SQLAzure),
-                string(web.SQLServer),
-              }, true),
-              DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
-            },
-          },
-        },
-      },
+			"connection_string": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.APIHub),
+								string(web.Custom),
+								string(web.DocDb),
+								string(web.EventHub),
+								string(web.MySQL),
+								string(web.NotificationHub),
+								string(web.PostgreSQL),
+								string(web.RedisCache),
+								string(web.ServiceBus),
+								string(web.SQLAzure),
+								string(web.SQLServer),
+							}, true),
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+						},
+					},
+				},
+			},
 
-      // TODO: (tombuildsstuff) support Update once the API is fixed:
-      // https://github.com/Azure/azure-rest-api-specs/issues/1697
-      "tags": tagsForceNewSchema(),
+			// TODO: (tombuildsstuff) support Update once the API is fixed:
+			// https://github.com/Azure/azure-rest-api-specs/issues/1697
+			"tags": tagsForceNewSchema(),
 
-      "default_site_hostname": {
-        Type:     schema.TypeString,
-        Computed: true,
-      },
+			"default_site_hostname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 
-      "outbound_ip_addresses": {
-        Type:     schema.TypeString,
-        Computed: true,
-      },
-    },
-  }
+			"outbound_ip_addresses": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
 }
 
 func resourceArmAppServiceSlotCreate(d *schema.ResourceData, meta interface{}) error {
-  client := meta.(*ArmClient).appServicesClient
+	client := meta.(*ArmClient).appServicesClient
 
-  log.Printf("[INFO] preparing arguments for AzureRM App Service Slot creation.")
+	log.Printf("[INFO] preparing arguments for AzureRM App Service Slot creation.")
 
-  slot := d.Get("name").(string)
-  resGroup := d.Get("resource_group_name").(string)
-  location := d.Get("location").(string)
-  appServiceName := d.Get("app_service_name").(string)
-  appServicePlanId := d.Get("app_service_plan_id").(string)
-  enabled := d.Get("enabled").(bool)
-  tags := d.Get("tags").(map[string]interface{})
+	slot := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	location := d.Get("location").(string)
+	appServiceName := d.Get("app_service_name").(string)
+	appServicePlanId := d.Get("app_service_plan_id").(string)
+	enabled := d.Get("enabled").(bool)
+	tags := d.Get("tags").(map[string]interface{})
 
-  siteConfig := expandAppServiceSiteConfig(d)
+	siteConfig := expandAppServiceSiteConfig(d)
 
-  siteEnvelope := web.Site{
-    Location: &location,
-    Tags:     expandTags(tags),
-    SiteProperties: &web.SiteProperties{
-      ServerFarmID: utils.String(appServicePlanId),
-      Enabled:      utils.Bool(enabled),
-      SiteConfig:   &siteConfig,
-    },
-  }
+	siteEnvelope := web.Site{
+		Location: &location,
+		Tags:     expandTags(tags),
+		SiteProperties: &web.SiteProperties{
+			ServerFarmID: utils.String(appServicePlanId),
+			Enabled:      utils.Bool(enabled),
+			SiteConfig:   &siteConfig,
+		},
+	}
 
-  if v, ok := d.GetOk("client_affinity_enabled"); ok {
-    enabled := v.(bool)
-    siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
-  }
+	if v, ok := d.GetOk("client_affinity_enabled"); ok {
+		enabled := v.(bool)
+		siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
+	}
 
-  // NOTE: these seem like sensible defaults, in lieu of any better documentation.
-  skipDNSRegistration := false
-  forceDNSRegistration := false
-  skipCustomDomainVerification := true
-  ttlInSeconds := "60"
-  ctx := meta.(*ArmClient).StopContext
+	// NOTE: these seem like sensible defaults, in lieu of any better documentation.
+	skipDNSRegistration := false
+	forceDNSRegistration := false
+	skipCustomDomainVerification := true
+	ttlInSeconds := "60"
+	ctx := meta.(*ArmClient).StopContext
 
-  resp, err := client.Get(ctx, resGroup, appServiceName)
-  if err != nil {
-    if utils.ResponseWasNotFound(resp.Response) {
-      return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
-    }
-    return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
-  }
+	resp, err := client.Get(ctx, resGroup, appServiceName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("[DEBUG] App Service %q (resource group %q) was not found.", appServiceName, resGroup)
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", appServiceName, err)
+	}
 
-  createFuture, err := client.CreateOrUpdateSlot(ctx, resGroup, appServiceName, siteEnvelope, slot, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds)
-  if err != nil {
-    return err
-  }
+	createFuture, err := client.CreateOrUpdateSlot(ctx, resGroup, appServiceName, siteEnvelope, slot, &skipDNSRegistration, &skipCustomDomainVerification, &forceDNSRegistration, ttlInSeconds)
+	if err != nil {
+		return err
+	}
 
-  err = createFuture.WaitForCompletion(ctx, client.Client)
-  if err != nil {
-    return err
-  }
+	err = createFuture.WaitForCompletion(ctx, client.Client)
+	if err != nil {
+		return err
+	}
 
-  read, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
-  if err != nil {
-    return err
-  }
+	read, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return err
+	}
 
-  if read.ID == nil {
-    return fmt.Errorf("Cannot read App Service Slot %q/%q (resource group %q) ID", appServiceName, slot, resGroup)
-  }
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read App Service Slot %q/%q (resource group %q) ID", appServiceName, slot, resGroup)
+	}
 
-  d.SetId(*read.ID)
+	d.SetId(*read.ID)
 
-  return resourceArmAppServiceSlotUpdate(d, meta)
+	return resourceArmAppServiceSlotUpdate(d, meta)
 }
 
 func resourceArmAppServiceSlotUpdate(d *schema.ResourceData, meta interface{}) error {
-  client := meta.(*ArmClient).appServicesClient
-  ctx := meta.(*ArmClient).StopContext
+	client := meta.(*ArmClient).appServicesClient
+	ctx := meta.(*ArmClient).StopContext
 
-  id, err := parseAzureResourceID(d.Id())
-  if err != nil {
-    return err
-  }
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
 
-  resGroup := id.ResourceGroup
-  appServiceName := id.Path["sites"]
-  slot := id.Path["slots"]
+	resGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+	slot := id.Path["slots"]
 
-  if d.HasChange("site_config") {
-    // update the main configuration
-    siteConfig := expandAppServiceSiteConfig(d)
-    siteConfigResource := web.SiteConfigResource{
-      SiteConfig: &siteConfig,
-    }
-    _, err := client.CreateOrUpdateConfigurationSlot(ctx, resGroup, appServiceName, siteConfigResource, slot)
-    if err != nil {
-      return fmt.Errorf("Error updating Configuration for App Service Slot %q/%q: %+v", appServiceName, slot, err)
-    }
-  }
+	if d.HasChange("site_config") {
+		// update the main configuration
+		siteConfig := expandAppServiceSiteConfig(d)
+		siteConfigResource := web.SiteConfigResource{
+			SiteConfig: &siteConfig,
+		}
+		_, err := client.CreateOrUpdateConfigurationSlot(ctx, resGroup, appServiceName, siteConfigResource, slot)
+		if err != nil {
+			return fmt.Errorf("Error updating Configuration for App Service Slot %q/%q: %+v", appServiceName, slot, err)
+		}
+	}
 
-  if d.HasChange("app_settings") {
-    // update the AppSettings
-    appSettings := expandAppServiceAppSettings(d)
-    settings := web.StringDictionary{
-      Properties: appSettings,
-    }
+	if d.HasChange("app_settings") {
+		// update the AppSettings
+		appSettings := expandAppServiceAppSettings(d)
+		settings := web.StringDictionary{
+			Properties: appSettings,
+		}
 
-    _, err := client.UpdateApplicationSettingsSlot(ctx, resGroup, appServiceName, settings, slot)
-    if err != nil {
-      return fmt.Errorf("Error updating Application Settings for App Service Slot %q/%q: %+v", appServiceName, slot, err)
-    }
-  }
+		_, err := client.UpdateApplicationSettingsSlot(ctx, resGroup, appServiceName, settings, slot)
+		if err != nil {
+			return fmt.Errorf("Error updating Application Settings for App Service Slot %q/%q: %+v", appServiceName, slot, err)
+		}
+	}
 
-  if d.HasChange("connection_string") {
-    // update the ConnectionStrings
-    connectionStrings := expandAppServiceConnectionStrings(d)
-    properties := web.ConnectionStringDictionary{
-      Properties: connectionStrings,
-    }
+	if d.HasChange("connection_string") {
+		// update the ConnectionStrings
+		connectionStrings := expandAppServiceConnectionStrings(d)
+		properties := web.ConnectionStringDictionary{
+			Properties: connectionStrings,
+		}
 
-    _, err := client.UpdateConnectionStringsSlot(ctx, resGroup, appServiceName, properties, slot)
-    if err != nil {
-      return fmt.Errorf("Error updating Connection Strings for App Service %q/%q: %+v", appServiceName, slot, err)
-    }
-  }
+		_, err := client.UpdateConnectionStringsSlot(ctx, resGroup, appServiceName, properties, slot)
+		if err != nil {
+			return fmt.Errorf("Error updating Connection Strings for App Service %q/%q: %+v", appServiceName, slot, err)
+		}
+	}
 
-  return resourceArmAppServiceSlotRead(d, meta)
+	return resourceArmAppServiceSlotRead(d, meta)
 }
 
 func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) error {
-  client := meta.(*ArmClient).appServicesClient
+	client := meta.(*ArmClient).appServicesClient
 
-  id, err := parseAzureResourceID(d.Id())
-  if err != nil {
-    return err
-  }
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
 
-  resGroup := id.ResourceGroup
-  appServiceName := id.Path["sites"]
-  slot := id.Path["slots"]
+	resGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+	slot := id.Path["slots"]
 
-  ctx := meta.(*ArmClient).StopContext
-  resp, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
-  if err != nil {
-    if utils.ResponseWasNotFound(resp.Response) {
-      log.Printf("[DEBUG] App Service Slot %q/%q (resource group %q) was not found - removing from state", appServiceName, slot, resGroup)
-      d.SetId("")
-      return nil
-    }
-    return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, slot, err)
-  }
+	ctx := meta.(*ArmClient).StopContext
+	resp, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] App Service Slot %q/%q (resource group %q) was not found - removing from state", appServiceName, slot, resGroup)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot %q/%q: %+v", appServiceName, slot, err)
+	}
 
-  configResp, err := client.GetConfigurationSlot(ctx, resGroup, appServiceName, slot)
-  if err != nil {
-    return fmt.Errorf("Error making Read request on AzureRM App Service Slot Configuration %q/%q: %+v", appServiceName, slot, err)
-  }
+	configResp, err := client.GetConfigurationSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot Configuration %q/%q: %+v", appServiceName, slot, err)
+	}
 
-  appSettingsResp, err := client.ListApplicationSettingsSlot(ctx, resGroup, appServiceName, slot)
-  if err != nil {
-    return fmt.Errorf("Error making Read request on AzureRM App Service Slot AppSettings %q/%q: %+v", appServiceName, slot, err)
-  }
+	appSettingsResp, err := client.ListApplicationSettingsSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot AppSettings %q/%q: %+v", appServiceName, slot, err)
+	}
 
-  connectionStringsResp, err := client.ListConnectionStringsSlot(ctx, resGroup, appServiceName, slot)
-  if err != nil {
-    return fmt.Errorf("Error making Read request on AzureRM App Service Slot ConnectionStrings %q/%q: %+v", appServiceName, slot, err)
-  }
+	connectionStringsResp, err := client.ListConnectionStringsSlot(ctx, resGroup, appServiceName, slot)
+	if err != nil {
+		return fmt.Errorf("Error making Read request on AzureRM App Service Slot ConnectionStrings %q/%q: %+v", appServiceName, slot, err)
+	}
 
-  d.Set("name", slot)
-  d.Set("app_service_name", appServiceName)
-  d.Set("resource_group_name", resGroup)
-  d.Set("location", azureRMNormalizeLocation(*resp.Location))
+	d.Set("name", slot)
+	d.Set("app_service_name", appServiceName)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
-  if props := resp.SiteProperties; props != nil {
-    d.Set("app_service_plan_id", props.ServerFarmID)
-    d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
-    d.Set("enabled", props.Enabled)
-    d.Set("default_site_hostname", props.DefaultHostName)
-    d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
-  }
+	if props := resp.SiteProperties; props != nil {
+		d.Set("app_service_plan_id", props.ServerFarmID)
+		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
+		d.Set("enabled", props.Enabled)
+		d.Set("default_site_hostname", props.DefaultHostName)
+		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
+	}
 
-  if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {
-    return err
-  }
-  if err := d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties)); err != nil {
-    return err
-  }
+	if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {
+		return err
+	}
+	if err := d.Set("connection_string", flattenAppServiceConnectionStrings(connectionStringsResp.Properties)); err != nil {
+		return err
+	}
 
-  siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
-  if err := d.Set("site_config", siteConfig); err != nil {
-    return err
-  }
+	siteConfig := flattenAppServiceSiteConfig(configResp.SiteConfig)
+	if err := d.Set("site_config", siteConfig); err != nil {
+		return err
+	}
 
-  flattenAndSetTags(d, resp.Tags)
+	flattenAndSetTags(d, resp.Tags)
 
-  return nil
+	return nil
 }
 
 func resourceArmAppServiceSlotDelete(d *schema.ResourceData, meta interface{}) error {
-  client := meta.(*ArmClient).appServicesClient
+	client := meta.(*ArmClient).appServicesClient
 
-  id, err := parseAzureResourceID(d.Id())
-  if err != nil {
-    return err
-  }
-  resGroup := id.ResourceGroup
-  appServiceName := id.Path["sites"]
-  slot := id.Path["slots"]
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+	slot := id.Path["slots"]
 
-  log.Printf("[DEBUG] Deleting App Service Slot %q/%q (resource group %q)", appServiceName, slot, resGroup)
+	log.Printf("[DEBUG] Deleting App Service Slot %q/%q (resource group %q)", appServiceName, slot, resGroup)
 
-  deleteMetrics := true
-  deleteEmptyServerFarm := false
-  skipDNSRegistration := true
-  ctx := meta.(*ArmClient).StopContext
-  resp, err := client.DeleteSlot(ctx, resGroup, appServiceName, slot, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
-  if err != nil {
-    if !utils.ResponseWasNotFound(resp) {
-      return err
-    }
-  }
+	deleteMetrics := true
+	deleteEmptyServerFarm := false
+	skipDNSRegistration := true
+	ctx := meta.(*ArmClient).StopContext
+	resp, err := client.DeleteSlot(ctx, resGroup, appServiceName, slot, &deleteMetrics, &deleteEmptyServerFarm, &skipDNSRegistration)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return err
+		}
+	}
 
-  return nil
+	return nil
 }

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -114,7 +114,7 @@ resource "azurerm_app_service" "test" {
 
 resource "azurerm_app_service_slot" "test" {
 	name                = "acctestASSlot-%d"
-	app_service_name    = "${azurerm_app_service.test.name}
+	app_service_name    = "${azurerm_app_service.test.name}"
 	location            = "${azurerm_resource_group.test.location}"
 	resource_group_name = "${azurerm_resource_group.test.name}"
 	app_service_plan_id = "${azurerm_app_service_plan.test.id}"

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -51,6 +51,498 @@ func TestAccAzureRMAppServiceSlot_freeTier(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServiceSlot_sharedTier(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_sharedTier(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_32Bit(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_32Bit(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_alwaysOn(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_alwaysOn(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.always_on", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_appSettings(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_appSettings(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "app_settings.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_clientAffinityEnabled(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_clientAffinityEnabled(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_affinity_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_connectionStrings(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_connectionStrings(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.name", "Example"),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.value", "some-postgresql-connection-string"),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.type", "PostgreSQL"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_defaultDocuments(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_defaultDocuments(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.0", "first.html"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.1", "second.jsp"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.2", "third.aspx"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_enabled(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_enabled(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_localMySql(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_localMySql(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.local_mysql_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_managedPipelineMode(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_managedPipelineMode(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.managed_pipeline_mode", "Classic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_tagsUpdate(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_tags(ri, testLocation())
+	updatedConfig := testAccAzureRMAppServiceSlot_tagsUpdated(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "AcceptanceTests"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_remoteDebugging(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_remoteDebugging(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_version", "VS2015"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsDotNet2(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsDotNet4(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsDotNetUpdate(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
+	updatedConfig := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsJava7Jetty(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "JETTY", "9.3")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsJava8Jetty(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "JETTY", "9.3")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+				),
+			},
+		},
+	})
+}
+func TestAccAzureRMAppServiceSlot_windowsJava7Tomcat(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "TOMCAT", "9.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsJava8Tomcat(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "TOMCAT", "9.0")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsPHP7(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsPHP(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.php_version", "7.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_windowsPython(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsPython(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.python_version", "3.4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceSlot_webSockets(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_webSockets(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.websockets_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMAppServiceSlotDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
@@ -156,8 +648,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   sku {
-    tier = "Standard"
-    size = "S1"
+    tier = "Free"
+    size = "F1"
   }
 }
 
@@ -176,6 +668,716 @@ resource "azurerm_app_service_slot" "test" {
 	app_service_name    = "${azurerm_app_service.test.name}"
   site_config {
 		use_32_bit_worker_process = true
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_sharedTier(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+	name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+	name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+	use_32_bit_worker_process = true
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_32Bit(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+  	use_32_bit_worker_process = true
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_alwaysOn(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+  	always_on = true
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_appSettings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  app_settings {
+  	"foo" = "bar"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_clientAffinityEnabled(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                    = "acctestASSlot-%d"
+  location                = "${azurerm_resource_group.test.location}"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+	app_service_plan_id     = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+  client_affinity_enabled = true
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_connectionStrings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  connection_string {
+  	name  = "Example"
+  	value = "some-postgresql-connection-string"
+  	type  = "PostgreSQL"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_defaultDocuments(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+  	default_documents = [
+		"first.html",
+		"second.jsp",
+		"third.aspx",
+  	]
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_enabled(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+  enabled = false
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_localMySql(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+  	local_mysql_enabled = true
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_managedPipelineMode(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+  	managed_pipeline_mode = "Classic"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_tags(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  tags {
+  	"Hello" = "World"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_tagsUpdated(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  tags {
+  	"Hello"     = "World"
+  	"Terraform" = "AcceptanceTests"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_remoteDebugging(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+    remote_debugging_enabled = true
+    remote_debugging_version = "VS2015"
+  }
+
+  tags {
+  	"Hello" = "World"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_windowsDotNet(rInt int, location, version string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+    dotnet_framework_version = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, version)
+}
+
+func testAccAzureRMAppServiceSlot_windowsJava(rInt int, location, javaVersion, container, containerVersion string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+    java_version           = "%s"
+    java_container         = "%s"
+    java_container_version = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, javaVersion, container, containerVersion)
+}
+
+func testAccAzureRMAppServiceSlot_windowsPHP(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+    php_version = "7.1"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_windowsPython(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+    python_version = "3.4"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_webSockets(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+	app_service_name    = "${azurerm_app_service.test.name}"
+
+  site_config {
+    websockets_enabled = true
   }
 }
 `, rInt, location, rInt, rInt, rInt)

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -30,46 +30,8 @@ func TestAccAzureRMAppServiceSlot_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMAppServiceSlot_freeTier(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_freeTier(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMAppServiceSlot_sharedTier(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_sharedTier(ri, testLocation())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-				),
-			},
-		},
-	})
-}
+// Removed freeTier Test Case because Slots are not supported in the Free App Service plan
+// Removed sharedTier Test Case because Slots are not supported in the Shared App Service plan
 
 func TestAccAzureRMAppServiceSlot_32Bit(t *testing.T) {
 	resourceName := "azurerm_app_service_slot.test"
@@ -627,87 +589,10 @@ resource "azurerm_app_service" "test" {
 
 resource "azurerm_app_service_slot" "test" {
 	name                = "acctestASSlot-%d"
-	app_service_name    = "${azurerm_app_service.test.name}"
 	location            = "${azurerm_resource_group.test.location}"
 	resource_group_name = "${azurerm_resource_group.test.name}"
 	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-  }
-`, rInt, location, rInt, rInt, rInt)
-}
-
-func testAccAzureRMAppServiceSlot_freeTier(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    tier = "Free"
-    size = "F1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-}
-
-resource "azurerm_app_service_slot" "test" {
-  name                = "acctestASSlot-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
 	app_service_name    = "${azurerm_app_service.test.name}"
-  site_config {
-		use_32_bit_worker_process = true
-  }
-}
-`, rInt, location, rInt, rInt, rInt)
-}
-
-func testAccAzureRMAppServiceSlot_sharedTier(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-	name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-}
-
-resource "azurerm_app_service_slot" "test" {
-	name                = "acctestASSlot-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
-
-  site_config {
-	use_32_bit_worker_process = true
-  }
 }
 `, rInt, location, rInt, rInt, rInt)
 }

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -1,604 +1,566 @@
 package azurerm
 
 import (
-	"fmt"
-	"testing"
+  "fmt"
+  "testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+  "github.com/hashicorp/terraform/helper/acctest"
+  "github.com/hashicorp/terraform/helper/resource"
+  "github.com/hashicorp/terraform/terraform"
+  "github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMAppServiceSlot_basic(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_basic(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_basic(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+        ),
+      },
+    },
+  })
 }
 
-// Removed freeTier Test Case because Slots are not supported in the Free App Service plan
-// Removed sharedTier Test Case because Slots are not supported in the Shared App Service plan
-
 func TestAccAzureRMAppServiceSlot_32Bit(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_32Bit(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_32Bit(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_alwaysOn(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_alwaysOn(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_alwaysOn(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.always_on", "true"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.always_on", "true"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_appSettings(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_appSettings(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_appSettings(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "app_settings.foo", "bar"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "app_settings.foo", "bar"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_clientAffinityEnabled(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_clientAffinityEnabled(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_clientAffinityEnabled(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "client_affinity_enabled", "true"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "client_affinity_enabled", "true"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_connectionStrings(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_connectionStrings(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_connectionStrings(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "connection_string.0.name", "Example"),
-					resource.TestCheckResourceAttr(resourceName, "connection_string.0.value", "some-postgresql-connection-string"),
-					resource.TestCheckResourceAttr(resourceName, "connection_string.0.type", "PostgreSQL"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "connection_string.0.name", "Example"),
+          resource.TestCheckResourceAttr(resourceName, "connection_string.0.value", "some-postgresql-connection-string"),
+          resource.TestCheckResourceAttr(resourceName, "connection_string.0.type", "PostgreSQL"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_defaultDocuments(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_defaultDocuments(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_defaultDocuments(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.0", "first.html"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.1", "second.jsp"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.2", "third.aspx"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.0", "first.html"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.1", "second.jsp"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.2", "third.aspx"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_enabled(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_enabled(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_enabled(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_localMySql(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_localMySql(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_localMySql(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.local_mysql_enabled", "true"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.local_mysql_enabled", "true"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_managedPipelineMode(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_managedPipelineMode(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_managedPipelineMode(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.managed_pipeline_mode", "Classic"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.managed_pipeline_mode", "Classic"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_tagsUpdate(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_tags(ri, testLocation())
-	updatedConfig := testAccAzureRMAppServiceSlot_tagsUpdated(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_tags(ri, testLocation())
+  updatedConfig := testAccAzureRMAppServiceSlot_tagsUpdated(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
-				),
-			},
-			{
-				Config: updatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
-					resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "AcceptanceTests"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+          resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+        ),
+      },
+      {
+        Config: updatedConfig,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+          resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+          resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "AcceptanceTests"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_remoteDebugging(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_remoteDebugging(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_remoteDebugging(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_version", "VS2015"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_enabled", "true"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_version", "VS2015"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsDotNet2(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsDotNet4(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsDotNetUpdate(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
-	updatedConfig := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
+  updatedConfig := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
-				),
-			},
-			{
-				Config: updatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+        ),
+      },
+      {
+        Config: updatedConfig,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsJava7Jetty(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "JETTY", "9.3")
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "JETTY", "9.3")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsJava8Jetty(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "JETTY", "9.3")
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "JETTY", "9.3")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+        ),
+      },
+    },
+  })
 }
 func TestAccAzureRMAppServiceSlot_windowsJava7Tomcat(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "TOMCAT", "9.0")
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "TOMCAT", "9.0")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsJava8Tomcat(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "TOMCAT", "9.0")
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "TOMCAT", "9.0")
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsPHP7(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsPHP(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsPHP(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.php_version", "7.1"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.php_version", "7.1"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_windowsPython(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_windowsPython(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_windowsPython(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.python_version", "3.4"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.python_version", "3.4"),
+        ),
+      },
+    },
+  })
 }
 
 func TestAccAzureRMAppServiceSlot_webSockets(t *testing.T) {
-	resourceName := "azurerm_app_service_slot.test"
-	ri := acctest.RandInt()
-	config := testAccAzureRMAppServiceSlot_webSockets(ri, testLocation())
+  resourceName := "azurerm_app_service_slot.test"
+  ri := acctest.RandInt()
+  config := testAccAzureRMAppServiceSlot_webSockets(ri, testLocation())
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSlotExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.websockets_enabled", "true"),
-				),
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+    Steps: []resource.TestStep{
+      {
+        Config: config,
+        Check: resource.ComposeTestCheckFunc(
+          testCheckAzureRMAppServiceSlotExists(resourceName),
+          resource.TestCheckResourceAttr(resourceName, "site_config.0.websockets_enabled", "true"),
+        ),
+      },
+    },
+  })
 }
 
 func testCheckAzureRMAppServiceSlotDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).appServicesClient
+  client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "azurerm_app_service_slot" {
-			continue
-		}
+  for _, rs := range s.RootModule().Resources {
+    if rs.Type != "azurerm_app_service_slot" {
+      continue
+    }
 
-		slot := rs.Primary.Attributes["name"]
-		appServiceName := rs.Primary.Attributes["app_service_name"]
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+    slot := rs.Primary.Attributes["name"]
+    appServiceName := rs.Primary.Attributes["app_service_name"]
+    resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
+    ctx := testAccProvider.Meta().(*ArmClient).StopContext
+    resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
 
-		if err != nil {
-			if utils.ResponseWasNotFound(resp.Response) {
-				return nil
-			}
-			return err
-		}
+    if err != nil {
+      if utils.ResponseWasNotFound(resp.Response) {
+        return nil
+      }
+      return err
+    }
 
-		return nil
-	}
+    return nil
+  }
 
-	return nil
+  return nil
 }
 
 func testCheckAzureRMAppServiceSlotExists(slot string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[slot]
-		if !ok {
-			return fmt.Errorf("Slot Not found: %q", slot)
-		}
+  return func(s *terraform.State) error {
+    // Ensure we have enough information in state to look up in API
+    rs, ok := s.RootModule().Resources[slot]
+    if !ok {
+      return fmt.Errorf("Slot Not found: %q", slot)
+    }
 
-		appServiceName := rs.Primary.Attributes["app_service_name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for App Service Slot: %q/%q", appServiceName, slot)
-		}
+    appServiceName := rs.Primary.Attributes["app_service_name"]
+    resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+    if !hasResourceGroup {
+      return fmt.Errorf("Bad: no resource group found in state for App Service Slot: %q/%q", appServiceName, slot)
+    }
 
-		client := testAccProvider.Meta().(*ArmClient).appServicesClient
-		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
-		if err != nil {
-			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: App Service slot %q/%q (resource group: %q) does not exist", appServiceName, slot, resourceGroup)
-			}
+    client := testAccProvider.Meta().(*ArmClient).appServicesClient
+    ctx := testAccProvider.Meta().(*ArmClient).StopContext
+    resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
+    if err != nil {
+      if utils.ResponseWasNotFound(resp.Response) {
+        return fmt.Errorf("Bad: App Service slot %q/%q (resource group: %q) does not exist", appServiceName, slot, resourceGroup)
+      }
 
-			return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
-		}
+      return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
+    }
 
-		return nil
-	}
-}
-
-func testAccAzureRMAppServiceSlot_basic(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
+    return nil
   }
 }
 
-resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-}
-
-resource "azurerm_app_service_slot" "test" {
-	name                = "acctestASSlot-%d"
-	location            = "${azurerm_resource_group.test.location}"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
-}
-`, rInt, location, rInt, rInt, rInt)
-}
-
-func testAccAzureRMAppServiceSlot_32Bit(rInt int, location string) string {
-	return fmt.Sprintf(`
+func testAccAzureRMAppServiceSlot_basic(rInt int, location string) string {
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -626,18 +588,53 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_32Bit(rInt int, location string) string {
+  return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
-  	use_32_bit_worker_process = true
+    use_32_bit_worker_process = true
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_alwaysOn(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -665,18 +662,18 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
-  	always_on = true
+    always_on = true
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_appSettings(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -704,18 +701,18 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   app_settings {
-  	"foo" = "bar"
+    "foo" = "bar"
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_clientAffinityEnabled(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -743,15 +740,15 @@ resource "azurerm_app_service_slot" "test" {
   name                    = "acctestASSlot-%d"
   location                = "${azurerm_resource_group.test.location}"
   resource_group_name     = "${azurerm_resource_group.test.name}"
-	app_service_plan_id     = "${azurerm_app_service_plan.test.id}"
-	app_service_name        = "${azurerm_app_service.test.name}"
+  app_service_plan_id     = "${azurerm_app_service_plan.test.id}"
+  app_service_name        = "${azurerm_app_service.test.name}"
   client_affinity_enabled = true
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_connectionStrings(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -779,20 +776,20 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   connection_string {
-  	name  = "Example"
-  	value = "some-postgresql-connection-string"
-  	type  = "PostgreSQL"
+    name  = "Example"
+    value = "some-postgresql-connection-string"
+    type  = "PostgreSQL"
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_defaultDocuments(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -820,22 +817,22 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
-  	default_documents = [
-		"first.html",
-		"second.jsp",
-		"third.aspx",
-  	]
+    default_documents = [
+      "first.html",
+      "second.jsp",
+      "third.aspx",
+    ]
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_enabled(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -863,15 +860,15 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
   enabled = false
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_localMySql(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -899,18 +896,18 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
-  	local_mysql_enabled = true
+    local_mysql_enabled = true
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_managedPipelineMode(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -938,18 +935,18 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
-  	managed_pipeline_mode = "Classic"
+    managed_pipeline_mode = "Classic"
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_tags(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -977,18 +974,18 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   tags {
-  	"Hello" = "World"
+    "Hello" = "World"
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_tagsUpdated(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1016,19 +1013,19 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   tags {
-  	"Hello"     = "World"
-  	"Terraform" = "AcceptanceTests"
+    "Hello"     = "World"
+    "Terraform" = "AcceptanceTests"
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_remoteDebugging(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1056,8 +1053,8 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
     remote_debugging_enabled = true
@@ -1065,14 +1062,14 @@ resource "azurerm_app_service_slot" "test" {
   }
 
   tags {
-  	"Hello" = "World"
+    "Hello" = "World"
   }
 }
 `, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMAppServiceSlot_windowsDotNet(rInt int, location, version string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1100,8 +1097,8 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
     dotnet_framework_version = "%s"
@@ -1111,7 +1108,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_windowsJava(rInt int, location, javaVersion, container, containerVersion string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1139,8 +1136,8 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
     java_version           = "%s"
@@ -1152,7 +1149,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_windowsPHP(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1180,8 +1177,8 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
     php_version = "7.1"
@@ -1191,7 +1188,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_windowsPython(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1219,8 +1216,8 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
     python_version = "3.4"
@@ -1230,7 +1227,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_webSockets(rInt int, location string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1258,8 +1255,8 @@ resource "azurerm_app_service_slot" "test" {
   name                = "acctestASSlot-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
 
   site_config {
     websockets_enabled = true

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -137,7 +137,7 @@ func TestAccAzureRMAppServiceSlot_appSettings(t *testing.T) {
 func TestAccAzureRMAppServiceSlot_clientAffinityEnabled(t *testing.T) {
 	resourceName := "azurerm_app_service_slot.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMAppService_clientAffinityEnabled(ri, testLocation())
+	config := testAccAzureRMAppServiceSlot_clientAffinityEnabled(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -859,7 +859,7 @@ resource "azurerm_app_service_slot" "test" {
   location                = "${azurerm_resource_group.test.location}"
   resource_group_name     = "${azurerm_resource_group.test.name}"
 	app_service_plan_id     = "${azurerm_app_service_plan.test.id}"
-	app_service_name    = "${azurerm_app_service.test.name}"
+	app_service_name        = "${azurerm_app_service.test.name}"
   client_affinity_enabled = true
 }
 `, rInt, location, rInt, rInt, rInt)

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -1,0 +1,123 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMAppServiceSlot_basic(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMAppServiceSlotDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ArmClient).appServicesClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_app_service_slot" {
+			continue
+		}
+
+		slot := rs.Primary.Attributes["name"]
+		appServiceName := rs.Primary.Attributes["app_service_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
+
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testCheckAzureRMAppServiceSlotExists(slot string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[slot]
+		if !ok {
+			return fmt.Errorf("Slot Not found: %q", slot)
+		}
+
+		appServiceName := rs.Primary.Attributes["app_service_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for App Service Slot: %q/%q", appServiceName, slot)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).appServicesClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: App Service slot %q/%q (resource group: %q) does not exist", appServiceName, slot, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMAppServiceSlot_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+	name                = "acctestASSlot-%d"
+	app_service_name    = "${azurerm_app_service.test.name}
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  }
+`, rInt, location, rInt, rInt, rInt)
+}

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -1,566 +1,566 @@
 package azurerm
 
 import (
-  "fmt"
-  "testing"
+	"fmt"
+	"testing"
 
-  "github.com/hashicorp/terraform/helper/acctest"
-  "github.com/hashicorp/terraform/helper/resource"
-  "github.com/hashicorp/terraform/terraform"
-  "github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMAppServiceSlot_basic(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_basic(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_basic(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_32Bit(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_32Bit(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_32Bit(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_alwaysOn(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_alwaysOn(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_alwaysOn(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.always_on", "true"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.always_on", "true"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_appSettings(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_appSettings(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_appSettings(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "app_settings.foo", "bar"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "app_settings.foo", "bar"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_clientAffinityEnabled(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_clientAffinityEnabled(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_clientAffinityEnabled(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "client_affinity_enabled", "true"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_affinity_enabled", "true"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_connectionStrings(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_connectionStrings(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_connectionStrings(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "connection_string.0.name", "Example"),
-          resource.TestCheckResourceAttr(resourceName, "connection_string.0.value", "some-postgresql-connection-string"),
-          resource.TestCheckResourceAttr(resourceName, "connection_string.0.type", "PostgreSQL"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.name", "Example"),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.value", "some-postgresql-connection-string"),
+					resource.TestCheckResourceAttr(resourceName, "connection_string.0.type", "PostgreSQL"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_defaultDocuments(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_defaultDocuments(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_defaultDocuments(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.0", "first.html"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.1", "second.jsp"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.2", "third.aspx"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.0", "first.html"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.1", "second.jsp"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.default_documents.2", "third.aspx"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_enabled(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_enabled(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_enabled(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_localMySql(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_localMySql(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_localMySql(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.local_mysql_enabled", "true"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.local_mysql_enabled", "true"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_managedPipelineMode(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_managedPipelineMode(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_managedPipelineMode(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.managed_pipeline_mode", "Classic"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.managed_pipeline_mode", "Classic"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_tagsUpdate(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_tags(ri, testLocation())
-  updatedConfig := testAccAzureRMAppServiceSlot_tagsUpdated(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_tags(ri, testLocation())
+	updatedConfig := testAccAzureRMAppServiceSlot_tagsUpdated(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-          resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
-        ),
-      },
-      {
-        Config: updatedConfig,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-          resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
-          resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "AcceptanceTests"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Hello", "World"),
+					resource.TestCheckResourceAttr(resourceName, "tags.Terraform", "AcceptanceTests"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_remoteDebugging(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_remoteDebugging(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_remoteDebugging(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_enabled", "true"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_version", "VS2015"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.remote_debugging_version", "VS2015"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsDotNet2(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsDotNet4(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsDotNetUpdate(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
-  updatedConfig := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v2.0")
+	updatedConfig := testAccAzureRMAppServiceSlot_windowsDotNet(ri, testLocation(), "v4.0")
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
-        ),
-      },
-      {
-        Config: updatedConfig,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v2.0"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.dotnet_framework_version", "v4.0"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsJava7Jetty(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "JETTY", "9.3")
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "JETTY", "9.3")
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsJava8Jetty(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "JETTY", "9.3")
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "JETTY", "9.3")
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "JETTY"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.3"),
+				),
+			},
+		},
+	})
 }
 func TestAccAzureRMAppServiceSlot_windowsJava7Tomcat(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "TOMCAT", "9.0")
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.7", "TOMCAT", "9.0")
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.7"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsJava8Tomcat(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "TOMCAT", "9.0")
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsJava(ri, testLocation(), "1.8", "TOMCAT", "9.0")
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_version", "1.8"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container", "TOMCAT"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.java_container_version", "9.0"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsPHP7(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsPHP(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsPHP(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.php_version", "7.1"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.php_version", "7.1"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_windowsPython(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_windowsPython(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_windowsPython(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.python_version", "3.4"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.python_version", "3.4"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccAzureRMAppServiceSlot_webSockets(t *testing.T) {
-  resourceName := "azurerm_app_service_slot.test"
-  ri := acctest.RandInt()
-  config := testAccAzureRMAppServiceSlot_webSockets(ri, testLocation())
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_webSockets(ri, testLocation())
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
-    Steps: []resource.TestStep{
-      {
-        Config: config,
-        Check: resource.ComposeTestCheckFunc(
-          testCheckAzureRMAppServiceSlotExists(resourceName),
-          resource.TestCheckResourceAttr(resourceName, "site_config.0.websockets_enabled", "true"),
-        ),
-      },
-    },
-  })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.websockets_enabled", "true"),
+				),
+			},
+		},
+	})
 }
 
 func testCheckAzureRMAppServiceSlotDestroy(s *terraform.State) error {
-  client := testAccProvider.Meta().(*ArmClient).appServicesClient
+	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
-  for _, rs := range s.RootModule().Resources {
-    if rs.Type != "azurerm_app_service_slot" {
-      continue
-    }
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_app_service_slot" {
+			continue
+		}
 
-    slot := rs.Primary.Attributes["name"]
-    appServiceName := rs.Primary.Attributes["app_service_name"]
-    resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		slot := rs.Primary.Attributes["name"]
+		appServiceName := rs.Primary.Attributes["app_service_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-    ctx := testAccProvider.Meta().(*ArmClient).StopContext
-    resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
 
-    if err != nil {
-      if utils.ResponseWasNotFound(resp.Response) {
-        return nil
-      }
-      return err
-    }
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+			return err
+		}
 
-    return nil
-  }
+		return nil
+	}
 
-  return nil
+	return nil
 }
 
 func testCheckAzureRMAppServiceSlotExists(slot string) resource.TestCheckFunc {
-  return func(s *terraform.State) error {
-    // Ensure we have enough information in state to look up in API
-    rs, ok := s.RootModule().Resources[slot]
-    if !ok {
-      return fmt.Errorf("Slot Not found: %q", slot)
-    }
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[slot]
+		if !ok {
+			return fmt.Errorf("Slot Not found: %q", slot)
+		}
 
-    appServiceName := rs.Primary.Attributes["app_service_name"]
-    resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-    if !hasResourceGroup {
-      return fmt.Errorf("Bad: no resource group found in state for App Service Slot: %q/%q", appServiceName, slot)
-    }
+		appServiceName := rs.Primary.Attributes["app_service_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for App Service Slot: %q/%q", appServiceName, slot)
+		}
 
-    client := testAccProvider.Meta().(*ArmClient).appServicesClient
-    ctx := testAccProvider.Meta().(*ArmClient).StopContext
-    resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
-    if err != nil {
-      if utils.ResponseWasNotFound(resp.Response) {
-        return fmt.Errorf("Bad: App Service slot %q/%q (resource group: %q) does not exist", appServiceName, slot, resourceGroup)
-      }
+		client := testAccProvider.Meta().(*ArmClient).appServicesClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.GetSlot(ctx, resourceGroup, appServiceName, slot)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: App Service slot %q/%q (resource group: %q) does not exist", appServiceName, slot, resourceGroup)
+			}
 
-      return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
-    }
+			return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
+		}
 
-    return nil
-  }
+		return nil
+	}
 }
 
 func testAccAzureRMAppServiceSlot_basic(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -595,7 +595,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_32Bit(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -634,7 +634,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_alwaysOn(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -673,7 +673,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_appSettings(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -712,7 +712,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_clientAffinityEnabled(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -748,7 +748,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_connectionStrings(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -789,7 +789,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_defaultDocuments(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -832,7 +832,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_enabled(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -868,7 +868,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_localMySql(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -907,7 +907,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_managedPipelineMode(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -946,7 +946,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_tags(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -985,7 +985,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_tagsUpdated(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1025,7 +1025,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_remoteDebugging(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1069,7 +1069,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_windowsDotNet(rInt int, location, version string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1108,7 +1108,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_windowsJava(rInt int, location, javaVersion, container, containerVersion string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1149,7 +1149,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_windowsPHP(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1188,7 +1188,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_windowsPython(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"
@@ -1227,7 +1227,7 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 func testAccAzureRMAppServiceSlot_webSockets(rInt int, location string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name = "acctestRG-%d"
   location = "%s"

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -115,6 +115,10 @@
                   <a href="/docs/providers/azurerm/r/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-app-service-active-slot") %>>
+                <a href="/docs/providers/azurerm/r/app_service_active_slot.html">azurerm_app_service_active_slot</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-resource-app-service-slot") %>>
                   <a href="/docs/providers/azurerm/r/app_service_slot.html">azurerm_app_service_slot</a>
                 </li>

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -115,6 +115,10 @@
                   <a href="/docs/providers/azurerm/r/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-app-service-slot") %>>
+                  <a href="/docs/providers/azurerm/r/app_service_slot.html">azurerm_app_service_slot</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-resource-function-app") %>>
                   <a href="/docs/providers/azurerm/r/function_app.html">azurerm_function_app</a>
                 </li>

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -1,0 +1,55 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_active_slot"
+sidebar_current: "docs-azurerm-resource-app-service-active-slot"
+description: |-
+  Swaps an App Service Slot (within an App Service) with the Production slot.
+
+---
+
+# azurerm_app_service_slot
+
+Swaps an App Service Slot (within an App Service) with the Production slot.
+
+## Example Usage
+
+```hcl
+resource "random_id" "server" {
+  # ...
+}
+
+resource "azurerm_resource_group" "test" {
+  # ...
+}
+
+resource "azurerm_app_service_plan" "test" {
+  # ...
+}
+
+resource "azurerm_app_service" "test" {
+  # ...
+}
+
+resource "azurerm_app_service_slot" "test" {
+  # ...
+}
+
+resource "azurerm_app_service_active_slot" "test" {
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    app_service_name    = "${azurerm_app_service.test.name}"
+    preserve_vnet       = true
+    source_slot_name    = "${azurerm_app_service_slot.test.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Slot component.
+
+* `app_service_name` - (Required) The name of the App Service within which to create the App Service Slot.  Changing this forces a new resource to be created.
+
+* `preserve_vnet` - (Required) `true` to preserve Virtual Network to the slot during swap; otherwise, `false`.
+
+* `source_slot_name` - (Required) Source deployment slot for the swap operation.

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -50,6 +50,4 @@ The following arguments are supported:
 
 * `app_service_name` - (Required) The name of the App Service within which the Slot exists.  Changing this forces a new resource to be created.
 
-* `preserve_vnet` - (Required) `true` to preserve Virtual Network to the slot during swap; otherwise, `false`.
-
 * `app_service_slot_name` - (Required) Source deployment slot for the swap operation.

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -3,13 +3,13 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_active_slot"
 sidebar_current: "docs-azurerm-resource-app-service-active-slot"
 description: |-
-  Swaps an App Service Slot (within an App Service) with the Production slot.
+  Promotes an App Service Slot to Production within an App Service
 
 ---
 
-# azurerm_app_service_slot
+# azurerm_app_service_active_slot
 
-Swaps an App Service Slot (within an App Service) with the Production slot.
+Promotes an App Service Slot to Production within an App Service.
 
 ## Example Usage
 
@@ -46,10 +46,10 @@ resource "azurerm_app_service_active_slot" "test" {
 
 The following arguments are supported:
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Slot component.
+* `resource_group_name` - (Required) The name of the resource group in which the App Service exists. Changing this forces a new resource to be created.
 
-* `app_service_name` - (Required) The name of the App Service within which to create the App Service Slot.  Changing this forces a new resource to be created.
+* `app_service_name` - (Required) The name of the App Service within which the Slot exists.  Changing this forces a new resource to be created.
 
 * `preserve_vnet` - (Required) `true` to preserve Virtual Network to the slot during swap; otherwise, `false`.
 
-* `source_slot_name` - (Required) Source deployment slot for the swap operation.
+* `app_service_slot_name` - (Required) Source deployment slot for the swap operation.

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -49,4 +49,5 @@ The following arguments are supported:
 
 * `app_service_name` - (Required) The name of the App Service within which the Slot exists.  Changing this forces a new resource to be created.
 
-* `app_service_slot_name` - (Required) Source deployment slot for the swap operation.
+* `app_service_slot_name` - (Required) The name of the App Service Slot which should be promoted to the Production Slot within the App Service.
+

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -37,7 +37,6 @@ resource "azurerm_app_service_slot" "test" {
 resource "azurerm_app_service_active_slot" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     app_service_name    = "${azurerm_app_service.test.name}"
-    preserve_vnet       = true
     source_slot_name    = "${azurerm_app_service_slot.test.name}"
 }
 ```

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -1,0 +1,217 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_slot"
+sidebar_current: "docs-azurerm-resource-app-service-slot"
+description: |-
+  Manages an App Service Slot (within an App Service).
+
+---
+
+# azurerm_app_service_slot
+
+Manages an App Service Slot (within an App Service).
+
+## Example Usage (.net 4.x)
+
+```hcl
+resource "random_id" "server" {
+  keepers = {
+    azi_id = 1
+  }
+
+  byte_length = 8
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "some-resource-group"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "some-app-service-plan"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "${random_id.server.hex}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    dotnet_framework_version = "v4.0"
+  }
+
+  app_settings {
+    "SOME_KEY" = "some-value"
+  }
+
+  connection_string {
+    name  = "Database"
+    type  = "SQLServer"
+    value = "Server=some-server.mydomain.com;Integrated Security=SSPI"
+  }
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "${random_id.server.hex}"
+  app_service_name    = "${azurerm_app_service.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    dotnet_framework_version = "v4.0"
+  }
+
+  app_settings {
+    "SOME_KEY" = "some-value"
+  }
+
+  connection_string {
+    name  = "Database"
+    type  = "SQLServer"
+    value = "Server=some-server.mydomain.com;Integrated Security=SSPI"
+  }
+}
+```
+
+## Example Usage (Java 1.8)
+
+```hcl
+resource "random_id" "server" {
+  keepers = {
+    azi_id = 1
+  }
+
+  byte_length = 8
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "some-resource-group"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "some-app-service-plan"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "${random_id.server.hex}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    java_version           = "1.8"
+    java_container         = "JETTY"
+    java_container_version = "9.3"
+  }
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "${random_id.server.hex}"
+  app_service_name    = "${azurerm_app_service.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    java_version           = "1.8"
+    java_container         = "JETTY"
+    java_container_version = "9.3"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the App Service Slot component. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Slot component.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this App Service Slot. Changing this forces a new resource to be created.
+
+* `app_service_name` - (Required) The name of the App Service within which to create the App Service Slot.  Changing this forces a new resource to be created.
+
+* `app_settings` - (Optional) A key-value pair of App Settings.
+
+* `connection_string` - (Optional) An `connection_string` block as defined below.
+
+* `client_affinity_enabled` - (Optional) Should the App Service Slot send session affinity cookies, which route client requests in the same session to the same instance? Changing this forces a new resource to be created.
+
+* `enabled` - (Optional) Is the App Service Slot Enabled? Changing this forces a new resource to be created.
+
+* `site_config` - (Optional) A `site_config` object as defined below.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+
+---
+
+`connection_string` supports the following:
+
+* `name` - (Required) The name of the Connection String.
+* `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure` and  `SQLServer`.
+* `value` - (Required) The value for the Connection String.
+
+---
+
+`site_config` supports the following:
+
+* `always_on` - (Optional) Should the app be loaded at all times? Defaults to `false`.
+* `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
+* `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service Slot. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`) and `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`). [For more information on which .net CLR version to use based on the .net framework you're targetting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
+
+* `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7` and `1.8`.
+* `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.
+* `java_container_version` - (Optional) The version of the Java Container to use. If specified `java_version` and `java_container` must also be specified.
+
+* `local_mysql_enabled` - (Optional) Is "MySQL In App" Enabled? This runs a local MySQL instance with your app and shares resources from the App Service plan.
+
+~> **NOTE:** MySQL In App is not intended for production environments and will not scale beyond a single instance. Instead you may wish [to use Azure Database for MySQL](/docs/providers/azurerm/r/mysql_database.html).
+
+* `managed_pipeline_mode` - (Optional) The Managed Pipeline Mode. Possible values are `Integrated` and `Classic`. Defaults to `Integrated`.
+* `php_version` - (Optional) The version of PHP to use in this App Service Slot. Possible values are `5.5`, `5.6`, `7.0` and `7.1`.
+* `python_version` - (Optional) The version of Python to use in this App Service Slot. Possible values are `2.7` and `3.4`.
+* `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.
+* `remote_debugging_version` - (Optional) Which version of Visual Studio should the Remote Debugger be compatible with? Possible values are `VS2012`, `VS2013`, `VS2015` and `VS2017`.
+* `use_32_bit_worker_process` - (Optional) Should the App Service Slot run in 32 bit mode, rather than 64 bit mode?
+
+~> **Note:** When using an App Service Plan in the `Free` or `Shared` Tiers `use_32_bit_worker_process` must be set to `true`.
+
+* `websockets_enabled` - (Optional) Should WebSockets be enabled?
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the App Service Slot.
+
+* `default_site_hostname` - The Default Hostname associated with the App Service Slot - such as `mysite.azurewebsites.net`
+
+* `outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12`
+
+## Import
+
+App Service Slots can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_app_service_slot.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/default/slots/instance1
+```

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -211,5 +211,5 @@ The following attributes are exported:
 App Service Slots can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_app_service_slot.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/default/slots/instance1
+terraform import azurerm_app_service_slot.instance1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/website1/slots/instance1
 ```

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -194,7 +194,7 @@ The following arguments are supported:
 * `remote_debugging_version` - (Optional) Which version of Visual Studio should the Remote Debugger be compatible with? Possible values are `VS2012`, `VS2013`, `VS2015` and `VS2017`.
 * `use_32_bit_worker_process` - (Optional) Should the App Service Slot run in 32 bit mode, rather than 64 bit mode?
 
-~> **Note:** When using an App Service Plan in the `Free` or `Shared` Tiers `use_32_bit_worker_process` must be set to `true`.
+~> **Note:** Deployment Slots are not supported in the `Free`, `Shared`, or `Basic` App Service Plans. 
 
 * `websockets_enabled` - (Optional) Should WebSockets be enabled?
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -206,8 +206,6 @@ The following attributes are exported:
 
 * `default_site_hostname` - The Default Hostname associated with the App Service Slot - such as `mysite.azurewebsites.net`
 
-* `outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12`
-
 ## Import
 
 App Service Slots can be imported using the `resource id`, e.g.


### PR DESCRIPTION
This PR adds support for App Service Slot and Active Slot features to the Azure Terraform Provider.

**Added Resources**
* `resource_arm_app_service_active_slot`
* `resource_arm_app_service_active_slot_test`
* `resource_arm_app_service_slot`
* `resource_arm_app_service_slot_test`
* `app_service_slot.html.markdown`
* `app_service_active_slot.html.markdown`

**Updated Resources**
* `azurerm.erb`
* `provider`

[Test Results](https://gist.github.com/jeffreyCline/34f239d6c2f76128ffdc9da164a15d9c)