### PR TITLE
Fixing Broken Acceptance Tests

### DIFF
--- a/azurerm/import_arm_express_route_circuit_authorization_test.go
+++ b/azurerm/import_arm_express_route_circuit_authorization_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAzureRMExpressRouteCircuitAuthorization_importBasic(t *testing.T) {
+func testAccAzureRMExpressRouteCircuitAuthorization_importBasic(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit_authorization.test"
 
 	ri := acctest.RandInt()

--- a/azurerm/import_arm_express_route_circuit_authorization_test.go
+++ b/azurerm/import_arm_express_route_circuit_authorization_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMExpressRouteCircuitAuthorization_importBasic(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit_authorization.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMExpressRouteCircuitAuthorization_basic(ri, testLocation())
+	config := testAccAzureRMExpressRouteCircuitAuthorization_basicConfig(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_express_route_circuit_test.go
+++ b/azurerm/import_arm_express_route_circuit_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMExpressRouteCircuit_importMetered(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMExpressRouteCircuit_basicMetered(ri, testLocation())
+	config := testAccAzureRMExpressRouteCircuit_basicMeteredConfig(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -34,7 +34,7 @@ func TestAccAzureRMExpressRouteCircuit_importUnlimited(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMExpressRouteCircuit_basicUnlimited(ri, testLocation())
+	config := testAccAzureRMExpressRouteCircuit_basicUnlimitedConfig(ri, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/import_arm_express_route_circuit_test.go
+++ b/azurerm/import_arm_express_route_circuit_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAzureRMExpressRouteCircuit_importMetered(t *testing.T) {
+func testAccAzureRMExpressRouteCircuit_importMetered(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit.test"
 
 	ri := acctest.RandInt()
@@ -30,7 +30,7 @@ func TestAccAzureRMExpressRouteCircuit_importMetered(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMExpressRouteCircuit_importUnlimited(t *testing.T) {
+func testAccAzureRMExpressRouteCircuit_importUnlimited(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit.test"
 
 	ri := acctest.RandInt()

--- a/azurerm/resource_arm_availability_set_test.go
+++ b/azurerm/resource_arm_availability_set_test.go
@@ -103,8 +103,8 @@ func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAvailabilitySetExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "platform_update_domain_count", "10"),
-					resource.TestCheckResourceAttr(resourceName, "platform_fault_domain_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "platform_update_domain_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "platform_fault_domain_count", "3"),
 				),
 			},
 		},
@@ -279,8 +279,8 @@ resource "azurerm_availability_set" "test" {
   name                         = "acctestavset-%d"
   location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
-  platform_update_domain_count = 10
-  platform_fault_domain_count  = 1
+  platform_update_domain_count = 3
+  platform_fault_domain_count  = 3
 }
 `, rInt, location, rInt)
 }
@@ -296,8 +296,8 @@ resource "azurerm_availability_set" "test" {
   name                         = "acctestavset-%d"
   location                     = "${azurerm_resource_group.test.location}"
   resource_group_name          = "${azurerm_resource_group.test.name}"
-  platform_update_domain_count = 10
-  platform_fault_domain_count  = 1
+  platform_update_domain_count = 3
+  platform_fault_domain_count  = 3
   managed                      = true
 }
 `, rInt, location, rInt)

--- a/azurerm/resource_arm_express_route_circuit_authorization_test.go
+++ b/azurerm/resource_arm_express_route_circuit_authorization_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMExpressRouteCircuitAuthorization_basic(t *testing.T) {
+func testAccAzureRMExpressRouteCircuitAuthorization_basic(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit_authorization.test"
 	ri := acctest.RandInt()
 
@@ -21,7 +21,7 @@ func TestAccAzureRMExpressRouteCircuitAuthorization_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMExpressRouteCircuitAuthorizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMExpressRouteCircuitAuthorization_basic(ri, testLocation()),
+				Config: testAccAzureRMExpressRouteCircuitAuthorization_basicConfig(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMExpressRouteCircuitAuthorizationExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "authorization_key"),
@@ -31,7 +31,7 @@ func TestAccAzureRMExpressRouteCircuitAuthorization_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMExpressRouteCircuitAuthorization_multiple(t *testing.T) {
+func testAccAzureRMExpressRouteCircuitAuthorization_multiple(t *testing.T) {
 	firstResourceName := "azurerm_express_route_circuit_authorization.test1"
 	secondResourceName := "azurerm_express_route_circuit_authorization.test2"
 	ri := acctest.RandInt()
@@ -42,7 +42,7 @@ func TestAccAzureRMExpressRouteCircuitAuthorization_multiple(t *testing.T) {
 		CheckDestroy: testCheckAzureRMExpressRouteCircuitAuthorizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMExpressRouteCircuitAuthorization_multiple(ri, testLocation()),
+				Config: testAccAzureRMExpressRouteCircuitAuthorization_multipleConfig(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMExpressRouteCircuitAuthorizationExists(firstResourceName),
 					resource.TestCheckResourceAttrSet(firstResourceName, "authorization_key"),
@@ -111,7 +111,7 @@ func testCheckAzureRMExpressRouteCircuitAuthorizationDestroy(s *terraform.State)
 	return nil
 }
 
-func testAccAzureRMExpressRouteCircuitAuthorization_basic(rInt int, location string) string {
+func testAccAzureRMExpressRouteCircuitAuthorization_basicConfig(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestrg-%d"
@@ -147,7 +147,7 @@ resource "azurerm_express_route_circuit_authorization" "test" {
 `, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMExpressRouteCircuitAuthorization_multiple(rInt int, location string) string {
+func testAccAzureRMExpressRouteCircuitAuthorization_multipleConfig(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestrg-%d"

--- a/azurerm/resource_arm_express_route_circuit_peering_test.go
+++ b/azurerm/resource_arm_express_route_circuit_peering_test.go
@@ -11,38 +11,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMExpressRouteCircuitPeering(t *testing.T) {
-	// NOTE: this is a combined test rather than separate split out tests due to
-	// Azure only being happy about provisioning one at once
-	// (which our test suite can't easily workaround)
-	testCases := map[string]map[string]func(t *testing.T){
-		"PrivatePeering": {
-			"azurePrivatePeering":  testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering,
-			"importPrivatePeering": testAccAzureRMExpressRouteCircuitPeering_importAzurePrivatePeering,
-		},
-		"PublicPeering": {
-			"azurePublicPeering":  testAccAzureRMExpressRouteCircuitPeering_azurePublicPeering,
-			"importPublicPeering": testAccAzureRMExpressRouteCircuitPeering_importAzurePublicPeering,
-		},
-		"MicrosoftPeering": {
-			"microsoftPeering":       testAccAzureRMExpressRouteCircuitPeering_microsoftPeering,
-			"importMicrosoftPeering": testAccAzureRMExpressRouteCircuitPeering_importMicrosoftPeering,
-		},
-	}
-
-	for group, m := range testCases {
-		m := m
-		t.Run(group, func(t *testing.T) {
-			for name, tc := range m {
-				tc := tc
-				t.Run(name, func(t *testing.T) {
-					tc(t)
-				})
-			}
-		})
-	}
-}
-
 func testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit_peering.test"
 	ri := acctest.RandInt()

--- a/azurerm/resource_arm_express_route_circuit_test.go
+++ b/azurerm/resource_arm_express_route_circuit_test.go
@@ -36,6 +36,14 @@ func TestAccAzureRMExpressRouteCircuit(t *testing.T) {
 		"authorization": {
 			"basic":    testAccAzureRMExpressRouteCircuitAuthorization_basic,
 			"multiple": testAccAzureRMExpressRouteCircuitAuthorization_multiple,
+			"import":   testAccAzureRMExpressRouteCircuitAuthorization_importBasic,
+		},
+		"authorizationImport": {
+			"basic": testAccAzureRMExpressRouteCircuitAuthorization_importBasic,
+		},
+		"circuitImport": {
+			"metered":   testAccAzureRMExpressRouteCircuit_importMetered,
+			"unlimited": testAccAzureRMExpressRouteCircuit_importUnlimited,
 		},
 	}
 


### PR DESCRIPTION
- Switches the ExpressRoute tests to use a combined test, to work around Azure provisioning limitations
- Fixing the Availability Set tests (to use the stricter API validation requirements)
- Switches the Template Deployment test from using the `template` provider to a local