### PR TITLE
`azurem_sql_elasticpool` - fixing a crash where `location` isn't returned for legacy resources

### DIFF
--- a/azurerm/resource_arm_sql_elasticpool.go
+++ b/azurerm/resource_arm_sql_elasticpool.go
@@ -140,7 +140,9 @@ func resourceArmSqlElasticPoolRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resGroup)
-	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+	if location := resp.Location; location != nil {
+		d.Set("location", azureRMNormalizeLocation(*location))
+	}
 	d.Set("server_name", serverName)
 
 	if elasticPool := resp.ElasticPoolProperties; elasticPool != nil {


### PR DESCRIPTION
Fixes #678