### PR TITLE
Change network_interface ip_config subnet_id to be case insensitive 

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -60,8 +60,9 @@ func resourceArmNetworkInterface() *schema.Resource {
 						},
 
 						"subnet_id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 
 						"private_ip_address": {


### PR DESCRIPTION
Changes azurerm_network_interface.ip_configuration.subnet_id to be case insensitive. Fixes #535.