### PR TITLE
`r/kubernetes_cluster`: Only setting the `VnetSubnetID` when it's != ""

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -441,18 +441,21 @@ func expandAzureRmKubernetesClusterAgentProfiles(d *schema.ResourceData) []conta
 	dnsPrefix := config["dns_prefix"].(string)
 	vmSize := config["vm_size"].(string)
 	osDiskSizeGB := int32(config["os_disk_size_gb"].(int))
-	vnetSubnetID := config["vnet_subnet_id"].(string)
 	osType := config["os_type"].(string)
 
 	profile := containerservice.AgentPoolProfile{
-		Name:           &name,
-		Count:          &count,
+		Name:           utils.String(name),
+		Count:          utils.Int32(count),
 		VMSize:         containerservice.VMSizeTypes(vmSize),
-		DNSPrefix:      &dnsPrefix,
-		OsDiskSizeGB:   &osDiskSizeGB,
+		DNSPrefix:      utils.String(dnsPrefix),
+		OsDiskSizeGB:   utils.Int32(osDiskSizeGB),
 		StorageProfile: containerservice.ManagedDisks,
-		VnetSubnetID:   &vnetSubnetID,
 		OsType:         containerservice.OSType(osType),
+	}
+
+	vnetSubnetID := config["vnet_subnet_id"].(string)
+	if vnetSubnetID != "" {
+		profile.VnetSubnetID = utils.String(vnetSubnetID)
 	}
 
 	profiles = append(profiles, profile)


### PR DESCRIPTION
There was a breaking change in the Kubernetes API released recently which means the API will fail when submitting an empty string for a Subnet ID. This PR fixes this failing test, which started this morning:

Fixes:

```
------- Stdout: -------
=== RUN   TestAccAzureRMKubernetesCluster_basic
--- FAIL: TestAccAzureRMKubernetesCluster_basic (55.13s)
    testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:

        * azurerm_kubernetes_cluster.test: 1 error(s) occurred:

        * azurerm_kubernetes_cluster.test: containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="LinkedInvalidPropertyId" Message="Property id '' at path 'properties.agentPoolProfiles[0].vnetSubnetID' is invalid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}' or '/providers/{resourceProviderNamespace}/'."
FAIL
```

Passing test:

```
$ acctests azurerm TestAccAzureRMKubernetesCluster_basic
=== RUN   TestAccAzureRMKubernetesCluster_basic
--- PASS: TestAccAzureRMKubernetesCluster_basic (1713.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1713.661s
```