### PR TITLE
Adding in a reference for the older "App" App Service Plans

### DIFF
--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -39,6 +39,9 @@ func resourceArmAppServicePlan() *schema.Resource {
 				Default:  "Windows",
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
+					// @tombuildsstuff: I believe `app` is the older representation of `Windows`
+					// thus we need to support it to be able to import resources without recreating them.
+					"App",
 					"FunctionApp",
 					"Linux",
 					"Windows",

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows`, `Linux` and `FunctionApp` (for a Consumption Plan). Defaults to `Windows`. Changing this forces a new resource to be created.
+* `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows` (also available as `App`), `Linux` and `FunctionApp` (for a Consumption Plan). Defaults to `Windows`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** When creating a `Linux` App Service Plan, the `reserved` field must be set to `true`.
 


### PR DESCRIPTION
From my understanding the App Service Kind `app` is the older alias for creating a Windows App Service Plan. This is available in [the Swagger example](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/web/resource-manager/Microsoft.Web/stable/2018-02-01/examples/CreateOrUpdateAppServicePlan.json#L11), the [Azure API Docs](https://docs.microsoft.com/en-us/rest/api/appservice/AppServicePlans/CreateOrUpdate) [which actually come from the Swagger] and are confirmed in https://github.com/terraform-providers/terraform-provider-azurerm/issues/1148

This PR adds support for this alias which fixes #1148