### PR TITLE
`azurerm_cdn_endpoint` extensions

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -96,8 +96,9 @@ type ArmClient struct {
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
 
 	// CDN
-	cdnProfilesClient  cdn.ProfilesClient
-	cdnEndpointsClient cdn.EndpointsClient
+	cdnCustomDomainsClient cdn.CustomDomainsClient
+	cdnEndpointsClient     cdn.EndpointsClient
+	cdnProfilesClient      cdn.ProfilesClient
 
 	// Compute
 	availSetClient         compute.AvailabilitySetsClient
@@ -425,18 +426,16 @@ func (c *ArmClient) registerAuthentication(endpoint, graphEndpoint, subscription
 }
 
 func (c *ArmClient) registerCDNClients(endpoint, subscriptionId string, auth autorest.Authorizer, sender autorest.Sender) {
+	customDomainsClient := cdn.NewCustomDomainsClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&customDomainsClient.Client, auth)
+	c.cdnCustomDomainsClient = customDomainsClient
+
 	endpointsClient := cdn.NewEndpointsClientWithBaseURI(endpoint, subscriptionId)
-	setUserAgent(&endpointsClient.Client)
-	endpointsClient.Authorizer = auth
-	endpointsClient.Sender = sender
-	endpointsClient.SkipResourceProviderRegistration = c.skipProviderRegistration
+	c.configureClient(&endpointsClient.Client, auth)
 	c.cdnEndpointsClient = endpointsClient
 
 	profilesClient := cdn.NewProfilesClientWithBaseURI(endpoint, subscriptionId)
-	setUserAgent(&profilesClient.Client)
-	profilesClient.Authorizer = auth
-	profilesClient.Sender = sender
-	profilesClient.SkipResourceProviderRegistration = c.skipProviderRegistration
+	c.configureClient(&profilesClient.Client, auth)
 	c.cdnProfilesClient = profilesClient
 }
 

--- a/azurerm/resource_arm_cdn_endpoint.go
+++ b/azurerm/resource_arm_cdn_endpoint.go
@@ -1,12 +1,10 @@
 package azurerm
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
@@ -67,27 +65,30 @@ func resourceArmCdnEndpoint() *schema.Resource {
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 
 						"host_name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 
 						"http_port": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 							Default:  80,
 						},
 
 						"https_port": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							ForceNew: true,
 							Default:  443,
 						},
 					},
 				},
