### PR TITLE
VM Data Disk Attachment: support for setting Write Accelerator Enabled

### DIFF
--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
@@ -66,6 +66,12 @@ func resourceArmVirtualMachineDataDiskAttachment() *schema.Resource {
 				}, true),
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
+
+			"write_accelerator_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -109,6 +115,7 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 	lun := int32(d.Get("lun").(int))
 	caching := d.Get("caching").(string)
 	createOption := compute.DiskCreateOptionTypes(d.Get("create_option").(string))
+	writeAcceleratorEnabled := d.Get("write_accelerator_enabled").(bool)
 
 	expandedDisk := compute.DataDisk{
 		Name:         utils.String(name),
@@ -119,6 +126,7 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 			ID:                 utils.String(managedDiskId),
 			StorageAccountType: managedDisk.Sku.Name,
 		},
+		WriteAcceleratorEnabled: utils.Bool(writeAcceleratorEnabled),
 	}
 
 	disks := *virtualMachine.StorageProfile.DataDisks
@@ -205,6 +213,7 @@ func resourceArmVirtualMachineDataDiskAttachmentRead(d *schema.ResourceData, met
 	d.Set("virtual_machine_id", virtualMachine.ID)
 	d.Set("caching", string(disk.Caching))
 	d.Set("create_option", string(disk.CreateOption))
+	d.Set("write_accelerator_enabled", disk.WriteAcceleratorEnabled)
 
 	if managedDisk := disk.ManagedDisk; managedDisk != nil {
 		d.Set("managed_disk_id", managedDisk.ID)

--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -119,6 +119,8 @@ The following arguments are supported:
 
 * `create_option` - (Optional) The Create Option of the Data Disk, such as `Empty` or `Attach`. Defaults to `Attach`. Changing this forces a new resource to be created.
 
+* `write_accelerator_enabled` - (Optional) Specifies if Write Accelerator is enabled on the disk. This can only be enabled on `Premium_LRS` managed disks with no caching and [M-Series VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/how-to-enable-write-accelerator). Defaults to `false`.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
```
acctests azurerm TestAccAzureRMVirtualMachineDataDiskAttachment_updatingWriteAccelerator
=== RUN   TestAccAzureRMVirtualMachineDataDiskAttachment_updatingWriteAccelerator
--- PASS: TestAccAzureRMVirtualMachineDataDiskAttachment_updatingWriteAccelerator (1068.82s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1068.861s
```

Fixes #1468