### PR TITLE
Storage Account Network Rules

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -145,6 +145,7 @@ func resourceArmStorageAccount() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"bypass": {
@@ -165,7 +166,7 @@ func resourceArmStorageAccount() *schema.Resource {
 						"default_access_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Computed: true,
 						},
 						"ip_rules": {
 							Type:     schema.TypeSet,
@@ -705,10 +706,12 @@ func expandStorageAccountNetworkRules(d *schema.ResourceData) *storage.NetworkRu
 	networkRuleSet.IPRules = expandStorageAccountIPRules(networkRule)
 	networkRuleSet.VirtualNetworkRules = expandStorageAccountVirtualNetworks(networkRule)
 	networkRuleSet.Bypass = expandStorageAccountBypass(networkRule)
-	if networkRule["default_access_enabled"].(bool) {
-		networkRuleSet.DefaultAction = storage.DefaultActionAllow
-	} else {
-		networkRuleSet.DefaultAction = storage.DefaultActionDeny
+	if val, ok := networkRule["default_access_enabled"]; ok {
+		if val.(bool) {
+			networkRuleSet.DefaultAction = storage.DefaultActionAllow
+		} else {
+			networkRuleSet.DefaultAction = storage.DefaultActionDeny
+		}
 	}
 
 	return networkRuleSet

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -141,6 +141,48 @@ func resourceArmStorageAccount() *schema.Resource {
 				Optional: true,
 			},
 
+			"network_rules": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bypass": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(storage.AzureServices),
+									string(storage.Logging),
+									string(storage.Metrics),
+									string(storage.None),
+								}, true),
+							},
+							Set: schema.HashString,
+						},
+						"default_access_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"ip_rules": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"virtual_network_subnet_ids": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+			},
+
 			"primary_location": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -245,6 +287,8 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 	storageType := fmt.Sprintf("%s_%s", accountTier, replicationType)
 	storageAccountEncryptionSource := d.Get("account_encryption_source").(string)
 
+	networkRules := expandStorageAccountNetworkRules(d)
+
 	parameters := storage.AccountCreateParameters{
 		Location: &location,
 		Sku: &storage.Sku{
@@ -261,6 +305,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 				KeySource: storage.KeySource(storageAccountEncryptionSource),
 			},
 			EnableHTTPSTrafficOnly: &enableHTTPSTrafficOnly,
+			NetworkRuleSet:         networkRules,
 		},
 	}
 
@@ -457,6 +502,22 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 		d.SetPartial("enable_https_traffic_only")
 	}
 
+	if d.HasChange("network_rules") {
+		networkRules := expandStorageAccountNetworkRules(d)
+
+		opts := storage.AccountUpdateParameters{
+			AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
+				NetworkRuleSet: networkRules,
+			},
+		}
+		_, err := client.Update(ctx, resourceGroupName, storageAccountName, opts)
+		if err != nil {
+			return fmt.Errorf("Error updating Azure Storage Account network_rules %q: %+v", storageAccountName, err)
+		}
+
+		d.SetPartial("network_rules")
+	}
+
 	d.Partial(false)
 	return nil
 }
@@ -571,6 +632,12 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 				d.Set("secondary_table_endpoint", "")
 			}
 		}
+
+		if networkRules := props.NetworkRuleSet; networkRules != nil {
+			if err := d.Set("network_rules", flattenStorageAccountNetworkRules(networkRules)); err != nil {
+				return fmt.Errorf("Error flattening `network_rules`: %+v", err)
+			}
+		}
 	}
 
 	d.Set("primary_access_key", accessKeys[0].Value)
