### PR TITLE
Fixing the spacing on the managed disk docs

### DIFF
--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -122,11 +122,15 @@ For more information on managed disks, such as sizing options and pricing, pleas
 * `key_encryption_key` - (Optional) A `key_encryption_key` block as defined below.
 
 `disk_encryption_key` supports:
+
 * `secret_url` - (Required) The URL to the Key Vault Secret used as the Disk Encryption Key. This can be found as `id` on the `azurerm_key_vault_secret` resource.
+
 * `source_vault_id` - (Required) The URL of the Key Vault. This can be found as `vault_uri` on the `azurerm_key_vault` resource.
 
 `key_encryption_key` supports:
+
 * `key_url` - (Required) The URL to the Key Vault Key used as the Key Encryption Key. This can be found as `id` on the `azurerm_key_vault_secret` resource.
+
 * `source_vault_id` - (Required) The URL of the Key Vault. This can be found as `vault_uri` on the `azurerm_key_vault` resource.
 
 


### PR DESCRIPTION
Browsing through the docs I noticed this wasn't rendering correctly (as shown below) - this PR fixes that:

<img width="893" alt="screen shot 2018-04-10 at 17 58 10" src="https://user-images.githubusercontent.com/666005/38571621-eb34801e-3ce8-11e8-9cdc-89a99d58addc.png">
