### PR TITLE
Log Analytics: support for Sovereign clouds

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -799,11 +799,11 @@ func (c *ArmClient) registerNetworkingClients(endpoint, subscriptionId string, a
 }
 
 func (c *ArmClient) registerOperationalInsightsClients(endpoint, subscriptionId string, auth autorest.Authorizer, sender autorest.Sender) {
-	opwc := operationalinsights.NewWorkspacesClient(subscriptionId)
+	opwc := operationalinsights.NewWorkspacesClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&opwc.Client, auth)
 	c.workspacesClient = opwc
 
-	solutionsClient := operationsmanagement.NewSolutionsClient(subscriptionId, "Microsoft.OperationsManagement", "solutions", "testing")
+	solutionsClient := operationsmanagement.NewSolutionsClientWithBaseURI(endpoint, subscriptionId, "Microsoft.OperationsManagement", "solutions", "testing")
 	c.configureClient(&solutionsClient.Client, auth)
 	c.solutionsClient = solutionsClient
 }

--- a/azurerm/resource_arm_log_analytics_solution_test.go
+++ b/azurerm/resource_arm_log_analytics_solution_test.go
@@ -113,7 +113,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   name                = "acctest-dep-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Free"
+  sku                 = "PerGB2018"
 }
   
 resource "azurerm_log_analytics_solution" "test" {
@@ -142,7 +142,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   name                = "acctest-dep-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Free"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_log_analytics_solution" "test" {


### PR DESCRIPTION
Issue #1348 identified an issue in the Log Analytics client registration where we weren't specifying the endpoint, which meant that this would default to Azure Public (and thus wouldn't work on Sovereign Clouds). This PR fixes that by specifying the ARM Endpoint to used based on the Azure Environment

Fixes #1348 