@@ -624,6 +691,111 @@ func flattenStorageAccountCustomDomain(input *storage.CustomDomain) []interface{
 	// use_subdomain isn't returned
 
 	return []interface{}{domain}
+}
+
+func expandStorageAccountNetworkRules(d *schema.ResourceData) *storage.NetworkRuleSet {
+	networkRules := d.Get("network_rules").([]interface{})
+	if networkRules == nil || len(networkRules) == 0 {
+		return nil
+	}
+
+	networkRule := networkRules[0].(map[string]interface{})
+	networkRuleSet := &storage.NetworkRuleSet{}
+
+	networkRuleSet.IPRules = expandStorageAccountIPRules(networkRule)
+	networkRuleSet.VirtualNetworkRules = expandStorageAccountVirtualNetworks(networkRule)
+	networkRuleSet.Bypass = expandStorageAccountBypass(networkRule)
+	if networkRule["default_access_enabled"].(bool) {
+		networkRuleSet.DefaultAction = storage.DefaultActionAllow
+	} else {
+		networkRuleSet.DefaultAction = storage.DefaultActionDeny
+	}
+
+	return networkRuleSet
+}
+
+func expandStorageAccountIPRules(networkRule map[string]interface{}) *[]storage.IPRule {
+	ipRulesInfo := networkRule["ip_rules"].(*schema.Set).List()
+	ipRules := make([]storage.IPRule, len(ipRulesInfo))
+
+	for i, ipRuleConfig := range ipRulesInfo {
+		attrs := ipRuleConfig.(string)
+		ipRule := storage.IPRule{
+			IPAddressOrRange: utils.String(attrs),
+			Action:           storage.Allow,
+		}
+		ipRules[i] = ipRule
+	}
+
+	return &ipRules
+}
+
+func expandStorageAccountVirtualNetworks(networkRule map[string]interface{}) *[]storage.VirtualNetworkRule {
+	virtualNetworkInfo := networkRule["virtual_network_subnet_ids"].(*schema.Set).List()
+	virtualNetworks := make([]storage.VirtualNetworkRule, len(virtualNetworkInfo))
+
+	for i, virtualNetworkConfig := range virtualNetworkInfo {
+		attrs := virtualNetworkConfig.(string)
+		virtualNetwork := storage.VirtualNetworkRule{
+			VirtualNetworkResourceID: utils.String(attrs),
+			Action: storage.Allow,
+		}
+		virtualNetworks[i] = virtualNetwork
+	}
+
+	return &virtualNetworks
+}
+
+func expandStorageAccountBypass(networkRule map[string]interface{}) storage.Bypass {
+	bypassInfo := networkRule["bypass"].(*schema.Set).List()
+
+	var bypassValues []string
+	for _, bypassConfig := range bypassInfo {
+		bypassValues = append(bypassValues, bypassConfig.(string))
+	}
+
+	return storage.Bypass(strings.Join(bypassValues, ", "))
+}
+
+func flattenStorageAccountNetworkRules(input *storage.NetworkRuleSet) []interface{} {
+	networkRules := make(map[string]interface{}, 0)
+
+	networkRules["ip_rules"] = schema.NewSet(schema.HashString, flattenStorageAccountIPRules(input.IPRules))
+	networkRules["virtual_network_subnet_ids"] = schema.NewSet(schema.HashString, flattenStorageAccountVirtualNetworks(input.VirtualNetworkRules))
+	if input.DefaultAction != "" {
+		networkRules["default_access_enabled"] = (input.DefaultAction == storage.DefaultActionAllow)
+	}
+	networkRules["bypass"] = schema.NewSet(schema.HashString, flattenStorageAccountBypass(input.Bypass))
+	return []interface{}{networkRules}
+}
+
+func flattenStorageAccountIPRules(input *[]storage.IPRule) []interface{} {
+	ipRules := make([]interface{}, len(*input))
+	for i, ipRule := range *input {
+		ipRules[i] = *ipRule.IPAddressOrRange
+	}
+
+	return ipRules
+}
+
+func flattenStorageAccountVirtualNetworks(input *[]storage.VirtualNetworkRule) []interface{} {
+	virtualNetworks := make([]interface{}, len(*input))
+	for i, virtualNetwork := range *input {
+		virtualNetworks[i] = *virtualNetwork.VirtualNetworkResourceID
+	}
+
+	return virtualNetworks
+}
+
+func flattenStorageAccountBypass(input storage.Bypass) []interface{} {
+	bypassValues := strings.Split(string(input), ", ")
+	bypass := make([]interface{}, len(bypassValues))
+
+	for i, value := range bypassValues {
+		bypass[i] = value
+	}
+
+	return bypass
 }
 
 func validateArmStorageAccountName(v interface{}, k string) (ws []string, es []error) {

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -803,12 +803,12 @@ resource "azurerm_storage_account" "testsa" {
 
     location = "${azurerm_resource_group.testrg.location}"
     account_tier = "Standard"
-	account_replication_type = "LRS"
+    account_replication_type = "LRS"
 	
-	network_rules {
-		ip_rules = ["127.0.0.1"]
-		virtual_network_subnet_ids = ["${azurerm_subnet.test.id}"]
-	}
+    network_rules {
+        ip_rules = ["127.0.0.1"]
+        virtual_network_subnet_ids = ["${azurerm_subnet.test.id}"]
+    }
 
     tags {
         environment = "production"

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -845,13 +845,13 @@ resource "azurerm_storage_account" "testsa" {
 
     location = "${azurerm_resource_group.testrg.location}"
     account_tier = "Standard"
-	account_replication_type = "LRS"
+    account_replication_type = "LRS"
 	
-	network_rules {
-		ip_rules = ["127.0.0.1", "127.0.0.2"]
-		bypass = ["Logging", "Metrics"]
-		default_access_enabled = true
-	}
+    network_rules {
+        ip_rules = ["127.0.0.1", "127.0.0.2"]
+        bypass = ["Logging", "Metrics"]
+        default_access_enabled = true
+    }
 
     tags {
         environment = "production"

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -60,12 +60,12 @@ resource "azurerm_storage_account" "testsa" {
 
     location = "${azurerm_resource_group.testrg.location}"
     account_tier = "Standard"
-	account_replication_type = "LRS"
+    account_replication_type = "LRS"
 	
-	network_rules {
-		ip_rules = ["127.0.0.1"]
-		virtual_network_subnet_ids = ["${azurerm_subnet.test.id}"]
-	}
+    network_rules {
+        ip_rules = ["127.0.0.1"]
+        virtual_network_subnet_ids = ["${azurerm_subnet.test.id}"]
+    }
 
     tags {
         environment = "staging"

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -31,6 +31,48 @@ resource "azurerm_storage_account" "testsa" {
 }
 ```
 
+## Example Usage with Network Rules
+
+```hcl
+resource "azurerm_resource_group" "testrg" {
+  name     = "resourceGroupName"
+  location = "westus"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "virtnetname"
+    address_space = ["10.0.0.0/16"]
+    location = "${azurerm_resource_group.testrg.location}"
+    resource_group_name = "${azurerm_resource_group.testrg.name}"
+}
+
+resource "azurerm_subnet" "test" {
+	name                 = "subnetname"
+	resource_group_name  = "${azurerm_resource_group.testrg.name}"
+	virtual_network_name = "${azurerm_virtual_network.test.name}"
+	address_prefix       = "10.0.2.0/24"
+	service_endpoints    = ["Microsoft.Sql","Microsoft.Storage"]
+  }
+
+resource "azurerm_storage_account" "testsa" {
+    name = "storageaccountname"
+    resource_group_name = "${azurerm_resource_group.testrg.name}"
+
+    location = "${azurerm_resource_group.testrg.location}"
+    account_tier = "Standard"
+	account_replication_type = "LRS"
+	
+	network_rules {
+		ip_rules = ["127.0.0.1"]
+		virtual_network_subnet_ids = ["${azurerm_subnet.test.id}"]
+	}
+
+    tags {
+        environment = "staging"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -70,6 +112,8 @@ The following arguments are supported:
 
 * `custom_domain` - (Optional) A `custom_domain` block as documented below.
 
+* `network_rules` - (Optional) A `network_rules` block as documented below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -78,6 +122,17 @@ The following arguments are supported:
 
 * `name` - (Optional) The Custom Domain Name to use for the Storage Account, which will be validated by Azure.
 * `use_subdomain` - (Optional) Should the Custom Domain Name be validated by using indirect CNAME validation?
+
+---
+
+* `network_rules` supports the following:
+
+* `bypass` - (Optional)  Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are
+any combination of `Logging`, `Metrics`, `AzureServices`, or `None`. 
+* `default_access_enabled` - (Optional) Boolean flag to specify the default action of allow or deny when no other rules 
+match.
+* `ip_rules` - (Optional) List of IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed.
+* `virtual_network_subnet_ids` - (Optional) A list of resource ids for subnets.
 
 ~> **Note:** [More information on Validation is available here](https://docs.microsoft.com/en-gb/azure/storage/blobs/storage-custom-domain-name)
 


### PR DESCRIPTION
This PR adds support for network rules inside of the storage account resource. Addressing #416 

```
=== RUN   TestAccAzureRMStorageAccount_basic
--- PASS: TestAccAzureRMStorageAccount_basic (78.69s)
=== RUN   TestAccAzureRMStorageAccount_importNetworkRules
--- PASS: TestAccAzureRMStorageAccount_importNetworkRules (131.81s)
```

The existing tests are also passing.