### PR TITLE
VMSS: ensuring we always set the `vhd_containers` field

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -1176,13 +1176,13 @@ func flattenAzureRmVirtualMachineScaleSetStorageProfileOSDisk(profile *compute.V
 		result["image"] = *profile.Image.URI
 	}
 
+	containers := make([]interface{}, 0)
 	if profile.VhdContainers != nil {
-		containers := make([]interface{}, 0, len(*profile.VhdContainers))
 		for _, container := range *profile.VhdContainers {
 			containers = append(containers, container)
 		}
-		result["vhd_containers"] = schema.NewSet(schema.HashString, containers)
 	}
+	result["vhd_containers"] = schema.NewSet(schema.HashString, containers)
 
 	if profile.ManagedDisk != nil {
 		result["managed_disk_type"] = string(profile.ManagedDisk.StorageAccountType)


### PR DESCRIPTION
Issue #1043 shows a Diff Mismatch where the `vhd_containers` field isn't set; this PR fixes that by ensuring the field is always set.

Fixes #1043