### PR TITLE
`azurerm_app_service` - adding support for HTTP2

### DIFF
--- a/azurerm/data_source_app_service.go
+++ b/azurerm/data_source_app_service.go
@@ -50,6 +50,12 @@ func dataSourceArmAppService() *schema.Resource {
 							Computed: true,
 						},
 
+						"http2_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
 						"java_version": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/azurerm/data_source_app_service_test.go
+++ b/azurerm/data_source_app_service_test.go
@@ -126,6 +126,25 @@ func TestAccDataSourceAzureRMAppService_connectionString(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMAppService_http2Enabled(t *testing.T) {
+	dataSourceName := "data.azurerm_app_service.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppService_http2Enabled(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "site_config.0.http2_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAppService_basic(rInt int, location string) string {
 	config := testAccAzureRMAppService_basic(rInt, location)
 	return fmt.Sprintf(`
@@ -188,6 +207,18 @@ data "azurerm_app_service" "test" {
 
 func testAccDataSourceAppService_connectionStrings(rInt int, location string) string {
 	config := testAccAzureRMAppService_connectionStrings(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_app_service" "test" {
+  name                = "${azurerm_app_service.test.name}"
+  resource_group_name = "${azurerm_app_service.test.resource_group_name}"
+}
+`, config)
+}
+
+func testAccDataSourceAppService_http2Enabled(rInt int, location string) string {
+	config := testAccAzureRMAppService_http2Enabled(rInt, location)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -97,6 +97,12 @@ func resourceArmAppService() *schema.Resource {
 							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 
+						"http2_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
 						"java_version": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -674,6 +680,10 @@ func expandAppServiceSiteConfig(d *schema.ResourceData) web.SiteConfig {
 		siteConfig.JavaContainerVersion = utils.String(v.(string))
 	}
 
+	if v, ok := config["http2_enabled"]; ok {
+		siteConfig.HTTP20Enabled = utils.Bool(v.(bool))
+	}
+
 	if v, ok := config["local_mysql_enabled"]; ok {
 		siteConfig.LocalMySQLEnabled = utils.Bool(v.(bool))
 	}
@@ -753,6 +763,10 @@ func flattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 
 	if input.LocalMySQLEnabled != nil {
 		result["local_mysql_enabled"] = *input.LocalMySQLEnabled
+	}
+
+	if input.HTTP20Enabled != nil {
+		result["http2_enabled"] = *input.HTTP20Enabled
 	}
 
 	result["managed_pipeline_mode"] = string(input.ManagedPipelineMode)

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -132,6 +132,27 @@ func TestAccAzureRMAppService_32Bit(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_http2Enabled(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_http2Enabled(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.http2_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_alwaysOn(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
@@ -966,6 +987,37 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     use_32_bit_worker_process = true
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_http2Enabled(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    http2_enabled = true
   }
 }
 `, rInt, location, rInt, rInt)

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -71,6 +71,8 @@ output "app_service_id" {
 
 * `dotnet_framework_version` - The version of the .net framework's CLR used in this App Service.
 
+* `http2_enabled` - Is HTTP2 Enabled on this App Service?
+
 * `java_version` - The version of Java in use.
 
 * `java_container` - The Java Container in use.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -127,8 +127,6 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`.
 
-* `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`. Changing this forces a new resource to be created.
-
 * `site_config` - (Optional) A `site_config` object as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -158,7 +156,7 @@ The following arguments are supported:
 * `always_on` - (Optional) Should the app be loaded at all times? Defaults to `false`.
 * `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
 * `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`) and `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`). [For more information on which .net CLR version to use based on the .net framework you're targetting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
-
+* `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`.
 * `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7` and `1.8`.
 * `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.
 * `java_container_version` - (Optional) The version of the Java Container to use. If specified `java_version` and `java_container` must also be specified.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -127,6 +127,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`.
 
+* `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`. Changing this forces a new resource to be created.
+
 * `site_config` - (Optional) A `site_config` object as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
```
$ acctests azurerm TestAccAzureRMAppService_http2Enabled
=== RUN   TestAccAzureRMAppService_http2Enabled
--- PASS: TestAccAzureRMAppService_http2Enabled (98.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	98.568s
```