### PR TITLE
Data Sources: returning an error when resources don't exist

### DIFF
--- a/azurerm/data_source_app_service.go
+++ b/azurerm/data_source_app_service.go
@@ -2,7 +2,6 @@ package azurerm
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -218,9 +217,7 @@ func dataSourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] App Service %q (resource group %q) was not found - removing from state", name, resourceGroup)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: App Service %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 		return fmt.Errorf("Error making Read request on AzureRM App Service %q: %+v", name, err)
 	}

--- a/azurerm/data_source_app_service_plan.go
+++ b/azurerm/data_source_app_service_plan.go
@@ -94,8 +94,7 @@ func dataSourceAppServicePlanRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if utils.ResponseWasNotFound(resp.Response) {
-		d.SetId("")
-		return nil
+		return fmt.Errorf("Error: App Service Plan %q (Resource Group %q) was not found", name, resourceGroup)
 	}
 
 	d.SetId(*resp.ID)

--- a/azurerm/data_source_application_security_group.go
+++ b/azurerm/data_source_application_security_group.go
@@ -39,8 +39,7 @@ func dataSourceArmApplicationSecurityGroupRead(d *schema.ResourceData, meta inte
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: Application Security Group %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 
 		return fmt.Errorf("Error making Read request on Application Security Group %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/data_source_cdn_profile.go
+++ b/azurerm/data_source_cdn_profile.go
@@ -41,8 +41,7 @@ func dataSourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: CDN Profile %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 		return fmt.Errorf("Error making Read request on Azure CDN Profile %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}

--- a/azurerm/data_source_cosmos_db_account.go
+++ b/azurerm/data_source_cosmos_db_account.go
@@ -147,8 +147,7 @@ func dataSourceArmCosmosDBAccountRead(d *schema.ResourceData, meta interface{}) 
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: CosmosDB Account %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 
 		return fmt.Errorf("Error making Read request on AzureRM CosmosDB Account %s (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/data_source_dns_zone.go
+++ b/azurerm/data_source_dns_zone.go
@@ -51,8 +51,7 @@ func dataSourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: DNS Zone %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 		return fmt.Errorf("Error reading DNS Zone %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}

--- a/azurerm/data_source_eventhub_namespace.go
+++ b/azurerm/data_source_eventhub_namespace.go
@@ -77,8 +77,7 @@ func dataSourceEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) e
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: EventHub Namespace %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 
 		return fmt.Errorf("Error making Read request on EventHub Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/data_source_image.go
+++ b/azurerm/data_source_image.go
@@ -126,8 +126,7 @@ func dataSourceArmImageRead(d *schema.ResourceData, meta interface{}) error {
 		var err error
 		if img, err = client.Get(ctx, resGroup, name, ""); err != nil {
 			if utils.ResponseWasNotFound(img.Response) {
-				d.SetId("")
-				return nil
+				return fmt.Errorf("Error: Image %q (Resource Group %q) was not found", name, resGroup)
 			}
 			return fmt.Errorf("[ERROR] Error making Read request on Azure Image %q (resource group %q): %+v", name, resGroup, err)
 		}
@@ -138,8 +137,7 @@ func dataSourceArmImageRead(d *schema.ResourceData, meta interface{}) error {
 		resp, err := client.ListByResourceGroupComplete(ctx, resGroup)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response().Response) {
-				d.SetId("")
-				return nil
+				return fmt.Errorf("Error: Image %q (Resource Group %q) was not found", name, resGroup)
 			}
 			return fmt.Errorf("[ERROR] Error getting list of images (resource group %q): %+v", resGroup, err)
 		}

--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -174,8 +174,7 @@ func dataSourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}
 	resp, err := kubernetesClustersClient.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: AKS Managed Cluster %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 
 		return fmt.Errorf("Error making Read request on AKS Managed Cluster %q (resource group %q): %+v", name, resourceGroup, err)

--- a/azurerm/data_source_managed_disk.go
+++ b/azurerm/data_source_managed_disk.go
@@ -2,9 +2,9 @@ package azurerm
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmManagedDisk() *schema.Resource {
@@ -60,11 +60,10 @@ func dataSourceArmManagedDiskRead(d *schema.ResourceData, meta interface{}) erro
 
 	resp, err := client.Get(ctx, resGroup, name)
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
-			d.SetId("")
-			return nil
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Managed Disk %q (Resource Group %q) was not found", name, resGroup)
 		}
-		return fmt.Errorf("[ERROR] Error making Read request on Azure Managed Disk %s (resource group %s): %s", name, resGroup, err)
+		return fmt.Errorf("[ERROR] Error making Read request on Azure Managed Disk %q (Resource Group %q): %s", name, resGroup, err)
 	}
 
 	d.SetId(*resp.ID)

--- a/azurerm/data_source_network_interface.go
+++ b/azurerm/data_source_network_interface.go
@@ -171,8 +171,7 @@ func dataSourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{})
 	resp, err := client.Get(ctx, resGroup, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: Network Interface %q (Resource Group %q) was not found", name, resGroup)
 		}
 		return fmt.Errorf("Error making Read request on Azure Network Interface %q (Resource Group %q): %+v", name, resGroup, err)
 	}

--- a/azurerm/data_source_network_security_group.go
+++ b/azurerm/data_source_network_security_group.go
@@ -135,7 +135,7 @@ func dataSourceArmNetworkSecurityGroupRead(d *schema.ResourceData, meta interfac
 	resp, err := client.Get(ctx, resourceGroup, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
+			return fmt.Errorf("Error: Network Security Group %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 		return fmt.Errorf("Error making Read request on Network Security Group %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}

--- a/azurerm/data_source_public_ip.go
+++ b/azurerm/data_source_public_ip.go
@@ -53,7 +53,7 @@ func dataSourceArmPublicIPRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, resGroup, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
+			return fmt.Errorf("Error: Public IP %q (Resource Group %q) was not found", name, resGroup)
 		}
 		return fmt.Errorf("Error making Read request on Azure public ip %s: %s", name, err)
 	}

--- a/azurerm/data_source_public_ips.go
+++ b/azurerm/data_source_public_ips.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmPublicIPs() *schema.Resource {
@@ -79,11 +78,6 @@ func dataSourceArmPublicIPsRead(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Reading Public IP's in Resource Group %q", resourceGroup)
 	resp, err := client.List(ctx, resourceGroup)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response().Response) {
-			d.SetId("")
-			return nil
-		}
-
 		return fmt.Errorf("Error listing Public IP Addresses in the Resource Group %q: %v", resourceGroup, err)
 	}
 

--- a/azurerm/data_source_recovery_services_vault.go
+++ b/azurerm/data_source_recovery_services_vault.go
@@ -48,8 +48,7 @@ func dataSourceArmRecoveryServicesVaultRead(d *schema.ResourceData, meta interfa
 	vault, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(vault.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: Recovery Services Vault %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 
 		return fmt.Errorf("Error making Read request on Recovery Service Vault %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/data_source_resource_group.go
+++ b/azurerm/data_source_resource_group.go
@@ -1,7 +1,10 @@
 package azurerm
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmResourceGroup() *schema.Resource {
@@ -23,6 +26,9 @@ func dataSourceArmResourceGroupRead(d *schema.ResourceData, meta interface{}) er
 	name := d.Get("name").(string)
 	resp, err := client.Get(ctx, name)
 	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Resource Group %q was not found", name)
+		}
 		return err
 	}
 

--- a/azurerm/data_source_role_definition.go
+++ b/azurerm/data_source_role_definition.go
@@ -74,7 +74,7 @@ func dataSourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) e
 
 	role, err := client.Get(ctx, scope, roleDefinitionId)
 	if err != nil {
-		return fmt.Errorf("Error loadng Role Definition: %+v", err)
+		return fmt.Errorf("Error loading Role Definition: %+v", err)
 	}
 
 	d.SetId(*role.ID)

--- a/azurerm/data_source_route_table.go
+++ b/azurerm/data_source_route_table.go
@@ -72,8 +72,7 @@ func dataSourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	resp, err := client.Get(ctx, resourceGroup, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: Route Table %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 		return fmt.Errorf("Error making Read request on Azure Route Table %q: %+v", name, err)
 	}

--- a/azurerm/data_source_scheduler_job_collection.go
+++ b/azurerm/data_source_scheduler_job_collection.go
@@ -77,8 +77,7 @@ func dataSourceArmSchedulerJobCollectionRead(d *schema.ResourceData, meta interf
 	collection, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(collection.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: Scheduler Job Collection %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 
 		return fmt.Errorf("Error making Read request on Scheduler Job Collection %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/data_source_snapshot.go
+++ b/azurerm/data_source_snapshot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmSnapshot() *schema.Resource {
@@ -106,6 +107,9 @@ func dataSourceArmSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Snapshot %q (Resource Group %q) was not found", name, resourceGroup)
+		}
 		return fmt.Errorf("Error loading Snapshot %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 

--- a/azurerm/data_source_storage_account.go
+++ b/azurerm/data_source_storage_account.go
@@ -169,8 +169,7 @@ func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) e
 	resp, err := client.GetProperties(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: Storage Account %q (Resource Group %q) was not found", name, resourceGroup)
 		}
 		return fmt.Errorf("Error reading the state of AzureRM Storage Account %q: %+v", name, err)
 	}

--- a/azurerm/data_source_subnet.go
+++ b/azurerm/data_source_subnet.go
@@ -57,9 +57,9 @@ func dataSourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 	virtualNetworkName := d.Get("virtual_network_name").(string)
-	resourceGroupName := d.Get("resource_group_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
 
-	resp, err := client.Get(ctx, resourceGroupName, virtualNetworkName, name, "")
+	resp, err := client.Get(ctx, resourceGroup, virtualNetworkName, name, "")
 	if err != nil {
 		return fmt.Errorf("Error reading Subnet: %+v", err)
 	}
@@ -68,14 +68,13 @@ func dataSourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Error: Subnet %q (Virtual Network %q / Resource Group %q) was not found", name, resourceGroup, virtualNetworkName)
 		}
 		return fmt.Errorf("Error making Read request on Azure Subnet %q: %+v", name, err)
 	}
 
 	d.Set("name", name)
-	d.Set("resource_group_name", resourceGroupName)
+	d.Set("resource_group_name", resourceGroup)
 	d.Set("virtual_network_name", virtualNetworkName)
 
 	if props := resp.SubnetPropertiesFormat; props != nil {

--- a/azurerm/data_source_subscription.go
+++ b/azurerm/data_source_subscription.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/subscription"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmSubscription() *schema.Resource {
@@ -26,6 +27,10 @@ func dataSourceArmSubscriptionRead(d *schema.ResourceData, meta interface{}) err
 
 	resp, err := groupClient.Get(ctx, subscriptionId)
 	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Subscription %q was not found", subscriptionId)
+		}
+
 		return fmt.Errorf("Error reading subscription: %+v", err)
 	}
 

--- a/azurerm/data_source_virtual_network.go
+++ b/azurerm/data_source_virtual_network.go
@@ -64,9 +64,10 @@ func dataSourceArmVnetRead(d *schema.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, resGroup, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error making Read request on Azure virtual network %q (resource group %q): %+v", name, resGroup, err)
+			return fmt.Errorf("Error: Virtual Network %q (Resource Group %q) was not found", name, resGroup)
 		}
-		return err
+
+		return fmt.Errorf("Error making Read request on Virtual Network %q (resource group %q): %+v", name, resGroup, err)
 	}
 
 	d.SetId(*resp.ID)

--- a/azurerm/data_source_virtual_network_gateway.go
+++ b/azurerm/data_source_virtual_network_gateway.go
@@ -162,7 +162,7 @@ func dataSourceArmVirtualNetworkGatewayRead(d *schema.ResourceData, meta interfa
 	resp, err := client.Get(ctx, resGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Virtual Network Gateway %q (Resource Group %q) was not found!", name, resGroup)
+			return fmt.Errorf("Virtual Network Gateway %q (Resource Group %q) was not found", name, resGroup)
 		}
 
 		return fmt.Errorf("Error making Read request on AzureRM Virtual Network Gateway %q (Resource Group %q): %+v", name, resGroup, err)


### PR DESCRIPTION
A comment in https://github.com/terraform-providers/terraform-provider-aws/pull/4480 has raised an issue where Data Sources in the AzureRM Provider don't fail on errors (where they do in other providers). This PR updates the data sources to return an error when resources don't exist - to make this consistent