### PR TITLE
Update VM Extension example to use CustomScript 2.0

### DIFF
--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -108,13 +108,13 @@ resource "azurerm_virtual_machine_extension" "test" {
   location             = "West US"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_machine_name = "${azurerm_virtual_machine.test.name}"
-  publisher            = "Microsoft.OSTCExtensions"
-  type                 = "CustomScriptForLinux"
-  type_handler_version = "1.2"
+  publisher            = "Microsoft.Azure.Extensions"
+  type                 = "CustomScript"
+  type_handler_version = "2.0"
 
   settings = <<SETTINGS
 	{
-		"commandToExecute": "hostname"
+		"commandToExecute": "hostname && uptime"
 	}
 SETTINGS
 


### PR DESCRIPTION
I'd like to propose updating the VM extension example to show the use of the newer CustomScript for Linux  (v2.0.x). 
This version adds support for a base64-encoded script (multi-line).
More info: https://github.com/Azure/custom-script-extension-linux

I also updated the `commandToExecute` example to demonstrate a more complex command.