### PR TITLE
r/keyvault: increasing the availability checks

### DIFF
--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -238,8 +238,9 @@ func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 					Target:                    []string{"available"},
 					Refresh:                   keyVaultRefreshFunc(*vault),
 					Timeout:                   30 * time.Minute,
+					Delay:                     30 * time.Second,
 					PollInterval:              10 * time.Second,
-					ContinuousTargetOccurence: 5,
+					ContinuousTargetOccurence: 10,
 				}
 
 				if _, err := stateConf.WaitForState(); err != nil {


### PR DESCRIPTION
During some edge case testing I noticed that the Key Vault itself is available, however some of the external tests fail as the DNS wasn't fully available. This PR adds a 30s delay before checking, and then bumps the number of continuous target occurrences to correct this.

```
$ acctests azurerm TestAccAzureRMKeyVaultSecret_importComplete
=== RUN   TestAccAzureRMKeyVaultSecret_importComplete
go --ver--- PASS: TestAccAzureRMKeyVaultSecret_importComplete (166.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	166.533s
```