### PR TITLE
Fixing issue 1286 : We are unable to disassociate a PIP once attached

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -68,7 +68,6 @@ func resourceArmNetworkInterface() *schema.Resource {
 						"private_ip_address": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 
 						"private_ip_address_allocation": {
@@ -85,7 +84,6 @@ func resourceArmNetworkInterface() *schema.Resource {
 						"public_ip_address_id": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 
 						"application_gateway_backend_address_pools_ids": {

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -333,6 +333,32 @@ func TestAccAzureRMNetworkInterface_withTags(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterface_IPAddressesBug1286(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterface_withIPAddresses(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_configuration.0.private_ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_configuration.0.public_ip_address_id"),
+				),
+			},
+			{
+				Config: testAccAzureRMNetworkInterface_withIPAddressesUpdate(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterface_bug7986(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
@@ -788,6 +814,94 @@ resource "azurerm_network_interface" "test" {
   }
 }
 `, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMNetworkInterface_withIPAddresses(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "testsubnet"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "test-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
+  domain_name_label            = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "static"
+    private_ip_address            = "10.0.2.9"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMNetworkInterface_withIPAddressesUpdate(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "testsubnet"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "test-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
+  domain_name_label            = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
 }
 
 func testAccAzureRMNetworkInterface_multipleLoadBalancers(rInt int, location string) string {

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -353,6 +353,8 @@ func TestAccAzureRMNetworkInterface_IPAddressesBug1286(t *testing.T) {
 				Config: testAccAzureRMNetworkInterface_withIPAddressesUpdate(rInt, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetworkInterfaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ip_configuration.0.private_ip_address", ""),
+					resource.TestCheckResourceAttr(resourceName, "ip_configuration.0.public_ip_address_id", ""),
 				),
 			},
 		},


### PR DESCRIPTION
I have run all the NIC test cases. Most of them pass and couple failed due to unrelated issues. 

```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMNetwork -timeout 180m
=== RUN   TestAccAzureRMNetworkInterface_importBasic
--- PASS: TestAccAzureRMNetworkInterface_importBasic (105.28s)
=== RUN   TestAccAzureRMNetworkInterface_importIPForwarding
--- PASS: TestAccAzureRMNetworkInterface_importIPForwarding (104.16s)
=== RUN   TestAccAzureRMNetworkInterface_importWithTags
--- PASS: TestAccAzureRMNetworkInterface_importWithTags (105.04s)
=== RUN   TestAccAzureRMNetworkInterface_importMultipleLoadBalancers
--- PASS: TestAccAzureRMNetworkInterface_importMultipleLoadBalancers (115.82s)
=== RUN   TestAccAzureRMNetworkInterface_importApplicationGateway
--- PASS: TestAccAzureRMNetworkInterface_importApplicationGateway (1682.79s)
=== RUN   TestAccAzureRMNetworkInterface_importPublicIP
--- PASS: TestAccAzureRMNetworkInterface_importPublicIP (105.56s)
=== RUN   TestAccAzureRMNetworkInterface_importApplicationSecurityGroup
--- PASS: TestAccAzureRMNetworkInterface_importApplicationSecurityGroup (108.86s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_importBasic
--- PASS: TestAccAzureRMNetworkSecurityGroup_importBasic (75.94s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_importSingleRule
--- PASS: TestAccAzureRMNetworkSecurityGroup_importSingleRule (72.72s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_importMultipleRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_importMultipleRules (72.90s)
=== RUN   TestAccAzureRMNetworkSecurityRule_importBasic
--- PASS: TestAccAzureRMNetworkSecurityRule_importBasic (85.64s)
=== RUN   TestAccAzureRMNetworkInterface_basic
--- PASS: TestAccAzureRMNetworkInterface_basic (103.60s)
=== RUN   TestAccAzureRMNetworkInterface_disappears
--- PASS: TestAccAzureRMNetworkInterface_disappears (104.81s)
=== RUN   TestAccAzureRMNetworkInterface_setNetworkSecurityGroupId
--- PASS: TestAccAzureRMNetworkInterface_setNetworkSecurityGroupId (109.83s)
=== RUN   TestAccAzureRMNetworkInterface_removeNetworkSecurityGroupId
--- FAIL: TestAccAzureRMNetworkInterface_removeNetworkSecurityGroupId (107.59s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:
		
		* azurerm_network_security_group.test (destroy): 1 error(s) occurred:
		
		* azurerm_network_security_group.test: Error deleting Network Security Group "acctestnsg-3735975067294333692" (Resource Group "acctest-rg-3735975067294333692"): network.SecurityGroupsClient#Delete: Failure sending request: StatusCode=400 -- Original Error: Code="InUseNetworkSecurityGroupCannotBeDeleted" Message="Network security group /subscriptions/cba4e087-aceb-44f0-970e-65e96eff4081/resourceGroups/acctest-rg-3735975067294333692/providers/Microsoft.Network/networkSecurityGroups/acctestnsg-3735975067294333692 cannot be deleted because it is in use by the following resources: /subscriptions/cba4e087-aceb-44f0-970e-65e96eff4081/resourceGroups/acctest-rg-3735975067294333692/providers/Microsoft.Network/networkInterfaces/acctestni-3735975067294333692." Details=[]
=== RUN   TestAccAzureRMNetworkInterface_multipleSubnets
--- PASS: TestAccAzureRMNetworkInterface_multipleSubnets (103.12s)
=== RUN   TestAccAzureRMNetworkInterface_multipleSubnetsPrimary
--- PASS: TestAccAzureRMNetworkInterface_multipleSubnetsPrimary (111.85s)
=== RUN   TestAccAzureRMNetworkInterface_enableIPForwarding
--- PASS: TestAccAzureRMNetworkInterface_enableIPForwarding (103.90s)
=== RUN   TestAccAzureRMNetworkInterface_enableAcceleratedNetworking
--- PASS: TestAccAzureRMNetworkInterface_enableAcceleratedNetworking (104.70s)
=== RUN   TestAccAzureRMNetworkInterface_multipleLoadBalancers
--- PASS: TestAccAzureRMNetworkInterface_multipleLoadBalancers (106.81s)
=== RUN   TestAccAzureRMNetworkInterface_applicationGateway
--- PASS: TestAccAzureRMNetworkInterface_applicationGateway (1520.50s)
=== RUN   TestAccAzureRMNetworkInterface_withTags
--- PASS: TestAccAzureRMNetworkInterface_withTags (110.16s)
=== RUN   TestAccAzureRMNetworkInterface_bug7986
--- PASS: TestAccAzureRMNetworkInterface_bug7986 (107.25s)
=== RUN   TestAccAzureRMNetworkInterface_applicationSecurityGroups
--- PASS: TestAccAzureRMNetworkInterface_applicationSecurityGroups (93.98s)
=== RUN   TestAccAzureRMNetworkInterface_internalFQDN
--- FAIL: TestAccAzureRMNetworkInterface_internalFQDN (102.52s)
	testing.go:513: Step 0 error: Check failed: Check 2/2 error: azurerm_network_interface.test: Attribute 'internal_fqdn' expected "acctestnic-4928547999410651021.example.com", got ""
```

Fixes #1286 