### PR TITLE
Fixing `azurerm_network_security_group` Data Source

### DIFF
--- a/azurerm/data_source_network_security_group.go
+++ b/azurerm/data_source_network_security_group.go
@@ -45,9 +45,23 @@ func dataSourceArmNetworkSecurityGroup() *schema.Resource {
 							Computed: true,
 						},
 
+						"source_port_ranges": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+
 						"destination_port_range": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+
+						"destination_port_ranges": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
 						},
 
 						"source_address_prefix": {
@@ -55,9 +69,23 @@ func dataSourceArmNetworkSecurityGroup() *schema.Resource {
 							Computed: true,
 						},
 
+						"source_address_prefixes": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+
 						"destination_address_prefix": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+
+						"destination_address_prefixes": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
 						},
 
 						"access": {


### PR DESCRIPTION
Adding the `source_address_prefixes` and `destination_address_prefixes` fields to the schema to fix the failing test; since the flatten method is shared