### PR TITLE
`azurerm_virtual_network_gateway`: making `peering_address` Computed+ForceNew

### DIFF
--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -189,6 +189,8 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 						"peering_address": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
+							ForceNew: true,
 						},
 						"peer_weight": {
 							Type:     schema.TypeInt,

--- a/azurerm/resource_arm_virtual_network_gateway_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_test.go
@@ -48,6 +48,25 @@ func TestAccAzureRMVirtualNetworkGateway_vpnGw1(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetworkGateway_activeActive(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualNetworkGateway_activeActive(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkGatewayExists("azurerm_virtual_network_gateway.test"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMVirtualNetworkGatewayExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		name, resourceGroup, err := getArmResourceNameAndGroup(s, name)
@@ -187,4 +206,71 @@ resource "azurerm_virtual_network_gateway" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualNetworkGateway_activeActive(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name = "acctestvn-%d"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  address_space = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name = "GatewaySubnet"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix = "10.0.1.0/24"
+}
+
+resource "azurerm_public_ip" "first" {
+  name = "acctestpip1-%d"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "Dynamic"
+}
+
+resource "azurerm_public_ip" "second" {
+  name = "acctestpip2-%d"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name = "acctestvng-%d"
+  location = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  type = "Vpn"
+  vpn_type = "RouteBased"
+  sku = "VpnGw1"
+  active_active = true
+  enable_bgp = true
+
+  ip_configuration {
+    name = "gw-ip1"
+    public_ip_address_id = "${azurerm_public_ip.first.id}"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  ip_configuration {
+    name = "gw-ip2"
+    public_ip_address_id = "${azurerm_public_ip.second.id}"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  bgp_settings {
+    asn = "65010"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt)
 }

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -188,6 +188,7 @@ The `bgp_settings` block supports:
 
 * `peer_weight` - (Optional) The weight added to routes which have been learned
     through BGP peering. Valid values can be between `0` and `100`.
+    Changing this forces a new resource to be created.
 
 The `root_certificate` block supports:
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -184,11 +184,10 @@ The `bgp_settings` block supports:
 * `peering_address` - (Optional) The BGP peer IP address of the virtual network
     gateway. This address is needed to configure the created gateway as a BGP Peer
     on the on-premises VPN devices. The IP address must be part of the subnet of
-    the Virtual Network Gateway.
+    the Virtual Network Gateway. Changing this forces a new resource to be created.
 
 * `peer_weight` - (Optional) The weight added to routes which have been learned
     through BGP peering. Valid values can be between `0` and `100`.
-    Changing this forces a new resource to be created.
 
 The `root_certificate` block supports:
 


### PR DESCRIPTION
Adding a test covering spinning up an active-active VPN

Fixes #916

Before:
```
$ acctests azurerm TestAccAzureRMVirtualNetworkGateway_activeActive
=== RUN   TestAccAzureRMVirtualNetworkGateway_activeActive
--- FAIL: TestAccAzureRMVirtualNetworkGateway_activeActive (1956.69s)
	testing.go:513: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: azurerm_virtual_network_gateway.test
		  bgp_settings.0.peering_address: "10.0.1.4,10.0.1.5" => ""

		STATE:

		azurerm_public_ip.first:
		  ID = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/publicIPAddresses/acctestpip1-7126263343628930289
		  provider = provider.azurerm
		  location = eastus
		  name = acctestpip1-7126263343628930289
		  public_ip_address_allocation = dynamic
		  resource_group_name = acctestRG-7126263343628930289
		  sku = Basic
		  tags.% = 0
		  zones.# = 0

		  Dependencies:
		    azurerm_resource_group.test
		azurerm_public_ip.second:
		  ID = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/publicIPAddresses/acctestpip2-7126263343628930289
		  provider = provider.azurerm
		  location = eastus
		  name = acctestpip2-7126263343628930289
		  public_ip_address_allocation = dynamic
		  resource_group_name = acctestRG-7126263343628930289
		  sku = Basic
		  tags.% = 0
		  zones.# = 0

		  Dependencies:
		    azurerm_resource_group.test
		azurerm_resource_group.test:
		  ID = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289
		  provider = provider.azurerm
		  location = eastus
		  name = acctestRG-7126263343628930289
		  tags.% = 0
		azurerm_subnet.test:
		  ID = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/virtualNetworks/acctestvn-7126263343628930289/subnets/GatewaySubnet
		  provider = provider.azurerm
		  address_prefix = 10.0.1.0/24
		  ip_configurations.# = 0
		  name = GatewaySubnet
		  resource_group_name = acctestRG-7126263343628930289
		  service_endpoints.# = 0
		  virtual_network_name = acctestvn-7126263343628930289

		  Dependencies:
		    azurerm_resource_group.test
		    azurerm_virtual_network.test
		azurerm_virtual_network.test:
		  ID = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/virtualNetworks/acctestvn-7126263343628930289
		  provider = provider.azurerm
		  address_space.# = 1
		  address_space.0 = 10.0.0.0/16
		  dns_servers.# = 0
		  location = eastus
		  name = acctestvn-7126263343628930289
		  resource_group_name = acctestRG-7126263343628930289
		  subnet.# = 0
		  tags.% = 0

		  Dependencies:
		    azurerm_resource_group.test
		azurerm_virtual_network_gateway.test:
		  ID = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/virtualNetworkGateways/acctestvng-7126263343628930289
		  provider = provider.azurerm
		  active_active = true
		  bgp_settings.# = 1
		  bgp_settings.0.asn = 65010
		  bgp_settings.0.peer_weight = 0
		  bgp_settings.0.peering_address = 10.0.1.4,10.0.1.5
		  enable_bgp = true
		  ip_configuration.# = 2
		  ip_configuration.0.name = gw-ip1
		  ip_configuration.0.private_ip_address_allocation = Dynamic
		  ip_configuration.0.public_ip_address_id = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/publicIPAddresses/acctestpip1-7126263343628930289
		  ip_configuration.0.subnet_id = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/virtualNetworks/acctestvn-7126263343628930289/subnets/GatewaySubnet
		  ip_configuration.1.name = gw-ip2
		  ip_configuration.1.private_ip_address_allocation = Dynamic
		  ip_configuration.1.public_ip_address_id = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/publicIPAddresses/acctestpip2-7126263343628930289
		  ip_configuration.1.subnet_id = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/acctestRG-7126263343628930289/providers/Microsoft.Network/virtualNetworks/acctestvn-7126263343628930289/subnets/GatewaySubnet
		  location = eastus
		  name = acctestvng-7126263343628930289
		  resource_group_name = acctestRG-7126263343628930289
		  sku = VpnGw1
		  tags.% = 0
		  type = Vpn
		  vpn_type = RouteBased

		  Dependencies:
		    azurerm_public_ip.first
		    azurerm_public_ip.second
		    azurerm_resource_group.test
		    azurerm_subnet.test
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1956.721s
```

Now:

```
$ acctests azurerm TestAccAzureRMVirtualNetworkGateway_activeActive
=== RUN   TestAccAzureRMVirtualNetworkGateway_activeActive
--- PASS: TestAccAzureRMVirtualNetworkGateway_activeActive (1968.01s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1968.050s
```