### PR TITLE
App Service Plan: support for attaching to an App Service Environment

### DIFF
--- a/azurerm/data_source_app_service_plan.go
+++ b/azurerm/data_source_app_service_plan.go
@@ -55,6 +55,10 @@ func dataSourceAppServicePlan() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"app_service_environment_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"reserved": {
 							Type:     schema.TypeBool,
 							Computed: true,

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -270,8 +270,10 @@ func expandAppServicePlanProperties(d *schema.ResourceData, name string) *web.Ap
 	config := configs[0].(map[string]interface{})
 
 	appServiceEnvironmentId := config["app_service_environment_id"].(string)
-	properties.HostingEnvironmentProfile = &web.HostingEnvironmentProfile{
-		ID: utils.String(appServiceEnvironmentId),
+	if appServiceEnvironmentId != "" {
+		properties.HostingEnvironmentProfile = &web.HostingEnvironmentProfile{
+			ID: utils.String(appServiceEnvironmentId),
+		}
 	}
 
 	perSiteScaling := config["per_site_scaling"].(bool)

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -75,6 +75,11 @@ func resourceArmAppServicePlan() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"app_service_environment_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"reserved": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -264,6 +269,11 @@ func expandAppServicePlanProperties(d *schema.ResourceData, name string) *web.Ap
 	}
 	config := configs[0].(map[string]interface{})
 
+	appServiceEnvironmentId := config["app_service_environment_id"].(string)
+	properties.HostingEnvironmentProfile = &web.HostingEnvironmentProfile{
+		ID: utils.String(appServiceEnvironmentId),
+	}
+
 	perSiteScaling := config["per_site_scaling"].(bool)
 	properties.PerSiteScaling = utils.Bool(perSiteScaling)
 
@@ -276,6 +286,10 @@ func expandAppServicePlanProperties(d *schema.ResourceData, name string) *web.Ap
 func flattenAppServiceProperties(props *web.AppServicePlanProperties) []interface{} {
 	result := make([]interface{}, 0, 1)
 	properties := make(map[string]interface{}, 0)
+
+	if props.HostingEnvironmentProfile != nil {
+		properties["app_service_environment_id"] = *props.HostingEnvironmentProfile.ID
+	}
 
 	if props.PerSiteScaling != nil {
 		properties["per_site_scaling"] = *props.PerSiteScaling

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -42,6 +42,10 @@ output "app_service_plan_id" {
 
 * `tags` - A mapping of tags to assign to the resource.
 
+* `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.
+
+---
+
 A `sku` block supports the following:
 
 * `tier` - Specifies the plan's pricing tier.
@@ -50,12 +54,13 @@ A `sku` block supports the following:
 
 * `capacity` - Specifies the number of workers associated with this App Service Plan.
 
+
 A `properties` block supports the following:
+
+* `app_service_environment_id` - The ID of the App Service Environment where the App Service Plan is located.
 
 * `maximum_number_of_workers` - Maximum number of instances that can be assigned to this App Service plan.
 
 * `reserved` - Is this App Service Plan `Reserved`?
 
 * `per_site_scaling` - Can Apps assigned to this App Service Plan be scaled independently?
-
-* `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -58,6 +58,8 @@ The following arguments are supported:
 
 `properties` supports the following:
 
+* `app_service_environment_id` - (Optional) The ID of the App Service Environment where the App Service Plan should be located. Changing forces a new resource to be created.
+
 * `maximum_number_of_workers` - (Optional) Maximum number of instances that can be assigned to this App Service plan.
 
 * `reserved` - (Optional) Is this App Service Plan `Reserved`. Defaults to `false`.

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `app_service_environment_id` - (Optional) The ID of the App Service Environment where the App Service Plan should be located. Changing forces a new resource to be created.
 
+~> **NOTE:** Attaching to an App Service Environment requires the App Service Plan use a `Premium` SKU.
+
 * `maximum_number_of_workers` - (Optional) Maximum number of instances that can be assigned to this App Service plan.
 
 * `reserved` - (Optional) Is this App Service Plan `Reserved`. Defaults to `false`.


### PR DESCRIPTION
Unfortunately as we don't support creating App Service Environments in Terraform yet (they take 1.5-2 hours to provision) - I can't add a test for this behaviour at the current time.. 

I've got a branch with some initial scaffolding for App Service Environments, but testing it is kind of painful - but I'd hope that we should be able to add support for this in the near future, when we do - I'll be sure to add some tests for this retroactively