### PR TITLE
Make additional_unattend_config.content sensitive to hide AutoLogon Password

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -430,8 +430,9 @@ func resourceArmVirtualMachine() *schema.Resource {
 										Required: true,
 									},
 									"content": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:      schema.TypeString,
+										Required:  true,
+										Sensitive: true,
 									},
 								},
 							},

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -238,8 +238,9 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 										Required: true,
 									},
 									"content": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:      schema.TypeString,
+										Required:  true,
+										Sensitive: true,
 									},
 								},
 							},


### PR DESCRIPTION
Creating Windows VM's in Azure RM sometimes needs the AutoLogon feature. Terraform currently shows the password in the console output. This PR hides sensitive information by setting the `content` to `Sensitive: true`.

## Input os_profile_windows_config

```hcl
  os_profile_windows_config {
    provision_vm_agent        = true
    enable_automatic_upgrades = true

    additional_unattend_config {
      pass         = "oobeSystem"
      component    = "Microsoft-Windows-Shell-Setup"
      setting_name = "AutoLogon"
      content      = "<AutoLogon><Password><Value>${var.admin_password[count.index]}</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount><Username>${var.admin_username}</Username></AutoLogon>"
    }

    additional_unattend_config {
      pass         = "oobeSystem"
      component    = "Microsoft-Windows-Shell-Setup"
      setting_name = "FirstLogonCommands"
      content      = "${file("./FirstLogonCommands.xml")}"
    }
  }
```

## Before:
The `admin_password` is hidden as sensitive, but the `additional_unattend_config.0.content` shows the plaintext `Password1234!`.

```
  os_profile.#:                                                                   "" => "1"
  os_profile.3976634070.admin_password:                                           "<sensitive>" => "<sensitive>"
  os_profile.3976634070.admin_username:                                           "" => "training"
  os_profile.3976634070.computer_name:                                            "" => "ba-01"
  os_profile.3976634070.custom_data:                                              "" => "c81bdf1953fd9d0c6788387f9c148de62396cd24"
  os_profile_windows_config.#:                                                    "" => "1"
  os_profile_windows_config.1060902566.additional_unattend_config.#:              "" => "2"
  os_profile_windows_config.1060902566.additional_unattend_config.0.component:    "" => "Microsoft-Windows-Shell-Setup"
  os_profile_windows_config.1060902566.additional_unattend_config.0.content:      "" => "<AutoLogon><Password><Value>Password1234!</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount><Username>training</Username></AutoLogon>"
  os_profile_windows_config.1060902566.additional_unattend_config.0.pass:         "" => "oobeSystem"
  os_profile_windows_config.1060902566.additional_unattend_config.0.setting_name: "" => "AutoLogon"
  os_profile_windows_config.1060902566.additional_unattend_config.1.component:    "" => "Microsoft-Windows-Shell-Setup"
  os_profile_windows_config.1060902566.additional_unattend_config.1.content:      "" => "<FirstLogonCommands>\n    <SynchronousCommand>\n        <CommandLine>cmd /c \"copy C:\\AzureData\\CustomData.bin C:\\provision.ps1\"</CommandLine\n        ><Description>CopyScript</Description>\n        <Order>11</Order>\n    </SynchronousCommand>\n    <SynchronousCommand>\n        <CommandLine>powershell.exe -sta -ExecutionPolicy Unrestricted -file C:\\provision.ps1</CommandLine\n        ><Description>RunScript</Description>\n        <Order>12</Order>\n    </SynchronousCommand>\n</FirstLogonCommands>\n"
  os_profile_windows_config.1060902566.additional_unattend_config.1.pass:         "" => "oobeSystem"
  os_profile_windows_config.1060902566.additional_unattend_config.1.setting_name: "" => "FirstLogonCommands"
  os_profile_windows_config.1060902566.enable_automatic_upgrades:                 "" => "true"
  os_profile_windows_config.1060902566.provision_vm_agent:                        "" => "true"
  os_profile_windows_config.1060902566.winrm.#:                                   "" => "0"
```

## After:

```
      os_profile.#:                                                                   "1"
      os_profile.3324759317.admin_password:                                           <sensitive>
      os_profile.3324759317.admin_username:                                           "training"
      os_profile.3324759317.computer_name:                                            "ba-02"
      os_profile.3324759317.custom_data:                                              "565bed3819b6aee3742f0232403bc458e5e5534d"
      os_profile_windows_config.#:                                                    "1"
      os_profile_windows_config.1060902566.additional_unattend_config.#:              "2"
      os_profile_windows_config.1060902566.additional_unattend_config.0.component:    "Microsoft-Windows-Shell-Setup"
      os_profile_windows_config.1060902566.additional_unattend_config.0.content:      <sensitive>
      os_profile_windows_config.1060902566.additional_unattend_config.0.pass:         "oobeSystem"
      os_profile_windows_config.1060902566.additional_unattend_config.0.setting_name: "AutoLogon"
      os_profile_windows_config.1060902566.additional_unattend_config.1.component:    "Microsoft-Windows-Shell-Setup"
      os_profile_windows_config.1060902566.additional_unattend_config.1.content:      <sensitive>
      os_profile_windows_config.1060902566.additional_unattend_config.1.pass:         "oobeSystem"
      os_profile_windows_config.1060902566.additional_unattend_config.1.setting_name: "FirstLogonCommands"
      os_profile_windows_config.1060902566.enable_automatic_upgrades:                 "true"
      os_profile_windows_config.1060902566.provision_vm_agent:                        "true"
      os_profile_windows_config.1060902566.winrm.#:                                   "0"
```

PS: Thanks for the Terraform workshop in Amsterdam this week.
