### PR TITLE
fix link to RSV datasource

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -101,7 +101,7 @@
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-recovery-services-vault") %>>
-                    <a href="/docs/providers/azurerm/d/resource_group.html">azurerm_recovery_services_vault</a>
+                    <a href="/docs/providers/azurerm/d/recovery_services_vault.html">azurerm_recovery_services_vault</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-resource-group") %>>

--- a/website/docs/d/recovery_services_vault.markdown
+++ b/website/docs/d/recovery_services_vault.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_recovery_services_vault
 
-Use this data source to access the properties of an Recovery Services Vault.
+Use this data source to access the properties of a Recovery Services Vault.
 
 ## Example Usage
 


### PR DESCRIPTION
Very minor, but I spotted that the link to the datasource for recovery services vault points to resource group currently.

Hope this is the right target branch.