### PR TITLE
Fix dead_lettering_on_message_expiration property name for azure service bus queue

### DIFF
--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
     a queue can guarantee first-in-first-out delivery of messages. 
     Changing this forces a new resource to be created. Defaults to `false`.
 
-* `requires_session` - (Optional) Boolean flag which controls whether the Queue has dead letter support when a message expires. Defaults to `false`.
+* `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls whether the Queue has dead letter support when a message expires. Defaults to `false`.
     
 ### TimeSpan Format
 


### PR DESCRIPTION
This fixes a typo in the documentation for the azure service bus queue dead_lettering_on_message_expiration property