### PR TITLE
azurerm_sql_firewall_rule doc: fix Name description

### DIFF
--- a/website/docs/r/sql_firewall_rule.html.markdown
+++ b/website/docs/r/sql_firewall_rule.html.markdown
@@ -39,7 +39,7 @@ resource "azurerm_sql_firewall_rule" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the SQL Server.
+* `name` - (Required) The name of the firewall rule.
 
 * `resource_group_name` - (Required) The name of the resource group in which to
     create the sql server.


### PR DESCRIPTION
Typo in the `name` attribute's description.  (Was set to the same as the `server_name`)