### PR TITLE
App Service: adding a disclaimer about a perpetual diff with Slots

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages an App Service (within an App Service Plan).
 
+-> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
+
 ## Example Usage (.net 4.x)
 
 ```hcl

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Promotes an App Service Slot to Production within an App Service.
 
+-> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
+
 ## Example Usage
 
 ```hcl
@@ -35,9 +37,9 @@ resource "azurerm_app_service_slot" "test" {
 }
 
 resource "azurerm_app_service_active_slot" "test" {
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    app_service_name    = "${azurerm_app_service.test.name}"
-    source_slot_name    = "${azurerm_app_service_slot.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_name    = "${azurerm_app_service.test.name}"
+  source_slot_name    = "${azurerm_app_service_slot.test.name}"
 }
 ```
 
@@ -50,4 +52,3 @@ The following arguments are supported:
 * `app_service_name` - (Required) The name of the App Service within which the Slot exists.  Changing this forces a new resource to be created.
 
 * `app_service_slot_name` - (Required) The name of the App Service Slot which should be promoted to the Production Slot within the App Service.
-

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Create an App Service Plan component.
 ---
 
-# azurerm\_app\_service\_plan
+# azurerm_app_service_plan
 
 Create an App Service Plan component.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -11,6 +11,9 @@ description: |-
 
 Manages an App Service Slot (within an App Service).
 
+-> **Note:** When using Slots - the `app_settings`, `connection_string` and `site_config` blocks on the `azurerm_app_service` resource will be overwritten when promoting a Slot using the `azurerm_app_service_active_slot` resource.
+
+
 ## Example Usage (.net 4.x)
 
 ```hcl
@@ -194,7 +197,7 @@ The following arguments are supported:
 * `remote_debugging_version` - (Optional) Which version of Visual Studio should the Remote Debugger be compatible with? Possible values are `VS2012`, `VS2013`, `VS2015` and `VS2017`.
 * `use_32_bit_worker_process` - (Optional) Should the App Service Slot run in 32 bit mode, rather than 64 bit mode?
 
-~> **Note:** Deployment Slots are not supported in the `Free`, `Shared`, or `Basic` App Service Plans. 
+~> **Note:** Deployment Slots are not supported in the `Free`, `Shared`, or `Basic` App Service Plans.
 
 * `websockets_enabled` - (Optional) Should WebSockets be enabled?
 


### PR DESCRIPTION
You can either specify the Site Configuration on the Active Slot or in the App Service - but not both or there'll be a perpetual diff. This PR adds a disclaimer to this effect.