### PR TITLE
Update to make example 2-vms-loadbalancer-lbrules work

### DIFF
--- a/examples/2-vms-loadbalancer-lbrules/main.tf
+++ b/examples/2-vms-loadbalancer-lbrules/main.tf
@@ -143,4 +143,6 @@ resource "azurerm_virtual_machine" "vm" {
     admin_username = "${var.admin_username}"
     admin_password = "${var.admin_password}"
   }
+
+  os_profile_windows_config {}
 }

--- a/examples/2-vms-loadbalancer-lbrules/outputs.tf
+++ b/examples/2-vms-loadbalancer-lbrules/outputs.tf
@@ -6,6 +6,6 @@ output "vm_fqdn" {
   value = "${azurerm_public_ip.lbpip.fqdn}"
 }
 
-output "ssh_command" {
-  value = "ssh ${var.admin_username}@${azurerm_public_ip.lbpip.fqdn}"
+output "VMs RDP acces" {
+  value = "${formatlist("RDP_URL=%v:%v", azurerm_public_ip.lbpip.fqdn, azurerm_lb_nat_rule.tcp.*.frontend_port)}"
 }

--- a/examples/2-vms-loadbalancer-lbrules/variables.tf
+++ b/examples/2-vms-loadbalancer-lbrules/variables.tf
@@ -51,7 +51,7 @@ variable "storage_replication_type" {
 
 variable "vm_size" {
   description = "Specifies the size of the virtual machine."
-  default     = "Standard_D1"
+  default     = "Standard_D1_v2"
 }
 
 variable "image_publisher" {


### PR DESCRIPTION
- Add necessary os_profile_windows_config as the default image is windows
- Change the default vm image size to an available one
- Add an output with the access to RDP to each vm
- Remove the ssh output as the default image is windows