### PR TITLE
Helpers: fixing test failures

### DIFF
--- a/azurerm/helpers/validate/network.go
+++ b/azurerm/helpers/validate/network.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 )
 
@@ -12,8 +13,9 @@ func Ip4Address(i interface{}, k string) (_ []string, errors []error) {
 		return
 	}
 
-	if matched := regexp.MustCompile(`((^[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`).Match([]byte(v)); !matched {
-		errors = append(errors, fmt.Errorf("%q is not a valid IP4 address: %q", k, i))
+	ip := net.ParseIP(v)
+	if four := ip.To4(); four == nil {
+		errors = append(errors, fmt.Errorf("%q is not a valid IP4 address: %q", k, v))
 	}
 
 	return

--- a/azurerm/helpers/validate/network.go
+++ b/azurerm/helpers/validate/network.go
@@ -13,7 +13,7 @@ func Ip4Address(i interface{}, k string) (_ []string, errors []error) {
 	}
 
 	if matched := regexp.MustCompile(`((^[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`).Match([]byte(v)); !matched {
-		errors = append(errors, fmt.Errorf("%q is not a valid IP4 address: '%q`", k, i))
+		errors = append(errors, fmt.Errorf("%q is not a valid IP4 address: %q", k, i))
 	}
 
 	return
@@ -26,8 +26,8 @@ func MacAddress(i interface{}, k string) (_ []string, errors []error) {
 		return
 	}
 
-	if matched := regexp.MustCompile(`((^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$`).Match([]byte(v)); !matched {
-		errors = append(errors, fmt.Errorf("%q is not a valid MAC address: '%q`", k, i))
+	if matched := regexp.MustCompile(`^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q is not a valid MAC address: %q", k, i))
 	}
 
 	return

--- a/azurerm/helpers/validate/network_test.go
+++ b/azurerm/helpers/validate/network_test.go
@@ -45,7 +45,7 @@ func TestHelper_Validate_Ip4Address(t *testing.T) {
 		_, errors := Ip4Address(tc.Ip, "test")
 
 		if len(errors) < tc.Errors {
-			t.Fatalf("Expected AzureResourceId to have an error for %q", tc.Ip)
+			t.Fatalf("Expected Ip4Address to have an error for %q", tc.Ip)
 		}
 	}
 }
@@ -86,10 +86,10 @@ func TestHelper_Validate_MacAddress(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, errors := Ip4Address(tc.Ip, "test")
+		_, errors := MacAddress(tc.Ip, "test")
 
 		if len(errors) < tc.Errors {
-			t.Fatalf("Expected AzureResourceId to have an error for %q", tc.Ip)
+			t.Fatalf("Expected MacAddress to have an error for %q", tc.Ip)
 		}
 	}
 }

--- a/azurerm/helpers/validate/network_test.go
+++ b/azurerm/helpers/validate/network_test.go
@@ -12,8 +12,8 @@ func TestHelper_Validate_Ip4Address(t *testing.T) {
 			Errors: 1,
 		},
 		{
-			Ip:     "000.000.000.000",
-			Errors: 1,
+			Ip:     "0.0.0.0",
+			Errors: 0,
 		},
 		{
 			Ip:     "1.2.3.no",


### PR DESCRIPTION
Fixing a test failure identified whilst running the tests for #1409 - fixes this:

```
------- Stdout: -------
=== RUN   TestAccAzureRMVirtualNetworkGateway_vpnClientConfig
--- FAIL: TestAccAzureRMVirtualNetworkGateway_vpnClientConfig (0.18s)
    testing.go:513: Step 0 error: config is invalid: azurerm_virtual_network_gateway.test: "vpn_client_configuration.0.radius_server_address" is not a valid IP4 address: '"1.2.3.4"`
FAIL
```


The validation functions also now pass:

```
$ go test -v ./azurerm/helpers/validate/
=== RUN   TestHelper_Validate_Ip4Address
--- PASS: TestHelper_Validate_Ip4Address (0.00s)
=== RUN   TestHelper_Validate_MacAddress
--- PASS: TestHelper_Validate_MacAddress (0.00s)
=== RUN   TestHelper_Validate_RFC3339Time
--- PASS: TestHelper_Validate_RFC3339Time (0.00s)
=== RUN   TestHelper_Validate_Rfc3339DateInFutureBy
--- PASS: TestHelper_Validate_Rfc3339DateInFutureBy (0.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate	0.027s
```