### PR TITLE
Docs: adding a section on configuring auth to the Service Principal auth page

### DIFF
--- a/website/docs/authenticating_via_service_principal.html.markdown
+++ b/website/docs/authenticating_via_service_principal.html.markdown
@@ -143,3 +143,9 @@ Secondly, search for and select the name of the Application created in Azure Act
 ## Creating a Service Principal through the Legacy CLI's
 
 It's also possible to create credentials via [the legacy cross-platform CLI](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal-cli/) and the [legacy PowerShell Cmdlets](https://azure.microsoft.com/en-us/documentation/articles/resource-group-authenticate-service-principal/) - however we would highly recommend using the Azure CLI above.
+
+## Configuring your Service Principal
+
+Service Principals can be configured in Terraform in one of two ways, either as Environment Variables or in the Provider block. Please see [this section](index.html#argument-reference) for an example of which fields are available and can be specified either through Environment Variables - or in the Provider Block.
+
+~> **NOTE:** Authenticating using a Service Principal via the Azure CLI is unsupported. Service Principal credentials either need to be specified either as Environment Variables or in the Provider Block.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -102,4 +102,14 @@ The following arguments are supported:
 
 ## Testing
 
-Credentials must be provided via the `ARM_SUBSCRIPTION_ID`, `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID` and `ARM_TEST_LOCATION` environment variables in order to run acceptance tests.
+The following Environment Variables must be set to run the acceptance tests:
+
+~> **NOTE:** The Acceptance Tests require the use of a Service Principal - authenticating via either the Azure CLI or MSI is not supported.
+
+* `ARM_SUBSCRIPTION_ID` - The ID of the Azure Subscription in which to run the Acceptance Tests.
+* `ARM_CLIENT_ID` - The Client Secret of the Service Principal.
+* `ARM_CLIENT_SECRET` - The Client Secret associated with the Service Principal.
+* `ARM_TENANT_ID` - The Tenant ID to use.
+* `ARM_ENVIRONMENT` - The Azure Cloud Environment to use, such as `public`, `german` etc. Defaults to `public`.
+* `ARM_TEST_LOCATION` - The primary Azure Region to provision resources in for the Acceptance Tests.
+* `ARM_TEST_LOCATION_ALT` - The secondary Azure Region to provision resources in for the Acceptance Tests. This needs to be a different region to `ARM_TEST_LOCATION`.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -107,7 +107,7 @@ The following Environment Variables must be set to run the acceptance tests:
 ~> **NOTE:** The Acceptance Tests require the use of a Service Principal - authenticating via either the Azure CLI or MSI is not supported.
 
 * `ARM_SUBSCRIPTION_ID` - The ID of the Azure Subscription in which to run the Acceptance Tests.
-* `ARM_CLIENT_ID` - The Client Secret of the Service Principal.
+* `ARM_CLIENT_ID` - The Client ID of the Service Principal.
 * `ARM_CLIENT_SECRET` - The Client Secret associated with the Service Principal.
 * `ARM_TENANT_ID` - The Tenant ID to use.
 * `ARM_ENVIRONMENT` - The Azure Cloud Environment to use, such as `public`, `german` etc. Defaults to `public`.


### PR DESCRIPTION
Clarifying how to use a Service Principal as part of #474