### PR TITLE
App Service / App Service Slot / Function Apps - support for HTTPS Only

### DIFF
--- a/azurerm/data_source_app_service.go
+++ b/azurerm/data_source_app_service.go
@@ -118,6 +118,11 @@ func dataSourceArmAppService() *schema.Resource {
 				Computed: true,
 			},
 
+			"https_only": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"enabled": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -259,6 +264,7 @@ func dataSourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("enabled", props.Enabled)
+		d.Set("https_only", props.HTTPSOnly)
 		d.Set("default_site_hostname", props.DefaultHostName)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 	}

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -185,6 +185,10 @@ func resourceArmAppService() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
 			},
 
 			"enabled": {

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -181,6 +181,12 @@ func resourceArmAppService() *schema.Resource {
 				Computed: true,
 			},
 
+			"https_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -310,6 +316,7 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
+	httpsOnly := d.Get("https_only").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
 	siteConfig := expandAppServiceSiteConfig(d)
@@ -320,6 +327,7 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 		SiteProperties: &web.SiteProperties{
 			ServerFarmID: utils.String(appServicePlanId),
 			Enabled:      utils.Bool(enabled),
+			HTTPSOnly:    utils.Bool(httpsOnly),
 			SiteConfig:   &siteConfig,
 		},
 	}
@@ -501,6 +509,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("enabled", props.Enabled)
+		d.Set("https_only", props.HTTPSOnly)
 		d.Set("default_site_hostname", props.DefaultHostName)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 	}

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -190,6 +190,12 @@ func resourceArmAppServiceSlot() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"https_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -265,6 +271,7 @@ func resourceArmAppServiceSlotCreate(d *schema.ResourceData, meta interface{}) e
 	appServiceName := d.Get("app_service_name").(string)
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
+	httpsOnly := d.Get("https_only").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
 	siteConfig := expandAppServiceSiteConfig(d)
@@ -275,6 +282,7 @@ func resourceArmAppServiceSlotCreate(d *schema.ResourceData, meta interface{}) e
 		SiteProperties: &web.SiteProperties{
 			ServerFarmID: utils.String(appServicePlanId),
 			Enabled:      utils.Bool(enabled),
+			HTTPSOnly:    utils.Bool(httpsOnly),
 			SiteConfig:   &siteConfig,
 		},
 	}
@@ -426,6 +434,7 @@ func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("enabled", props.Enabled)
+		d.Set("https_only", props.HTTPSOnly)
 		d.Set("default_site_hostname", props.DefaultHostName)
 	}
 

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -194,6 +194,10 @@ func resourceArmAppServiceSlot() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
 			},
 
 			"enabled": {

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -181,6 +181,27 @@ func TestAccAzureRMAppServiceSlot_enabled(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServiceSlot_httpsOnly(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_httpsOnly(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "https_only", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppServiceSlot_localMySql(t *testing.T) {
 	resourceName := "azurerm_app_service_slot.test"
 	ri := acctest.RandInt()
@@ -863,6 +884,42 @@ resource "azurerm_app_service_slot" "test" {
   app_service_plan_id = "${azurerm_app_service_plan.test.id}"
   app_service_name    = "${azurerm_app_service.test.name}"
   enabled = false
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_httpsOnly(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+}
+
+resource "azurerm_app_service_slot" "test" {
+  name                = "acctestASSlot-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  app_service_name    = "${azurerm_app_service.test.name}"
+  https_only          = true
 }
 `, rInt, location, rInt, rInt, rInt)
 }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -152,6 +152,27 @@ func TestAccAzureRMAppService_alwaysOn(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_httpsOnly(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_httpsOnly(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "https_only", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_appSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
@@ -825,6 +846,34 @@ resource "azurerm_app_service" "test" {
   site_config {
     always_on = true
   }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_httpsOnly(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  https_only          = true
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -132,6 +132,12 @@ func resourceArmFunctionApp() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"https_only": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"site_config": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -136,6 +136,10 @@ func resourceArmFunctionApp() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+
+				// TODO: (tombuildsstuff) support Update once the API is fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/1697
+				ForceNew: true,
 			},
 
 			"site_config": {

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -45,6 +45,8 @@ output "app_service_id" {
 
 * `enabled` - Is the App Service Enabled?
 
+* `https_only` - Can the App Service only be accessed via HTTPS?
+
 * `site_config` - A `site_config` object as defined below.
 
 * `tags` - A mapping of tags to assign to the resource.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the App Service Enabled? Changing this forces a new resource to be created.
 
-* `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`.
+* `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`. Changing this forces a new resource to be created.
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -125,6 +125,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the App Service Enabled? Changing this forces a new resource to be created.
 
+* `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`.
+
 * `site_config` - (Optional) A `site_config` object as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -162,6 +162,8 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the App Service Slot Enabled? Changing this forces a new resource to be created.
 
+* `https_only` - (Optional) Can the App Service Slot only be accessed via HTTPS? Defaults to `false`.
+
 * `site_config` - (Optional) A `site_config` object as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -162,7 +162,7 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the App Service Slot Enabled? Changing this forces a new resource to be created.
 
-* `https_only` - (Optional) Can the App Service Slot only be accessed via HTTPS? Defaults to `false`.
+* `https_only` - (Optional) Can the App Service Slot only be accessed via HTTPS? Defaults to `false`. Changing this forces a new resource to be created.
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -105,7 +105,7 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Is the Function App enabled? Changing this forces a new resource to be created.
 
-* `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
+* `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`. Changing this forces a new resource to be created.
 
 * `version` - (Optional) The runtime version associated with the Function App. Possible values are `~1` and `beta`. Defaults to `~1`.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -101,9 +101,11 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) An `connection_string` block as defined below.
 
+* `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance? Changing this forces a new resource to be created.
+
 * `enabled` - (Optional) Is the Function App enabled? Changing this forces a new resource to be created.
 
-* `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance? Changing this forces a new resource to be created.
+* `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
 * `version` - (Optional) The runtime version associated with the Function App. Possible values are `~1` and `beta`. Defaults to `~1`.
 


### PR DESCRIPTION
Adds support for `https_only` to App Service, App Service Slot, Function App resources and the App Service Data Source

Fixes #756