-				Set: resourceArmCdnEndpointOriginHash,
 			},
 
 			"origin_path": {
@@ -499,17 +500,6 @@ func flattenAzureRMCdnEndpointContentTypes(input *[]string) []interface{} {
 	return output
 }
 
-func resourceArmCdnEndpointOriginHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["host_name"].(string)))
-
-	// TODO: can we remove this; and do we need a state migration?
-
-	return hashcode.String(buf.String())
-}
-
 func expandAzureRmCdnEndpointOrigins(d *schema.ResourceData) ([]cdn.DeepCreatedOrigin, error) {
 	configs := d.Get("origin").(*schema.Set).List()
 	origins := make([]cdn.DeepCreatedOrigin, 0)
@@ -543,8 +533,8 @@ func expandAzureRmCdnEndpointOrigins(d *schema.ResourceData) ([]cdn.DeepCreatedO
 	return origins, nil
 }
 
-func flattenAzureRMCdnEndpointOrigin(input *[]cdn.DeepCreatedOrigin) []map[string]interface{} {
-	results := make([]map[string]interface{}, 0)
+func flattenAzureRMCdnEndpointOrigin(input *[]cdn.DeepCreatedOrigin) []interface{} {
+	results := make([]interface{}, 0)
 
 	if list := input; list != nil {
 		for _, i := range *list {

--- a/azurerm/resource_arm_cdn_endpoint.go
+++ b/azurerm/resource_arm_cdn_endpoint.go
@@ -266,7 +266,7 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
-	resGroup := d.Get("resource_group_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
 	profileName := d.Get("profile_name").(string)
 	httpAllowed := d.Get("is_http_allowed").(bool)
 	httpsAllowed := d.Get("is_https_allowed").(bool)
@@ -307,14 +307,14 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 		endpoint.EndpointPropertiesUpdateParameters.ProbePath = utils.String(probePath)
 	}
 
-	future, err := endpointsClient.Update(ctx, resGroup, profileName, name, endpoint)
+	future, err := endpointsClient.Update(ctx, resourceGroup, profileName, name, endpoint)
 	if err != nil {
-		return fmt.Errorf("Error updating CDN Endpoint %q (Profile %q / Resource Group %q): %s", name, profileName, resGroup, err)
+		return fmt.Errorf("Error updating CDN Endpoint %q (Profile %q / Resource Group %q): %s", name, profileName, resourceGroup, err)
 	}
 
 	err = future.WaitForCompletion(ctx, endpointsClient.Client)
 	if err != nil {
-		return fmt.Errorf("Error waiting for the CDN Endpoint %q (Profile %q / Resource Group %q) to finish updating: %+v", name, profileName, resGroup, err)
+		return fmt.Errorf("Error waiting for the CDN Endpoint %q (Profile %q / Resource Group %q) to finish updating: %+v", name, profileName, resourceGroup, err)
 	}
 
 	return resourceArmCdnEndpointRead(d, meta)

--- a/azurerm/resource_arm_cdn_endpoint.go
+++ b/azurerm/resource_arm_cdn_endpoint.go
@@ -172,9 +172,6 @@ func resourceArmCdnEndpoint() *schema.Resource {
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
-			// TODO: custom_domain within this resource?
-			// 	https://docs.microsoft.com/en-us/azure/templates/microsoft.cdn/profiles/endpoints/customdomains
-
 			"host_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -264,7 +261,7 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).cdnEndpointsClient
+	endpointsClient := meta.(*ArmClient).cdnEndpointsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -309,12 +306,12 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 		endpoint.EndpointPropertiesUpdateParameters.ProbePath = utils.String(probePath)
 	}
 
-	future, err := client.Update(ctx, resGroup, profileName, name, endpoint)
+	future, err := endpointsClient.Update(ctx, resGroup, profileName, name, endpoint)
 	if err != nil {
 		return fmt.Errorf("Error updating CDN Endpoint %q (Profile %q / Resource Group %q): %s", name, profileName, resGroup, err)
 	}
 
-	err = future.WaitForCompletion(ctx, client.Client)
+	err = future.WaitForCompletion(ctx, endpointsClient.Client)
 	if err != nil {
 		return fmt.Errorf("Error waiting for the CDN Endpoint %q (Profile %q / Resource Group %q) to finish updating: %+v", name, profileName, resGroup, err)
 	}

--- a/azurerm/resource_arm_cdn_endpoint.go
+++ b/azurerm/resource_arm_cdn_endpoint.go
@@ -124,6 +124,12 @@ func resourceArmCdnEndpoint() *schema.Resource {
 				Default:  false,
 			},
 
+			"probe_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"host_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -150,6 +156,7 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
 	originHostHeader := d.Get("origin_host_header").(string)
 	originPath := d.Get("origin_path").(string)
+	probePath := d.Get("probe_path").(string)
 	tags := d.Get("tags").(map[string]interface{})
 
 	endpoint := cdn.Endpoint{
@@ -161,12 +168,12 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 			QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(cachingBehaviour),
 			OriginHostHeader:           utils.String(originHostHeader),
 			OriginPath:                 utils.String(originPath),
+			ProbePath:                  utils.String(probePath),
 			//GeoFilters: []cdn.GeoFilter{{
 			//  Action: cdn.Allow || cdn.Block
 			//  CountryCodes: []string{}
 			//  RelativePath: ""
 			//}}
-			//ProbePath: ""
 		},
 		Tags: expandTags(tags),
 	}
@@ -217,16 +224,18 @@ func resourceArmCdnEndpointUpdate(d *schema.ResourceData, meta interface{}) erro
 	cachingBehaviour := d.Get("querystring_caching_behaviour").(string)
 	hostHeader := d.Get("origin_host_header").(string)
 	originPath := d.Get("origin_path").(string)
+	probePath := d.Get("probe_path").(string)
 	tags := d.Get("tags").(map[string]interface{})
 
 	endpoint := cdn.EndpointUpdateParameters{
 		EndpointPropertiesUpdateParameters: &cdn.EndpointPropertiesUpdateParameters{
-			IsHTTPAllowed:              &httpAllowed,
-			IsHTTPSAllowed:             &httpsAllowed,
-			IsCompressionEnabled:       &compressionEnabled,
+			IsHTTPAllowed:              utils.Bool(httpAllowed),
+			IsHTTPSAllowed:             utils.Bool(httpsAllowed),
+			IsCompressionEnabled:       utils.Bool(compressionEnabled),
 			QueryStringCachingBehavior: cdn.QueryStringCachingBehavior(cachingBehaviour),
-			OriginHostHeader:           &hostHeader,
-			OriginPath:                 &originPath,
+			OriginHostHeader:           utils.String(hostHeader),
+			OriginPath:                 utils.String(originPath),
+			ProbePath:                  utils.String(probePath),
 		},
 		Tags: expandTags(tags),
 	}
@@ -291,6 +300,7 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("querystring_caching_behaviour", props.QueryStringCachingBehavior)
 		d.Set("origin_host_header", props.OriginHostHeader)
 		d.Set("origin_path", props.OriginPath)
+		d.Set("probe_path", props.ProbePath)
 
 		contentTypes := flattenAzureRMCdnEndpointContentTypes(props.ContentTypesToCompress)
 		if err := d.Set("content_types_to_compress", contentTypes); err != nil {

--- a/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/resource_arm_cdn_endpoint_test.go
@@ -116,6 +116,27 @@ func TestAccAzureRMCdnEndpoint_withTags(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCdnEndpoint_withGeoFilters(t *testing.T) {
+	resourceName := "azurerm_cdn_endpoint.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMCdnEndpoint_geoFilters(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMCdnEndpointExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "geo_filter.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMCdnEndpointExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -335,6 +356,52 @@ resource "azurerm_cdn_endpoint" "test" {
 
   tags {
     environment = "staging"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMCdnEndpoint_geoFilters(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard_Verizon"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+  name                = "acctestcdnend%d"
+  profile_name        = "${azurerm_cdn_profile.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  is_http_allowed     = false
+  is_https_allowed    = true
+  origin_path          = "/origin-path"
+  probe_path          = "/origin-path/probe"
+
+  origin {
+    name       = "acceptanceTestCdnOrigin1"
+    host_name  = "www.example.com"
+    https_port = 443
+    http_port  = 80
+  }
+
+  geo_filter {
+    relative_path = "/some-example-endpoint"
+    action = "Allow"
+    country_codes = [ "GB" ]
+  }
+
+  geo_filter {
+    relative_path = "/some-other-endpoint"
+    action = "Block"
+    country_codes = [ "US" ]
   }
 }
 `, rInt, location, rInt, rInt)

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -85,13 +85,13 @@ The following arguments are supported:
 
 The `origin` block supports:
 
-* `name` - (Required) The name of the origin. This is an arbitrary value. However, this value needs to be unique under endpoint.
+* `name` - (Required) The name of the origin. This is an arbitrary value. However, this value needs to be unique under endpoint. Changing this forces a new resource to be created.
 
-* `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string can be a domain name, Storage Account endpoint, Web App endpoint, IPv4 address or IPv6 address.
+* `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string can be a domain name, Storage Account endpoint, Web App endpoint, IPv4 address or IPv6 address. Changing this forces a new resource to be created.
 
-* `http_port` - (Optional) The HTTP port of the origin. Defaults to `80`.
+* `http_port` - (Optional) The HTTP port of the origin. Defaults to `80`. Changing this forces a new resource to be created.
 
-* `https_port` - (Optional) The HTTPS port of the origin. Defaults to `443`.
+* `https_port` - (Optional) The HTTPS port of the origin. Defaults to `443`. Changing this forces a new resource to be created.
 
 The `geo_filter` block supports:
 

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -80,6 +80,8 @@ Each `origin` block supports fields documented below.
 
 * `is_compression_enabled` - (Optional) Indicates whether compression is to be enabled. Defaults to false.
 
+* `geo_filter` - (Optional) A set of Geo Filters for this CDN Endpoint. Each `geo_filter` block supports fields documented below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `origin` block supports:
@@ -91,6 +93,14 @@ The `origin` block supports:
 * `http_port` - (Optional) The HTTP port of the origin. Defaults to `80`.
 
 * `https_port` - (Optional) The HTTPS port of the origin. Defaults to `443`.
+
+The `geo_filter` block supports:
+
+* `relative_path` - (Required) The relative path applicable to geo filter.
+
+* `action` - (Required) The Action of the Geo Filter. Possible values include `Allow` and `Block`.
+
+* `country_codes` - (Required) A List of two letter country codes (e.g. `US`, `GB`) to be associated with this Geo Filter.
 
 ## Attributes Reference
 

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -51,38 +51,35 @@ resource "azurerm_cdn_endpoint" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the CDN Endpoint. Changing this forces a
-    new resource to be created.
+* `name` - (Required) Specifies the name of the CDN Endpoint. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the CDN Endpoint.
+* `resource_group_name` - (Required) The name of the resource group in which to create the CDN Endpoint.
 
 * `profile_name` - (Required) The CDN Profile to which to attach the CDN Endpoint.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
-
 * `is_http_allowed` - (Optional) Defaults to `true`.
 
 * `is_https_allowed` - (Optional) Defaults to `true`.
 
-* `origin` - (Optional) The set of origins of the CDN endpoint. When multiple origins exist, the first origin will be used as primary and rest will be used as failover options.
-Each `origin` block supports fields documented below.
+* `content_types_to_compress` - (Optional) An array of strings that indicates a content types on which compression will be applied. The value for the elements should be MIME types.
+
+* `geo_filter` - (Optional) A set of Geo Filters for this CDN Endpoint. Each `geo_filter` block supports fields documented below.
+
+* `is_compression_enabled` - (Optional) Indicates whether compression is to be enabled. Defaults to false.
+
+* `querystring_caching_behaviour` - (Optional) Sets query string caching behavior. Allowed values are `IgnoreQueryString`, `BypassCaching` and `UseQueryString`. Defaults to `IgnoreQueryString`.
+
+* `optimization_type` - (Optional) What types of optimization should this CDN Endpoint optimize for? Possible values include `DynamicSiteAcceleration`, `GeneralMediaStreaming`, `GeneralWebDelivery`, `LargeFileDownload` and `VideoOnDemandMediaStreaming`.
+
+* `origin` - (Optional) The set of origins of the CDN endpoint. When multiple origins exist, the first origin will be used as primary and rest will be used as failover options. Each `origin` block supports fields documented below.
+
+* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
 
 * `origin_path` - (Optional) The path used at for origin requests.
 
 * `probe_path` - (Optional) the path to a file hosted on the origin which helps accelerate delivery of the dynamic content and calculate the most optimal routes for the CDN. This is relative to the `origin_path`.
-
-* `querystring_caching_behaviour` - (Optional) Sets query string caching behavior. Allowed values are `IgnoreQueryString`, `BypassCaching` and `UseQueryString`. Defaults to `IgnoreQueryString`.
-
-* `content_types_to_compress` - (Optional) An array of strings that indicates a content types on which compression will be applied. The value for the elements should be MIME types.
-
-* `is_compression_enabled` - (Optional) Indicates whether compression is to be enabled. Defaults to false.
-
-* `geo_filter` - (Optional) A set of Geo Filters for this CDN Endpoint. Each `geo_filter` block supports fields documented below.
-
-* `optimization_type` - (Optional) What types of optimization should this CDN Endpoint optimize for? Possible values include `DynamicSiteAcceleration`, `GeneralMediaStreaming`, `GeneralWebDelivery`, `LargeFileDownload` and `VideoOnDemandMediaStreaming`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -7,7 +7,7 @@ description: |-
 
 ---
 
-# azurerm\_cdn\_endpoint
+# azurerm_cdn_endpoint
 
 A CDN Endpoint is the entity within a CDN Profile containing configuration information regarding caching behaviors and origins. The CDN Endpoint is exposed using the URL format <endpointname>.azureedge.net by default, but custom domains can also be created.
 
@@ -71,6 +71,8 @@ The following arguments are supported:
 Each `origin` block supports fields documented below.
 
 * `origin_path` - (Optional) The path used at for origin requests.
+
+* `probe_path` - (Optional) the path to a file hosted on the origin which helps accelerate delivery of the dynamic content and calculate the most optimal routes for the CDN. This is relative to the `origin_path`.
 
 * `querystring_caching_behaviour` - (Optional) Sets query string caching behavior. Allowed values are `IgnoreQueryString`, `BypassCaching` and `UseQueryString`. Defaults to `IgnoreQueryString`.
 

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -82,6 +82,8 @@ Each `origin` block supports fields documented below.
 
 * `geo_filter` - (Optional) A set of Geo Filters for this CDN Endpoint. Each `geo_filter` block supports fields documented below.
 
+* `optimization_type` - (Optional) What types of optimization should this CDN Endpoint optimize for? Possible values include `DynamicSiteAcceleration`, `GeneralMediaStreaming`, `GeneralWebDelivery`, `LargeFileDownload` and `VideoOnDemandMediaStreaming`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 The `origin` block supports:

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 The `origin` block supports:
 
-* `name` - (Required) The name of the origin. This is an arbitrary value. However, this value needs to be unique under endpoint. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the origin. This is an arbitrary value. However, this value needs to be unique under the endpoint. Changing this forces a new resource to be created.
 
 * `host_name` - (Required) A string that determines the hostname/IP address of the origin server. This string can be a domain name, Storage Account endpoint, Web App endpoint, IPv4 address or IPv6 address. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
- [x] Support for Geo Filters and ProbePaths
- [x] Refactoring
- [x] ~Determine if a state migration is needed for the `origin` block~ doesn't look like it
- [x] Makes the `origin` block properties `ForceNew`