### PR TITLE
Support for Function Apps in Consumption Plans

### DIFF
--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -39,6 +39,7 @@ func resourceArmAppServicePlan() *schema.Resource {
 				Default:  "Windows",
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
+					"FunctionApp",
 					"Linux",
 					"Windows",
 				}, true),

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -255,6 +255,29 @@ func TestAccAzureRMFunctionApp_3264bit(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFunctionApp_consumptionPlan(t *testing.T) {
+	resourceName := "azurerm_function_app.test"
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	location := testLocation()
+	config := testAccAzureRMFunctionApp_consumptionPlan(ri, rs, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFunctionAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.use_32_bit_worker_process", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMFunctionAppDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
@@ -656,6 +679,43 @@ resource "azurerm_function_app" "test" {
   site_config {
     use_32_bit_worker_process = false
   }
+}
+`, rInt, location, rString, rInt, rInt)
+}
+
+func testAccAzureRMFunctionApp_consumptionPlan(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  kind                = "FunctionApp"
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                      = "acctest-%d-func"
+  location                  = "${azurerm_resource_group.test.location}"
+  resource_group_name       = "${azurerm_resource_group.test.name}"
+  app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+  storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
 }
 `, rInt, location, rString, rInt, rInt)
 }

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Create an App Service Plan component.
 
-## Example Usage
+## Example Usage (Dedicated)
 
 ```hcl
 resource "azurerm_resource_group" "test" {
@@ -20,12 +20,33 @@ resource "azurerm_resource_group" "test" {
 
 resource "azurerm_app_service_plan" "test" {
   name                = "api-appserviceplan-pro"
-  location            = "West Europe"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   sku {
     tier = "Standard"
     size = "S1"
+  }
+}
+```
+
+## Example Usage (Shared / Consumption Plan)
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "api-rg-pro"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "api-appserviceplan-pro"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "FunctionApp"
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
   }
 }
 ```
@@ -40,7 +61,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows` and `Linux`. Defaults to `Windows`. Changing this forces a new resource to be created.
+* `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows`, `Linux` and `FunctionApp` (for a Consumption Plan). Defaults to `Windows`. Changing this forces a new resource to be created.
 
 * `sku` - (Required) A `sku` block as documented below.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -11,8 +11,6 @@ description: |-
 
 Manages a Function App.
 
--> **Note:** Function Apps can be deployed to either an App Service Plan or to a Consumption Plan. At this time it's possible to deploy a Function App into an existing Consumption Plan or a new/existing App Service Plan [using the `azurerm_app_service_plan` Data Source](app_service_plan.html) - however it's not currently possible to create a new Consumption Plan natively in Terraform. Support for this will be added in the future, and in the interim can be achieved by using [the `azurerm_template_deployment` resource](template_deployment.html).
-
 ## Example Usage (with App Service Plan)
 
 ```hcl
@@ -37,6 +35,42 @@ resource "azurerm_app_service_plan" "test" {
   sku {
     tier = "Standard"
     size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                      = "test-azure-functions"
+  location                  = "${azurerm_resource_group.test.location}"
+  resource_group_name       = "${azurerm_resource_group.test.name}"
+  app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+  storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+}
+```
+## Example Usage (in a Consumption Plan)
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "azure-functions-cptest-rg"
+  location = "westus2"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "functionsapptestsa"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "azure-functions-test-service-plan"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "FunctionApp"
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
   }
 }
 


### PR DESCRIPTION
After [a PR yesterday to the Swagger repository](https://github.com/Azure/azure-rest-api-specs/pull/2645) - it appears [this is possible without any extra code changes](https://github.com/Azure/azure-rest-api-specs/pull/2645#issuecomment-373240638) - as such this PR adds support for Function Apps in Consumption Plans

Fixes #960