### PR TITLE
Support OS disk size or storage type changes

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -198,6 +198,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"managed_disk_type": {
 							Type:          schema.TypeString,
 							Optional:      true,
+							ForceNew:      true,
 							Computed:      true,
 							ConflictsWith: []string{"storage_os_disk.0.vhd_uri"},
 							ValidateFunc: validation.StringInSlice([]string{
@@ -226,6 +227,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"disk_size_gb": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							ForceNew:     true,
 							Computed:     true,
 							ValidateFunc: validateDiskSizeGB,
 						},


### PR DESCRIPTION
Related issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/345

This change allows to change OS disk size and/or storage type by forcing VM recreation.

This is my first code contribution to terraform provider. Please point me if docs/tests adjustments are needed.

# Use case

This fits our use case: We switch our "ephemeral" VMs to new storage_type and want terraform to handle it. In current state it fails with

```
* azurerm_virtual_machine.test: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=409 -- Original Error: failed r
equest: autorest/azure: Service returned an error. Status=<nil> Code="OperationNotAllowed" Message="Managed disk storage account type change thro
ugh Virtual Machine 'acctvm' is not allowed. Please update disk resource at /subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ro
mantest1/providers/Microsoft.Compute/disks/myosdisk1." Target="osDisk.managedDisk.storageAccountType"
```

# Limitations

This does not work if "delete_os_disk_on_termination" is set to "false" (default) and fails with 
```
* azurerm_virtual_machine.test: Long running operation terminated with status 'Failed': Code="ConflictingUserInput" Message="Disk myosdisk1 alrea
dy exists in resource group ROMANTEST1. Only CreateOption.Attach is supported."  
```
What is the best way to handle such use cases?

# Notes

This is nothing to do with data disks changes. In case data disks, i assume we need to gently detach disk/stop vm and make changes. https://github.com/terraform-providers/terraform-provider-azurerm/pull/1207 looks like requirement for data disk changes.


