### PR TITLE
Adding support for connecting Network Security Rules to Application Security Groups

### DIFF
--- a/azurerm/data_source_network_security_group.go
+++ b/azurerm/data_source_network_security_group.go
@@ -76,6 +76,13 @@ func dataSourceArmNetworkSecurityGroup() *schema.Resource {
 							Set:      schema.HashString,
 						},
 
+						"source_application_security_group_ids": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+
 						"destination_address_prefix": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -84,6 +91,13 @@ func dataSourceArmNetworkSecurityGroup() *schema.Resource {
 						"destination_address_prefixes": {
 							Type:     schema.TypeSet,
 							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+
+						"destination_application_security_group_ids": {
+							Type:     schema.TypeSet,
+							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},

--- a/azurerm/import_arm_network_security_rule_test.go
+++ b/azurerm/import_arm_network_security_rule_test.go
@@ -20,10 +20,9 @@ func TestAccAzureRMNetworkSecurityRule_importBasic(t *testing.T) {
 				Config: testAccAzureRMNetworkSecurityRule_basic(rInt, testLocation()),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"network_security_group_name"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azurerm/resource_arm_network_security_group_test.go
+++ b/azurerm/resource_arm_network_security_group_test.go
@@ -168,6 +168,25 @@ func TestAccAzureRMNetworkSecurityGroup_augmented(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkSecurityGroup_applicationSecurityGroup(t *testing.T) {
+	resourceName := "azurerm_network_security_group.test"
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkSecurityGroup_applicationSecurityGroup(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkSecurityGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "security_rule.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMNetworkSecurityGroupExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -422,4 +441,43 @@ resource "azurerm_network_security_group" "test" {
   }
 }
 `, rInt, location)
+}
+
+func testAccAzureRMNetworkSecurityGroup_applicationSecurityGroup(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_security_group" "first" {
+  name                = "acctest-first%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_application_security_group" "second" {
+  name                = "acctest-second%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  security_rule {
+    name                                       = "test123"
+    priority                                   = 100
+    direction                                  = "Inbound"
+    access                                     = "Allow"
+    protocol                                   = "Tcp"
+    source_application_security_group_ids      = ["${azurerm_application_security_group.first.id}"]
+    destination_application_security_group_ids = ["${azurerm_application_security_group.second.id}"]
+    source_port_ranges                         = [ "10000-40000" ]
+    destination_port_ranges                    = [ "80", "443", "8080", "8190" ]
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
 }

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -56,6 +56,10 @@ The `security_rule` block supports:
 
 * `destination_address_prefix` - CIDR or destination IP range or * to match any IP.
 
+* `source_application_security_group_ids` - A List of source Application Security Group ID's
+
+* `destination_application_security_group_ids` - A List of destination Application Security Group ID's
+
 * `access` - Is network traffic is allowed or denied?
 
 * `priority` - The priority of the rule

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -81,9 +81,13 @@ The `security_rule` block supports:
 
 * `source_address_prefixes` - (Optional) List of source address prefixes. Tags may not be used. This is required if `source_address_prefix` is not specified.
 
+* `source_application_security_group_ids` - (Optional) A List of source Application Security Group ID's
+
 * `destination_address_prefix` - (Optional) CIDR or destination IP range or * to match any IP. Tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used. This is required if `destination_address_prefixes` is not specified.
 
 * `destination_address_prefixes` - (Optional) List of destination address prefixes. Tags may not be used. This is required if `destination_address_prefix` is not specified.
+
+* `destination_application_security_group_ids` - (Optional) A List of destination Application Security Group ID's
 
 * `access` - (Required) Specifies whether network traffic is allowed or denied. Possible values are `Allow` and `Deny`.
 

--- a/website/docs/r/network_security_rule.html.markdown
+++ b/website/docs/r/network_security_rule.html.markdown
@@ -70,9 +70,13 @@ The following arguments are supported:
 
 * `source_address_prefixes` - (Optional) List of source address prefixes. Tags may not be used. This is required if `source_address_prefix` is not specified.
 
+* `source_application_security_group_ids` - (Optional) A List of source Application Security Group ID's
+
 * `destination_address_prefix` - (Optional) CIDR or destination IP range or * to match any IP. Tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used. This is required if `destination_address_prefixes` is not specified.
 
 * `destination_address_prefixes` - (Optional) List of destination address prefixes. Tags may not be used. This is required if `destination_address_prefix` is not specified.
+
+* `destination_application_security_group_ids` - (Optional) A List of destination Application Security Group ID's
 
 * `access` - (Required) Specifies whether network traffic is allowed or denied. Possible values are `Allow` and `Deny`.
 


### PR DESCRIPTION
Fixes #912

Tests pass:

```
$ acctests azurerm TestAccAzureRMNetworkSecurityGroup_
=== RUN   TestAccAzureRMNetworkSecurityGroup_importBasic
--- PASS: TestAccAzureRMNetworkSecurityGroup_importBasic (73.74s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_importSingleRule
--- PASS: TestAccAzureRMNetworkSecurityGroup_importSingleRule (41.86s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_importMultipleRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_importMultipleRules (57.78s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_basic
--- PASS: TestAccAzureRMNetworkSecurityGroup_basic (60.71s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_singleRule
--- PASS: TestAccAzureRMNetworkSecurityGroup_singleRule (52.22s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_update
--- PASS: TestAccAzureRMNetworkSecurityGroup_update (65.59s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_disappears
--- PASS: TestAccAzureRMNetworkSecurityGroup_disappears (57.15s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_withTags
--- PASS: TestAccAzureRMNetworkSecurityGroup_withTags (48.17s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_addingExtraRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_addingExtraRules (57.86s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_augmented
--- PASS: TestAccAzureRMNetworkSecurityGroup_augmented (56.66s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_applicationSecurityGroup
--- PASS: TestAccAzureRMNetworkSecurityGroup_applicationSecurityGroup (48.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	619.783s
```

```
$ acctests azurerm TestAccAzureRMNetworkSecurityRule_
=== RUN   TestAccAzureRMNetworkSecurityRule_importBasic
--- PASS: TestAccAzureRMNetworkSecurityRule_importBasic (277.23s)
=== RUN   TestAccAzureRMNetworkSecurityRule_basic
--- PASS: TestAccAzureRMNetworkSecurityRule_basic (63.75s)
=== RUN   TestAccAzureRMNetworkSecurityRule_disappears
--- PASS: TestAccAzureRMNetworkSecurityRule_disappears (59.09s)
=== RUN   TestAccAzureRMNetworkSecurityRule_addingRules
--- PASS: TestAccAzureRMNetworkSecurityRule_addingRules (72.74s)
=== RUN   TestAccAzureRMNetworkSecurityRule_augmented
--- PASS: TestAccAzureRMNetworkSecurityRule_augmented (43.52s)
=== RUN   TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups
--- PASS: TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups (61.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	578.113s
```