### PR TITLE
DOCS: Fixes typo in storage_account_sas example

### DIFF
--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -65,7 +65,7 @@ data "azurerm_storage_account_sas" "test" {
 }
 
 output "sas_url_query_string" {
-  value = "${data.azurerm_storage_account_sas.sas}"
+  value = "${data.azurerm_storage_account_sas.test.sas}"
 }
 ```
 


### PR DESCRIPTION
Just a small typo fix in `storage_account_sas` example.