### PR TITLE
`azurerm_application_gateway` - removing crash points

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -1357,10 +1357,12 @@ func flattenApplicationGatewayWafConfig(waf *network.ApplicationGatewayWebApplic
 }
 
 func flattenApplicationGatewaySslPolicy(policy *network.ApplicationGatewaySslPolicy) []interface{} {
-	result := make([]interface{}, 0, len(*policy.DisabledSslProtocols))
+	result := make([]interface{}, 0)
 
-	for _, proto := range *policy.DisabledSslProtocols {
-		result = append(result, string(proto))
+	if protocols := policy.DisabledSslProtocols; protocols != nil {
+		for _, proto := range *protocols {
+			result = append(result, string(proto))
+		}
 	}
 
 	return result

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -1597,7 +1597,7 @@ func flattenApplicationGatewayProbes(input *[]network.ApplicationGatewayProbe) [
 				}
 
 				if timeout := props.Timeout; timeout != nil {
-					settings["interval"] = int(*timeout)
+					settings["timeout"] = int(*timeout)
 				}
 
 				if threshold := props.UnhealthyThreshold; threshold != nil {


### PR DESCRIPTION
The Azure API returns the latest version of a resource at the last time it was changed, which for an existing resource could be from 2 years ago not conforming to the latest schema; such that some fields which are Required in the API are missing from the API response.

As such - this PR goes through and removes all potential crash points that I could see in the App Gateway resource's flatten functions - which should fix #816 and a few other issues

Unfortunately this is painful to test, since each test takes 30m - so this is a WIP until I can confirm everything works as expected. This is kind of a rework of #632 but without all the additional tests (which we can't add due to an API bug)

Fixes #816