### PR TITLE
Support application gateway backend pool configuration

### DIFF
--- a/azurerm/data_source_network_interface.go
+++ b/azurerm/data_source_network_interface.go
@@ -72,6 +72,13 @@ func dataSourceArmNetworkInterface() *schema.Resource {
 							Computed: true,
 						},
 
+						"application_gateway_backend_address_pools_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+
 						"load_balancer_backend_address_pools_ids": {
 							Type:     schema.TypeSet,
 							Computed: true,

--- a/azurerm/import_arm_network_interface_test.go
+++ b/azurerm/import_arm_network_interface_test.go
@@ -91,6 +91,27 @@ func TestAccAzureRMNetworkInterface_importMultipleLoadBalancers(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterface_importApplicationGateway(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterface_applicationGatewayBackendPool(rInt, testLocation()),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterface_importPublicIP(t *testing.T) {
 	resourceName := "azurerm_network_interface.test"
 	rInt := acctest.RandInt()

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -285,6 +285,25 @@ func TestAccAzureRMNetworkInterface_multipleLoadBalancers(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterface_applicationGateway(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterface_applicationGatewayBackendPool(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test"),
+					resource.TestCheckResourceAttr(resourceName, "ip_configuration.0.application_gateway_backend_address_pools_ids.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterface_withTags(t *testing.T) {
 	resourceName := "azurerm_network_interface.test"
 	rInt := acctest.RandInt()
@@ -901,6 +920,118 @@ resource "azurerm_network_interface" "test2" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMNetworkInterface_applicationGatewayBackendPool(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-vnet-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  address_space       = ["10.254.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+}
+
+resource "azurerm_subnet" "gateway" {
+  name                 = "subnet-gateway-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.254.0.0/24"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "subnet-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.254.1.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "acctest-pubip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "dynamic"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestgw-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    name     = "Standard_Medium"
+    tier     = "Standard"
+    capacity = 1
+  }
+
+  gateway_ip_configuration {
+    name      = "gw-ip-config1"
+    subnet_id = "${azurerm_subnet.gateway.id}"
+  }
+
+  frontend_port {
+    name = "port-8080"
+    port = 8080
+  }
+
+  frontend_ip_configuration {
+    name                 = "ip-config-public"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
+
+  backend_address_pool {
+    name = "pool-1"
+  }
+
+  backend_http_settings {
+    name                  = "backend-http-1"
+    port                  = 8080
+    protocol              = "Http"
+    cookie_based_affinity = "Enabled"
+    request_timeout       = 30
+  }
+
+  http_listener {
+    name = "listener-1"
+    frontend_ip_configuration_name = "ip-config-public"
+    frontend_port_name = "port-8080"
+    protocol           = "Http"
+  }
+
+  request_routing_rule {
+    name      = "rule-basic-1"
+    rule_type = "Basic"
+    http_listener_name = "listener-1"
+    backend_address_pool_name = "pool-1"
+    backend_http_settings_name = "backend-http-1"
+  }
+
+  tags {
+    environment = "tf01"
+  }
+}
+
+resource "azurerm_network_interface" "test" {
+  name                 = "acctestnic-%d"
+  location             = "${azurerm_resource_group.test.location}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  enable_ip_forwarding = true
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+
+    application_gateway_backend_address_pools_ids = [
+      "${azurerm_application_gateway.test.backend_address_pool.0.id}",
+    ]
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_bug7986(rInt int, location string) string {

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -361,6 +361,25 @@ func TestAccAzureRMVirtualMachineScaleSet_customImage(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineScaleSet_applicationGateway(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualMachineScaleSetApplicationGatewayTemplate(ri, testLocation())
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+					testCheckAzureRMVirtualMachineScaleSetHasApplicationGateway("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineScaleSet_loadBalancer(t *testing.T) {
 	ri := acctest.RandInt()
 	config := testAccAzureRMVirtualMachineScaleSetLoadBalancerTemplate(ri, testLocation())
@@ -656,6 +675,32 @@ func testCheckAzureRMVirtualMachineScaleSetHasLoadbalancer(name string) resource
 		pools := (*ip)[0].LoadBalancerBackendAddressPools
 		if pools == nil || len(*pools) == 0 {
 			return fmt.Errorf("Bad: Load balancer backend pools is empty for scale set %v", name)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMVirtualMachineScaleSetHasApplicationGateway(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resp, err := testGetAzureRMVirtualMachineScaleSet(s, name)
+		if err != nil {
+			return err
+		}
+
+		n := resp.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+		if n == nil || len(*n) == 0 {
+			return fmt.Errorf("Bad: Could not get network interface configurations for scale set %v", name)
+		}
+
+		ip := (*n)[0].IPConfigurations
+		if ip == nil || len(*ip) == 0 {
+			return fmt.Errorf("Bad: Could not get ip configurations for scale set %v", name)
+		}
+
+		pools := (*ip)[0].ApplicationGatewayBackendAddressPools
+		if pools == nil || len(*pools) == 0 {
+			return fmt.Errorf("Bad: Application gateway backend pools is empty for scale set %v", name)
 		}
 
 		return nil
@@ -2100,6 +2145,201 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetApplicationGatewayTemplate(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accsa%d"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name                = "acctvmss-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+
+  sku {
+    name     = "Standard_D1_v2"
+    tier     = "Standard"
+    capacity = 1
+  }
+
+  os_profile {
+    computer_name_prefix = "testvm-%d"
+    admin_username       = "myadmin"
+    admin_password       = "Passwword1234"
+  }
+
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name                                         = "TestIPConfiguration"
+      subnet_id                                    = "${azurerm_subnet.test.id}"
+      application_gateway_backend_address_pool_ids = ["${azurerm_application_gateway.test.backend_address_pool.0.id}"]
+    }
+  }
+
+  storage_profile_os_disk {
+    name           = "os-disk"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+
+# application gateway
+resource "azurerm_subnet" "gwtest" {
+  name                 = "gw-subnet-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.3.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "acctest-pubip-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "dynamic"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestgw-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    name     = "Standard_Medium"
+    tier     = "Standard"
+    capacity = 1
+  }
+
+  gateway_ip_configuration {
+    # id = computed
+    name      = "gw-ip-config1"
+    subnet_id = "${azurerm_subnet.gwtest.id}"
+  }
+
+  frontend_ip_configuration {
+    # id = computed
+    name                 = "ip-config-public"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
+
+  frontend_ip_configuration {
+    # id = computed
+    name      = "ip-config-private"
+    subnet_id = "${azurerm_subnet.gwtest.id}"
+
+    # private_ip_address = computed
+    private_ip_address_allocation = "Dynamic"
+  }
+
+  frontend_port {
+    # id = computed
+    name = "port-8080"
+    port = 8080
+  }
+
+  backend_address_pool {
+    # id = computed
+    name = "pool-1"
+  }
+
+  backend_http_settings {
+    # id = computed
+    name                  = "backend-http-1"
+    port                  = 8010
+    protocol              = "Http"
+    cookie_based_affinity = "Enabled"
+    request_timeout       = 30
+
+    # probe_id = computed
+    probe_name = "probe-1"
+  }
+
+  http_listener {
+    # id = computed
+    name = "listener-1"
+
+    # frontend_ip_configuration_id = computed
+    frontend_ip_configuration_name = "ip-config-public"
+
+    # frontend_ip_port_id = computed
+    frontend_port_name = "port-8080"
+    protocol           = "Http"
+  }
+
+  probe {
+    # id = computed
+    name                = "probe-1"
+    protocol            = "Http"
+    path                = "/test"
+    host                = "azure.com"
+    timeout             = 120
+    interval            = 300
+    unhealthy_threshold = 8
+  }
+
+  request_routing_rule {
+    # id = computed
+    name      = "rule-basic-1"
+    rule_type = "Basic"
+
+    # http_listener_id = computed
+    http_listener_name = "listener-1"
+
+    # backend_address_pool_id = computed
+    backend_address_pool_name = "pool-1"
+
+    # backend_http_settings_id = computed
+    backend_http_settings_name = "backend-http-1"
+  }
+
+  tags {
+    environment = "tf01"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMVirtualMachineScaleSetLoadBalancerTemplate(rInt int, location string) string {

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -88,6 +88,8 @@ The `ip_configuration` block supports:
 
 * `public_ip_address_id` - (Optional) Reference to a Public IP Address to associate with this NIC
 
+* `application_gateway_backend_address_pools_ids` - (Optional) List of Application Gateway Backend Address Pool IDs references to which this NIC belongs
+
 * `load_balancer_backend_address_pools_ids` - (Optional) List of Load Balancer Backend Address Pool IDs references to which this NIC belongs
 
 * `load_balancer_inbound_nat_rules_ids` - (Optional) List of Load Balancer Inbound Nat Rules IDs involving this NIC

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -326,6 +326,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies name of the IP configuration.
 * `subnet_id` - (Required) Specifies the identifier of the subnet.
+* `application_gateway_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of application gateways. A scale set can reference backend address pools of one application gateway. Multiple scale sets cannot use the same application gateway.
 * `load_balancer_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of load balancers. A scale set can reference backend address pools of one public and one internal load balancer. Multiple scale sets cannot use the same load balancer.
 * `load_balancer_inbound_nat_rules_ids` - (Optional) Specifies an array of references to inbound NAT rules for load balancers.
 * `primary` - (Optional) Specifies if this ip_configuration is the primary one.


### PR DESCRIPTION
Support application gateway pool configuration for both vmss and network interface. 

This change-set preserves code changes implemented by @agolomoodysaada in PR #884. A few changes were made to the original commit to get vmss working and verified as expected.

In addition to vmss, this also adds support for application gateway backend pool configuration for network interface resources and data sources.

Supersedes: #884
Closes #857