### PR TITLE
Overprovision should be default true. Terraform and the service back …

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -106,6 +106,7 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 			"overprovision": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 
 			"single_placement_group": {

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -245,7 +245,7 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 * `sku` - (Required) A sku block as documented below.
 * `upgrade_policy_mode` - (Required) Specifies the mode of an upgrade to virtual machines in the scale set. Possible values, `Manual` or `Automatic`.
-* `overprovision` - (Optional) Specifies whether the virtual machine scale set should be overprovisioned.
+* `overprovision` - (Optional) Specifies whether the virtual machine scale set should be overprovisioned. Default set to true when not specified.
 * `single_placement_group` - (Optional) Specifies whether the scale set is limited to a single placement group with a maximum size of 100 virtual machines. If set to false, managed disks must be used. Default is true. Changing this forces a
     new resource to be created. See [documentation](http://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-placement-groups) for more information.
 * `license_type` - (Optional, when a Windows machine) Specifies the Windows OS license type. If supplied, the only allowed values are `Windows_Client` and `Windows_Server`.

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -245,7 +245,7 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 * `sku` - (Required) A sku block as documented below.
 * `upgrade_policy_mode` - (Required) Specifies the mode of an upgrade to virtual machines in the scale set. Possible values, `Manual` or `Automatic`.
-* `overprovision` - (Optional) Specifies whether the virtual machine scale set should be overprovisioned. Default set to true when not specified.
+* `overprovision` - (Optional) Specifies whether the virtual machine scale set should be overprovisioned. Defaults to true.
 * `single_placement_group` - (Optional) Specifies whether the scale set is limited to a single placement group with a maximum size of 100 virtual machines. If set to false, managed disks must be used. Default is true. Changing this forces a
     new resource to be created. See [documentation](http://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-placement-groups) for more information.
 * `license_type` - (Optional, when a Windows machine) Specifies the Windows OS license type. If supplied, the only allowed values are `Windows_Client` and `Windows_Server`.

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -245,8 +245,8 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 * `sku` - (Required) A sku block as documented below.
 * `upgrade_policy_mode` - (Required) Specifies the mode of an upgrade to virtual machines in the scale set. Possible values, `Manual` or `Automatic`.
-* `overprovision` - (Optional) Specifies whether the virtual machine scale set should be overprovisioned. Defaults to true.
-* `single_placement_group` - (Optional) Specifies whether the scale set is limited to a single placement group with a maximum size of 100 virtual machines. If set to false, managed disks must be used. Default is true. Changing this forces a
+* `overprovision` - (Optional) Specifies whether the virtual machine scale set should be overprovisioned. Defaults to `true`.
+* `single_placement_group` - (Optional) Specifies whether the scale set is limited to a single placement group with a maximum size of 100 virtual machines. If set to false, managed disks must be used. Defaults to `true`. Changing this forces a
     new resource to be created. See [documentation](http://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-placement-groups) for more information.
 * `license_type` - (Optional, when a Windows machine) Specifies the Windows OS license type. If supplied, the only allowed values are `Windows_Client` and `Windows_Server`.
 * `os_profile` - (Required) A Virtual Machine OS Profile block as documented below.


### PR DESCRIPTION
…end is considering this as default false when nothing is specified. I have run all the VMSS tests. Most of them pass with some unrelated failures. 

```
TestAccAzureRMVirtualMachineScaleSet
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMVirtualMachineScaleSet -timeout 180m
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importBasic
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importBasic (355.53s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importBasic_managedDisk
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importBasic_managedDisk (354.05s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importBasic_managedDisk_withZones
--- FAIL: TestAccAzureRMVirtualMachineScaleSet_importBasic_managedDisk_withZones (101.70s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* azurerm_virtual_machine_scale_set.test: 1 error(s) occurred:
		
		* azurerm_virtual_machine_scale_set.test: compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ResourceTypeNotSupportAvailabilityZones" Message="The resource type 'virtualMachineScaleSets' does not support availability zones at location 'southcentralus' and api-version '2017-12-01'."
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importLinux
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importLinux (367.60s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importLoadBalancer
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importLoadBalancer (365.93s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importOverProvision
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importOverProvision (364.06s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importExtension
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importExtension (367.29s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importMultipleExtensions
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importMultipleExtensions (364.91s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basic
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basic (360.84s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicPublicIP
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicPublicIP (354.82s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicAcceleratedNetworking
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicAcceleratedNetworking (356.50s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_bootDiagnostic
--- PASS: TestAccAzureRMVirtualMachineScaleSet_bootDiagnostic (353.95s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_networkSecurityGroup
--- PASS: TestAccAzureRMVirtualMachineScaleSet_networkSecurityGroup (363.09s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicWindows
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicWindows (401.86s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_singlePlacementGroupFalse
--- PASS: TestAccAzureRMVirtualMachineScaleSet_singlePlacementGroupFalse (367.48s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_linuxUpdated
--- PASS: TestAccAzureRMVirtualMachineScaleSet_linuxUpdated (522.11s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_customDataUpdated
--- PASS: TestAccAzureRMVirtualMachineScaleSet_customDataUpdated (461.82s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDisk
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDisk (363.52s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk (470.57s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicWindows_managedDisk_resize (651.61s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDiskNoName
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDiskNoName (355.63s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicLinux_disappears
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicLinux_disappears (426.61s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_planManagedDisk
--- FAIL: TestAccAzureRMVirtualMachineScaleSet_planManagedDisk (103.15s)
	testing.go:513: Step 0 error: Error applying: 1 error(s) occurred:
		
		* azurerm_virtual_machine_scale_set.test: 1 error(s) occurred:
		
		* azurerm_virtual_machine_scale_set.test: compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ResourcePurchaseValidationFailed" Message="User failed validation to purchase resources. Error message: 'Legal terms have not been accepted for this item on this subscription. To accept legal terms using PowerShell, please use Get-AzureRmMarketplaceTerms and Set-AzureRmMarketplaceTerms API(https://go.microsoft.com/fwlink/?linkid=862451) or deploy via the Azure portal to accept the terms'"
```
