### PR TITLE
Added Import support to Redis Cache/Firewall Rule

### DIFF
--- a/azurerm/import_arm_redis_cache_test.go
+++ b/azurerm/import_arm_redis_cache_test.go
@@ -1,0 +1,213 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMRedisCache_importBasic(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisCache_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_importStandard(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisCache_standard(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_importPremium(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisCache_premium(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_importPremiumSharded(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisCache_premiumSharded(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_importNonStandardCasing(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisCacheNonStandardCasing(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_importBackupEnabled(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+
+	ri := acctest.RandInt()
+	rs := acctest.RandString(4)
+	config := testAccAzureRMRedisCacheBackupEnabled(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_importPatchSchedule(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+	config := testAccAzureRMRedisCachePatchSchedule(ri, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccAzureRMRedisCache_importInternalSubnet(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisCache_internalSubnet(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_importInternalSubnetStaticIP(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisCache_internalSubnetStaticIP(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/import_arm_redis_cache_test.go
+++ b/azurerm/import_arm_redis_cache_test.go
@@ -141,6 +141,13 @@ func TestAccAzureRMRedisCache_importBackupEnabled(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+
+				// `redis_configuration.0.rdb_storage_connection_string` is returned as:
+				// "...;AccountKey=[key hidden]" rather than "...;AccountKey=fsjfvjnfnf"
+				// TODO: remove this once the Bug's been fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/3037
+				ExpectNonEmptyPlan:      true,
+				ImportStateVerifyIgnore: []string{"redis_configuration.0.rdb_storage_connection_string"},
 			},
 		},
 	})

--- a/azurerm/import_arm_redis_cache_test.go
+++ b/azurerm/import_arm_redis_cache_test.go
@@ -136,17 +136,16 @@ func TestAccAzureRMRedisCache_importBackupEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-
 				// `redis_configuration.0.rdb_storage_connection_string` is returned as:
 				// "...;AccountKey=[key hidden]" rather than "...;AccountKey=fsjfvjnfnf"
 				// TODO: remove this once the Bug's been fixed:
 				// https://github.com/Azure/azure-rest-api-specs/issues/3037
-				ExpectNonEmptyPlan:      true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"redis_configuration.0.rdb_storage_connection_string"},
 			},
 		},

--- a/azurerm/import_arm_redis_firewall_rule_test.go
+++ b/azurerm/import_arm_redis_firewall_rule_test.go
@@ -1,0 +1,31 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMRedisFirewallRule_importBasic(t *testing.T) {
+	resourceName := "azurerm_redis_firewall_rule.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMRedisFirewallRule_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisFirewallRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -447,8 +447,13 @@ func resourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("subnet_id", props.SubnetID)
 	}
 
-	redisConfiguration := flattenRedisConfiguration(resp.RedisConfiguration)
-	d.Set("redis_configuration", &redisConfiguration)
+	redisConfiguration, err := flattenRedisConfiguration(resp.RedisConfiguration)
+	if err != nil {
+		return fmt.Errorf("Error flattening `redis_configuration`: %+v", err)
+	}
+	if err := d.Set("redis_configuration", redisConfiguration); err != nil {
+		return fmt.Errorf("Error setting `redis_configuration`: %+v", err)
+	}
 
 	d.Set("primary_access_key", keysResp.PrimaryKey)
 	d.Set("secondary_access_key", keysResp.SecondaryKey)
@@ -577,21 +582,64 @@ func expandRedisPatchSchedule(d *schema.ResourceData) (*redis.PatchSchedule, err
 	return &schedule, nil
 }
 
-func flattenRedisConfiguration(input map[string]*string) map[string]*string {
-	redisConfiguration := make(map[string]*string, len(input))
+func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) {
+	outputs := make(map[string]interface{}, len(input))
 
-	redisConfiguration["maxclients"] = input["maxclients"]
-	redisConfiguration["maxmemory_delta"] = input["maxmemory-delta"]
-	redisConfiguration["maxmemory_reserved"] = input["maxmemory-reserved"]
-	redisConfiguration["maxmemory_policy"] = input["maxmemory-policy"]
+	if v := input["maxclients"]; v != nil {
+		i, err := strconv.Atoi(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `maxclients` %q: %+v", v, err)
+		}
+		outputs["maxclients"] = i
+	}
+	if v := input["maxmemory-delta"]; v != nil {
+		i, err := strconv.Atoi(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `maxmemory-delta` %q: %+v", v, err)
+		}
+		outputs["maxmemory_delta"] = i
+	}
+	if v := input["maxmemory-reserved"]; v != nil {
+		i, err := strconv.Atoi(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `maxmemory-reserved` %q: %+v", v, err)
+		}
+		outputs["maxmemory_reserved"] = i
+	}
+	if v := input["maxmemory-policy"]; v != nil {
+		outputs["maxmemory_policy"] = *v
+	}
 
-	redisConfiguration["rdb_backup_enabled"] = input["rdb-backup-enabled"]
-	redisConfiguration["rdb_backup_frequency"] = input["rdb-backup-frequency"]
-	redisConfiguration["rdb_backup_max_snapshot_count"] = input["rdb-backup-max-snapshot-count"]
-	redisConfiguration["rdb_storage_connection_string"] = input["rdb-storage-connection-string"]
-	redisConfiguration["notify_keyspace_events"] = input["notify-keyspace-events"]
+	// delta, reserved, enabled, frequency,, count,
+	if v := input["rdb-backup-enabled"]; v != nil {
+		b, err := strconv.ParseBool(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `rdb-backup-enabled` %q: %+v", v, err)
+		}
+		outputs["rdb_backup_enabled"] = b
+	}
+	if v := input["rdb-backup-frequency"]; v != nil {
+		i, err := strconv.Atoi(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `rdb-backup-frequency` %q: %+v", v, err)
+		}
+		outputs["maxmemoryrdb_backup_frequency_policy"] = i
+	}
+	if v := input["rdb-backup-max-snapshot-count"]; v != nil {
+		i, err := strconv.Atoi(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `rdb-backup-max-snapshot-count` %q: %+v", v, err)
+		}
+		outputs["rdb_backup_max_snapshot_count"] = i
+	}
+	if v := input["rdb-storage-connection-string"]; v != nil {
+		outputs["rdb_storage_connection_string"] = *v
+	}
+	if v := input["notify-keyspace-events"]; v != nil {
+		outputs["notify_keyspace_events"] = *v
+	}
 
-	return redisConfiguration
+	return []interface{}{outputs}, nil
 }
 
 func flattenRedisPatchSchedules(schedule redis.PatchSchedule) []interface{} {

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -23,6 +23,9 @@ func resourceArmRedisCache() *schema.Resource {
 		Read:   resourceArmRedisCacheRead,
 		Update: resourceArmRedisCacheUpdate,
 		Delete: resourceArmRedisCacheDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -98,7 +98,6 @@ func resourceArmRedisCache() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"maxclients": {
 							Type:     schema.TypeInt,
-							Optional: true,
 							Computed: true,
 						},
 
@@ -623,7 +622,7 @@ func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) 
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing `rdb-backup-frequency` %q: %+v", v, err)
 		}
-		outputs["maxmemoryrdb_backup_frequency_policy"] = i
+		outputs["rdb_backup_frequency"] = i
 	}
 	if v := input["rdb-backup-max-snapshot-count"]; v != nil {
 		i, err := strconv.Atoi(*v)

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -265,6 +265,11 @@ func TestAccAzureRMRedisCache_BackupEnabledDisabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRedisCacheExists("azurerm_redis_cache.test"),
 				),
+				// `redis_configuration.0.rdb_storage_connection_string` is returned as:
+				// "...;AccountKey=[key hidden]" rather than "...;AccountKey=fsjfvjnfnf"
+				// TODO: remove this once the Bug's been fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/3037
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: updatedConfig,

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -449,7 +449,6 @@ resource "azurerm_redis_cache" "test" {
     enable_non_ssl_port = false
 
     redis_configuration {
-      maxclients = 256
     }
 }
 `, rInt, location, rInt)
@@ -471,7 +470,6 @@ resource "azurerm_redis_cache" "test" {
     sku_name            = "Standard"
     enable_non_ssl_port = false
     redis_configuration {
-      maxclients = 256
     }
 
     tags {
@@ -497,8 +495,7 @@ resource "azurerm_redis_cache" "test" {
     sku_name            = "Premium"
     enable_non_ssl_port = false
     redis_configuration {
-      maxclients         = 256,
-      maxmemory_reserved = 2,
+      maxmemory_reserved = 2
       maxmemory_delta    = 2
       maxmemory_policy   = "allkeys-lru"
     }
@@ -523,8 +520,7 @@ resource "azurerm_redis_cache" "test" {
     enable_non_ssl_port = true
     shard_count         = 3
     redis_configuration {
-      maxclients         = "256",
-      maxmemory_reserved = 2,
+      maxmemory_reserved = 2
       maxmemory_delta    = 2
       maxmemory_policy   = "allkeys-lru"
     }
@@ -548,7 +544,6 @@ resource "azurerm_redis_cache" "test" {
     sku_name            = "basic"
     enable_non_ssl_port = false
     redis_configuration {
-      maxclients = "256"
     }
 }
 `, ri, location, ri)
@@ -570,7 +565,6 @@ resource "azurerm_redis_cache" "test" {
     sku_name            = "Premium"
     enable_non_ssl_port = false
     redis_configuration {
-      maxclients         = "256"
       rdb_backup_enabled = false
     }
 }
@@ -605,7 +599,6 @@ resource "azurerm_redis_cache" "test" {
     sku_name            = "Premium"
     enable_non_ssl_port = false
     redis_configuration {
-      maxclients                    = "256"
       rdb_backup_enabled            = true
       rdb_backup_frequency          = 60
       rdb_backup_max_snapshot_count = 1
@@ -630,8 +623,7 @@ resource "azurerm_redis_cache" "test" {
     sku_name            = "Premium"
     enable_non_ssl_port = false
     redis_configuration {
-      maxclients         = 256,
-      maxmemory_reserved = 2,
+      maxmemory_reserved = 2
       maxmemory_delta    = 2
       maxmemory_policy   = "allkeys-lru"
     }
@@ -704,7 +696,6 @@ resource "azurerm_redis_cache" "test" {
   enable_non_ssl_port = false
   subnet_id           = "${azurerm_subnet.test.id}"
   redis_configuration {
-    maxclients = "256"
   }
 }
 `, ri, location, ri, ri)
@@ -742,7 +733,6 @@ resource "azurerm_redis_cache" "test" {
   subnet_id                 = "${azurerm_subnet.test.id}"
   private_static_ip_address = "10.0.1.20"
   redis_configuration {
-    maxclients = "256"
   }
 }
 `, ri, location, ri, ri)

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -238,6 +238,11 @@ func TestAccAzureRMRedisCache_BackupEnabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRedisCacheExists("azurerm_redis_cache.test"),
 				),
+				// `redis_configuration.0.rdb_storage_connection_string` is returned as:
+				// "...;AccountKey=[key hidden]" rather than "...;AccountKey=fsjfvjnfnf"
+				// TODO: remove this once the Bug's been fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/3037
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -266,6 +271,11 @@ func TestAccAzureRMRedisCache_BackupEnabledDisabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRedisCacheExists("azurerm_redis_cache.test"),
 				),
+				// `redis_configuration.0.rdb_storage_connection_string` is returned as:
+				// "...;AccountKey=[key hidden]" rather than "...;AccountKey=fsjfvjnfnf"
+				// TODO: remove this once the Bug's been fixed:
+				// https://github.com/Azure/azure-rest-api-specs/issues/3037
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -449,7 +449,7 @@ resource "azurerm_redis_cache" "test" {
     enable_non_ssl_port = false
 
     redis_configuration {
-      maxclients = "256"
+      maxclients = 256
     }
 }
 `, rInt, location, rInt)
@@ -471,7 +471,7 @@ resource "azurerm_redis_cache" "test" {
     sku_name            = "Standard"
     enable_non_ssl_port = false
     redis_configuration {
-      maxclients = "256"
+      maxclients = 256
     }
 
     tags {

--- a/azurerm/resource_arm_redis_firewall_rule.go
+++ b/azurerm/resource_arm_redis_firewall_rule.go
@@ -17,6 +17,9 @@ func resourceArmRedisFirewallRule() *schema.Resource {
 		Read:   resourceArmRedisFirewallRuleRead,
 		Update: resourceArmRedisFirewallRuleCreateUpdate,
 		Delete: resourceArmRedisFirewallRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -233,3 +233,11 @@ The following attributes are exported:
 ## Relevant Links
  - [Azure Redis Cache: SKU specific configuration limitations](https://azure.microsoft.com/en-us/documentation/articles/cache-configure/#advanced-settings)
  - [Redis: Available Configuration Settings](http://redis.io/topics/config)
+
+## Import
+
+Redis Cache's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_redis_cache.cache1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/Redis/cache1
+```

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -177,7 +177,6 @@ The pricing group for the Redis Family - either "C" or "P" at present.
 
 * `redis_configuration` supports the following:
 
-* `maxclients` - (Optional) Set the max number of connected clients at the same time. Defaults are shown below.
 * `maxmemory_reserve` - (Optional) Value in megabytes reserved for non-cache usage e.g. failover. Defaults are shown below.
 * `maxmemory_delta` - (Optional) The max-memory delta for this Redis instance. Defaults are shown below.
 * `maxmemory_policy` - (Optional) How Redis will select what to remove when `maxmemory` is reached. Defaults are shown below.
@@ -186,11 +185,20 @@ The pricing group for the Redis Family - either "C" or "P" at present.
 * `rdb_backup_frequency` - (Optional) The Backup Frequency in Minutes. Only supported on Premium SKU's. Possible values are: `15`, `30`, `60`, `360`, `720` and `1440`.
 * `rdb_backup_max_snapshot_count` - (Optional) The maximum number of snapshots to create as a backup. Only supported for Premium SKU's.
 * `rdb_storage_connection_string` - (Optional) The Connection String to the Storage Account. Only supported for Premium SKU's. In the format: `DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key}`.
+
+~> **NOTE:** There's a bug in the Redis API where the original storage connection string isn't being returned, which [is being tracked in this issue](https://github.com/Azure/azure-rest-api-specs/issues/3037). In the interim you can use [the `ignore_changes` attribute to ignore changes to this field](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) e.g.:
+
+```
+resource "azurerm_redis_cache" "test" {
+  # ...
+  ignore_changes = ["redis_configuration.0.rdb_storage_connection_string"]
+}
+```
+
 * `notify_keyspace_events` - (Optional) Keyspace notifications allows clients to subscribe to Pub/Sub channels in order to receive events affecting the Redis data set in some way. [Reference](https://redis.io/topics/notifications#configuration)
 
 ```hcl
 redis_configuration {
-  maxclients         = 512
   maxmemory_reserve  = 10
   maxmemory_delta    = 2
   maxmemory_policy   = "allkeys-lru"
@@ -200,7 +208,6 @@ redis_configuration {
 ## Default Redis Configuration Values
 | Redis Value        | Basic        | Standard     | Premium      |
 | ------------------ | ------------ | ------------ | ------------ |
-| maxclients         | 256          | 1000         | 7500         |
 | maxmemory_reserved | 2            | 50           | 200          |
 | maxmemory_delta    | 2            | 50           | 200          |
 | maxmemory_policy   | volatile-lru | volatile-lru | volatile-lru |
@@ -229,6 +236,14 @@ The following attributes are exported:
 * `primary_access_key` - The Primary Access Key for the Redis Instance
 
 * `secondary_access_key` - The Secondary Access Key for the Redis Instance
+
+* `redis_configuration` - A `redis_configuration` block as defined below:
+
+---
+
+A `redis_configuration` block exports the following:
+
+* `maxclients` - Returns the max number of connected clients at the same time.
 
 ## Relevant Links
  - [Azure Redis Cache: SKU specific configuration limitations](https://azure.microsoft.com/en-us/documentation/articles/cache-configure/#advanced-settings)

--- a/website/docs/r/redis_firewall_rule.html.markdown
+++ b/website/docs/r/redis_firewall_rule.html.markdown
@@ -75,3 +75,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Redis Firewall Rule ID.
+
+## Import
+
+Redis Firewall Rules can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_redis_firewall_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/Redis/cache1/firewallRules/rule1
+```


### PR DESCRIPTION
This was a feature request that came up IRL at Microsoft Build

This also makes the `maxclients` field Computed, since it's not set-able anymore; and adds a note about the storage connection string bug in https://github.com/Azure/azure-rest-api-specs/issues/3037