### PR TITLE
Minor cleanup: validators & provider.go

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -385,12 +385,6 @@ func registerAzureResourceProvidersWithSubscription(ctx context.Context, provide
 // armMutexKV is the instance of MutexKV for ARM resources
 var armMutexKV = mutexkv.NewMutexKV()
 
-// Resource group names can be capitalised, but we store them in lowercase.
-// Use a custom diff function to avoid creation of new resources.
-func resourceAzurermResourceGroupNameDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	return strings.ToLower(old) == strings.ToLower(new)
-}
-
 // ignoreCaseDiffSuppressFunc is a DiffSuppressFunc from helper/schema that is
 // used to ignore any case-changes in a return value.
 func ignoreCaseDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {

--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -36,7 +36,7 @@ func resourceArmCosmosDBAccount() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringMatch(
 					regexp.MustCompile("^[-a-z0-9]{3,50}$"),
-					"Cosmos DB Account Name name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+					"Cosmos DB Account name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
 				),
 			},
 

--- a/azurerm/resource_arm_network_security_group.go
+++ b/azurerm/resource_arm_network_security_group.go
@@ -47,7 +47,7 @@ func resourceArmNetworkSecurityGroup() *schema.Resource {
 						"description": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validateStringLength(140),
+							ValidateFunc: validation.StringLenBetween(0, 140),
 						},
 
 						"protocol": {

--- a/azurerm/resource_arm_network_security_rule.go
+++ b/azurerm/resource_arm_network_security_rule.go
@@ -37,7 +37,7 @@ func resourceArmNetworkSecurityRule() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validateStringLength(140),
+				ValidateFunc: validation.StringLenBetween(0, 140),
 			},
 
 			"protocol": {

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"regexp"
 )
 
 func resourceArmSqlServer() *schema.Resource {
@@ -23,10 +24,13 @@ func resourceArmSqlServer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validateDBAccountName,
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[-a-z0-9]{3,50}$"),
+					"SQL server name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+				),
 			},
 
 			"location": locationSchema(),

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -3,13 +3,13 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/services/sql/mgmt/2015-05-01-preview/sql"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-	"regexp"
 )
 
 func resourceArmSqlServer() *schema.Resource {

--- a/azurerm/resource_group_name.go
+++ b/azurerm/resource_group_name.go
@@ -52,3 +52,9 @@ func validateArmResourceGroupName(v interface{}, k string) (ws []string, es []er
 
 	return
 }
+
+// Resource group names can be capitalised, but we store them in lowercase.
+// Use a custom diff function to avoid creation of new resources.
+func resourceAzurermResourceGroupNameDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return strings.ToLower(old) == strings.ToLower(new)
+}

--- a/azurerm/validators.go
+++ b/azurerm/validators.go
@@ -48,22 +48,6 @@ func validateUUID(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validateDBAccountName(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-
-	r, _ := regexp.Compile("^[a-z0-9\\-]+$")
-	if !r.MatchString(value) {
-		errors = append(errors, fmt.Errorf("Account Name can only contain lower-case characters, numbers and the `-` character."))
-	}
-
-	length := len(value)
-	if length > 50 || 3 > length {
-		errors = append(errors, fmt.Errorf("Account Name can only be between 3 and 50 characters."))
-	}
-
-	return
-}
-
 func evaluateSchemaValidateFunc(i interface{}, k string, validateFunc schema.SchemaValidateFunc) (bool, error) {
 	_, es := validateFunc(i, k)
 
@@ -72,17 +56,6 @@ func evaluateSchemaValidateFunc(i interface{}, k string, validateFunc schema.Sch
 	}
 
 	return true, nil
-}
-
-func validateStringLength(maxLength int) schema.SchemaValidateFunc {
-	return func(v interface{}, k string) (ws []string, errors []error) {
-		value := v.(string)
-		if len(value) > maxLength {
-			errors = append(errors, fmt.Errorf(
-				"The %q can be no longer than %d chars", k, maxLength))
-		}
-		return
-	}
 }
 
 func validateIso8601Duration() schema.SchemaValidateFunc {

--- a/azurerm/validators_test.go
+++ b/azurerm/validators_test.go
@@ -90,47 +90,6 @@ func TestValidateIntInSlice(t *testing.T) {
 
 }
 
-func TestDBAccountName_validation(t *testing.T) {
-	str := acctest.RandString(50)
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "ab",
-			ErrCount: 1,
-		},
-		{
-			Value:    "abc",
-			ErrCount: 0,
-		},
-		{
-			Value:    "cosmosDBAccount1",
-			ErrCount: 1,
-		},
-		{
-			Value:    "hello-world",
-			ErrCount: 0,
-		},
-		{
-			Value:    str,
-			ErrCount: 0,
-		},
-		{
-			Value:    str + "a",
-			ErrCount: 1,
-		},
-	}
-
-	for _, tc := range cases {
-		_, errors := validateDBAccountName(tc.Value, "azurerm_cosmosdb_account")
-
-		if len(errors) != tc.ErrCount {
-			t.Fatalf("Expected the AzureRM CosmosDB Name to trigger a validation error for '%s'", tc.Value)
-		}
-	}
-}
-
 func TestValidateIso8601Duration(t *testing.T) {
 	cases := []struct {
 		Value  string

--- a/azurerm/validators_test.go
+++ b/azurerm/validators_test.go
@@ -2,8 +2,6 @@ package azurerm
 
 import (
 	"testing"
-
-	"github.com/hashicorp/terraform/helper/acctest"
 )
 
 func TestValidateRFC3339Date(t *testing.T) {


### PR DESCRIPTION
- replaced `validateStringLength()` with existing terraform validation function 
- replaced the sole use of `validateDBAccountName()` by `azurerm_sql_server` with inline regex
- azurerm_cosmosdb_account: fixed small log message typo
- moved `resourceAzurermResourceGroupNameDiffSuppress()` from `provider.go` to it's only use in `resource_group_name.go`