### PR TITLE
azure vm size Standard_A0 is not working

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -39,7 +39,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   agent_pool_profile {
     name            = "default"
     count           = 1
-    vm_size         = "Standard_A0"
+    vm_size         = "Standard_DS1_v2"
     os_type         = "Linux"
     os_disk_size_gb = 30
   }


### PR DESCRIPTION
the azure sample for AKS is not working cause the vm size Standard_A0 can't be used for AKS use Standard_DS1_v2 instead