### PR TITLE
App Service Slot: removing a computed field

### DIFF
--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -239,11 +239,6 @@ func resourceArmAppServiceSlot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"outbound_ip_addresses": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -419,7 +414,6 @@ func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("enabled", props.Enabled)
 		d.Set("default_site_hostname", props.DefaultHostName)
-		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 	}
 
 	if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {


### PR DESCRIPTION
Removing the computed field `outbound_ip_addresses` since it's the same information as is available on the App Service resource (promoting a slot to production won't change the Outbound IP Addresses, since it's the same hosts running the code)

This hasn't shipped in a release yet - so this is a safe operation - and is easy to add back in should we need it in the future