### PR TITLE
Add support for custom IPsec/IKE policies for VPN connections

### DIFF
--- a/azurerm/resource_arm_virtual_network_gateway_connection.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection.go
@@ -79,19 +79,128 @@ func resourceArmVirtualNetworkGatewayConnection() *schema.Resource {
 			"enable_bgp": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
+			},
+
+			"use_policy_based_traffic_selectors": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
 			},
 
 			"routing_weight": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  10,
+				Computed: true,
 			},
 
 			"shared_key": {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
+			},
+
+			"ipsec_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dh_group": {
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.DHGroup1),
+								string(network.DHGroup14),
+								string(network.DHGroup2),
+								string(network.DHGroup2048),
+								string(network.DHGroup24),
+								string(network.ECP256),
+								string(network.ECP384),
+								string(network.None),
+							}, true),
+						},
+						"ike_encryption": {
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.AES128),
+								string(network.AES192),
+								string(network.AES256),
+								string(network.DES),
+								string(network.DES3),
+							}, true),
+						},
+						"ike_integrity": {
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.MD5),
+								string(network.SHA1),
+								string(network.SHA256),
+								string(network.SHA384),
+							}, true),
+						},
+						"ipsec_encryption": {
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.IpsecEncryptionAES128),
+								string(network.IpsecEncryptionAES192),
+								string(network.IpsecEncryptionAES256),
+								string(network.IpsecEncryptionDES),
+								string(network.IpsecEncryptionDES3),
+								string(network.IpsecEncryptionGCMAES128),
+								string(network.IpsecEncryptionGCMAES192),
+								string(network.IpsecEncryptionGCMAES256),
+								string(network.IpsecEncryptionNone),
+							}, true),
+						},
+						"ipsec_integrity": {
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.IpsecIntegrityGCMAES128),
+								string(network.IpsecIntegrityGCMAES192),
+								string(network.IpsecIntegrityGCMAES256),
+								string(network.IpsecIntegrityMD5),
+								string(network.IpsecIntegritySHA1),
+								string(network.IpsecIntegritySHA256),
+							}, true),
+						},
+						"pfs_group": {
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.PfsGroupECP256),
+								string(network.PfsGroupECP384),
+								string(network.PfsGroupNone),
+								string(network.PfsGroupPFS1),
+								string(network.PfsGroupPFS2),
+								string(network.PfsGroupPFS2048),
+								string(network.PfsGroupPFS24),
+							}, true),
+						},
+						"sa_datasize": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntAtLeast(1024),
+						},
+						"sa_lifetime": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntAtLeast(300),
+						},
+					},
+				},
 			},
 
 			"tags": tagsSchema(),
@@ -180,7 +289,9 @@ func resourceArmVirtualNetworkGatewayConnectionRead(d *schema.ResourceData, meta
 		d.Set("virtual_network_gateway_id", conn.VirtualNetworkGateway1.ID)
 	}
 
