### PR TITLE
azurerm_virtual_machine: make the `vm_size` property case insensitive

### DIFF
--- a/azurerm/data_source_snapshot.go
+++ b/azurerm/data_source_snapshot.go
@@ -14,10 +14,8 @@ func dataSourceArmSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
 
 			// Computed
 			"os_type": {

--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -25,11 +25,7 @@ func resourceArmContainerGroup() *schema.Resource {
 
 			"location": locationSchema(),
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+			"resource_group_name": resourceGroupNameSchema(),
 
 			"ip_address_type": {
 				Type:             schema.TypeString,

--- a/azurerm/resource_arm_container_service.go
+++ b/azurerm/resource_arm_container_service.go
@@ -126,8 +126,9 @@ func resourceArmContainerService() *schema.Resource {
 						},
 
 						"vm_size": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 					},
 				},

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -111,9 +111,10 @@ func resourceArmKubernetesCluster() *schema.Resource {
 						},
 
 						"vm_size": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							ForceNew:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 
 						"os_disk_size_gb": {

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -107,8 +107,9 @@ func resourceArmVirtualMachine() *schema.Resource {
 			},
 
 			"vm_size": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"storage_image_reference": {

--- a/azurerm/resource_arm_virtual_network_gateway_connection.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection.go
@@ -28,11 +28,7 @@ func resourceArmVirtualNetworkGatewayConnection() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+			"resource_group_name": resourceGroupNameSchema(),
 
 			"location": locationSchema(),
 


### PR DESCRIPTION
Closes #1073.

Also switches some `resource_group` fields to use the shared schema function.