### PR TITLE
Authorization: upgrading to the `2018-01-01` Preview SDK

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	appinsights "github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
-	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-12-01/compute"
@@ -33,6 +32,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/operationalinsights/mgmt/2015-11-01-preview/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/services/operationsmanagement/mgmt/2015-11-01-preview/operationsmanagement"
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2016-06-01/recoveryservices"
 	"github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
 	"github.com/Azure/azure-sdk-for-go/services/relay/mgmt/2017-04-01/relay"

--- a/azurerm/data_source_builtin_role_definition.go
+++ b/azurerm/data_source_builtin_role_definition.go
@@ -83,10 +83,10 @@ func dataSourceArmBuiltInRoleDefinitionRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error loading Role Definition: %+v", err)
 	}
 
-	if props := role.Properties; props != nil {
+	if props := role.RoleDefinitionProperties; props != nil {
 		d.Set("name", props.RoleName)
 		d.Set("description", props.Description)
-		d.Set("type", props.Type)
+		d.Set("type", props.RoleType)
 
 		permissions := flattenRoleDefinitionPermissions(props.Permissions)
 		if err := d.Set("permissions", permissions); err != nil {

--- a/azurerm/data_source_role_definition.go
+++ b/azurerm/data_source_role_definition.go
@@ -79,10 +79,10 @@ func dataSourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(*role.ID)
 
-	if props := role.Properties; props != nil {
+	if props := role.RoleDefinitionProperties; props != nil {
 		d.Set("name", props.RoleName)
 		d.Set("description", props.Description)
-		d.Set("type", props.Type)
+		d.Set("type", props.RoleType)
 
 		permissions := flattenRoleDefinitionPermissions(props.Permissions)
 		if err := d.Set("permissions", permissions); err != nil {

--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -99,7 +99,7 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	properties := authorization.RoleAssignmentCreateParameters{
-		Properties: &authorization.RoleAssignmentProperties{
+		RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
 			RoleDefinitionID: utils.String(roleDefinitionId),
 			PrincipalID:      utils.String(principalId),
 		},
@@ -139,7 +139,7 @@ func resourceArmRoleAssignmentRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("name", resp.Name)
 
-	if props := resp.Properties; props != nil {
+	if props := resp.RoleAssignmentPropertiesWithScope; props != nil {
 		d.Set("scope", props.Scope)
 		d.Set("role_definition_id", props.RoleDefinitionID)
 		d.Set("principal_id", props.PrincipalID)

--- a/azurerm/resource_arm_role_assignment_test.go
+++ b/azurerm/resource_arm_role_assignment_test.go
@@ -16,10 +16,11 @@ func TestAccAzureRMRoleAssignment(t *testing.T) {
 	// Azure only being happy about provisioning a couple at a time
 	testCases := map[string]map[string]func(t *testing.T){
 		"basic": {
-			"emptyName": testAccAzureRMRoleAssignment_emptyName,
-			"roleName":  testAccAzureRMRoleAssignment_roleName,
-			"builtin":   testAccAzureRMRoleAssignment_builtin,
-			"custom":    testAccAzureRMRoleAssignment_custom,
+			"emptyName":   testAccAzureRMRoleAssignment_emptyName,
+			"roleName":    testAccAzureRMRoleAssignment_roleName,
+			"dataActions": testAccAzureRMRoleAssignment_dataActions,
+			"builtin":     testAccAzureRMRoleAssignment_builtin,
+			"custom":      testAccAzureRMRoleAssignment_custom,
 		},
 		"import": {
 			"basic":  testAccAzureRMRoleAssignment_importBasic,
@@ -64,6 +65,27 @@ func testAccAzureRMRoleAssignment_roleName(t *testing.T) {
 	id := uuid.New().String()
 	resourceName := "azurerm_role_assignment.test"
 	config := testAccAzureRMRoleAssignment_roleNameConfig(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRoleAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRoleAssignmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "role_definition_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAzureRMRoleAssignment_dataActions(t *testing.T) {
+	id := uuid.New().String()
+	resourceName := "azurerm_role_assignment.test"
+	config := testAccAzureRMRoleAssignment_dataActionsConfig(id)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -201,6 +223,21 @@ resource "azurerm_role_assignment" "test" {
   name                 = "%s"
   scope                = "${data.azurerm_subscription.primary.id}"
   role_definition_name = "Log Analytics Reader"
+  principal_id         = "${data.azurerm_client_config.test.service_principal_object_id}"
+}
+`, id)
+}
+
+func testAccAzureRMRoleAssignment_dataActionsConfig(id string) string {
+	return fmt.Sprintf(`
+data "azurerm_subscription" "primary" {}
+
+data "azurerm_client_config" "test" {}
+
+resource "azurerm_role_assignment" "test" {
+  name                 = "%s"
+  scope                = "${data.azurerm_subscription.primary.id}"
+  role_definition_name = "Virtual Machine User Login"
   principal_id         = "${data.azurerm_client_config.test.service_principal_object_id}"
 }
 `, id)

--- a/azurerm/resource_arm_role_assignment_test.go
+++ b/azurerm/resource_arm_role_assignment_test.go
@@ -180,7 +180,7 @@ data "azurerm_subscription" "primary" {}
 data "azurerm_client_config" "test" {}
 
 data "azurerm_builtin_role_definition" "test" {
-  name = "Reader"
+  name = "Monitoring Reader"
 }
 
 resource "azurerm_role_assignment" "test" {
@@ -200,7 +200,7 @@ data "azurerm_client_config" "test" {}
 resource "azurerm_role_assignment" "test" {
   name                 = "%s"
   scope                = "${data.azurerm_subscription.primary.id}"
-  role_definition_name = "Reader"
+  role_definition_name = "Log Analytics Reader"
   principal_id         = "${data.azurerm_client_config.test.service_principal_object_id}"
 }
 `, id)
@@ -213,7 +213,7 @@ data "azurerm_subscription" "primary" {}
 data "azurerm_client_config" "test" {}
 
 data "azurerm_builtin_role_definition" "test" {
-  name = "Reader"
+  name = "Site Recovery Reader"
 }
 
 resource "azurerm_role_assignment" "test" {

--- a/azurerm/resource_arm_role_definition.go
+++ b/azurerm/resource_arm_role_definition.go
@@ -2,10 +2,9 @@ package azurerm
 
 import (
 	"fmt"
-
 	"log"
 
-	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -90,10 +89,10 @@ func resourceArmRoleDefinitionCreateUpdate(d *schema.ResourceData, meta interfac
 	assignableScopes := expandRoleDefinitionAssignableScopes(d)
 
 	properties := authorization.RoleDefinition{
-		Properties: &authorization.RoleDefinitionProperties{
+		RoleDefinitionProperties: &authorization.RoleDefinitionProperties{
 			RoleName:         utils.String(name),
 			Description:      utils.String(description),
-			Type:             utils.String(roleType),
+			RoleType:         utils.String(roleType),
 			Permissions:      &permissions,
 			AssignableScopes: &assignableScopes,
 		},
@@ -131,7 +130,7 @@ func resourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error loading Role Definition %q: %+v", d.Id(), err)
 	}
 
-	if props := resp.Properties; props != nil {
+	if props := resp.RoleDefinitionProperties; props != nil {
 		d.Set("name", props.RoleName)
 		d.Set("description", props.Description)
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/classicadministrators.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/classicadministrators.go
@@ -72,7 +72,7 @@ func (client ClassicAdministratorsClient) ListPreparer(ctx context.Context) (*ht
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2015-06-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/client.go
@@ -1,4 +1,4 @@
-// Package authorization implements the Azure ARM Authorization service API version 2015-07-01.
+// Package authorization implements the Azure ARM Authorization service API version .
 //
 // Role based access control provides you a way to apply granular level policy administration down to individual
 // resources or resource groups. These operations enable you to manage role definitions and role assignments. A role

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/models.go
@@ -18,6 +18,7 @@ package authorization
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 import (
+	"encoding/json"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 	"net/http"
@@ -31,8 +32,77 @@ type ClassicAdministrator struct {
 	Name *string `json:"name,omitempty"`
 	// Type - The type of the administrator.
 	Type *string `json:"type,omitempty"`
-	// Properties - Properties for the classic administrator.
-	Properties *ClassicAdministratorProperties `json:"properties,omitempty"`
+	// ClassicAdministratorProperties - Properties for the classic administrator.
+	*ClassicAdministratorProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for ClassicAdministrator.
+func (ca ClassicAdministrator) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if ca.ID != nil {
+		objectMap["id"] = ca.ID
+	}
+	if ca.Name != nil {
+		objectMap["name"] = ca.Name
+	}
+	if ca.Type != nil {
+		objectMap["type"] = ca.Type
+	}
+	if ca.ClassicAdministratorProperties != nil {
+		objectMap["properties"] = ca.ClassicAdministratorProperties
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for ClassicAdministrator struct.
+func (ca *ClassicAdministrator) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				ca.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				ca.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				ca.Type = &typeVar
+			}
+		case "properties":
+			if v != nil {
+				var classicAdministratorProperties ClassicAdministratorProperties
+				err = json.Unmarshal(*v, &classicAdministratorProperties)
+				if err != nil {
+					return err
+				}
+				ca.ClassicAdministratorProperties = &classicAdministratorProperties
+			}
+		}
+	}
+
+	return nil
 }
 
 // ClassicAdministratorListResult classicAdministrator list result information.
@@ -151,6 +221,10 @@ type Permission struct {
 	Actions *[]string `json:"actions,omitempty"`
 	// NotActions - Denied actions.
 	NotActions *[]string `json:"notActions,omitempty"`
+	// DataActions - Allowed Data actions.
+	DataActions *[]string `json:"dataActions,omitempty"`
+	// NotDataActions - Denied Data actions.
+	NotDataActions *[]string `json:"notDataActions,omitempty"`
 }
 
 // PermissionGetResult permissions information.
@@ -267,6 +341,8 @@ type ProviderOperation struct {
 	Origin *string `json:"origin,omitempty"`
 	// Properties - The operation properties.
 	Properties interface{} `json:"properties,omitempty"`
+	// IsDataAction - The dataAction flag to specify the operation type.
+	IsDataAction *bool `json:"isDataAction,omitempty"`
 }
 
 // ProviderOperationsMetadata provider Operations metadata
@@ -408,20 +484,124 @@ type RoleAssignment struct {
 	Name *string `json:"name,omitempty"`
 	// Type - The role assignment type.
 	Type *string `json:"type,omitempty"`
-	// Properties - Role assignment properties.
-	Properties *RoleAssignmentPropertiesWithScope `json:"properties,omitempty"`
+	// RoleAssignmentPropertiesWithScope - Role assignment properties.
+	*RoleAssignmentPropertiesWithScope `json:"properties,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for RoleAssignment.
+func (ra RoleAssignment) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if ra.ID != nil {
+		objectMap["id"] = ra.ID
+	}
+	if ra.Name != nil {
+		objectMap["name"] = ra.Name
+	}
+	if ra.Type != nil {
+		objectMap["type"] = ra.Type
+	}
+	if ra.RoleAssignmentPropertiesWithScope != nil {
+		objectMap["properties"] = ra.RoleAssignmentPropertiesWithScope
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for RoleAssignment struct.
+func (ra *RoleAssignment) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				ra.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				ra.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				ra.Type = &typeVar
+			}
+		case "properties":
+			if v != nil {
+				var roleAssignmentPropertiesWithScope RoleAssignmentPropertiesWithScope
+				err = json.Unmarshal(*v, &roleAssignmentPropertiesWithScope)
+				if err != nil {
+					return err
+				}
+				ra.RoleAssignmentPropertiesWithScope = &roleAssignmentPropertiesWithScope
+			}
+		}
+	}
+
+	return nil
 }
 
 // RoleAssignmentCreateParameters role assignment create parameters.
 type RoleAssignmentCreateParameters struct {
-	// Properties - Role assignment properties.
-	Properties *RoleAssignmentProperties `json:"properties,omitempty"`
+	// RoleAssignmentProperties - Role assignment properties.
+	*RoleAssignmentProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for RoleAssignmentCreateParameters.
+func (racp RoleAssignmentCreateParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if racp.RoleAssignmentProperties != nil {
+		objectMap["properties"] = racp.RoleAssignmentProperties
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for RoleAssignmentCreateParameters struct.
+func (racp *RoleAssignmentCreateParameters) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "properties":
+			if v != nil {
+				var roleAssignmentProperties RoleAssignmentProperties
+				err = json.Unmarshal(*v, &roleAssignmentProperties)
+				if err != nil {
+					return err
+				}
+				racp.RoleAssignmentProperties = &roleAssignmentProperties
+			}
+		}
+	}
+
+	return nil
 }
 
 // RoleAssignmentFilter role Assignments filter
 type RoleAssignmentFilter struct {
 	// PrincipalID - Returns role assignment of the specific principal.
 	PrincipalID *string `json:"principalId,omitempty"`
+	// CanDelegate - The Delegation flag for the roleassignment
+	CanDelegate *bool `json:"canDelegate,omitempty"`
 }
 
 // RoleAssignmentListResult role assignment list operation result.
@@ -532,6 +712,8 @@ type RoleAssignmentProperties struct {
 	RoleDefinitionID *string `json:"roleDefinitionId,omitempty"`
 	// PrincipalID - The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user, service principal, or security group.
 	PrincipalID *string `json:"principalId,omitempty"`
+	// CanDelegate - The delgation flag used for creating a role assignment
+	CanDelegate *bool `json:"canDelegate,omitempty"`
 }
 
 // RoleAssignmentPropertiesWithScope role assignment properties with scope.
@@ -542,6 +724,8 @@ type RoleAssignmentPropertiesWithScope struct {
 	RoleDefinitionID *string `json:"roleDefinitionId,omitempty"`
 	// PrincipalID - The principal ID.
 	PrincipalID *string `json:"principalId,omitempty"`
+	// CanDelegate - The Delegation flag for the roleassignment
+	CanDelegate *bool `json:"canDelegate,omitempty"`
 }
 
 // RoleDefinition role definition.
@@ -553,14 +737,85 @@ type RoleDefinition struct {
 	Name *string `json:"name,omitempty"`
 	// Type - The role definition type.
 	Type *string `json:"type,omitempty"`
-	// Properties - Role definition properties.
-	Properties *RoleDefinitionProperties `json:"properties,omitempty"`
+	// RoleDefinitionProperties - Role definition properties.
+	*RoleDefinitionProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON is the custom marshaler for RoleDefinition.
+func (rd RoleDefinition) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if rd.ID != nil {
+		objectMap["id"] = rd.ID
+	}
+	if rd.Name != nil {
+		objectMap["name"] = rd.Name
+	}
+	if rd.Type != nil {
+		objectMap["type"] = rd.Type
+	}
+	if rd.RoleDefinitionProperties != nil {
+		objectMap["properties"] = rd.RoleDefinitionProperties
+	}
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON is the custom unmarshaler for RoleDefinition struct.
+func (rd *RoleDefinition) UnmarshalJSON(body []byte) error {
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(body, &m)
+	if err != nil {
+		return err
+	}
+	for k, v := range m {
+		switch k {
+		case "id":
+			if v != nil {
+				var ID string
+				err = json.Unmarshal(*v, &ID)
+				if err != nil {
+					return err
+				}
+				rd.ID = &ID
+			}
+		case "name":
+			if v != nil {
+				var name string
+				err = json.Unmarshal(*v, &name)
+				if err != nil {
+					return err
+				}
+				rd.Name = &name
+			}
+		case "type":
+			if v != nil {
+				var typeVar string
+				err = json.Unmarshal(*v, &typeVar)
+				if err != nil {
+					return err
+				}
+				rd.Type = &typeVar
+			}
+		case "properties":
+			if v != nil {
+				var roleDefinitionProperties RoleDefinitionProperties
+				err = json.Unmarshal(*v, &roleDefinitionProperties)
+				if err != nil {
+					return err
+				}
+				rd.RoleDefinitionProperties = &roleDefinitionProperties
+			}
+		}
+	}
+
+	return nil
 }
 
 // RoleDefinitionFilter role Definitions filter
 type RoleDefinitionFilter struct {
 	// RoleName - Returns role definition with the specific name.
 	RoleName *string `json:"roleName,omitempty"`
+	// Type - Returns role definition with the specific type.
+	Type *string `json:"type,omitempty"`
 }
 
 // RoleDefinitionListResult role definition list operation result.
@@ -671,8 +926,8 @@ type RoleDefinitionProperties struct {
 	RoleName *string `json:"roleName,omitempty"`
 	// Description - The role definition description.
 	Description *string `json:"description,omitempty"`
-	// Type - The role type.
-	Type *string `json:"type,omitempty"`
+	// RoleType - The role type.
+	RoleType *string `json:"type,omitempty"`
 	// Permissions - Role definition permissions.
 	Permissions *[]Permission `json:"permissions,omitempty"`
 	// AssignableScopes - Role definition assignable scopes.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/permissions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/permissions.go
@@ -44,7 +44,7 @@ func NewPermissionsClientWithBaseURI(baseURI string, subscriptionID string) Perm
 
 // ListForResource gets all permissions the caller has for a resource.
 // Parameters:
-// resourceGroupName - the name of the resource group containing the resource. The name is case insensitive.
+// resourceGroupName - the name of the resource group.
 // resourceProviderNamespace - the namespace of the resource provider.
 // parentResourcePath - the parent resource identity.
 // resourceType - the resource type of the resource.
@@ -83,7 +83,7 @@ func (client PermissionsClient) ListForResourcePreparer(ctx context.Context, res
 		"subscriptionId":            autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -145,7 +145,7 @@ func (client PermissionsClient) ListForResourceComplete(ctx context.Context, res
 
 // ListForResourceGroup gets all permissions the caller has for a resource group.
 // Parameters:
-// resourceGroupName - the name of the resource group to get the permissions for. The name is case insensitive.
+// resourceGroupName - the name of the resource group.
 func (client PermissionsClient) ListForResourceGroup(ctx context.Context, resourceGroupName string) (result PermissionGetResultPage, err error) {
 	result.fn = client.listForResourceGroupNextResults
 	req, err := client.ListForResourceGroupPreparer(ctx, resourceGroupName)
@@ -176,7 +176,7 @@ func (client PermissionsClient) ListForResourceGroupPreparer(ctx context.Context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/provideroperationsmetadata.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/provideroperationsmetadata.go
@@ -74,7 +74,7 @@ func (client ProviderOperationsMetadataClient) GetPreparer(ctx context.Context, 
 		"resourceProviderNamespace": autorest.Encode("path", resourceProviderNamespace),
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -140,7 +140,7 @@ func (client ProviderOperationsMetadataClient) List(ctx context.Context, expand 
 
 // ListPreparer prepares the List request.
 func (client ProviderOperationsMetadataClient) ListPreparer(ctx context.Context, expand string) (*http.Request, error) {
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/roleassignments.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/roleassignments.go
@@ -80,7 +80,7 @@ func (client RoleAssignmentsClient) CreatePreparer(ctx context.Context, scope st
 		"scope":              scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -117,13 +117,10 @@ func (client RoleAssignmentsClient) CreateResponder(resp *http.Response) (result
 
 // CreateByID creates a role assignment by ID.
 // Parameters:
-// roleAssignmentID - the fully qualified ID of the role assignment, including the scope, resource name and
-// resource type. Use the format,
-// /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}. Example:
-// /subscriptions/{subId}/resourcegroups/{rgname}//providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}.
+// roleID - the ID of the role assignment to create.
 // parameters - parameters for the role assignment.
-func (client RoleAssignmentsClient) CreateByID(ctx context.Context, roleAssignmentID string, parameters RoleAssignmentCreateParameters) (result RoleAssignment, err error) {
-	req, err := client.CreateByIDPreparer(ctx, roleAssignmentID, parameters)
+func (client RoleAssignmentsClient) CreateByID(ctx context.Context, roleID string, parameters RoleAssignmentCreateParameters) (result RoleAssignment, err error) {
+	req, err := client.CreateByIDPreparer(ctx, roleID, parameters)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "authorization.RoleAssignmentsClient", "CreateByID", nil, "Failure preparing request")
 		return
@@ -145,12 +142,12 @@ func (client RoleAssignmentsClient) CreateByID(ctx context.Context, roleAssignme
 }
 
 // CreateByIDPreparer prepares the CreateByID request.
-func (client RoleAssignmentsClient) CreateByIDPreparer(ctx context.Context, roleAssignmentID string, parameters RoleAssignmentCreateParameters) (*http.Request, error) {
+func (client RoleAssignmentsClient) CreateByIDPreparer(ctx context.Context, roleID string, parameters RoleAssignmentCreateParameters) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"roleAssignmentId": roleAssignmentID,
+		"roleId": roleID,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -159,7 +156,7 @@ func (client RoleAssignmentsClient) CreateByIDPreparer(ctx context.Context, role
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/{roleAssignmentId}", pathParameters),
+		autorest.WithPathParameters("/{roleId}", pathParameters),
 		autorest.WithJSON(parameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
@@ -218,7 +215,7 @@ func (client RoleAssignmentsClient) DeletePreparer(ctx context.Context, scope st
 		"scope":              scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -253,12 +250,9 @@ func (client RoleAssignmentsClient) DeleteResponder(resp *http.Response) (result
 
 // DeleteByID deletes a role assignment.
 // Parameters:
-// roleAssignmentID - the fully qualified ID of the role assignment, including the scope, resource name and
-// resource type. Use the format,
-// /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}. Example:
-// /subscriptions/{subId}/resourcegroups/{rgname}//providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}.
-func (client RoleAssignmentsClient) DeleteByID(ctx context.Context, roleAssignmentID string) (result RoleAssignment, err error) {
-	req, err := client.DeleteByIDPreparer(ctx, roleAssignmentID)
+// roleID - the ID of the role assignment to delete.
+func (client RoleAssignmentsClient) DeleteByID(ctx context.Context, roleID string) (result RoleAssignment, err error) {
+	req, err := client.DeleteByIDPreparer(ctx, roleID)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "authorization.RoleAssignmentsClient", "DeleteByID", nil, "Failure preparing request")
 		return
@@ -280,12 +274,12 @@ func (client RoleAssignmentsClient) DeleteByID(ctx context.Context, roleAssignme
 }
 
 // DeleteByIDPreparer prepares the DeleteByID request.
-func (client RoleAssignmentsClient) DeleteByIDPreparer(ctx context.Context, roleAssignmentID string) (*http.Request, error) {
+func (client RoleAssignmentsClient) DeleteByIDPreparer(ctx context.Context, roleID string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"roleAssignmentId": roleAssignmentID,
+		"roleId": roleID,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -293,7 +287,7 @@ func (client RoleAssignmentsClient) DeleteByIDPreparer(ctx context.Context, role
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/{roleAssignmentId}", pathParameters),
+		autorest.WithPathParameters("/{roleId}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -351,7 +345,7 @@ func (client RoleAssignmentsClient) GetPreparer(ctx context.Context, scope strin
 		"scope":              scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -386,12 +380,9 @@ func (client RoleAssignmentsClient) GetResponder(resp *http.Response) (result Ro
 
 // GetByID gets a role assignment by ID.
 // Parameters:
-// roleAssignmentID - the fully qualified ID of the role assignment, including the scope, resource name and
-// resource type. Use the format,
-// /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}. Example:
-// /subscriptions/{subId}/resourcegroups/{rgname}//providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}.
-func (client RoleAssignmentsClient) GetByID(ctx context.Context, roleAssignmentID string) (result RoleAssignment, err error) {
-	req, err := client.GetByIDPreparer(ctx, roleAssignmentID)
+// roleID - the ID of the role assignment to get.
+func (client RoleAssignmentsClient) GetByID(ctx context.Context, roleID string) (result RoleAssignment, err error) {
+	req, err := client.GetByIDPreparer(ctx, roleID)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "authorization.RoleAssignmentsClient", "GetByID", nil, "Failure preparing request")
 		return
@@ -413,12 +404,12 @@ func (client RoleAssignmentsClient) GetByID(ctx context.Context, roleAssignmentI
 }
 
 // GetByIDPreparer prepares the GetByID request.
-func (client RoleAssignmentsClient) GetByIDPreparer(ctx context.Context, roleAssignmentID string) (*http.Request, error) {
+func (client RoleAssignmentsClient) GetByIDPreparer(ctx context.Context, roleID string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"roleAssignmentId": roleAssignmentID,
+		"roleId": roleID,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -426,7 +417,7 @@ func (client RoleAssignmentsClient) GetByIDPreparer(ctx context.Context, roleAss
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/{roleAssignmentId}", pathParameters),
+		autorest.WithPathParameters("/{roleId}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -485,7 +476,7 @@ func (client RoleAssignmentsClient) ListPreparer(ctx context.Context, filter str
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -592,7 +583,7 @@ func (client RoleAssignmentsClient) ListForResourcePreparer(ctx context.Context,
 		"subscriptionId":            autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -691,7 +682,7 @@ func (client RoleAssignmentsClient) ListForResourceGroupPreparer(ctx context.Con
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -789,7 +780,7 @@ func (client RoleAssignmentsClient) ListForScopePreparer(ctx context.Context, sc
 		"scope": scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/roledefinitions.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/roledefinitions.go
@@ -76,7 +76,7 @@ func (client RoleDefinitionsClient) CreateOrUpdatePreparer(ctx context.Context, 
 		"scope":            scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -144,7 +144,7 @@ func (client RoleDefinitionsClient) DeletePreparer(ctx context.Context, scope st
 		"scope":            scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -210,7 +210,7 @@ func (client RoleDefinitionsClient) GetPreparer(ctx context.Context, scope strin
 		"scope":            scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -245,12 +245,12 @@ func (client RoleDefinitionsClient) GetResponder(resp *http.Response) (result Ro
 
 // GetByID gets a role definition by ID.
 // Parameters:
-// roleDefinitionID - the fully qualified role definition ID. Use the format,
+// roleID - the fully qualified role definition ID. Use the format,
 // /subscriptions/{guid}/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId} for subscription
 // level role definitions, or /providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId} for tenant
 // level role definitions.
-func (client RoleDefinitionsClient) GetByID(ctx context.Context, roleDefinitionID string) (result RoleDefinition, err error) {
-	req, err := client.GetByIDPreparer(ctx, roleDefinitionID)
+func (client RoleDefinitionsClient) GetByID(ctx context.Context, roleID string) (result RoleDefinition, err error) {
+	req, err := client.GetByIDPreparer(ctx, roleID)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "authorization.RoleDefinitionsClient", "GetByID", nil, "Failure preparing request")
 		return
@@ -272,12 +272,12 @@ func (client RoleDefinitionsClient) GetByID(ctx context.Context, roleDefinitionI
 }
 
 // GetByIDPreparer prepares the GetByID request.
-func (client RoleDefinitionsClient) GetByIDPreparer(ctx context.Context, roleDefinitionID string) (*http.Request, error) {
+func (client RoleDefinitionsClient) GetByIDPreparer(ctx context.Context, roleID string) (*http.Request, error) {
 	pathParameters := map[string]interface{}{
-		"roleDefinitionId": roleDefinitionID,
+		"roleId": roleID,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -285,7 +285,7 @@ func (client RoleDefinitionsClient) GetByIDPreparer(ctx context.Context, roleDef
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/{roleDefinitionId}", pathParameters),
+		autorest.WithPathParameters("/{roleId}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -344,7 +344,7 @@ func (client RoleDefinitionsClient) ListPreparer(ctx context.Context, scope stri
 		"scope": scope,
 	}
 
-	const APIVersion = "2015-07-01"
+	const APIVersion = "2018-01-01-preview"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization/version.go
@@ -21,7 +21,7 @@ import "github.com/Azure/azure-sdk-for-go/version"
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/" + version.Number + " authorization/2015-07-01"
+	return "Azure-SDK-For-Go/" + version.Number + " authorization/2018-01-01-preview"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -11,14 +11,6 @@
 			"versionExact": "v16.2.1"
 		},
 		{
-			"checksumSHA1": "jf0lz1wRA07ILyDujw/NzoU3kMA=",
-			"path": "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization",
-			"revision": "4650843026a7fdec254a8d9cf893693a254edd0b",
-			"revisionTime": "2018-05-04T19:14:26Z",
-			"version": "v16.2.1",
-			"versionExact": "v16.2.1"
-		},
-		{
 			"checksumSHA1": "cL5VuAorqkBbkDvfOpB8Mh8Mm48=",
 			"path": "github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation",
 			"revision": "4650843026a7fdec254a8d9cf893693a254edd0b",
@@ -181,6 +173,14 @@
 		{
 			"checksumSHA1": "q0OKr6uBD4lgnHN/EIDrv0GQWW8=",
 			"path": "github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql",
+			"revision": "4650843026a7fdec254a8d9cf893693a254edd0b",
+			"revisionTime": "2018-05-04T19:14:26Z",
+			"version": "v16.2.1",
+			"versionExact": "v16.2.1"
+		},
+		{
+			"checksumSHA1": "e4hCajXDSuWNkUvwA35jMHGm20E=",
+			"path": "github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization",
 			"revision": "4650843026a7fdec254a8d9cf893693a254edd0b",
 			"revisionTime": "2018-05-04T19:14:26Z",
 			"version": "v16.2.1",


### PR DESCRIPTION
Trying to create a Role Assignment using a Role that's got Data Actions assigned returns the following error:

```
authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="UnsupportedApiVersionForRoleDefinitionHasDataActions" Message="Assignments to roles with DataActions and NotDataActions are not supported on API version '2015-07-01'. The minimum required API version for this operations is '2018-01-01-preview'."
```

I'd consider this an API bug (and have raised [this SDK issue](https://github.com/Azure/azure-sdk-for-go/issues/1895)) - but we can work around this in Terraform by upgrading to the new Preview API (which I've done here).

This PR also fixes the intermittently failing Role Assignments tests, where the tests were running in parallel using the same Role Definition (thus causing conflicts).

Fixes #1280