### PR TITLE
Documentation: fixing the sidebar highlight

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -337,7 +337,7 @@
                   <a href="/docs/providers/azurerm/r/sql_database.html">azurerm_sql_database</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-datbase-sql-administrator") %>>
+                <li<%= sidebar_current("docs-azurerm-resource-database-sql-administrator") %>>
                   <a href="/docs/providers/azurerm/r/sql_active_directory_administrator.html">azurerm_sql_active_directory_administrator</a>
                 </li>
 

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -354,7 +354,7 @@
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-resource-database-sql-virtual-network-rule") %>>
-                  <a href="/docs/providers/azurerm/r/sql_virtual_network_rule.html">sql_virtual_network_rule</a>
+                  <a href="/docs/providers/azurerm/r/sql_virtual_network_rule.html">azurerm_sql_virtual_network_rule</a>
                 </li>
 
               </ul>

--- a/website/docs/r/sql_virtual_network_rule.html.markdown
+++ b/website/docs/r/sql_virtual_network_rule.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_virtual_network_rule"
-sidebar_current: "docs-azurerm-resource-database-sql-virtual_network_rule"
+sidebar_current: "docs-azurerm-resource-database-sql-virtual-network-rule"
 description: |-
   Create a SQL Virtual Network Rule.
 ---


### PR DESCRIPTION
Noticed the`azurerm_sql_virtual_network` resource was missing the `azurerm_` prefix & the highlight was broken for a couple of resources