### PR TITLE
enable_partitioning not supported servicebus Premium Sku.

### DIFF
--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -166,10 +166,9 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 		return nsErr
 	}
 
-	// Enforce Premium namespace to have partitioning enabled in Terraform. It is always enabled in Azure for
-	// Premium SKU.
-	if namespace.Sku.Name == servicebus.Premium && !d.Get("enable_partitioning").(bool) {
-		return fmt.Errorf("ServiceBus Queue (%s) must have Partitioning enabled for Premium SKU", name)
+	// In a Premium tier namespace, partitioning entities is not supported.
+	if namespace.Sku.Name == servicebus.Premium && d.Get("enable_partitioning").(bool) {
+		return fmt.Errorf("ServiceBus Queue (%s) does not support Partitioning enabled for Premium SKU", name)
 	}
 
 	// Enforce Premium namespace to have Express Entities disabled in Terraform since they are not supported for

--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -172,7 +172,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("ServiceBus Queue (%s) does not support Express Entities in Premium SKU and must be disabled", name)
 	}
 
-	_, err := client.CreateOrUpdate(ctx, resourceGroup, namespaceName, name, parameters)
+	_, err = client.CreateOrUpdate(ctx, resourceGroup, namespaceName, name, parameters)
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -161,14 +161,9 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 	// We need to retrieve the namespace because Premium namespace works differently from Basic and Standard,
 	// so it needs different rules applied to it.
 	namespacesClient := meta.(*ArmClient).serviceBusNamespacesClient
-	namespace, nsErr := namespacesClient.Get(ctx, resourceGroup, namespaceName)
-	if nsErr != nil {
-		return nsErr
-	}
-
-	// In a Premium tier namespace, partitioning entities is not supported.
-	if namespace.Sku.Name == servicebus.Premium && d.Get("enable_partitioning").(bool) {
-		return fmt.Errorf("ServiceBus Queue (%s) does not support Partitioning enabled for Premium SKU", name)
+	namespace, err := namespacesClient.Get(ctx, resourceGroup, namespaceName)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ServiceBus Namespace %q (Resource Group %q): %+v", resourceGroup, namespaceName, err)
 	}
 
 	// Enforce Premium namespace to have Express Entities disabled in Terraform since they are not supported for

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -108,7 +108,7 @@ func TestAccAzureRMServiceBusQueue_defaultEnablePartitioningPremium(t *testing.T
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceBusQueueExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "enable_partitioning", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_partitioning", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enable_express", "false"),
 				),
 			},
@@ -331,7 +331,7 @@ resource "azurerm_servicebus_queue" "test" {
     name = "acctestservicebusqueue-%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
-    enable_partitioning = true
+    enable_partitioning = false
     enable_express = false
 }
 `, rInt, location, rInt, rInt)

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -165,7 +165,7 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningPremium(t *testing.T) {
 			{
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "enable_partitioning", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_partitioning", "false"),
 					resource.TestCheckResourceAttr(resourceName, "max_size_in_megabytes", "81920"),
 				),
 			},
@@ -349,7 +349,7 @@ resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    enable_partitioning = true
+    enable_partitioning = false
 }
 `, rInt, location, rInt, rInt)
 }
@@ -397,7 +397,7 @@ resource "azurerm_servicebus_topic" "test" {
     name = "acctestservicebustopic-%d"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    enable_partitioning = true
+    enable_partitioning = false
     max_size_in_megabytes = 81920
 }
 `, rInt, location, rInt, rInt)

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
     a new resource to be created. Defaults to `false` for Basic and Standard. For Premium, it MUST
     be set to `true`.
 
-~> **NOTE:** Service Bus Premium namespaces are always partitioned, so `enable_partitioning` MUST be set to `true`.
+-> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. It is not available for the Premium messaging SKU, but any previously existing partitioned entities in Premium namespaces continue to work as expected. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning) for more information.
 
 * `lock_duration` - (Optional) The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. Maximum value is 5 minutes. Defaults to 1 minute. (`PT1M`)
 

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -85,6 +85,8 @@ The following arguments are supported:
     the topic to be partitioned across multiple message brokers. Defaults to false.
     Changing this forces a new resource to be created.
 
+-> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. It is not available for the Premium messaging SKU, but any previously existing partitioned entities in Premium namespaces continue to work as expected. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning) for more information.
+
 * `max_size_in_megabytes` - (Optional) Integer value which controls the size of
     memory allocated for the topic. For supported values see the "Queue/topic size"
     section of [this document](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).


### PR DESCRIPTION
According to azure-doc last update, enable_partitioning is not supported in a Premium tier namespace.

reference:
In a Premium tier namespace, partitioning entities is not supported. However, you can still create Service Bus queues and topics in 1, 2, 3, 4, 5, 10, 20, 40, or 80-GB sizes (the default is 1 GB). You can see the size of your queue or topic by looking at its entry on the Azure portal, in the Overview blade for that entity.
https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning
