### PR TITLE
TestAccDataSourceAzureRMAppService_ipRestriction test fix

### DIFF
--- a/azurerm/data_source_app_service_test.go
+++ b/azurerm/data_source_app_service_test.go
@@ -138,8 +138,8 @@ func TestAccDataSourceAzureRMAppService_ipRestriction(t *testing.T) {
 			{
 				Config: testAccDataSourceAppService_ipRestriction(rInt, location),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "ip_restriction.0.ip_address", "10.10.10.10"),
-					resource.TestCheckResourceAttr(dataSourceName, "ip_restriction.0.subnet_mask", "255.255.255.255"),
+					resource.TestCheckResourceAttr(dataSourceName, "site_config.0.ip_restriction.0.ip_address", "10.10.10.10"),
+					resource.TestCheckResourceAttr(dataSourceName, "site_config.0.ip_restriction.0.subnet_mask", "255.255.255.255"),
 				),
 			},
 		},


### PR DESCRIPTION
TestAccDataSourceAzureRMAppService_ipRestriction
--- FAIL: TestAccDataSourceAzureRMAppService_ipRestriction (126.97s)
testing.go:513: Step 0 error: Check failed: Check 1/2 error: data.azurerm_app_service.test: Attribute 'ip_restriction.0.ip_address' not found

Attribute **ip_restriction.0.ip_address** should be **site_config.0.ip_restriction.0.ip_address**