### PR TITLE
[Docs] SRV should be MX

### DIFF
--- a/website/docs/r/dns_mx_record.html.markdown
+++ b/website/docs/r/dns_mx_record.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record.
 
-* `record` - (Required) A list of values that make up the SRV record. Each `record` block supports fields documented below.
+* `record` - (Required) A list of values that make up the MX record. Each `record` block supports fields documented below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Small error in the MX documentation. Likely copy paste error.