### PR TITLE
`azurerm_key_vault_certificate` - exposing the certificate's secret id

### DIFF
--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -1,9 +1,13 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
+	"log"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -222,6 +226,11 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 				Computed: true,
 			},
 
+			"secret_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -260,6 +269,18 @@ func resourceArmKeyVaultCertificateCreate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return err
 		}
+
+		log.Printf("[DEBUG] Waiting for Key Vault Certificate %q in Vault %q to be provisioned", name, keyVaultBaseUrl)
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"Provisioning"},
+			Target:     []string{"Ready"},
+			Refresh:    keyVaultCertificateCreationRefreshFunc(ctx, client, keyVaultBaseUrl, name),
+			Timeout:    60 * time.Minute,
+			MinTimeout: 15 * time.Second,
+		}
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf("Error waiting for Certificate %q in Vault %q to become available: %s", name, keyVaultBaseUrl, err)
+		}
 	}
 
 	resp, err := client.GetCertificate(ctx, keyVaultBaseUrl, name, "")
@@ -270,6 +291,21 @@ func resourceArmKeyVaultCertificateCreate(d *schema.ResourceData, meta interface
 	d.SetId(*resp.ID)
 
 	return resourceArmKeyVaultCertificateRead(d, meta)
+}
+
+func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client keyvault.BaseClient, keyVaultBaseUrl string, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.GetCertificate(ctx, keyVaultBaseUrl, name, "")
+		if err != nil {
+			return nil, "", fmt.Errorf("Error issuing read request in keyVaultCertificateCreationRefreshFunc for Certificate %q in Vault %q: %s", name, keyVaultBaseUrl, err)
+		}
+
+		if res.Sid == nil || *res.Sid == "" {
+			return nil, "Provisioning", nil
+		}
+
+		return res, "Ready", nil
+	}
 }
 
 func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}) error {
@@ -302,6 +338,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 
 	// Computed
 	d.Set("version", id.Version)
+	d.Set("secret_id", cert.Sid)
 	flattenAndSetTags(d, cert.Tags)
 
 	return nil

--- a/azurerm/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/resource_arm_key_vault_certificate_test.go
@@ -44,6 +44,7 @@ func TestAccAzureRMKeyVaultCertificate_basicGenerate(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKeyVaultCertificateExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "secret_id"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -361,6 +361,230 @@ func TestAccAzureRMVirtualMachine_enableAnWithVM(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachine_winRMCerts(t *testing.T) {
+	var vm compute.VirtualMachine
+	resourceName := "azurerm_virtual_machine.test"
+	rString := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachine_winRMCerts(rString, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists(resourceName, &vm),
+				),
+			},
+		},
+	})
+}
+
+func testAccAzureRMVirtualMachine_winRMCerts(rString string, location string) string {
+	return fmt.Sprintf(`
+variable "prefix" {
+  default = "acctest%s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "${var.prefix}-resources"
+  location = "%s"
+
+  tags {
+    source = "TestAccAzureRMVirtualMachine_winRMCerts"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "${var.prefix}-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "${var.prefix}-nic"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "${var.prefix}-keyvault"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+
+  sku {
+    name = "standard"
+  }
+
+  tenant_id = "${data.azurerm_client_config.current.tenant_id}"
+
+  access_policy {
+    tenant_id = "${data.azurerm_client_config.current.tenant_id}"
+    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+
+    key_permissions = [
+      "backup",
+      "create",
+      "decrypt",
+      "delete",
+      "encrypt",
+      "get",
+      "import",
+      "list",
+      "purge",
+      "recover",
+      "restore",
+      "sign",
+      "unwrapKey",
+      "update",
+      "verify",
+      "wrapKey",
+    ]
+
+    secret_permissions = [
+      "backup",
+      "delete",
+      "get",
+      "list",
+      "purge",
+      "recover",
+      "restore",
+      "set",
+    ]
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "deleteissuers",
+      "get",
+      "getissuers",
+      "import",
+      "list",
+      "listissuers",
+      "managecontacts",
+      "manageissuers",
+      "setissuers",
+      "update",
+    ]
+  }
+
+  enabled_for_deployment          = true
+  enabled_for_template_deployment = true
+}
+
+resource "azurerm_key_vault_certificate" "test" {
+  name      = "${var.prefix}-cert"
+  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=${azurerm_network_interface.test.private_ip_address}"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_virtual_machine" "test" {
+  name                          = "${var.prefix}-vm"
+  location                      = "${azurerm_resource_group.test.location}"
+  resource_group_name           = "${azurerm_resource_group.test.name}"
+  network_interface_ids         = ["${azurerm_network_interface.test.id}"]
+  vm_size                       = "Standard_F2"
+  delete_os_disk_on_termination = true
+
+  storage_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "${var.prefix}-osdisk"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "${var.prefix}-vm"
+    admin_username = "mradministrator"
+    admin_password = "Th15IsD0g1234!"
+  }
+
+  os_profile_windows_config {
+    provision_vm_agent = true
+
+    winrm {
+      protocol        = "https"
+      certificate_url = "${azurerm_key_vault_certificate.test.secret_id}"
+    }
+  }
+
+  os_profile_secrets {
+    source_vault_id = "${azurerm_key_vault.test.id}"
+
+    vault_certificates {
+      certificate_url   = "${azurerm_key_vault_certificate.test.secret_id}"
+      certificate_store = "My"
+    }
+  }
+}
+
+`, rString, location)
+}
+
 func testAccAzureRMVirtualMachine_withManagedServiceIdentity(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -249,6 +249,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Key Vault Certificate ID.
+* `secret_id` - The ID of the associated Key Vault Secret.
 * `version` - The current version of the Key Vault Certificate.
 
 


### PR DESCRIPTION
KeyVault Certificates get a matching Secret which has a different URI needed when provisioning VM's. This PR exposes that and adds an end-to-end test case for this scenario. Fixes #1067

```
$ acctests azurerm TestAccAzureRMVirtualMachine_winRMCerts
=== RUN   TestAccAzureRMVirtualMachine_winRMCerts
--- PASS: TestAccAzureRMVirtualMachine_winRMCerts (599.44s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	599.469s
```