### PR TITLE
allow postgres version 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ IMPROVEMENTS:
 * `azurerm_route_table` - adding the  disable BGP propagation property [GH-1435]
 * `azurerm_sql_database` - support for importing from a bacpac backup [GH-972]
 * `azurerm_virtual_machine` - support for setting the TimeZone on Windows [GH-1265]
-* `azurerm_postgresql_server` - adding support for version 10.0 [GH-1457]
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ IMPROVEMENTS:
 * `azurerm_route_table` - adding the  disable BGP propagation property [GH-1435]
 * `azurerm_sql_database` - support for importing from a bacpac backup [GH-972]
 * `azurerm_virtual_machine` - support for setting the TimeZone on Windows [GH-1265]
+* `azurerm_postgresql_server` - adding support for version 10.0 [GH-1457]
 
 BUG FIXES:
 

--- a/azurerm/resource_arm_postgresql_server.go
+++ b/azurerm/resource_arm_postgresql_server.go
@@ -122,6 +122,7 @@ func resourceArmPostgreSQLServer() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(postgresql.NineFullStopFive),
 					string(postgresql.NineFullStopSix),
+					"10.0",
 				}, true),
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},

--- a/azurerm/resource_arm_postgresql_server.go
+++ b/azurerm/resource_arm_postgresql_server.go
@@ -122,6 +122,7 @@ func resourceArmPostgreSQLServer() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(postgresql.NineFullStopFive),
 					string(postgresql.NineFullStopSix),
+					// TODO: Swap for the azure go api enum once supported.
 					"10.0",
 				}, true),
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,

--- a/azurerm/resource_arm_postgresql_server_test.go
+++ b/azurerm/resource_arm_postgresql_server_test.go
@@ -56,6 +56,28 @@ func TestAccAzureRMPostgreSQLServer_basicNinePointSix(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPostgreSQLServer_basicTenPointZero(t *testing.T) {
+	resourceName := "azurerm_postgresql_server.test"
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPostgreSQLServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMPostgreSQLServer_basicTenPointZero(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPostgreSQLServerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "administrator_login", "acctestun"),
+					resource.TestCheckResourceAttr(resourceName, "version", "10.0"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enforcement", "Enabled"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMPostgreSQLServer_basicMaxStorage(t *testing.T) {
 	resourceName := "azurerm_postgresql_server.test"
 	ri := acctest.RandInt()
@@ -294,6 +316,39 @@ resource "azurerm_postgresql_server" "test" {
   administrator_login          = "acctestun"
   administrator_login_password = "H@Sh1CoR3!"
   version                      = "9.6"
+  ssl_enforcement              = "Enabled"
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMPostgreSQLServer_basicTenPointZero(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_postgresql_server" "test" {
+  name                = "acctestpsqlsvr-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    name     = "B_Gen4_2"
+    capacity = 2
+    tier     = "Basic"
+    family   = "Gen4"
+  }
+
+  storage_profile {
+    storage_mb = 51200
+    backup_retention_days = 7
+    geo_redundant_backup = "Disabled"
+  }
+
+  administrator_login          = "acctestun"
+  administrator_login_password = "H@Sh1CoR3!"
+  version                      = "10.0"
   ssl_enforcement              = "Enabled"
 }
 `, rInt, location, rInt)

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Required) The Password associated with the `administrator_login` for the PostgreSQL Server.
 
-* `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5` and `9.6`. Changing this forces a new resource to be created.
+* `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5`, `9.6`, and `10.0`. Changing this forces a new resource to be created.
 
 * `ssl_enforcement` - (Required) Specifies if SSL should be enforced on connections. Possible values are `Enabled` and `Disabled`.
 


### PR DESCRIPTION
We're attempting to get a Postgres 10 instance up through Terraform, but are unable to due to restrictive version checks.

This is a fix that adds support "10.0" as a valid version string until the azure go api adds a proper "10.0" enum.