### PR TITLE
Fixing the broken website link

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -96,7 +96,7 @@
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-scheduler-job-collection") %>>
-                    <a href="/docs/providers/azurerm/d/scheduler-job-collection.html">azurerm_scheduler_job_collection</a>
+                    <a href="/docs/providers/azurerm/d/scheduler_job_collection.html">azurerm_scheduler_job_collection</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-storage-account") %>>


### PR DESCRIPTION
The website deploy has highlighted a broken link for the Scheduler Job Collection Data Source