### PR TITLE
Correcting line endings in Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Treat all files in the repo as binary, with no git magic updating
+# line endings. Windows users contributing will need to use a
+# modern version of git and editors capable of LF line endings.
+#
+# We'll prevent accidental CRLF line endings from entering the repo
+# via the git-review gofmt checks.
+#
+# See golang.org/issue/9281
+
+* -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 # We'll prevent accidental CRLF line endings from entering the repo
 # via the git-review gofmt checks.
 #
-# See golang.org/issue/9281
+# See golang.org/issue/9281 and an example from Golang:
+# https://github.com/golang/go/blob/master/.gitattributes
 
 * -text


### PR DESCRIPTION
Just correcting the way that line endings are done in windows avoid git magic on line endings.

Similar to the way that the golang project uses.