### PR TITLE
Fixing the Network Interface Data Source Documentation

### DIFF
--- a/azurerm/data_source_network_interface.go
+++ b/azurerm/data_source_network_interface.go
@@ -20,12 +20,12 @@ func dataSourceArmNetworkInterface() *schema.Resource {
 				Required: true,
 			},
 
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
 			"location": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"resource_group_name": resourceGroupNameForDataSourceSchema(),
 
 			"network_security_group_id": {
 				Type:     schema.TypeString,

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -25,24 +25,38 @@ output "network_interface_id" {
 
 ## Argument Reference
 
+
 * `name` - (Required) Specifies the name of the Network Interface.
 * `resource_group_name` - (Required) Specifies the name of the resource group the Network Interface is located in.
 
 ## Attributes Reference
 
-* `applied_dns_servers` - List of DNS servers applied to the specified network interface.
-* `dns_servers` - The list of DNS servers used by the specified network interface.
-* `enable_accelerated_networking` - Indicates if accelerated networking is set on the specified network interface.
-* `enable_ip_forwarding` - Indicate if IP forwarding is set on the specified network interface.
-* `id` - The ID of the virtual network that the specified network interface is associated to.
-* `internal_dns_name_label` - The internal dns name label of the specified network interface.
-* `internal_fqdn` - The internal FQDN associated to the specified network interface.
-* `ip_configuration` - The list of IP configurations associated to the specified network interface.
-* `location` - The location of the specified network interface.
-* `network_security_group_id` - The ID of the network security group associated to the specified network interface.
-* `mac_address` - The MAC address used by the specified network interface.
-* `private_ip_address` - The primary private ip address associated to the specified network interface.
-* `private_ip_addresses` - The list of private ip addresses associates to the specified network interface.
-* `tags` - List the tags assocatied to the specified network interface.
-* `virtual_machine_id` - The ID of the virtual machine that the specified network interface is attached to.
+* `id` - The ID of the Network Interface.
+* `applied_dns_servers` - List of DNS servers applied to the specified Network Interface.
+* `enable_accelerated_networking` - Indicates if accelerated networking is set on the specified Network Interface.
+* `enable_ip_forwarding` - Indicate if IP forwarding is set on the specified Network Interface.
+* `dns_servers` - The list of DNS servers used by the specified Network Interface.
+* `internal_dns_name_label` - The internal dns name label of the specified Network Interface.
+* `internal_fqdn` - The internal FQDN associated to the specified Network Interface.
+* `ip_configuration` - One or more `ip_configuration` blocks as defined below.
+* `location` - The location of the specified Network Interface.
+* `mac_address` - The MAC address used by the specified Network Interface.
+* `network_security_group_id` - The ID of the network security group associated to the specified Network Interface.
+* `private_ip_address` - The primary private ip address associated to the specified Network Interface.
+* `private_ip_addresses` - The list of private ip addresses associates to the specified Network Interface.
+* `tags` - List the tags associated to the specified Network Interface.
+* `virtual_machine_id` - The ID of the virtual machine that the specified Network Interface is attached to.
 
+---
+
+A `ip_configuration` block contains:
+
+* `name` - The name of the IP Configuration.
+* `subnet_id` - The ID of the Subnet which the Network Interface is connected to.
+* `private_ip_address` - The Private IP Address assigned to this Network Interface.
+* `private_ip_address_allocation` - The IP Address allocation type for the Private address, such as `Dynamic` or `Standard`.
+* `public_ip_address_id` - The ID of the Public IP Address which is connected to this Network Interface.
+* `application_gateway_backend_address_pools_ids` - A list of Backend Address Pool ID's within a Application Gateway that this Network Interface is connected to.
+* `load_balancer_backend_address_pools_ids` - A list of Backend Address Pool ID's within a Load Balancer that this Network Interface is connected to.
+* `load_balancer_inbound_nat_rules_ids` - A list of Inbound NAT Rule ID's within a Load Balancer that this Network Interface is connected to.
+* `primary` - is this the Primary IP Configuration for this Network Interface?


### PR DESCRIPTION
Noticed the `ip_configuration` block was missing and a spurious `id` was added