### PR TITLE
Add additional helper instruction for locations

### DIFF
--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
     Azure subscription.
 
 * `location` - (Required) The location where the resource group should be created.
-    For a list of all Azure locations, please consult [this link](http://azure.microsoft.com/en-us/regions/) or run `az account list-locations`.
+    For a list of all Azure locations, please consult [this link](http://azure.microsoft.com/en-us/regions/) or run `az account list-locations --output table`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
     Azure subscription.
 
 * `location` - (Required) The location where the resource group should be created.
-    For a list of all Azure locations, please consult [this link](http://azure.microsoft.com/en-us/regions/).
+    For a list of all Azure locations, please consult [this link](http://azure.microsoft.com/en-us/regions/) or run `az account list-locations`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
The website link doesn't offer the 'system names' of locations, which is what actually needs entering in the location field. The Azure CLI does offer these, however, in a much quicker-to-digest format.