### PR TITLE
resource/azurerm_sql_database: Fix requested_service_objective_name updates

### DIFF
--- a/azurerm/resource_arm_sql_database.go
+++ b/azurerm/resource_arm_sql_database.go
@@ -283,6 +283,11 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
+	// The requested Service Objective Name does not match the requested Service Objective Id.
+	if d.HasChange("requested_service_objective_name") && !d.HasChange("requested_service_objective_id") {
+		properties.DatabaseProperties.RequestedServiceObjectiveID = nil
+	}
+
 	ctx := meta.(*ArmClient).StopContext
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, serverName, name, properties)
 	if err != nil {

--- a/azurerm/resource_arm_sql_database_test.go
+++ b/azurerm/resource_arm_sql_database_test.go
@@ -185,6 +185,36 @@ func TestAccAzureRMSqlDatabase_collation(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSqlDatabase_requestedServiceObjectiveName(t *testing.T) {
+	resourceName := "azurerm_sql_database.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+	preConfig := testAccAzureRMSqlDatabase_requestedServiceObjectiveName(ri, location, "S0")
+	postConfig := testAccAzureRMSqlDatabase_requestedServiceObjectiveName(ri, location, "S1")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "requested_service_objective_name", "S0"),
+				),
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSqlDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "requested_service_objective_name", "S1"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMSqlDatabaseExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -584,4 +614,33 @@ func testAccAzureRMSqlDatabase_bacpac(rInt int, location string) string {
 			}
 		}
 		`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMSqlDatabase_requestedServiceObjectiveName(rInt int, location, requestedServiceObjectiveName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "%s"
+}
+
+resource "azurerm_sql_server" "test" {
+    name = "acctestsqlserver%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "${azurerm_resource_group.test.location}"
+    version = "12.0"
+    administrator_login = "mradministrator"
+    administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_sql_database" "test" {
+    name = "acctestdb%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    server_name = "${azurerm_sql_server.test.name}"
+    location = "${azurerm_resource_group.test.location}"
+    edition = "Standard"
+    collation = "SQL_Latin1_General_CP1_CI_AS"
+    max_size_bytes = "1073741824"
+    requested_service_objective_name = %q
+}
+`, rInt, location, rInt, rInt, requestedServiceObjectiveName)
 }


### PR DESCRIPTION
Related: https://github.com/terraform-providers/terraform-provider-azurerm/issues/590#issuecomment-365670238

Previously, when attempting to update an `azurerm_sql_database` resource `requested_service_objective_name` argument without specifying a `request_service_objective_id`, the Azure would return an error because the resource was sending both the old (computed) ID and the new (updated) name:

```
$ make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMSqlDatabase_requestedServiceObjectiveName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMSqlDatabase_requestedServiceObjectiveName -timeout 180m
=== RUN   TestAccAzureRMSqlDatabase_requestedServiceObjectiveName
--- FAIL: TestAccAzureRMSqlDatabase_requestedServiceObjectiveName (195.12s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:

		* azurerm_sql_database.test: 1 error(s) occurred:

		* azurerm_sql_database.test: Code="0" Message="The requested Service Objective Name does not match the requested Service Objective Id."
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	195.151s
make: *** [testacc] Error 1
```

This update allows the resource to successfully update:

```
$ make testacc TEST=./azurerm TESTARGS='-run=TestAccAzureRMSqlDatabase_requestedServiceObjectiveName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -run=TestAccAzureRMSqlDatabase_requestedServiceObjectiveName -timeout 180m
=== RUN   TestAccAzureRMSqlDatabase_requestedServiceObjectiveName
--- PASS: TestAccAzureRMSqlDatabase_requestedServiceObjectiveName (282.32s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	282.352s
```