### PR TITLE
`azurerm_lb` - allow `private_ip_address` to be set to an empty value

### DIFF
--- a/azurerm/helpers/validate/network.go
+++ b/azurerm/helpers/validate/network.go
@@ -6,9 +6,21 @@ import (
 )
 
 func IP4Address(i interface{}, k string) (_ []string, errors []error) {
+	return validateIpv4Address(i, k, false)
+}
+
+func IPv4AddressOrEmpty(i interface{}, k string) (_ []string, errors []error) {
+	return validateIpv4Address(i, k, true)
+}
+
+func validateIpv4Address(i interface{}, k string, allowEmpty bool) (_ []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if v == "" && allowEmpty {
 		return
 	}
 

--- a/azurerm/helpers/validate/network.go
+++ b/azurerm/helpers/validate/network.go
@@ -5,7 +5,7 @@ import (
 	"net"
 )
 
-func IP4Address(i interface{}, k string) (_ []string, errors []error) {
+func IPv4Address(i interface{}, k string) (_ []string, errors []error) {
 	return validateIpv4Address(i, k, false)
 }
 

--- a/azurerm/helpers/validate/network_test.go
+++ b/azurerm/helpers/validate/network_test.go
@@ -2,7 +2,7 @@ package validate
 
 import "testing"
 
-func TestIP4Address(t *testing.T) {
+func TestIPv4Address(t *testing.T) {
 	cases := []struct {
 		IP     string
 		Errors int
@@ -43,10 +43,10 @@ func TestIP4Address(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.IP, func(t *testing.T) {
-			_, errors := IP4Address(tc.IP, "test")
+			_, errors := IPv4Address(tc.IP, "test")
 
 			if len(errors) != tc.Errors {
-				t.Fatalf("Expected IP4Address to return %d error(s) not %d", len(errors), tc.Errors)
+				t.Fatalf("Expected IPv4Address to return %d error(s) not %d", len(errors), tc.Errors)
 			}
 		})
 	}

--- a/azurerm/helpers/validate/network_test.go
+++ b/azurerm/helpers/validate/network_test.go
@@ -52,6 +52,56 @@ func TestIP4Address(t *testing.T) {
 	}
 }
 
+func TestIPv4AddressOrEmpty(t *testing.T) {
+	cases := []struct {
+		IP     string
+		Errors int
+	}{
+		{
+			IP:     "",
+			Errors: 0,
+		},
+		{
+			IP:     "0.0.0.0",
+			Errors: 0,
+		},
+		{
+			IP:     "1.2.3.no",
+			Errors: 1,
+		},
+		{
+			IP:     "text",
+			Errors: 1,
+		},
+		{
+			IP:     "1.2.3.4",
+			Errors: 0,
+		},
+		{
+			IP:     "12.34.43.21",
+			Errors: 0,
+		},
+		{
+			IP:     "100.123.199.0",
+			Errors: 0,
+		},
+		{
+			IP:     "255.255.255.255",
+			Errors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.IP, func(t *testing.T) {
+			_, errors := IPv4AddressOrEmpty(tc.IP, "test")
+
+			if len(errors) != tc.Errors {
+				t.Fatalf("Expected IPv4AddressOrEmpty to return %d error(s) not %d", len(errors), tc.Errors)
+			}
+		})
+	}
+}
+
 func TestMACAddress(t *testing.T) {
 	cases := []struct {
 		MAC    string

--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -73,7 +73,7 @@ func resourceArmLoadBalancer() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validate.IP4Address,
+							ValidateFunc: validate.IPv4AddressOrEmpty,
 						},
 
 						"public_ip_address_id": {

--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -202,7 +202,7 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 								"vpn_client_configuration.0.root_certificate",
 								"vpn_client_configuration.0.revoked_certificate",
 							},
-							ValidateFunc: validate.IP4Address,
+							ValidateFunc: validate.IPv4Address,
 						},
 						"radius_server_secret": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
Issue #1470 raises a regression in v1.8 of the Provider where it's no longer possible to set the `private_ip_address` field on `azurerm_lb` to a blank string. This PR extends the `validate.IP4Address` method to add an overload which allows for blank spaces.

On master the new test currently fails as an empty string isn't a valid IPv4 address:

```
$ acctests azurerm TestAccAzureRMLoadBalancer_emptyPrivateIP
=== RUN   TestAccAzureRMLoadBalancer_emptyPrivateIP
--- FAIL: TestAccAzureRMLoadBalancer_emptyPrivateIP (0.03s)
	testing.go:513: Step 0 error: config is invalid: azurerm_lb.test: "frontend_ip_configuration.0.private_ip_address" is not a valid IP4 address: ""
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	0.094s
```

On this branch - the tests pass as expected.

Fixes #1470