### PR TITLE
App Service / Function Apps: support for updating

### DIFF
--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -185,20 +185,12 @@ func resourceArmAppService() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-
-				// TODO: (tombuildsstuff) support Update once the API is fixed:
-				// https://github.com/Azure/azure-rest-api-specs/issues/1697
-				ForceNew: true,
 			},
 
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-
-				// TODO: (tombuildsstuff) support Update once the API is fixed:
-				// https://github.com/Azure/azure-rest-api-specs/issues/1697
-				ForceNew: true,
 			},
 
 			"app_settings": {
@@ -243,9 +235,7 @@ func resourceArmAppService() *schema.Resource {
 				},
 			},
 
-			// TODO: (tombuildsstuff) support Update once the API is fixed:
-			// https://github.com/Azure/azure-rest-api-specs/issues/1697
-			"tags": tagsForceNewSchema(),
+			"tags": tagsSchema(),
 
 			"site_credential": {
 				Type:     schema.TypeList,

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -366,6 +366,34 @@ func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error
 	resGroup := id.ResourceGroup
 	name := id.Path["sites"]
 
+	location := azureRMNormalizeLocation(d.Get("location").(string))
+	appServicePlanId := d.Get("app_service_plan_id").(string)
+	enabled := d.Get("enabled").(bool)
+	httpsOnly := d.Get("https_only").(bool)
+	tags := d.Get("tags").(map[string]interface{})
+
+	siteConfig := expandAppServiceSiteConfig(d)
+	siteEnvelope := web.Site{
+		Location: &location,
+		Tags:     expandTags(tags),
+		SiteProperties: &web.SiteProperties{
+			ServerFarmID: utils.String(appServicePlanId),
+			Enabled:      utils.Bool(enabled),
+			HTTPSOnly:    utils.Bool(httpsOnly),
+			SiteConfig:   &siteConfig,
+		},
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resGroup, name, siteEnvelope)
+	if err != nil {
+		return err
+	}
+
+	err = future.WaitForCompletion(ctx, client.Client)
+	if err != nil {
+		return err
+	}
+
 	if d.HasChange("site_config") {
 		// update the main configuration
 		siteConfig := expandAppServiceSiteConfig(d)

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -272,16 +272,14 @@ func resourceArmFunctionAppUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if d.HasChange("app_settings") || d.HasChange("version") {
-		appSettings := expandFunctionAppAppSettings(d)
-		settings := web.StringDictionary{
-			Properties: appSettings,
-		}
+	appSettings := expandFunctionAppAppSettings(d)
+	settings := web.StringDictionary{
+		Properties: appSettings,
+	}
 
-		_, err := client.UpdateApplicationSettings(ctx, resGroup, name, settings)
-		if err != nil {
-			return fmt.Errorf("Error updating Application Settings for Function App %q: %+v", name, err)
-		}
+	_, err = client.UpdateApplicationSettings(ctx, resGroup, name, settings)
+	if err != nil {
+		return fmt.Errorf("Error updating Application Settings for Function App %q: %+v", name, err)
 	}
 
 	if d.HasChange("site_config") {

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -44,10 +44,6 @@ func resourceArmFunctionApp() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-
-				// TODO: (tombuildsstuff) support Update once the API is fixed:
-				// https://github.com/Azure/azure-rest-api-specs/issues/1697
-				ForceNew: true,
 			},
 
 			"version": {
@@ -108,9 +104,7 @@ func resourceArmFunctionApp() *schema.Resource {
 				},
 			},
 
-			// TODO: (tombuildsstuff) support Update once the API is fixed:
-			// https://github.com/Azure/azure-rest-api-specs/issues/1697
-			"tags": tagsForceNewSchema(),
+			"tags": tagsSchema(),
 
 			"default_hostname": {
 				Type:     schema.TypeString,
@@ -126,20 +120,12 @@ func resourceArmFunctionApp() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
-
-				// TODO: (tombuildsstuff) support Update once the API is fixed:
-				// https://github.com/Azure/azure-rest-api-specs/issues/1697
-				ForceNew: true,
 			},
 
 			"https_only": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-
-				// TODO: (tombuildsstuff) support Update once the API is fixed:
-				// https://github.com/Azure/azure-rest-api-specs/issues/1697
-				ForceNew: true,
 			},
 
 			"site_config": {

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -56,6 +56,39 @@ func TestAccAzureRMFunctionApp_tags(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFunctionApp_tagsUpdate(t *testing.T) {
+	resourceName := "azurerm_function_app.test"
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := testAccAzureRMFunctionApp_tags(ri, rs, testLocation())
+	config := testAccAzureRMFunctionApp_tagsUpdated(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFunctionAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
+					resource.TestCheckResourceAttr(resourceName, "tags.hello", "Berlin"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMFunctionApp_appSettings(t *testing.T) {
 	resourceName := "azurerm_function_app.test"
 	ri := acctest.RandInt()
@@ -423,6 +456,45 @@ resource "azurerm_function_app" "test" {
 	storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
 	tags {
 		environment = "production"
+	}
+}
+`, rInt, location, storage)
+}
+
+func testAccAzureRMFunctionApp_tagsUpdated(rInt int, storage string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+	name     = "acctestRG-%[1]d"
+	location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+	name                     = "acctestsa%[3]s"
+	resource_group_name      = "${azurerm_resource_group.test.name}"
+	location                 = "${azurerm_resource_group.test.location}"
+	account_tier             = "Standard"
+	account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+	name                = "acctestASP-%[1]d"
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+	sku {
+		tier = "Standard"
+		size = "S1"
+	}
+}
+
+resource "azurerm_function_app" "test" {
+	name                      = "acctest-%[1]d-func"
+	location                  = "${azurerm_resource_group.test.location}"
+	resource_group_name       = "${azurerm_resource_group.test.name}"
+	app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+	storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+	tags {
+		environment = "production"
+		hello       = "Berlin"
 	}
 }
 `, rInt, location, storage)

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -61,7 +61,7 @@ func TestAccAzureRMFunctionApp_tagsUpdate(t *testing.T) {
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
 	config := testAccAzureRMFunctionApp_tags(ri, rs, testLocation())
-	config := testAccAzureRMFunctionApp_tagsUpdated(ri, rs, testLocation())
+	updatedConfig := testAccAzureRMFunctionApp_tagsUpdated(ri, rs, testLocation())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -121,15 +121,15 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) An `connection_string` block as defined below.
 
-* `client_affinity_enabled` - (Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance? Changing this forces a new resource to be created.
+* `client_affinity_enabled` - (Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance?
 
 * `enabled` - (Optional) Is the App Service Enabled? Changing this forces a new resource to be created.
 
-* `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`. Changing this forces a new resource to be created.
+* `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`.
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -101,17 +101,17 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) An `connection_string` block as defined below.
 
-* `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance? Changing this forces a new resource to be created.
+* `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance?
 
-* `enabled` - (Optional) Is the Function App enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Function App enabled?
 
-* `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`. Changing this forces a new resource to be created.
+* `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
 * `version` - (Optional) The runtime version associated with the Function App. Possible values are `~1` and `beta`. Defaults to `~1`.
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 


### PR DESCRIPTION
As part of SDKv15 it appears that Update support is now working; as such I've removed the `ForceNew` from the App Service / Function App resources.

We can verify this works as the update tests fail prior to the Update method being implemented:

```
$ acctests azurerm TestAccAzureRMAppService_tagsUpdate
=== RUN   TestAccAzureRMAppService_tagsUpdate
--- FAIL: TestAccAzureRMAppService_tagsUpdate (109.41s)
	testing.go:513: Step 1 error: Check failed: Check 2/4 error: azurerm_app_service.test: Attribute 'tags.%' expected "2", got "1"
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	109.444s
```

which subsequently pass:

```
$ acctests azurerm TestAccAzureRMAppService_tagsUpdate
=== RUN   TestAccAzureRMAppService_tagsUpdate
--- PASS: TestAccAzureRMAppService_tagsUpdate (144.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	144.156s
```