### PR TITLE
New Data Source: `azurerm_cdn_profile`

### DIFF
--- a/azurerm/data_source_cdn_profile.go
+++ b/azurerm/data_source_cdn_profile.go
@@ -1,0 +1,63 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmCdnProfile() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmCdnProfileRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"location": locationForDataSourceSchema(),
+
+			"sku": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsForDataSourceSchema(),
+		},
+	}
+}
+
+func dataSourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).cdnProfilesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on Azure CDN Profile %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+
+	if sku := resp.Sku; sku != nil {
+		d.Set("sku", string(sku.Name))
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}

--- a/azurerm/data_source_cdn_profile_test.go
+++ b/azurerm/data_source_cdn_profile_test.go
@@ -1,0 +1,100 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMCdnProfile_basic(t *testing.T) {
+	ri := acctest.RandInt()
+	location := testLocation()
+	config := testAccDataSourceAzureRMCdnProfile_basic(ri, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnProfileExists("data.azurerm_cdn_profile.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMCdnProfile_withTags(t *testing.T) {
+	resourceName := "data.azurerm_cdn_profile.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+	preConfig := testAccDataSourceAzureRMCdnProfile_withTags(ri, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMCdnProfile_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard_Verizon"
+}
+
+data "azurerm_cdn_profile" "test" {
+  name = "${azurerm_cdn_profile.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceAzureRMCdnProfile_withTags(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard_Verizon"
+
+  tags {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+
+data "azurerm_cdn_profile" "test" {
+  name = "${azurerm_cdn_profile.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -81,6 +81,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_app_service_plan":           dataSourceAppServicePlan(),
 			"azurerm_builtin_role_definition":    dataSourceArmBuiltInRoleDefinition(),
 			"azurerm_client_config":              dataSourceArmClientConfig(),
+			"azurerm_cdn_profile":                dataSourceArmCdnProfile(),
 			"azurerm_dns_zone":                   dataSourceArmDnsZone(),
 			"azurerm_eventhub_namespace":         dataSourceEventHubNamespace(),
 			"azurerm_image":                      dataSourceArmImage(),

--- a/azurerm/resource_arm_cdn_profile.go
+++ b/azurerm/resource_arm_cdn_profile.go
@@ -3,10 +3,10 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -33,10 +33,14 @@ func resourceArmCdnProfile() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"sku": {
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateFunc:     validateCdnProfileSku,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cdn.StandardAkamai),
+					string(cdn.StandardVerizon),
+					string(cdn.PremiumVerizon),
+				}, true),
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
@@ -88,39 +92,6 @@ func resourceArmCdnProfileCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceArmCdnProfileRead(d, meta)
 }
 
-func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).cdnProfilesClient
-	ctx := meta.(*ArmClient).StopContext
-
-	id, err := parseAzureResourceID(d.Id())
-	if err != nil {
-		return err
-	}
-	resGroup := id.ResourceGroup
-	name := id.Path["profiles"]
-
-	resp, err := client.Get(ctx, resGroup, name)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
-		}
-		return fmt.Errorf("Error making Read request on Azure CDN Profile %s: %s", name, err)
-	}
-
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
-	d.Set("location", azureRMNormalizeLocation(*resp.Location))
-
-	if resp.Sku != nil {
-		d.Set("sku", string(resp.Sku.Name))
-	}
-
-	flattenAndSetTags(d, resp.Tags)
-
-	return nil
-}
-
 func resourceArmCdnProfileUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).cdnProfilesClient
 	ctx := meta.(*ArmClient).StopContext
@@ -130,24 +101,57 @@ func resourceArmCdnProfileUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
 	newTags := d.Get("tags").(map[string]interface{})
 
 	props := cdn.ProfileUpdateParameters{
 		Tags: expandTags(newTags),
 	}
 
