### PR TITLE
Docs: `azure` -> `azurerm`

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_application_gateway"
+page_title: "Azure Resource Manager: azurerm_application_gateway"
 sidebar_current: "docs-azurerm-resource-application-gateway"
 description: |-
   Manages a application gateway based on a previously created virtual network with configured subnets.
@@ -217,8 +217,8 @@ The `backend_http_settings` block supports:
 * `probe_name` - (Optional) Reference to URL probe.
 
 * `authentication_certificate` - (Optional) - A list of `authentication_certificate` references for the `backend_http_setting` to use. Each element consists of:
-  
-  * `name` (Required) 
+
+  * `name` (Required)
   * `id` (Calculated)
 
 The `http_listener` block supports:

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_network_interface"
+page_title: "Azure Resource Manager: azurerm_network_interface"
 sidebar_current: "docs-azurerm-resource-network-interface"
 description: |-
   Manages a Network Interface located in a Virtual Network, usually attached to a Virtual Machine.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_subnet"
+page_title: "Azure Resource Manager: azurerm_subnet"
 sidebar_current: "docs-azurerm-resource-network-subnet"
 description: |-
   Manages a subnet. Subnets represent network segments within the IP space defined by the virtual network.

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_virtual_machine_extension"
+page_title: "Azure Resource Manager: azurerm_virtual_machine_extension"
 sidebar_current: "docs-azurerm-resource-compute-virtualmachine-extension"
 description: |-
     Manages a Virtual Machine Extension to provide post deployment

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_virtual_network"
+page_title: "Azure Resource Manager: azurerm_virtual_network"
 sidebar_current: "docs-azurerm-resource-network-virtual-network"
 description: |-
   Manages a virtual network including any configured subnets. Each subnet can optionally be configured with a security group to be associated with the subnet.

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_virtual_network_gateway"
+page_title: "Azure Resource Manager: azurerm_virtual_network_gateway"
 sidebar_current: "docs-azurerm-resource-network-virtual-network-gateway-x"
 description: |-
   Manages a virtual network gateway to establish secure, cross-premises connectivity.

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_virtual_network_gateway_connection"
+page_title: "Azure Resource Manager: azurerm_virtual_network_gateway_connection"
 sidebar_current: "docs-azurerm-resource-network-virtual-network-gateway-connection"
 description: |-
   Manages a connection in an existing Virtual Network Gateway.
@@ -274,7 +274,7 @@ The `ipsec_policy` block supports:
 
 * `ipsec_integrity` - (Required) The IPSec integrity algorithm. Valid
     options are `GCMAES128`, `GCMAES192`, `GCMAES256`, `MD5`, `SHA1`, or `SHA256`.
-    
+
 * `pfs_group` - (Required) The DH group used in IKE phase 2 for new child SA.
     Valid options are `ECP256`, `ECP384`, `PFS1`, `PFS2`, `PFS2048`, `PFS24`,
     or `None`.

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "azurerm"
-page_title: "Azure Resource Manager: azure_virtual_network_peering"
+page_title: "Azure Resource Manager: azurerm_virtual_network_peering"
 sidebar_current: "docs-azurerm-resource-network-virtual-network-peering"
 description: |-
   Manages a virtual network peering which allows resources to access other


### PR DESCRIPTION
Browsing the docs I noticed some of the titles had `azure_` instead of `azurerm_` as the prefix in the Website Title - this PR fixes that.