### PR TITLE
`azurerm_sql_database`: changes to `collation` force a new resource

### DIFF
--- a/azurerm/resource_arm_sql_database.go
+++ b/azurerm/resource_arm_sql_database.go
@@ -87,6 +87,7 @@ func resourceArmSqlDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"max_size_bytes": {

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `edition` - (Optional) The edition of the database to be created. Applies only if `create_mode` is `Default`. Valid values are: `Basic`, `Standard`, `Premium`, or `DataWarehouse`. Please see [Azure SQL Database Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
 
-* `collation` - (Optional) The name of the collation. Applies only if `create_mode` is `Default`.  Azure default is `SQL_LATIN1_GENERAL_CP1_CI_AS`
+* `collation` - (Optional) The name of the collation. Applies only if `create_mode` is `Default`.  Azure default is `SQL_LATIN1_GENERAL_CP1_CI_AS`. Changing this forces a new resource to be created. 
 
 * `max_size_bytes` - (Optional) The maximum size that the database can grow to. Applies only if `create_mode` is `Default`.  Please see [Azure SQL Database Service Tiers](https://azure.microsoft.com/en-gb/documentation/articles/sql-database-service-tiers/).
 


### PR DESCRIPTION
This PR builds off of https://github.com/terraform-providers/terraform-provider-azurerm/pull/969 by adding a test to confirm that the fix works

```
=== RUN   TestAccAzureRMSqlDatabase_collation
--- PASS: TestAccAzureRMSqlDatabase_collation (240.22s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	240.244s
```