### PR TITLE
Fix azure virtual machine resource documentation

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -179,7 +179,7 @@ resource "azurerm_virtual_machine" "test" {
   # Uncomment this line to delete the data disks automatically when deleting the VM
   # delete_data_disks_on_termination = true
 
-  storage_profile_image_reference {
+  storage_image_reference {
     id="${data.azurerm_image.image.id}"
   }
 


### PR DESCRIPTION
I was working on following the documentation for creating a virtual machine from a custom image and notices that there is a old or bad reference to a `storage_profile_image_reference` in it. It appears that this should actually be `storage_image_reference`. 

I believe I made the required change to fix this, let me know if anything needs to be changed.