### PR TITLE
Application Security Groups now GA

### DIFF
--- a/website/docs/d/application_security_group.html.markdown
+++ b/website/docs/d/application_security_group.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Get information about an Application Security Group.
 
--> **Note:** Application Security Groups are currently in Public Preview on an opt-in basis. [More information, including how you can register for the Preview, and which regions Application Security Groups are available in are available here](https://docs.microsoft.com/en-us/azure/virtual-network/create-network-security-group-preview)
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/application_security_group.html.markdown
+++ b/website/docs/r/application_security_group.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Create an Application Security Group.
 
--> **Note:** Application Security Groups are currently in Public Preview on an opt-in basis. [More information, including how you can register for the Preview, and which regions Application Security Groups are available in are available here](https://docs.microsoft.com/en-us/azure/virtual-network/create-network-security-group-preview)
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -96,8 +96,6 @@ The `ip_configuration` block supports:
 
 * `application_security_group_ids` - (Optional) List of Application Security Group IDs which should be attached to this NIC
 
--> **Note:** Application Security Groups are currently in Public Preview on an opt-in basis. [More information, including how you can register for the Preview, and which regions Application Security Groups are available in are available here](https://docs.microsoft.com/en-us/azure/virtual-network/create-network-security-group-preview)
-
 * `primary` - (Optional) Is this the Primary Network Interface? If set to `true` this should be the first `ip_configuration` in the array.
 
 ## Attributes Reference


### PR DESCRIPTION
Update documentation now the Application Security Groups are now Generally Available.

<https://github.com/terraform-providers/terraform-provider-azurerm/issues/1489>

(fixes #1489)