-	d.Set("authorization_key", conn.AuthorizationKey)
+	if conn.AuthorizationKey != nil {
+		d.Set("authorization_key", conn.AuthorizationKey)
+	}
 
 	if conn.Peer != nil {
 		d.Set("express_route_circuit_id", conn.Peer.ID)
@@ -194,9 +305,26 @@ func resourceArmVirtualNetworkGatewayConnectionRead(d *schema.ResourceData, meta
 		d.Set("local_network_gateway_id", conn.LocalNetworkGateway2.ID)
 	}
 
-	d.Set("enable_bgp", conn.EnableBgp)
-	d.Set("routing_weight", conn.RoutingWeight)
-	d.Set("shared_key", conn.SharedKey)
+	if conn.EnableBgp != nil {
+		d.Set("enable_bgp", conn.EnableBgp)
+	}
+
+	if conn.UsePolicyBasedTrafficSelectors != nil {
+		d.Set("use_policy_based_traffic_selectors", conn.UsePolicyBasedTrafficSelectors)
+	}
+
+	if conn.RoutingWeight != nil {
+		d.Set("routing_weight", conn.RoutingWeight)
+	}
+
+	if conn.SharedKey != nil {
+		d.Set("shared_key", conn.SharedKey)
+	}
+
+	if conn.IpsecPolicies != nil {
+		ipsec_policies := flattenArmVirtualNetworkGatewayConnectionIpsecPolicies(conn.IpsecPolicies)
+		d.Set("ipsec_policy", ipsec_policies)
+	}
 
 	flattenAndSetTags(d, resp.Tags)
 
@@ -227,11 +355,9 @@ func resourceArmVirtualNetworkGatewayConnectionDelete(d *schema.ResourceData, me
 
 func getArmVirtualNetworkGatewayConnectionProperties(d *schema.ResourceData) (*network.VirtualNetworkGatewayConnectionPropertiesFormat, error) {
 	connectionType := network.VirtualNetworkGatewayConnectionType(d.Get("type").(string))
-	enableBgp := d.Get("enable_bgp").(bool)
 
 	props := &network.VirtualNetworkGatewayConnectionPropertiesFormat{
 		ConnectionType: connectionType,
-		EnableBgp:      &enableBgp,
 	}
 
 	if v, ok := d.GetOk("virtual_network_gateway_id"); ok {
@@ -294,14 +420,27 @@ func getArmVirtualNetworkGatewayConnectionProperties(d *schema.ResourceData) (*n
 		}
 	}
 
+	if v, ok := d.GetOk("enable_bgp"); ok {
+		props.EnableBgp = utils.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("use_policy_based_traffic_selectors"); ok {
+		props.UsePolicyBasedTrafficSelectors = utils.Bool(v.(bool))
+	}
+
 	if v, ok := d.GetOk("routing_weight"); ok {
-		routingWeight := int32(v.(int))
-		props.RoutingWeight = &routingWeight
+		routing_weight := int32(v.(int))
+		props.RoutingWeight = &routing_weight
 	}
 
 	if v, ok := d.GetOk("shared_key"); ok {
-		sharedKey := v.(string)
-		props.SharedKey = &sharedKey
+		props.SharedKey = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ipsec_policy"); ok {
+		ipsec_policies := v.([]interface{})
+		props.IpsecPolicies = expandArmVirtualNetworkGatewayConnectionIpsecPolicies(ipsec_policies)
+		log.Printf("Ipsec policies: %+q", props.IpsecPolicies)
 	}
 
 	if props.ConnectionType == network.ExpressRoute {
@@ -338,4 +477,78 @@ func resourceGroupAndVirtualNetworkGatewayConnectionFromId(virtualNetworkGateway
 	resGroup := id.ResourceGroup
 
 	return resGroup, name, nil
+}
+
+func expandArmVirtualNetworkGatewayConnectionIpsecPolicies(ipsec_policies []interface{}) *[]network.IpsecPolicy {
+	ipsecPolicies := make([]network.IpsecPolicy, 0, len(ipsec_policies))
+
+	for _, d := range ipsec_policies {
+		ipsec_policy := d.(map[string]interface{})
+		ipsecPolicy := &network.IpsecPolicy{}
+
+		if dh_group, ok := ipsec_policy["dh_group"].(string); ok && dh_group != "" {
+			ipsecPolicy.DhGroup = network.DhGroup(dh_group)
+		}
+
+		if ike_encryption, ok := ipsec_policy["ike_encryption"].(string); ok && ike_encryption != "" {
+			ipsecPolicy.IkeEncryption = network.IkeEncryption(ike_encryption)
+		}
+
+		if ike_integrity, ok := ipsec_policy["ike_integrity"].(string); ok && ike_integrity != "" {
+			ipsecPolicy.IkeIntegrity = network.IkeIntegrity(ike_integrity)
+		}
+
+		if ipsec_encryption, ok := ipsec_policy["ipsec_encryption"].(string); ok && ipsec_encryption != "" {
+			ipsecPolicy.IpsecEncryption = network.IpsecEncryption(ipsec_encryption)
+		}
+
+		if ipsec_integrity, ok := ipsec_policy["ipsec_integrity"].(string); ok && ipsec_integrity != "" {
+			ipsecPolicy.IpsecIntegrity = network.IpsecIntegrity(ipsec_integrity)
+		}
+
+		if pfs_group, ok := ipsec_policy["pfs_group"].(string); ok && pfs_group != "" {
+			ipsecPolicy.PfsGroup = network.PfsGroup(pfs_group)
+		}
+
+		if v, ok := ipsec_policy["sa_datasize"].(int); ok {
+			sa_datasize := int32(v)
+			ipsecPolicy.SaDataSizeKilobytes = &sa_datasize
+		}
+
+		if v, ok := ipsec_policy["sa_lifetime"].(int); ok {
+			sa_lifetime := int32(v)
+			ipsecPolicy.SaLifeTimeSeconds = &sa_lifetime
+		}
+
+		ipsecPolicies = append(ipsecPolicies, *ipsecPolicy)
+	}
+
+	return &ipsecPolicies
+}
+
+func flattenArmVirtualNetworkGatewayConnectionIpsecPolicies(ipsecPolicies *[]network.IpsecPolicy) []interface{} {
+	ipsec_policies := make([]interface{}, 0, len(*ipsecPolicies))
+
+	for _, ipsecPolicy := range *ipsecPolicies {
+		ipsec_policy := make(map[string]interface{})
+
+		ipsec_policy["dh_group"] = string(ipsecPolicy.DhGroup)
+		ipsec_policy["ike_encryption"] = string(ipsecPolicy.IkeEncryption)
+		ipsec_policy["ike_integrity"] = string(ipsecPolicy.IkeIntegrity)
+		ipsec_policy["ipsec_encryption"] = string(ipsecPolicy.IpsecEncryption)
+		ipsec_policy["ipsec_integrity"] = string(ipsecPolicy.IpsecIntegrity)
+		ipsec_policy["pfs_group"] = string(ipsecPolicy.PfsGroup)
+
+		if ipsecPolicy.SaDataSizeKilobytes != nil {
+			ipsec_policy["sa_datasize"] = int(*ipsecPolicy.SaDataSizeKilobytes)
+		}
+
+		if ipsecPolicy.SaLifeTimeSeconds != nil {
+			ipsec_policy["sa_lifetime"] = int(*ipsecPolicy.SaLifeTimeSeconds)
+		}
+
+		ipsec_policies = append(ipsec_policies, ipsec_policy)
+	}
+
+	return ipsec_policies
 }

--- a/azurerm/resource_arm_virtual_network_gateway_connection.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection.go
@@ -423,13 +423,9 @@ func getArmVirtualNetworkGatewayConnectionProperties(d *schema.ResourceData) (*n
 		}
 	}
 
-	if v, ok := d.GetOk("enable_bgp"); ok {
-		props.EnableBgp = utils.Bool(v.(bool))
-	}
+	props.EnableBgp = utils.Bool(d.Get("enable_bgp").(bool))
 
-	if v, ok := d.GetOk("use_policy_based_traffic_selectors"); ok {
-		props.UsePolicyBasedTrafficSelectors = utils.Bool(v.(bool))
-	}
+	props.UsePolicyBasedTrafficSelectors = utils.Bool(d.Get("use_policy_based_traffic_selectors").(bool))
 
 	if v, ok := d.GetOk("routing_weight"); ok {
 		routingWeight := int32(v.(int))

--- a/azurerm/resource_arm_virtual_network_gateway_connection_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection_test.go
@@ -175,7 +175,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name = "test-${var.random}"
+  name = "acctestvn-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   address_space = ["10.0.0.0/16"]
@@ -189,14 +189,14 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "Dynamic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -213,7 +213,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 }
 
 resource "azurerm_local_network_gateway" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -222,7 +222,7 @@ resource "azurerm_local_network_gateway" "test" {
 }
 
 resource "azurerm_virtual_network_gateway_connection" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -255,7 +255,7 @@ resource "azurerm_resource_group" "test_1" {
 }
 
 resource "azurerm_virtual_network" "test_1" {
-  name = "acctest-${var.random1}"
+  name = "acctestvn-${var.random1}"
   location = "${azurerm_resource_group.test_1.location}"
   resource_group_name = "${azurerm_resource_group.test_1.name}"
   address_space = ["10.0.0.0/16"]
@@ -373,7 +373,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_virtual_network" "test" {
-  name = "test-${var.random}"
+  name = "acctestvn-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   address_space = ["10.0.0.0/16"]
@@ -387,14 +387,14 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   public_ip_address_allocation = "Dynamic"
 }
 
 resource "azurerm_virtual_network_gateway" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -411,7 +411,7 @@ resource "azurerm_virtual_network_gateway" "test" {
 }
 
 resource "azurerm_local_network_gateway" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -420,7 +420,7 @@ resource "azurerm_local_network_gateway" "test" {
 }
 
 resource "azurerm_virtual_network_gateway_connection" "test" {
-  name = "test-${var.random}"
+  name = "acctest-${var.random}"
   location = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 

--- a/azurerm/resource_arm_virtual_network_gateway_connection_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection_test.go
@@ -56,6 +56,25 @@ func TestAccAzureRMVirtualNetworkGatewayConnection_vnettonet(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetworkGatewayConnection_ipsecpolicy(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualNetworkGatewayConnection_ipsecpolicy(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkGatewayConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkGatewayConnectionExists("azurerm_virtual_network_gateway_connection.test"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.T) {
 	firstResourceName := "azurerm_virtual_network_gateway_connection.test_1"
 	secondResourceName := "azurerm_virtual_network_gateway_connection.test_2"
@@ -340,4 +359,90 @@ resource "azurerm_virtual_network_gateway_connection" "test_2" {
   shared_key = "${var.shared_key}"
 }
 `, rInt, rInt2, sharedKey, location, altLocation)
+}
+
+func testAccAzureRMVirtualNetworkGatewayConnection_ipsecpolicy(rInt int, location string) string {
+	return fmt.Sprintf(`
+variable "random" {
+  default = "%d"
+}
+
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-${var.random}"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name = "test-${var.random}"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  address_space = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name = "GatewaySubnet"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix = "10.0.1.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name = "test-${var.random}"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name = "test-${var.random}"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  type = "Vpn"
+  vpn_type = "RouteBased"
+  sku = "VpnGw1"
+
+  ip_configuration {
+    name = "vnetGatewayConfig"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id = "${azurerm_subnet.test.id}"
+  }
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name = "test-${var.random}"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  gateway_address = "168.62.225.23"
+  address_space = ["10.1.1.0/24"]
+}
+
+resource "azurerm_virtual_network_gateway_connection" "test" {
+  name = "test-${var.random}"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  type = "IPsec"
+  virtual_network_gateway_id = "${azurerm_virtual_network_gateway.test.id}"
+  local_network_gateway_id = "${azurerm_local_network_gateway.test.id}"
+
+  use_policy_based_traffic_selectors = true
+  routing_weight = 20
+
+  ipsec_policy {
+    dh_group = "DHGroup14"
+    ike_encryption = "AES256"
+    ike_integrity = "SHA256"
+    ipsec_encryption = "AES256"
+    ipsec_integrity = "SHA256"
+    pfs_group = "PFS2048"
+    sa_datasize = 102400000
+    sa_lifetime = 27000
+  }
+
+  shared_key = "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
+}
+`, rInt, location)
 }

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -197,7 +197,6 @@ resource "azurerm_virtual_network_gateway_connection" "europe_to_us" {
 
   shared_key = "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
 }
-
 ```
 
 ## Argument Reference
@@ -226,7 +225,7 @@ The following arguments are supported:
 * `authorization_key` - (Optional) The authorization key associated with the
     Express Route Circuit. This field is required only if the type is an
     ExpressRoute connection.
-§
+
 * `express_route_circuit_id` - (Optional) The ID of the Express Route Circuit
     when creating an ExpressRoute connection (i.e. when `type` is `ExpressRoute`).
     The Express Route Circuit can be in the same or in a different subscription.
@@ -248,7 +247,43 @@ The following arguments are supported:
 * `enable_bgp` - (Optional) If `true`, BGP (Border Gateway Protocol) is enabled
     for this connection. Defaults to `false`.
 
+* `use_policy_based_traffic_selectors` - (Optional) If `true`, policy-based traffic
+    selectors are enabled for this connection. Enabling policy-based traffic
+    selectors requires an `ipsec_policy` block. Defaults to `false`.
+
+* `ipsec_policy` (Optional) A `ipsec_policy` block which is documented below.
+    Only a single policy can be defined for a connection. For details on
+    custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+The `ipsec_policy` block supports:
+
+* `dh_group` - (Required) The DH group used in IKE phase 1 for initial SA. Valid
+    options are `DHGroup1`, `DHGroup14`, `DHGroup2`, `DHGroup2048`, `DHGroup24`,
+    `ECP256`, `ECP384`, or `None`.
+
+* `ike_encryption` - (Required) The IKE encryption algorithm. Valid
+    options are `AES128`, `AES192`, `AES256`, `DES`, or `DES3`.
+
+* `ike_integrity` - (Required) The IKE integrity algorithm. Valid
+    options are `MD5`, `SHA1`, `SHA256`, or `SHA384`.
+
+* `ipsec_encryption` - (Required) The IPSec encryption algorithm. Valid
+    options are `AES128`, `AES192`, `AES256`, `DES`, `DES3`, `GCMAES128`, `GCMAES192`, `GCMAES256`, or `None`.
+
+* `ipsec_integrity` - (Required) The IPSec integrity algorithm. Valid
+    options are `GCMAES128`, `GCMAES192`, `GCMAES256`, `MD5`, `SHA1`, or `SHA256`.
+    
+* `pfs_group` - (Required) The DH group used in IKE phase 2 for new child SA.
+    Valid options are `ECP256`, `ECP384`, `PFS1`, `PFS2`, `PFS2048`, `PFS24`,
+    or `None`.
+
+* `sa_datasize` - (Optional) The IPSec SA payload size in KB. Must be at least
+    `1024` KB. Defaults to `102400000` KB.
+
+* `sa_lifetime` - (Optional) The IPSec SA lifetime in seconds. Must be at least
+    `300` seconds. Defaults to `27000` seconds.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This pull requests adds support for custom IPsec/IKE policies for VPN connections. Also, policy based traffic selectors can now be enabled explicitly for a connection.

### Tests

I have added a new test which covers a custom `ipsec_policy` and the `use_policy_based_traffic_selectors` switch.

```
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMVirtualNetworkGatewayConnection_ipsecpolicy -timeout 180m
=== RUN   TestAccAzureRMVirtualNetworkGatewayConnection_ipsecpolicy
--- PASS: TestAccAzureRMVirtualNetworkGatewayConnection_ipsecpolicy (2401.33s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	2401.357s
```

### References

- Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/759