### PR TITLE
update backend_http_settings.authentication_certificate documentation…

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -216,7 +216,7 @@ The `backend_http_settings` block supports:
 
 * `probe_name` - (Optional) Reference to URL probe.
 
-* `authentication_certificate` - TODO - this doesn't seem to belong here
+* `authentication_certificate` - (Optional) - A list of maps of `authentication_certificate` references for the `backend_http_setting` to use. Each map consists of a `name` (required) and an `id` (calculated).
 
 The `http_listener` block supports:
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -216,7 +216,10 @@ The `backend_http_settings` block supports:
 
 * `probe_name` - (Optional) Reference to URL probe.
 
-* `authentication_certificate` - (Optional) - A list of maps of `authentication_certificate` references for the `backend_http_setting` to use. Each map consists of a `name` (required) and an `id` (calculated).
+* `authentication_certificate` - (Optional) - A list of `authentication_certificate` references for the `backend_http_setting` to use. Each element consists of:
+  
+  * `name` (Required) 
+  * `id` (Calculated)
 
 The `http_listener` block supports:
 


### PR DESCRIPTION
… to reflect current state of the element. Fixes #1181.

This matches my experience of a working configuration that connects the gateway's backend http settings to a provided authentication certificate.