### PR TITLE
New Example: joining a virtual machine to an Active Directory Domain

### DIFF
--- a/examples/vm-joined-to-active-directory/README.md
+++ b/examples/vm-joined-to-active-directory/README.md
@@ -1,0 +1,87 @@
+# Example: Joining a Windows Machine to an Active Directory Domain
+
+This example creates an Active Directory Domain, a Windows Client; to demonstrate how to bind a Windows Client to an Active Directory Domain using a Virtual Machine Extension in Terraform (using [the `azurerm_virtual_machine_extension` resource](https://www.terraform.io/docs/providers/azurerm/r/virtual_machine_extension.html)).
+
+This example is built around [the Virtual Machine Extension](https://www.terraform.io/docs/providers/azurerm/r/virtual_machine_extension.html) found in the `windows-client` module (documented below) - which demonstrates binding a Windows Virtual Machine to an Active Directory Domain. For the purposes of this example we create an Active Directory Domain, since it's easier to demonstrate - however you can achieve the same thing with an existing Active Directory Domain.
+
+## Notes
+
+- This is intended as an example of binding machines to an Active Directory Domain, and **we'd not recommend using it in production as-is** as the configuration has been simplified for example purposes, e.g.:
+  - The Active Directory Forest has a single node, for demonstration purposes
+  - There's no security rules configured on the network, so everything's open internally etc.
+- The numbering on the files within the modules below have no effect on which order the resources are created in - it's purely to make the examples easier to understand.
+
+## Running this Example
+
+Initialize the modules (and download the Azure Provider) by running `terraform init`:
+
+```bash
+$ terraform init
+```
+
+In order to run this example you'll need some kind of credentials configured - either a Service Principal or to be logged into the Azure CLI. You can find out more about this on [the Azure Provider overview page](https://www.terraform.io/docs/providers/azurerm/index.html)
+
+Once you've initialized the Provider - you can run the sample by running:
+
+```bash
+$ terraform apply
+```
+
+This will take around 20m to provision - once completed you should see the Public IP Address of the Windows Client machine (which is bound to the Active Directory Domain):
+
+```
+```
+
+## Variables
+
+ * `prefix` - The prefix used for all resources in this example. Needs to be a short (6 characters) alphanumeric string. Example: `myprefix`.
+ * `admin_username` - The username of the administrator account for both the local accounts, and Active Directory accounts. Example: `myexampleadmin`
+ * `admin_password` - The password of the administrator account for both the local accounts, and Active Directory accounts. Needs to comply with the Windows Password Policy. Example: `PassW0rd1234!`
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────────────────────────┐
+│                                    Internal Network                                    │
+└────────────────────────────────────────────────────────────────────────────────────────┘
+                                             ▲
+                         ┌───────────────────┴────────────────────┐
+                         │                                        │
+          ┌─────────────────────────────┐          ┌─────────────────────────────┐
+          │  Domain Controllers Subnet  │          │    Domain Clients Subnet    │
+          └─────────────────────────────┘          └─────────────────────────────┘
+                         ▲                                        ▲
+                         │                                        │
+         ┌───────────────────────────────┐        ┌───────────────────────────────┐
+         │    Domain Controllers NIC     │        │      Domain Clients NIC       │
+         │                               │        │                               │
+         │     ({prefix}-dc-primary)     │        │     ({prefix}-client-nic)     │
+         └───────────────────────────────┘        └───────────────────────────────┘
+                         ▲                                        ▲
+                         │                                        │
+         ┌───────────────────────────────┐        ┌───────────────────────────────┐
+         │     Domain Controller VM      │        │       Domain Client VM        │
+         │                               │        │                               │
+         │         ({prefix}-dc)         │        │       ({prefix}-client)       │
+         └───────────────────────────────┘        └───────────────────────────────┘
+                         ▲                                        ▲
+                         │                             ┌──────────┴───────────┐
+        ┌────────────────────────────────┐             │                      │
+        │   Virtual Machine Extension    │    ┌─────────────────┐ ┌───────────────────────┐
+        │                                │    │  VM Extension   │ │       Public IP       │
+        │(create-active-directory-forest)│    │                 │ │                       │
+        └────────────────────────────────┘    │  (join-domain)  │ │ ({prefix}-client-nic) │
+                                              └─────────────────┘ └───────────────────────┘
+```
+
+## Modules
+
+This example makes use of 3 modules:
+ * [modules/active-directory](modules/active-directory)
+    - This module creates an Active Directory Forest on a single Virtual Machine
+ * [modules/network](modules/network)
+    - This module creates the Network with 2 subnets, one for the Domain Controller and another for the Clients.
+    - In a Production environment there would be [Network Security Rules](https://www.terraform.io/docs/providers/azurerm/r/network_security_rule.html) in effect which limited which ports can be used between these Subnets, however for the purposes of keeping this demonstration simple, these have been omitted.
+ * [modules/windows-client](modules/windows-client)
+    - This module creates a Windows Client machine that is bound to the Active Directory Domain created in the `active-directory` module above.
+    - This module includes a sleep function designed to wait for 10 minutes (until the Active Directory Domain has provisioned) - however this isn't ideal for a number of reasons. In a Production Environment it's likely your Active Directory Domain already exists.

--- a/examples/vm-joined-to-active-directory/README.md
+++ b/examples/vm-joined-to-active-directory/README.md
@@ -6,7 +6,7 @@ This example is built around [the Virtual Machine Extension](https://www.terrafo
 
 ## Notes
 
-- This is intended as an example of binding machines to an Active Directory Domain, and **we'd not recommend using it in production as-is** as the configuration has been simplified for example purposes, e.g.:
+- This is intended as an example of binding machines to an Active Directory Domain, and **it is not recommended for production use** as the configuration has been simplified for example purposes, e.g.:
   - The Active Directory Forest has a single node, for demonstration purposes
   - There's no security rules configured on the network, so everything's open internally etc.
 - The numbering on the files within the modules below have no effect on which order the resources are created in - it's purely to make the examples easier to understand.
@@ -29,12 +29,13 @@ $ terraform apply
 
 This will take around 20m to provision - once completed you should see the Public IP Address of the Windows Client machine (which is bound to the Active Directory Domain):
 
-```
+```bash
+windows_client_public_ip = 0.0.0.0
 ```
 
 ## Variables
 
- * `prefix` - The prefix used for all resources in this example. Needs to be a short (6 characters) alphanumeric string. Example: `myprefix`.
+ * `prefix` - The prefix used for all resources in this example. Needs to be a short (6 characters) alphanumeric string. Example: `addemo`.
  * `admin_username` - The username of the administrator account for both the local accounts, and Active Directory accounts. Example: `myexampleadmin`
  * `admin_password` - The password of the administrator account for both the local accounts, and Active Directory accounts. Needs to comply with the Windows Password Policy. Example: `PassW0rd1234!`
 

--- a/examples/vm-joined-to-active-directory/main.tf
+++ b/examples/vm-joined-to-active-directory/main.tf
@@ -1,0 +1,48 @@
+provider "azurerm" {
+  version = "=1.1.2"
+}
+
+locals {
+  resource_group_name = "${var.prefix}-resources"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "${local.resource_group_name}"
+  location = "West Europe"
+}
+
+module "network" {
+  source              = "./modules/network"
+  prefix              = "${var.prefix}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+}
+
+module "active-directory-domain" {
+  source                        = "./modules/active-directory"
+  resource_group_name           = "${azurerm_resource_group.test.name}"
+  location                      = "${azurerm_resource_group.test.location}"
+  prefix                        = "${var.prefix}"
+  subnet_id                     = "${module.network.domain_controllers_subnet_id}"
+  active_directory_domain       = "${var.prefix}.local"
+  active_directory_netbios_name = "${var.prefix}"
+  admin_username                = "${var.admin_username}"
+  admin_password                = "${var.admin_password}"
+}
+
+module "windows-client" {
+  source                    = "./modules/windows-client"
+  resource_group_name       = "${azurerm_resource_group.test.name}"
+  location                  = "${azurerm_resource_group.test.location}"
+  prefix                    = "${var.prefix}"
+  subnet_id                 = "${module.network.domain_clients_subnet_id}"
+  active_directory_domain   = "${var.prefix}.local"
+  active_directory_username = "${var.admin_username}"
+  active_directory_password = "${var.admin_password}"
+  admin_username            = "${var.admin_username}"
+  admin_password            = "${var.admin_password}"
+}
+
+output "windows_client_public_ip" {
+  value = "${module.windows-client.public_ip_address}"
+}

--- a/examples/vm-joined-to-active-directory/modules/active-directory/1-network-interface.tf
+++ b/examples/vm-joined-to-active-directory/modules/active-directory/1-network-interface.tf
@@ -1,0 +1,13 @@
+resource "azurerm_network_interface" "primary" {
+  name                    = "${var.prefix}-dc-primary"
+  location                = "${var.location}"
+  resource_group_name     = "${var.resource_group_name}"
+  internal_dns_name_label = "${local.virtual_machine_name}"
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = "${var.subnet_id}"
+    private_ip_address_allocation = "static"
+    private_ip_address            = "10.0.1.4"
+  }
+}

--- a/examples/vm-joined-to-active-directory/modules/active-directory/2-virtual-machine.tf
+++ b/examples/vm-joined-to-active-directory/modules/active-directory/2-virtual-machine.tf
@@ -1,0 +1,56 @@
+locals {
+  virtual_machine_name = "${var.prefix}-dc"
+  virtual_machine_fqdn = "${local.virtual_machine_name}.${var.active_directory_domain}"
+  custom_data_params   = "Param($RemoteHostName = \"${local.virtual_machine_fqdn}\", $ComputerName = \"${local.virtual_machine_name}\")"
+  custom_data_content  = "${local.custom_data_params} ${file("${path.module}/files/winrm.ps1")}"
+}
+
+resource "azurerm_virtual_machine" "domain-controller" {
+  name                          = "${local.virtual_machine_name}"
+  location                      = "${var.location}"
+  resource_group_name           = "${var.resource_group_name}"
+  network_interface_ids         = ["${azurerm_network_interface.primary.id}"]
+  vm_size                       = "Standard_F2"
+  delete_os_disk_on_termination = true
+
+  storage_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "${local.virtual_machine_name}-disk1"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "${local.virtual_machine_name}"
+    admin_username = "${var.admin_username}"
+    admin_password = "${var.admin_password}"
+    custom_data    = "${local.custom_data_content}"
+  }
+
+  os_profile_windows_config {
+    provision_vm_agent        = true
+    enable_automatic_upgrades = true
+
+    additional_unattend_config {
+      pass         = "oobeSystem"
+      component    = "Microsoft-Windows-Shell-Setup"
+      setting_name = "AutoLogon"
+      content      = "<AutoLogon><Password><Value>${var.admin_password}</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount><Username>${var.admin_username}</Username></AutoLogon>"
+    }
+
+    # Unattend config is to enable basic auth in WinRM, required for the provisioner stage.
+    additional_unattend_config {
+      pass         = "oobeSystem"
+      component    = "Microsoft-Windows-Shell-Setup"
+      setting_name = "FirstLogonCommands"
+      content      = "${file("${path.module}/files/FirstLogonCommands.xml")}"
+    }
+  }
+}

--- a/examples/vm-joined-to-active-directory/modules/active-directory/3-provision-domain.tf
+++ b/examples/vm-joined-to-active-directory/modules/active-directory/3-provision-domain.tf
@@ -1,0 +1,28 @@
+// the `exit_code_hack` is to keep the VM Extension resource happy
+locals {
+  import_command       = "Import-Module ADDSDeployment"
+  password_command     = "$password = ConvertTo-SecureString ${var.admin_password} -AsPlainText -Force"
+  install_ad_command   = "Add-WindowsFeature -name ad-domain-services -IncludeManagementTools"
+  configure_ad_command = "Install-ADDSForest -CreateDnsDelegation:$false -DomainMode Win2012R2 -DomainName ${var.active_directory_domain} -DomainNetbiosName ${var.active_directory_netbios_name} -ForestMode Win2012R2 -InstallDns:$true -SafeModeAdministratorPassword $password -Force:$true"
+  shutdown_command     = "shutdown -r -t 10"
+  exit_code_hack       = "exit 0"
+  powershell_command   = "${local.import_command}; ${local.password_command}; ${local.install_ad_command}; ${local.configure_ad_command}; ${local.shutdown_command}; ${local.exit_code_hack}"
+}
+
+// NOTE: we **highly recommend** not using this configuration for your Production Environment
+// this provisions a single node configuration with no redundancy.
+resource "azurerm_virtual_machine_extension" "create-active-directory-forest" {
+  name                 = "create-active-directory-forest"
+  location             = "${azurerm_virtual_machine.domain-controller.location}"
+  resource_group_name  = "${var.resource_group_name}"
+  virtual_machine_name = "${azurerm_virtual_machine.domain-controller.name}"
+  publisher            = "Microsoft.Compute"
+  type                 = "CustomScriptExtension"
+  type_handler_version = "1.9"
+
+  settings = <<SETTINGS
+    {
+        "commandToExecute": "powershell.exe -Command \"${local.powershell_command}\""
+    }
+SETTINGS
+}

--- a/examples/vm-joined-to-active-directory/modules/active-directory/README.md
+++ b/examples/vm-joined-to-active-directory/modules/active-directory/README.md
@@ -1,0 +1,5 @@
+## Module: Active Directory
+
+This module is designed to quickly spin up an Active Directory Forest on a single node, this is **by no means best practice** and we'd **highly recommend** not using this approach in Production.
+
+This module was based on / heavily inspired by: https://github.com/bobalob/Terraform-AzureRM-Example/tree/winrm-https

--- a/examples/vm-joined-to-active-directory/modules/active-directory/files/FirstLogonCommands.xml
+++ b/examples/vm-joined-to-active-directory/modules/active-directory/files/FirstLogonCommands.xml
@@ -1,0 +1,17 @@
+<FirstLogonCommands>
+    <SynchronousCommand>
+        <CommandLine>cmd /c "mkdir C:\terraform"</CommandLine>
+        <Description>Create the Terraform working directory</Description>
+        <Order>11</Order>
+    </SynchronousCommand>
+    <SynchronousCommand>
+        <CommandLine>cmd /c "copy C:\AzureData\CustomData.bin C:\terraform\winrm.ps1"</CommandLine>
+        <Description>Move the CustomData file to the working directory</Description>
+        <Order>12</Order>
+    </SynchronousCommand>
+    <SynchronousCommand>
+        <CommandLine>powershell.exe -sta -ExecutionPolicy Unrestricted -file C:\terraform\winrm.ps1</CommandLine>
+        <Description>Execute the WinRM enabling script</Description>
+        <Order>13</Order>
+    </SynchronousCommand>
+</FirstLogonCommands>

--- a/examples/vm-joined-to-active-directory/modules/active-directory/files/winrm.ps1
+++ b/examples/vm-joined-to-active-directory/modules/active-directory/files/winrm.ps1
@@ -1,0 +1,18 @@
+$Cert = New-SelfSignedCertificate -DnsName $RemoteHostName, $ComputerName `
+    -CertStoreLocation "cert:\LocalMachine\My" `
+    -FriendlyName "Test WinRM Cert"
+
+$Cert | Out-String
+
+$Thumbprint = $Cert.Thumbprint
+
+Write-Host "Enable HTTPS in WinRM"
+$WinRmHttps = "@{Hostname=`"$RemoteHostName`"; CertificateThumbprint=`"$Thumbprint`"}"
+winrm create winrm/config/Listener?Address=*+Transport=HTTPS $WinRmHttps
+
+Write-Host "Set Basic Auth in WinRM"
+$WinRmBasic = "@{Basic=`"true`"}"
+winrm set winrm/config/service/Auth $WinRmBasic
+
+Write-Host "Open Firewall Port"
+netsh advfirewall firewall add rule name="Windows Remote Management (HTTPS-In)" dir=in action=allow protocol=TCP localport=5985

--- a/examples/vm-joined-to-active-directory/modules/active-directory/variables.tf
+++ b/examples/vm-joined-to-active-directory/modules/active-directory/variables.tf
@@ -1,0 +1,31 @@
+variable "resource_group_name" {
+  description = "The name of the Resource Group where the Domain Controllers resources will be created"
+}
+
+variable "location" {
+  description = "The Azure Region in which the Resource Group exists"
+}
+
+variable "prefix" {
+  description = "The Prefix used for the Domain Controller's resources"
+}
+
+variable "subnet_id" {
+  description = "The Subnet ID which the Domain Controller's NIC should be created in"
+}
+
+variable "active_directory_domain" {
+  description = "The name of the Active Directory domain, for example `consoto.local`"
+}
+
+variable "active_directory_netbios_name" {
+  description = "The netbios name of the Active Directory domain, for example `consoto`"
+}
+
+variable "admin_username" {
+  description = "The username associated with the local administrator account on the virtual machine"
+}
+
+variable "admin_password" {
+  description = "The password associated with the local administrator account on the virtual machine"
+}

--- a/examples/vm-joined-to-active-directory/modules/network/README.md
+++ b/examples/vm-joined-to-active-directory/modules/network/README.md
@@ -1,0 +1,8 @@
+## Module: Network
+
+This module creates a Network with 2 x Subnets:
+
+ - Domain Controllers
+ - Domain Clients
+
+This module shouldn't be used as-is in a Production Environment - where you'd probably have [Network Security Rules](https://www.terraform.io/docs/providers/azurerm/r/network_security_rule.html) configured - it's designed to be a simplified configuration for the purposes of this example.

--- a/examples/vm-joined-to-active-directory/modules/network/main.tf
+++ b/examples/vm-joined-to-active-directory/modules/network/main.tf
@@ -1,0 +1,25 @@
+// NOTE: in a Production Environment you're likely to have Network Security Rules
+// which lock down traffic between Subnets. These are omited below to keep the
+// examples easy to understand - and should be added before being used in Production.
+
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.prefix}-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+  dns_servers         = ["10.0.1.4", "8.8.8.8"]
+}
+
+resource "azurerm_subnet" "domain-controllers" {
+  name                 = "domain-controllers"
+  resource_group_name  = "${var.resource_group_name}"
+  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_subnet" "domain-clients" {
+  name                 = "domain-clients"
+  resource_group_name  = "${var.resource_group_name}"
+  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  address_prefix       = "10.0.2.0/24"
+}

--- a/examples/vm-joined-to-active-directory/modules/network/outputs.tf
+++ b/examples/vm-joined-to-active-directory/modules/network/outputs.tf
@@ -1,0 +1,7 @@
+output "domain_controllers_subnet_id" {
+  value = "${azurerm_subnet.domain-controllers.id}"
+}
+
+output "domain_clients_subnet_id" {
+  value = "${azurerm_subnet.domain-clients.id}"
+}

--- a/examples/vm-joined-to-active-directory/modules/network/variables.tf
+++ b/examples/vm-joined-to-active-directory/modules/network/variables.tf
@@ -1,0 +1,5 @@
+variable "prefix" {}
+
+variable "location" {}
+
+variable "resource_group_name" {}

--- a/examples/vm-joined-to-active-directory/modules/windows-client/1-network-interface.tf
+++ b/examples/vm-joined-to-active-directory/modules/windows-client/1-network-interface.tf
@@ -1,0 +1,20 @@
+resource "azurerm_public_ip" "static" {
+  name                         = "${var.prefix}-client-ppip"
+  location                     = "${var.location}"
+  resource_group_name          = "${var.resource_group_name}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "primary" {
+  name                    = "${var.prefix}-client-nic"
+  location                = "${var.location}"
+  resource_group_name     = "${var.resource_group_name}"
+  internal_dns_name_label = "${local.virtual_machine_name}"
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = "${var.subnet_id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.static.id}"
+  }
+}

--- a/examples/vm-joined-to-active-directory/modules/windows-client/2-virtual-machine.tf
+++ b/examples/vm-joined-to-active-directory/modules/windows-client/2-virtual-machine.tf
@@ -1,0 +1,37 @@
+locals {
+  virtual_machine_name = "${var.prefix}-client"
+}
+
+resource "azurerm_virtual_machine" "client" {
+  name                          = "${local.virtual_machine_name}"
+  location                      = "${var.location}"
+  resource_group_name           = "${var.resource_group_name}"
+  network_interface_ids         = ["${azurerm_network_interface.primary.id}"]
+  vm_size                       = "Standard_F2"
+  delete_os_disk_on_termination = true
+
+  storage_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "${local.virtual_machine_name}-disk1"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "${local.virtual_machine_name}"
+    admin_username = "${var.admin_username}"
+    admin_password = "${var.admin_password}"
+  }
+
+  os_profile_windows_config {
+    provision_vm_agent        = true
+    enable_automatic_upgrades = true
+  }
+}

--- a/examples/vm-joined-to-active-directory/modules/windows-client/3-wait-for-domain-to-provision.tf
+++ b/examples/vm-joined-to-active-directory/modules/windows-client/3-wait-for-domain-to-provision.tf
@@ -1,0 +1,11 @@
+// NOTE: this is a hack.
+// the AD Domain takes ~7m to provision, so we don't try and join an non-existant domain we sleep
+// unfortunately we can't depend on the Domain Creation VM Extension since there's a reboot.
+// We sleep for 12 minutes here to give Azure some breathing room.
+resource "null_resource" "wait-for-domain-to-provision" {
+  provisioner "local-exec" {
+    command = "sleep 720"
+  }
+
+  depends_on = ["azurerm_virtual_machine.client"]
+}

--- a/examples/vm-joined-to-active-directory/modules/windows-client/4-join-domain.tf
+++ b/examples/vm-joined-to-active-directory/modules/windows-client/4-join-domain.tf
@@ -1,0 +1,28 @@
+resource "azurerm_virtual_machine_extension" "join-domain" {
+  name                 = "${azurerm_virtual_machine.client.name}"
+  location             = "${azurerm_virtual_machine.client.location}"
+  resource_group_name  = "${var.resource_group_name}"
+  virtual_machine_name = "${azurerm_virtual_machine.client.name}"
+  publisher            = "Microsoft.Compute"
+  type                 = "JsonADDomainExtension"
+  type_handler_version = "1.3"
+
+  # NOTE: the `OUPath` field is intentionally blank, to put it in the Computers OU
+  settings = <<SETTINGS
+    {
+        "Name": "${var.active_directory_domain}",
+        "OUPath": "",
+        "User": "${var.active_directory_domain}\\${var.active_directory_username}",
+        "Restart": "true",
+        "Options": "3"
+    }
+SETTINGS
+
+  protected_settings = <<SETTINGS
+    {
+        "Password": "${var.active_directory_password}"
+    }
+SETTINGS
+
+  depends_on = ["null_resource.wait-for-domain-to-provision"]
+}

--- a/examples/vm-joined-to-active-directory/modules/windows-client/README.md
+++ b/examples/vm-joined-to-active-directory/modules/windows-client/README.md
@@ -1,0 +1,5 @@
+## Module: Windows Client
+
+This module provisions a Windows Client which will be bound to the Active Directory Domain created in the other module.
+
+There's a few hacks in here as we have to wait for Active Directory to become available, but this takes advantage of the `azurerm_virtual_machine_extension` resource. It's worth noting that the keys in this resource are case sensitive.

--- a/examples/vm-joined-to-active-directory/modules/windows-client/outputs.tf
+++ b/examples/vm-joined-to-active-directory/modules/windows-client/outputs.tf
@@ -1,0 +1,3 @@
+output "public_ip_address" {
+  value = "${azurerm_public_ip.static.ip_address}"
+}

--- a/examples/vm-joined-to-active-directory/modules/windows-client/variables.tf
+++ b/examples/vm-joined-to-active-directory/modules/windows-client/variables.tf
@@ -1,0 +1,35 @@
+variable "resource_group_name" {
+  description = "The name of the Resource Group where the Windows Client resources will be created"
+}
+
+variable "location" {
+  description = "The Azure Region in which the Resource Group exists"
+}
+
+variable "prefix" {
+  description = "The Prefix used for the Windows Client resources"
+}
+
+variable "subnet_id" {
+  description = "The Subnet ID which the Windows Client's NIC should be created in"
+}
+
+variable "active_directory_domain" {
+  description = "The name of the Active Directory domain, for example `consoto.local`"
+}
+
+variable "active_directory_username" {
+  description = "The username of an account with permissions to bind machines to the Active Directory Domain"
+}
+
+variable "active_directory_password" {
+  description = "The password of the account with permissions to bind machines to the Active Directory Domain"
+}
+
+variable "admin_username" {
+  description = "The username associated with the local administrator account on the virtual machine"
+}
+
+variable "admin_password" {
+  description = "The password associated with the local administrator account on the virtual machine"
+}

--- a/examples/vm-joined-to-active-directory/variables.tf
+++ b/examples/vm-joined-to-active-directory/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example. Needs to be a short (6 characters) alphanumeric string. Example: `myprefix`."
+}
+
+variable "admin_username" {
+  description = "The username of the administrator account for both the local accounts, and Active Directory accounts. Example: `myexampleadmin`"
+}
+
+variable "admin_password" {
+  description = "The password of the administrator account for both the local accounts, and Active Directory accounts. Needs to comply with the Windows Password Policy. Example: `PassW0rd1234!`"
+}


### PR DESCRIPTION
This PR adds an end-to-end example for joining a Windows Server (2016) Virtual Machine to a newly created Active Directory Domain. This question comes up a lot - so I believe it's helpful to have an example demonstrating how to use the VM Extension to bind a machine to an Active Directory domain.

For the purposes of this example we spin up an Active Directory Domain on demand (which, whilst on a single node isn't exactly production ready, it's suitable for an example/demo). This also provisions the VM Client with a Public IP, so users can confirm the machine is bound to the domain (it also ensures the binding process works as expected, since machines don't get a hostname/ip configuration from the AD server, but from Azure since that's booted first; given most users will have an Active Directory Domain provisioned ahead of time, I feel this is suitable for demonstration/example purposes).