### PR TITLE
Add build-docker and test-docker target to build without local Golang

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,6 +8,13 @@ default: build
 build: fmtcheck
 	go install
 
+build-docker:
+	mkdir -p bin
+	docker run --rm -v $$(pwd)/bin:/go/bin -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm -e GOOS golang:1.10 make build
+
+test-docker:
+	docker run --rm -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm golang:1.10 make test
+
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
@@ -62,5 +69,5 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
+.PHONY: build build-docker test test-docker testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test
 


### PR DESCRIPTION
This may be helpful for community to get started compiling the plugin and start sending pull requests without the need to setup Golang on the local machine.

My Golang setup on my MacBook is quite old, I tried several first beginners steps and I just didn't want to touch it right now. I wanted to send a PR for #1471 and compile and test the plugin for my MacBook.

These two additional make targets allow users to build and test the plugin within a Linux Docker container with eg. Docker4Mac (and probably Docker4Windows).

## Compiling the Linux version of the plugin:

```
$ make build-docker
mkdir -p bin
docker run --rm -v $(pwd)/bin:/go/bin -v $(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm -e GOOS golang:1.10 make build
==> Checking that code complies with gofmt requirements...
go install

$ ls bin
terraform-provider-azurerm
```

## Compiling the macOS version of the plugin:

```
$ GOOS=darwin make build-docker
mkdir -p bin
docker run --rm -v $(pwd)/bin:/go/bin -v $(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm -e GOOS golang:1.10 make build
==> Checking that code complies with gofmt requirements...
go install

$ ls bin/darwin_amd64/
terraform-provider-azurerm
```
