### PR TITLE
Increase max staleness prefix for multiple regions and fix documentation

### DIFF
--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -87,7 +87,7 @@ func resourceArmCosmosDBAccount() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      5,
-							ValidateFunc: validation.IntBetween(1, 100),
+							ValidateFunc: validation.IntBetween(1, 86400),
 						},
 
 						"max_staleness_prefix": {

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 `consistency_policy` supports the following:
 
 * `consistency_level` - (Required) The Consistency Level to use for this CosmosDB Account - can be either `BoundedStaleness`, `Eventual`, `Session` or `Strong`.
-* `max_interval_in_seconds` - (Optional) When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 1 - 100. Defaults to `5`. Required when `consistency_level` is set to `BoundedStaleness`.
+* `max_interval_in_seconds` - (Optional) When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 1 - 86400 (1 day). Defaults to `5`. Required when `consistency_level` is set to `BoundedStaleness`.
 * `max_staleness_prefix` - (Optional) When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Defaults to `100`. Required when `consistency_level` is set to `BoundedStaleness`.
 
 ~> **Note**: `max_interval_in_seconds` and `max_staleness_prefix` can only be set to custom values when `consistency_level` is set to `BoundedStaleness` - otherwise they will return the default values shown above.

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -77,9 +77,9 @@ The following arguments are supported:
 
 * `consistency_level` - (Required) The Consistency Level to use for this CosmosDB Account - can be either `BoundedStaleness`, `Eventual`, `Session` or `Strong`.
 * `max_interval_in_seconds` - (Optional) When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is 1 - 100. Defaults to `5`. Required when `consistency_level` is set to `BoundedStaleness`.
-* `max_staleness` - (Optional) When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Defaults to `100`. Required when `consistency_level` is set to `BoundedStaleness`.
+* `max_staleness_prefix` - (Optional) When used with the Bounded Staleness consistency level, this value represents the number of stale requests tolerated. Accepted range for this value is 1 – 2,147,483,647. Defaults to `100`. Required when `consistency_level` is set to `BoundedStaleness`.
 
-~> **Note**: `max_interval_in_seconds` and `max_staleness` can only be set to custom values when `consistency_level` is set to `BoundedStaleness` - otherwise they will return the default values shown above.
+~> **Note**: `max_interval_in_seconds` and `max_staleness_prefix` can only be set to custom values when `consistency_level` is set to `BoundedStaleness` - otherwise they will return the default values shown above.
 
 `failover_policy` supports the following:
 


### PR DESCRIPTION
Hi,

In this PR two fixes:

- fix in documentation, because key is unknown during planning
`Error: azurerm_cosmosdb_account.cosmosdb: consistency_policy.0: invalid or unknown key: max_staleness`
- increase max_staleness_prefix, because
`The maximum lag must be between 5 seconds and 1 day for accounts with a single region, and between 5 minutes and 1 day for accounts with multiple regions.`

Please let me know, if there are any questions.

Thanks