### PR TITLE
`azurerm_application_gateway` - fixes a crash where ssl_policy is nil when importing

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -1359,9 +1359,11 @@ func flattenApplicationGatewayWafConfig(waf *network.ApplicationGatewayWebApplic
 func flattenApplicationGatewaySslPolicy(policy *network.ApplicationGatewaySslPolicy) []interface{} {
 	result := make([]interface{}, 0)
 
-	if protocols := policy.DisabledSslProtocols; protocols != nil {
-		for _, proto := range *protocols {
-			result = append(result, string(proto))
+	if pol := policy; policy != nil {
+		if protocols := pol.DisabledSslProtocols; protocols != nil {
+			for _, proto := range *protocols {
+				result = append(result, string(proto))
+			}
 		}
 	}
 


### PR DESCRIPTION
This isn't possible to write a test for since it relies on an older version of the schema being returned from the API - but I've verified the response [in this crash log](https://gist.github.com/avnsiva/4b1f9763736f5bbfcbc35831e9cef4d5) which confirms this isn't returned (and [that it'll crash here](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/resource_arm_application_gateway.go#L1362)

Fixes #933