-	future, err := client.Update(ctx, resGroup, name, props)
+	future, err := client.Update(ctx, resourceGroup, name, props)
 	if err != nil {
-		return fmt.Errorf("Error issuing Azure ARM update request to update CDN Profile %q: %s", name, err)
+		return fmt.Errorf("Error issuing update request for CDN Profile %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	err = future.WaitForCompletion(ctx, client.Client)
 	if err != nil {
-		return fmt.Errorf("Error issuing Azure ARM update request to update CDN Profile %q: %s", name, err)
+		return fmt.Errorf("Error waiting for the update of CDN Profile %q (Resource Group %q) to commplete: %+v", name, resourceGroup, err)
 	}
 
 	return resourceArmCdnProfileRead(d, meta)
+}
+
+func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).cdnProfilesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	name := id.Path["profiles"]
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on Azure CDN Profile %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+
+	if sku := resp.Sku; sku != nil {
+		d.Set("sku", string(sku.Name))
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
 }
 
 func resourceArmCdnProfileDelete(d *schema.ResourceData, meta interface{}) error {
@@ -158,15 +162,15 @@ func resourceArmCdnProfileDelete(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return err
 	}
-	resGroup := id.ResourceGroup
-	name := id.Path["profiles"]
 
-	future, err := client.Delete(ctx, resGroup, name)
+	resourceGroup := id.ResourceGroup
+	name := id.Path["profiles"]
+	future, err := client.Delete(ctx, resourceGroup, name)
 	if err != nil {
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
-		return fmt.Errorf("Error issuing AzureRM delete request for CDN Profile %q: %s", name, err)
+		return fmt.Errorf("Error issuing delete request for CDN Profile %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	err = future.WaitForCompletion(ctx, client.Client)
@@ -174,22 +178,8 @@ func resourceArmCdnProfileDelete(d *schema.ResourceData, meta interface{}) error
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
-		return fmt.Errorf("Error issuing AzureRM delete request for CDN Profile %q: %s", name, err)
+		return fmt.Errorf("Error waiting for CDN Profile %q (Resource Group %q) to be deleted: %+v", name, resourceGroup, err)
 	}
 
 	return err
-}
-
-func validateCdnProfileSku(v interface{}, k string) (ws []string, errors []error) {
-	value := strings.ToLower(v.(string))
-	skus := map[string]bool{
-		"standard_akamai":  true,
-		"premium_verizon":  true,
-		"standard_verizon": true,
-	}
-
-	if !skus[value] {
-		errors = append(errors, fmt.Errorf("CDN Profile SKU can only be Premium_Verizon, Standard_Verizon or Standard_Akamai"))
-	}
-	return
 }

--- a/azurerm/resource_arm_cdn_profile_test.go
+++ b/azurerm/resource_arm_cdn_profile_test.go
@@ -61,46 +61,6 @@ func testSweepCDNProfiles(region string) error {
 	return nil
 }
 
-func TestResourceAzureRMCdnProfileSKU_validation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "Random",
-			ErrCount: 1,
-		},
-		{
-			Value:    "Standard_Verizon",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Premium_Verizon",
-			ErrCount: 0,
-		},
-		{
-			Value:    "Standard_Akamai",
-			ErrCount: 0,
-		},
-		{
-			Value:    "STANDARD_AKAMAI",
-			ErrCount: 0,
-		},
-		{
-			Value:    "standard_akamai",
-			ErrCount: 0,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateCdnProfileSku(tc.Value, "azurerm_cdn_profile")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the Azure RM CDN Profile SKU to trigger a validation error for '%s'", tc.Value)
-		}
-	}
-}
-
 func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMCdnProfile_basic(ri, testLocation())

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -39,6 +39,10 @@
                     <a href="/docs/providers/azurerm/d/builtin_role_definition.html">azurerm_builtin_role_definition</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-cdn-profile") %>>
+                    <a href="/docs/providers/azurerm/d/cdn_profile.html">azurerm_cdn_profile</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-client-config") %>>
                     <a href="/docs/providers/azurerm/d/client_config.html">azurerm_client_config</a>
                 </li>

--- a/website/docs/d/cdn_profile.html.markdown
+++ b/website/docs/d/cdn_profile.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cdn_profile"
+sidebar_current: "docs-azurerm-datasource-cdn-profile"
+description: |-
+  Gets information about a CDN Profile
+---
+
+# Data Source: azurerm_cdn_profile
+
+Use this data source to access information about a CDN Profile.
+
+## Example Usage
+
+```hcl
+data "azurerm_cdn_profile" "test" {
+  name = "myfirstcdnprofile"
+  resource_group_name = "example-resources"
+}
+
+output "cdn_profile_id" {
+  value = "${data.azurerm_cdn_profile.test.id}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the CDN Profile.
+
+* `resource_group_name` - The name of the resource group in which the CDN Profile exists.
+
+## Attributes Reference
+
+* `location` - The Azure Region where the resource exists.
+
+* `sku` - The pricing related information of current CDN profile.
+
+* `tags` - A mapping of tags to assign to the resource.


### PR DESCRIPTION
Also refactoring of the CDN Profile resource to use the built-in enum's

Tests pass:

```
$ acctests azurerm TestAccDataSourceAzureRMCdnProfile_
=== RUN   TestAccDataSourceAzureRMCdnProfile_basic
--- PASS: TestAccDataSourceAzureRMCdnProfile_basic (186.29s)
=== RUN   TestAccDataSourceAzureRMCdnProfile_withTags
--- PASS: TestAccDataSourceAzureRMCdnProfile_withTags (181.88s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	368.201s
```