### PR TITLE
Minor updates to tags documentation for data sources

### DIFF
--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -40,7 +40,7 @@ output "app_service_plan_id" {
 
 * `properties` - A `properties` block as documented below.
 
-* `tags` - A mapping of tags to assign to the resource.
+* `tags` - A mapping of tags assigned to the resource.
 
 * `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.
 

--- a/website/docs/d/application_security_group.html.markdown
+++ b/website/docs/d/application_security_group.html.markdown
@@ -41,4 +41,4 @@ The following attributes are exported:
 
 * `location` - The supported Azure location where the Application Security Group exists.
 
-* `tags` - A mapping of tags to assign to the resource.
+* `tags` - A mapping of tags assigned to the resource.

--- a/website/docs/d/cdn_profile.html.markdown
+++ b/website/docs/d/cdn_profile.html.markdown
@@ -27,7 +27,7 @@ output "cdn_profile_id" {
 
 * `name` - (Required) The name of the CDN Profile.
 
-* `resource_group_name` - The name of the resource group in which the CDN Profile exists.
+* `resource_group_name` - (Required) The name of the resource group in which the CDN Profile exists.
 
 ## Attributes Reference
 
@@ -35,4 +35,4 @@ output "cdn_profile_id" {
 
 * `sku` - The pricing related information of current CDN profile.
 
-* `tags` - A mapping of tags to assign to the resource.
+* `tags` - A mapping of tags assigned to the resource.

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -37,7 +37,7 @@ output "location" {
 
 * `security_rule` - One or more `security_rule` blocks as defined below.
 
-* `tags` - A mapping of tags to assign to the resource.
+* `tags` - A mapping of tags assigned to the resource.
 
 
 The `security_rule` block supports:

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -54,7 +54,7 @@ output "virtual_network_gateway_id" {
 
 * `vpn_client_configuration` - A `vpn_client_configuration` block which is documented below.
 
-* `tags` - A mapping of tags to assign to the resource.
+* `tags` - A mapping of tags assigned to the resource.
 
 The `ip_configuration` block supports:
 


### PR DESCRIPTION
I believe the tense of datasource tags descriptions should be "assigned" over "to assign".