### PR TITLE
Export FQDN for managed Kubernetes cluster

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -39,6 +39,11 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"kubernetes_version": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -99,8 +104,9 @@ func resourceArmKubernetesCluster() *schema.Resource {
 						},
 
 						"fqdn": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Type:       schema.TypeString,
+							Computed:   true,
+							Deprecated: "This field has been deprecated. Use the parent `fqdn` instead",
 						},
 
 						"vm_size": {
@@ -246,6 +252,7 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 	}
 	d.Set("resource_group_name", resGroup)
 	d.Set("dns_prefix", resp.DNSPrefix)
+	d.Set("fqdn", resp.Fqdn)
 	d.Set("kubernetes_version", resp.KubernetesVersion)
 
 	linuxProfile := flattenAzureRmKubernetesClusterLinuxProfile(*resp.ManagedClusterProperties.LinuxProfile)

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -260,7 +260,7 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error setting `linux_profile`: %+v", err)
 	}
 
-	agentPoolProfiles := flattenAzureRmKubernetesClusterAgentPoolProfiles(resp.ManagedClusterProperties.AgentPoolProfiles)
+	agentPoolProfiles := flattenAzureRmKubernetesClusterAgentPoolProfiles(resp.ManagedClusterProperties.AgentPoolProfiles, resp.Fqdn)
 	if err := d.Set("agent_pool_profile", &agentPoolProfiles); err != nil {
 		return fmt.Errorf("Error setting `agent_pool_profile`: %+v", err)
 	}
@@ -314,7 +314,7 @@ func flattenAzureRmKubernetesClusterLinuxProfile(profile containerservice.LinuxP
 	return profiles
 }
 
-func flattenAzureRmKubernetesClusterAgentPoolProfiles(profiles *[]containerservice.AgentPoolProfile) []interface{} {
+func flattenAzureRmKubernetesClusterAgentPoolProfiles(profiles *[]containerservice.AgentPoolProfile, fqdn *string) []interface{} {
 	agentPoolProfiles := make([]interface{}, 0, len(*profiles))
 
 	for _, profile := range *profiles {
@@ -328,8 +328,9 @@ func flattenAzureRmKubernetesClusterAgentPoolProfiles(profiles *[]containerservi
 			agentPoolProfile["dns_prefix"] = *profile.DNSPrefix
 		}
 
-		if profile.Fqdn != nil {
-			agentPoolProfile["fqdn"] = *profile.Fqdn
+		if fqdn != nil {
+			// temporarily persist the parent FQDN here until `fqdn` is removed from the `agent_pool_profile`
+			agentPoolProfile["fqdn"] = *fqdn
 		}
 
 		if profile.Name != nil {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -105,7 +105,7 @@ The following attributes are exported:
 
 * `id` - The Kubernetes Managed Cluster ID.
 
-* `agent_pool_profile.#.fqdn` - The FQDN of the Azure Kubernetes Managed Cluster.
+* `fqdn` - The FQDN of the Azure Kubernetes Managed Cluster.
 
 ## Import
 


### PR DESCRIPTION
- Set the FQDN for the Kubernetes cluster. Fixes #906 
- Remove the FQDN from the agent_pool_profile as it's not populated by
Azure for managed Kubernetes