### PR TITLE
r/kubernetes_cluster: info on unexpected errors

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2017-09-30/containerservice"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -127,9 +128,10 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validateKubernetesClusterAgentPoolName(),
 						},
 
 						"count": {
@@ -559,4 +561,11 @@ func resourceAzureRMKubernetesClusterServicePrincipalProfileHash(v interface{}) 
 	buf.WriteString(fmt.Sprintf("%s-", clientId))
 
 	return hashcode.String(buf.String())
+}
+
+func validateKubernetesClusterAgentPoolName() schema.SchemaValidateFunc {
+	return validation.StringMatch(
+		regexp.MustCompile("^[a-z]{1}[a-z0-9]{0,11}$"),
+		"Agent Pool names must start with a lowercase letter, have max length of 12, and only have characters a-z0-9.",
+	)
 }

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -11,6 +11,64 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccAzureRMKubernetesCluster_agentPoolName(t *testing.T) {
+	cases := []struct {
+		Input       string
+		ExpectError bool
+	}{
+		{
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			Input:       "hi",
+			ExpectError: false,
+		},
+		{
+			Input:       "hello",
+			ExpectError: false,
+		},
+		{
+			Input:       "hello-world",
+			ExpectError: true,
+		},
+		{
+			Input:       "helloworld123",
+			ExpectError: true,
+		},
+		{
+			Input:       "hello_world",
+			ExpectError: true,
+		},
+		{
+			Input:       "Hello-World",
+			ExpectError: true,
+		},
+		{
+			Input:       "20202020",
+			ExpectError: true,
+		},
+		{
+			Input:       "h20202020",
+			ExpectError: false,
+		},
+		{
+			Input:       "ABC123!@£",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateKubernetesClusterAgentPoolName()(tc.Input, "")
+
+		hasError := len(errors) > 0
+
+		if tc.ExpectError && !hasError {
+			t.Fatalf("Expected the Kubernetes Cluster Agent Pool Name to trigger a validation error for '%s'", tc.Input)
+		}
+	}
+}
+
 func TestAccAzureRMKubernetesCluster_basic(t *testing.T) {
 	resourceName := "azurerm_kubernetes_cluster.test"
 	ri := acctest.RandInt()

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -119,7 +119,7 @@ The following arguments are supported:
 * `os_type` - (Optional) The Operating System used for the Agents. Possible values are `Linux` and `Windows`.  Changing this forces a new resource to be created. Defaults to `Linux`.
 * `vnet_subnet_id` - (Optional) The ID of the Subnet where the Agents in the Pool should be provisioned. Changing this forces a new resource to be created.
 
-~> **NOTE:** There's a known issue where Agents connected to an Internal Network (e.g. on a Subnet) have their network routing configured incorrectly; such that Pods cannot be located across nodes. This is a bug in the Azure API - and will be fixed there in the future.
+~> **NOTE:** There's a known issue where Agents connected to an Internal Network (e.g. on a Subnet) have their network routing configured incorrectly; such that Pods cannot communicate across nodes. This is a bug in the Azure API - and will be fixed there in the future.
 
 `service_principal` supports the following:
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -119,6 +119,8 @@ The following arguments are supported:
 * `os_type` - (Optional) The Operating System used for the Agents. Possible values are `Linux` and `Windows`.  Changing this forces a new resource to be created. Defaults to `Linux`.
 * `vnet_subnet_id` - (Optional) The ID of the Subnet where the Agents in the Pool should be provisioned. Changing this forces a new resource to be created.
 
+~> **NOTE:** There's a known issue where Agents connected to an Internal Network (e.g. on a Subnet) have their network routing configured incorrectly; such that Pods cannot be located across nodes. This is a bug in the Azure API - and will be fixed there in the future.
+
 `service_principal` supports the following:
 
 * `client_id` - (Required) The Client ID for the Service Principal.
@@ -147,6 +149,19 @@ The following attributes are exported:
   * `username` - A username used to authenticate to the Kubernetes cluster.
 
   * `password` - A password or token used to authenticate to the Kubernetes cluster.
+
+-> **NOTE:** You can use this It's possible to use this information with [the Kubernetes Provider](/docs/providers/kubernetes/index.html) like so:
+
+```
+provider "kubernetes" {
+  host                   = "${azurerm_kubernetes_cluster.main.kube_config.0.host}"
+  username               = "${azurerm_kubernetes_cluster.main.kube_config.0.username}"
+  password               = "${azurerm_kubernetes_cluster.main.kube_config.0.password}"
+  client_certificate     = "${base64decode(azurerm_kubernetes_cluster.main.kube_config.0.client_certificate)}"
+  client_key             = "${base64decode(azurerm_kubernetes_cluster.main.kube_config.0.client_key)}"
+  cluster_ca_certificate = "${base64decode(azurerm_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate)}"
+}
+```
 
 ## Import
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -150,7 +150,7 @@ The following attributes are exported:
 
   * `password` - A password or token used to authenticate to the Kubernetes cluster.
 
--> **NOTE:** You can use this It's possible to use this information with [the Kubernetes Provider](/docs/providers/kubernetes/index.html) like so:
+-> **NOTE:** It's possible to use these credentials with [the Kubernetes Provider](/docs/providers/kubernetes/index.html) like so:
 
 ```
 provider "kubernetes" {


### PR DESCRIPTION
This PR cleans up a few rough edges in the Kubernetes resource:

- Whilst using the Kubernetes Cluster resource, I noticed there's an undocumented regex on the Agent Pool names - as such this PR adds validation to that affect (needs to start with a lower-case char, and be up to 12 chars of only a-z0-9. At the moment this fails with the unhelpful error message:

```
* azurerm_kubernetes_cluster.test: containerservice.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="" Message=""
```

- Documenting there's a known issue with routing on nodes attached to an internal subnet
- Documenting how to use the outputs with the Kubernetes Provider