### PR TITLE
Documenting that Linux App Service Plans require being reserved

### DIFF
--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 
 * `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows`, `Linux` and `FunctionApp` (for a Consumption Plan). Defaults to `Windows`. Changing this forces a new resource to be created.
 
+~> **NOTE:** When creating a `Linux` App Service Plan, the `reserved` field must be set to `true`.
+
 * `sku` - (Required) A `sku` block as documented below.
 
 * `properties` - (Optional) A `properties` block as documented below.


### PR DESCRIPTION
If `reserved` isn't set to `true` Azure will silently create a Windows App Service Environment (albeit with a Linux icon in the Portal). This behaviour isn't documented anywhere (hence this PR) - and has led to user confusion.

Fixes #602