### PR TITLE
Fixed AKS provider docs

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -27,7 +27,8 @@ resource "azurerm_kubernetes_cluster" "test" {
   location               = "${azurerm_resource_group.test.location}"
   resource_group_name    = "${azurerm_resource_group.test.name}"
   kubernetes_version     = "1.8.2"
-
+  dns_prefix             = "acctestagent1"
+  
   linux_profile {
     admin_username = "acctestuser1"
 
@@ -35,13 +36,11 @@ resource "azurerm_kubernetes_cluster" "test" {
       key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
     }
   }
-
+  
   agent_pool_profile {
     name            = "default"
     count           = 1
-    dns_prefix      = "acctestagent1"
     vm_size         = "Standard_A0"
-    storage_profile = "ManagedDisks"
     os_type         = "Linux"
   }
 


### PR DESCRIPTION
Moved `dns_prefix` to correct location and removed `storage_profile` as no longer settable.

Hope this is the correct way to update the doc, sorry if it isn't!

See issue: #860