### PR TITLE
Add Standard_Microsoft for CDN profile SKU type

### DIFF
--- a/azurerm/resource_arm_cdn_profile.go
+++ b/azurerm/resource_arm_cdn_profile.go
@@ -39,6 +39,7 @@ func resourceArmCdnProfile() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(cdn.StandardAkamai),
 					string(cdn.StandardVerizon),
+					string(cdn.StandardMicrosoft),
 					string(cdn.PremiumVerizon),
 				}, true),
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn/models.go
@@ -2539,7 +2539,7 @@ func (page ResourceUsageListResultPage) Values() []ResourceUsage {
 
 // Sku the pricing tier (defines a CDN provider, feature list and rate) of the CDN profile.
 type Sku struct {
-	// Name - Name of the pricing tier. Possible values include: 'StandardVerizon', 'PremiumVerizon', 'CustomVerizon', 'StandardAkamai', 'StandardChinaCdn'
+	// Name - Name of the pricing tier. Possible values include: 'StandardVerizon', 'PremiumVerizon', 'CustomVerizon', 'StandardAkamai', 'StandardMicrosoft', 'StandardChinaCdn'
 	Name SkuName `json:"name,omitempty"`
 }
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn/models.go
@@ -235,8 +235,6 @@ const (
 	StandardChinaCdn SkuName = "Standard_ChinaCdn"
 	// StandardVerizon ...
 	StandardVerizon SkuName = "Standard_Verizon"
-	// StandardMicrosoft...
-	StandardMicrosoft SkuName = "Standard_Microsoft"
 )
 
 // PossibleSkuNameValues returns an array of possible values for the SkuName const type.
@@ -2539,7 +2537,7 @@ func (page ResourceUsageListResultPage) Values() []ResourceUsage {
 
 // Sku the pricing tier (defines a CDN provider, feature list and rate) of the CDN profile.
 type Sku struct {
-	// Name - Name of the pricing tier. Possible values include: 'StandardVerizon', 'PremiumVerizon', 'CustomVerizon', 'StandardAkamai', 'StandardMicrosoft', 'StandardChinaCdn'
+	// Name - Name of the pricing tier. Possible values include: 'StandardVerizon', 'PremiumVerizon', 'CustomVerizon', 'StandardAkamai', 'StandardChinaCdn'
 	Name SkuName `json:"name,omitempty"`
 }
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn/models.go
@@ -235,6 +235,8 @@ const (
 	StandardChinaCdn SkuName = "Standard_ChinaCdn"
 	// StandardVerizon ...
 	StandardVerizon SkuName = "Standard_Verizon"
+	// StandardMicrosoft...
+	StandardMicrosoft SkuName = "Standard_Microsoft"
 )
 
 // PossibleSkuNameValues returns an array of possible values for the SkuName const type.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"checksumSHA1": "jNqFdbZdsFgDH9xhq3fXNIk1+eM=",
-			"path": "github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-04-02/cdn",
+			"path": "github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-10-12/cdn",
 			"revision": "4650843026a7fdec254a8d9cf893693a254edd0b",
 			"revisionTime": "2018-05-04T19:14:26Z",
 			"version": "v16.2.1",

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku` - (Required) The pricing related information of current CDN profile. Accepted values are `Standard_Verizon`, `Standard_Akamai` or `Premium_Verizon`.
+* `sku` - (Required) The pricing related information of current CDN profile. Accepted values are `Standard_Verizon`, `Standard_Akamai`, `Standard_Microsoft` or `Premium_Verizon`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Adding support to "Standard Microsoft" pricing tier.

As stated [HERE](https://azure.microsoft.com/en-us/pricing/details/cdn/) in MS doc.

cdn.StandardMicrosoft added in this [PR HERE](https://github.com/Azure/azure-sdk-for-go/pull/2082)

CI failing because of this, and I can't update the model in this repo because of govendor status check in makefile.
