### PR TITLE
Add dead_lettering_on_message_expiration property to servicebus queue resource

### DIFF
--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -93,6 +93,12 @@ func resourceArmServiceBusQueue() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"dead_lettering_on_message_expiration": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+
 			// TODO: remove these in the next major release
 			"enable_batched_operations": {
 				Type:       schema.TypeBool,
@@ -122,15 +128,17 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 	maxSize := int32(d.Get("max_size_in_megabytes").(int))
 	requiresDuplicateDetection := d.Get("requires_duplicate_detection").(bool)
 	requiresSession := d.Get("requires_session").(bool)
+	deadLetteringOnMessageExpiration := d.Get("dead_lettering_on_message_expiration").(bool)
 
 	parameters := servicebus.SBQueue{
 		Name: &name,
 		SBQueueProperties: &servicebus.SBQueueProperties{
-			EnableExpress:              &enableExpress,
-			EnablePartitioning:         &enablePartitioning,
-			MaxSizeInMegabytes:         &maxSize,
-			RequiresDuplicateDetection: &requiresDuplicateDetection,
-			RequiresSession:            &requiresSession,
+			EnableExpress:                    &enableExpress,
+			EnablePartitioning:               &enablePartitioning,
+			MaxSizeInMegabytes:               &maxSize,
+			RequiresDuplicateDetection:       &requiresDuplicateDetection,
+			RequiresSession:                  &requiresSession,
+			DeadLetteringOnMessageExpiration: &deadLetteringOnMessageExpiration,
 		},
 	}
 
@@ -223,6 +231,7 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("enable_partitioning", props.EnablePartitioning)
 		d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 		d.Set("requires_session", props.RequiresSession)
+		d.Set("dead_lettering_on_message_expiration", props.DeadLetteringOnMessageExpiration)
 
 		if maxSizeMB := props.MaxSizeInMegabytes; maxSizeMB != nil {
 			maxSize := int(*maxSizeMB)

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -172,6 +172,33 @@ func TestAccAzureRMServiceBusQueue_enableRequiresSession(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMServiceBusQueue_enableDeadLetteringOnMessageExpiration(t *testing.T) {
+	resourceName := "azurerm_servicebus_queue.test"
+	location := testLocation()
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMServiceBusQueue_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusQueueExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "dead_lettering_on_message_expiration", "false"),
+				),
+			},
+			{
+				Config: testAccAzureRMServiceBusQueue_enableDeadLetteringOnMessageExpiration(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "dead_lettering_on_message_expiration", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMServiceBusQueue_lockDuration(t *testing.T) {
 	resourceName := "azurerm_servicebus_queue.test"
 	ri := acctest.RandInt()
@@ -401,6 +428,30 @@ resource "azurerm_servicebus_queue" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     namespace_name      = "${azurerm_servicebus_namespace.test.name}"
     requires_session    = true
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMServiceBusQueue_enableDeadLetteringOnMessageExpiration(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name     = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+    name                = "acctestservicebusnamespace-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    sku = "standard"
+}
+
+resource "azurerm_servicebus_queue" "test" {
+    name                				 = "acctestservicebusqueue-%d"
+    resource_group_name 				 = "${azurerm_resource_group.test.name}"
+    namespace_name      				 = "${azurerm_servicebus_namespace.test.name}"
+    dead_lettering_on_message_expiration = true
 }
 `, rInt, location, rInt, rInt)
 }

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -102,6 +102,8 @@ The following arguments are supported:
     This will allow ordered handling of unbounded sequences of related messages. With sessions enabled 
     a queue can guarantee first-in-first-out delivery of messages. 
     Changing this forces a new resource to be created. Defaults to `false`.
+
+* `requires_session` - (Optional) Boolean flag which controls whether the Queue has dead letter support when a message expires. Defaults to `false`.
     
 ### TimeSpan Format
 


### PR DESCRIPTION
Hi Guys

This is an enhancement for the existing azurerm servicebus queue resource. 
This change enables support for dead lettering of messages on expiry. Let me know if you need any more info

Cheers

Jon