### PR TITLE
Continuing to fix test failures

### DIFF
--- a/azurerm/import_arm_express_route_circuit_peering_test.go
+++ b/azurerm/import_arm_express_route_circuit_peering_test.go
@@ -30,29 +30,6 @@ func testAccAzureRMExpressRouteCircuitPeering_importAzurePrivatePeering(t *testi
 	})
 }
 
-func testAccAzureRMExpressRouteCircuitPeering_importAzurePublicPeering(t *testing.T) {
-	rInt := acctest.RandInt()
-	location := testLocation()
-	resourceName := "azurerm_express_route_circuit_peering.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMExpressRouteCircuitPeeringDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMExpressRouteCircuitPeering_publicPeering(rInt, location),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"shared_key"},
-			},
-		},
-	})
-}
-
 func testAccAzureRMExpressRouteCircuitPeering_importMicrosoftPeering(t *testing.T) {
 	rInt := acctest.RandInt()
 	location := testLocation()

--- a/azurerm/resource_arm_express_route_circuit_peering_test.go
+++ b/azurerm/resource_arm_express_route_circuit_peering_test.go
@@ -33,28 +33,6 @@ func testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering(t *testing.T) 
 	})
 }
 
-func testAccAzureRMExpressRouteCircuitPeering_azurePublicPeering(t *testing.T) {
-	resourceName := "azurerm_express_route_circuit_peering.test"
-	ri := acctest.RandInt()
-	location := testLocation()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMExpressRouteCircuitPeeringDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMExpressRouteCircuitPeering_publicPeering(ri, location),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMExpressRouteCircuitPeeringExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "peering_type", "AzurePublicPeering"),
-					resource.TestCheckResourceAttr(resourceName, "microsoft_peering_config.#", "0"),
-				),
-			},
-		},
-	})
-}
-
 func testAccAzureRMExpressRouteCircuitPeering_microsoftPeering(t *testing.T) {
 	resourceName := "azurerm_express_route_circuit_peering.test"
 	ri := acctest.RandInt()
@@ -169,45 +147,6 @@ resource "azurerm_express_route_circuit_peering" "test" {
   primary_peer_address_prefix   = "192.168.1.0/30"
   secondary_peer_address_prefix = "192.168.2.0/30"
   vlan_id                       = 100
-}
-`, rInt, location, rInt)
-}
-
-func testAccAzureRMExpressRouteCircuitPeering_publicPeering(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestrg-%d"
-  location = "%s"
-}
-
-resource "azurerm_express_route_circuit" "test" {
-  name                  = "acctest-erc-%d"
-  location              = "${azurerm_resource_group.test.location}"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
-  service_provider_name = "Equinix"
-  peering_location      = "Silicon Valley"
-  bandwidth_in_mbps     = 50
-
-  sku {
-    tier   = "Standard"
-    family = "MeteredData"
-  }
-
-  tags {
-    Environment = "production"
-    Purpose     = "AcceptanceTests"
-  }
-}
-
-resource "azurerm_express_route_circuit_peering" "test" {
-  peering_type                  = "AzurePublicPeering"
-  express_route_circuit_name    = "${azurerm_express_route_circuit.test.name}"
-  resource_group_name           = "${azurerm_resource_group.test.name}"
-  shared_key                    = "ABCdefGHIJklm@nOPqrsTU!!"
-  peer_asn                      = 100
-  primary_peer_address_prefix   = "123.0.0.0/30"
-  secondary_peer_address_prefix = "123.0.0.4/30"
-  vlan_id                       = 300
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_express_route_circuit_test.go
+++ b/azurerm/resource_arm_express_route_circuit_test.go
@@ -25,10 +25,6 @@ func TestAccAzureRMExpressRouteCircuit(t *testing.T) {
 			"azurePrivatePeering":  testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering,
 			"importPrivatePeering": testAccAzureRMExpressRouteCircuitPeering_importAzurePrivatePeering,
 		},
-		"PublicPeering": {
-			"azurePublicPeering":  testAccAzureRMExpressRouteCircuitPeering_azurePublicPeering,
-			"importPublicPeering": testAccAzureRMExpressRouteCircuitPeering_importAzurePublicPeering,
-		},
 		"MicrosoftPeering": {
 			"microsoftPeering":       testAccAzureRMExpressRouteCircuitPeering_microsoftPeering,
 			"importMicrosoftPeering": testAccAzureRMExpressRouteCircuitPeering_importMicrosoftPeering,

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -198,6 +198,7 @@ func resourceArmFunctionAppCreate(d *schema.ResourceData, meta interface{}) erro
 	appServicePlanID := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	clientAffinityEnabled := d.Get("client_affinity_enabled").(bool)
+	httpsOnly := d.Get("https_only").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 	basicAppSettings := getBasicFunctionAppAppSettings(d)
 	siteConfig := expandFunctionAppSiteConfig(d)
@@ -211,6 +212,7 @@ func resourceArmFunctionAppCreate(d *schema.ResourceData, meta interface{}) erro
 			ServerFarmID:          utils.String(appServicePlanID),
 			Enabled:               utils.Bool(enabled),
 			ClientAffinityEnabled: utils.Bool(clientAffinityEnabled),
+			HTTPSOnly:             utils.Bool(httpsOnly),
 			SiteConfig:            &siteConfig,
 		},
 	}

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -331,6 +331,7 @@ func resourceArmFunctionAppRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("app_service_plan_id", props.ServerFarmID)
 		d.Set("enabled", props.Enabled)
 		d.Set("default_hostname", props.DefaultHostName)
+		d.Set("https_only", props.HTTPSOnly)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 	}


### PR DESCRIPTION
- Ensuring the `https_only` field is set for `azurerm_function_app`
- Removing the `AzurePublicPeering` tests since this is no longer available for new connections