### PR TITLE
Virtual Network Gateway - fixing a set error

### DIFF
--- a/azurerm/data_source_virtual_network_gateway.go
+++ b/azurerm/data_source_virtual_network_gateway.go
@@ -3,6 +3,10 @@ package azurerm
 import (
 	"fmt"
 
+	"bytes"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -98,7 +102,7 @@ func dataSourceArmVirtualNetworkGateway() *schema.Resource {
 									},
 								},
 							},
-							Set: hashVirtualNetworkGatewayRootCert,
+							Set: hashVirtualNetworkGatewayDataSourceRootCert,
 						},
 						"revoked_certificate": {
 							Type:     schema.TypeSet,
@@ -115,7 +119,7 @@ func dataSourceArmVirtualNetworkGateway() *schema.Resource {
 									},
 								},
 							},
-							Set: hashVirtualNetworkGatewayRevokedCert,
+							Set: hashVirtualNetworkGatewayDataSourceRevokedCert,
 						},
 					},
 				},
@@ -195,24 +199,156 @@ func dataSourceArmVirtualNetworkGatewayRead(d *schema.ResourceData, meta interfa
 			d.Set("sku", string(gw.Sku.Name))
 		}
 
-		d.Set("ip_configuration", flattenArmVirtualNetworkGatewayIPConfigurations(gw.IPConfigurations))
-
-		if gw.VpnClientConfiguration != nil {
-			vpnConfigFlat := flattenArmVirtualNetworkGatewayVpnClientConfig(gw.VpnClientConfiguration)
-			if err := d.Set("vpn_client_configuration", vpnConfigFlat); err != nil {
-				return fmt.Errorf("Error setting `vpn_client_configuration`: %+v", err)
-			}
+		if err := d.Set("ip_configuration", flattenArmVirtualNetworkGatewayDataSourceIPConfigurations(gw.IPConfigurations)); err != nil {
+			return fmt.Errorf("Error setting `ip_configuration`: %+v", err)
 		}
 
-		if gw.BgpSettings != nil {
-			bgpSettingsFlat := flattenArmVirtualNetworkGatewayBgpSettings(gw.BgpSettings)
-			if err := d.Set("bgp_settings", bgpSettingsFlat); err != nil {
-				return fmt.Errorf("Error setting `bgp_settings`: %+v", err)
-			}
+		vpnConfigFlat := flattenArmVirtualNetworkGatewayDataSourceVpnClientConfig(gw.VpnClientConfiguration)
+		if err := d.Set("vpn_client_configuration", vpnConfigFlat); err != nil {
+			return fmt.Errorf("Error setting `vpn_client_configuration`: %+v", err)
+		}
+
+		bgpSettingsFlat := flattenArmVirtualNetworkGatewayDataSourceBgpSettings(gw.BgpSettings)
+		if err := d.Set("bgp_settings", bgpSettingsFlat); err != nil {
+			return fmt.Errorf("Error setting `bgp_settings`: %+v", err)
 		}
 	}
 
 	flattenAndSetTags(d, resp.Tags)
 
 	return nil
+}
+
+func flattenArmVirtualNetworkGatewayDataSourceIPConfigurations(ipConfigs *[]network.VirtualNetworkGatewayIPConfiguration) []interface{} {
+	flat := make([]interface{}, 0)
+
+	if ipConfigs != nil {
+		for _, cfg := range *ipConfigs {
+			props := cfg.VirtualNetworkGatewayIPConfigurationPropertiesFormat
+			v := make(map[string]interface{})
+
+			if name := cfg.Name; name != nil {
+				v["name"] = *name
+			}
+			v["private_ip_address_allocation"] = string(props.PrivateIPAllocationMethod)
+
+			if subnet := props.Subnet; subnet != nil {
+				if id := subnet.ID; id != nil {
+					v["subnet_id"] = *id
+				}
+			}
+
+			if pip := props.PublicIPAddress; pip != nil {
+				if id := pip.ID; id != nil {
+					v["public_ip_address_id"] = *id
+				}
+			}
+
+			flat = append(flat, v)
+		}
+	}
+
+	return flat
+}
+
+func flattenArmVirtualNetworkGatewayDataSourceVpnClientConfig(cfg *network.VpnClientConfiguration) []interface{} {
+	if cfg == nil {
+		return []interface{}{}
+	}
+
+	flat := make(map[string]interface{})
+
+	addressSpace := make([]interface{}, 0)
+	if pool := cfg.VpnClientAddressPool; pool != nil {
+		if prefixes := pool.AddressPrefixes; prefixes != nil {
+			for _, addr := range *prefixes {
+				addressSpace = append(addressSpace, addr)
+			}
+		}
+	}
+	flat["address_space"] = addressSpace
+
+	rootCerts := make([]interface{}, 0)
+	if certs := cfg.VpnClientRootCertificates; certs != nil {
+		for _, cert := range *certs {
+			v := map[string]interface{}{
+				"name":             *cert.Name,
+				"public_cert_data": *cert.VpnClientRootCertificatePropertiesFormat.PublicCertData,
+			}
+			rootCerts = append(rootCerts, v)
+		}
+	}
+	flat["root_certificate"] = schema.NewSet(hashVirtualNetworkGatewayDataSourceRootCert, rootCerts)
+
+	revokedCerts := make([]interface{}, 0)
+	if certs := cfg.VpnClientRevokedCertificates; certs != nil {
+		for _, cert := range *certs {
+			v := map[string]interface{}{
+				"name":       *cert.Name,
+				"thumbprint": *cert.VpnClientRevokedCertificatePropertiesFormat.Thumbprint,
+			}
+			revokedCerts = append(revokedCerts, v)
+		}
+	}
+	flat["revoked_certificate"] = schema.NewSet(hashVirtualNetworkGatewayDataSourceRevokedCert, revokedCerts)
+
+	vpnClientProtocols := &schema.Set{F: schema.HashString}
+	if vpnProtocols := cfg.VpnClientProtocols; vpnProtocols != nil {
+		for _, protocol := range *vpnProtocols {
+			vpnClientProtocols.Add(string(protocol))
+		}
+	}
+	flat["vpn_client_protocols"] = vpnClientProtocols
+
+	if v := cfg.RadiusServerAddress; v != nil {
+		flat["radius_server_address"] = *v
+	}
+
+	if v := cfg.RadiusServerSecret; v != nil {
+		flat["radius_server_secret"] = *v
+	}
+
+	return []interface{}{flat}
+}
+
+func flattenArmVirtualNetworkGatewayDataSourceBgpSettings(settings *network.BgpSettings) []interface{} {
+	output := make([]interface{}, 0)
+
+	if settings != nil {
+		flat := make(map[string]interface{})
+
+		if asn := settings.Asn; asn != nil {
+			flat["asn"] = int(*asn)
+		}
+		if address := settings.BgpPeeringAddress; address != nil {
+			flat["peering_address"] = *address
+		}
+		if weight := settings.PeerWeight; weight != nil {
+			flat["peer_weight"] = int(*weight)
+		}
+
+		output = append(output, flat)
+	}
+
+	return output
+}
+
+func hashVirtualNetworkGatewayDataSourceRootCert(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["public_cert_data"].(string)))
+
+	return hashcode.String(buf.String())
+}
+
+func hashVirtualNetworkGatewayDataSourceRevokedCert(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["thumbprint"].(string)))
+
+	return hashcode.String(buf.String())
 }

--- a/azurerm/data_source_virtual_network_gateway.go
+++ b/azurerm/data_source_virtual_network_gateway.go
@@ -121,6 +121,21 @@ func dataSourceArmVirtualNetworkGateway() *schema.Resource {
 							},
 							Set: hashVirtualNetworkGatewayDataSourceRevokedCert,
 						},
+						"radius_server_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"radius_server_secret": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpn_client_protocols": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 					},
 				},
 			},

--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -321,9 +321,7 @@ func resourceArmVirtualNetworkGatewayRead(d *schema.ResourceData, meta interface
 		d.Set("location", azureRMNormalizeLocation(*location))
 	}
 
-	if resp.VirtualNetworkGatewayPropertiesFormat != nil {
-		gw := *resp.VirtualNetworkGatewayPropertiesFormat
-
+	if gw := resp.VirtualNetworkGatewayPropertiesFormat; gw != nil {
 		d.Set("type", string(gw.GatewayType))
 		d.Set("enable_bgp", gw.EnableBgp)
 		d.Set("active_active", gw.ActiveActive)
@@ -340,13 +338,13 @@ func resourceArmVirtualNetworkGatewayRead(d *schema.ResourceData, meta interface
 			d.Set("sku", string(gw.Sku.Name))
 		}
 
-		d.Set("ip_configuration", flattenArmVirtualNetworkGatewayIPConfigurations(gw.IPConfigurations))
+		if err := d.Set("ip_configuration", flattenArmVirtualNetworkGatewayIPConfigurations(gw.IPConfigurations)); err != nil {
+			return fmt.Errorf("Error setting `ip_configuration`: %+v", err)
+		}
 
-		if gw.VpnClientConfiguration != nil {
-			vpnConfigFlat := flattenArmVirtualNetworkGatewayVpnClientConfig(gw.VpnClientConfiguration)
-			if err := d.Set("vpn_client_configuration", vpnConfigFlat); err != nil {
-				return fmt.Errorf("Error setting `vpn_client_configuration`: %+v", err)
-			}
+		vpnConfigFlat := flattenArmVirtualNetworkGatewayVpnClientConfig(gw.VpnClientConfiguration)
+		if err := d.Set("vpn_client_configuration", vpnConfigFlat); err != nil {
+			return fmt.Errorf("Error setting `vpn_client_configuration`: %+v", err)
 		}
 
 		if gw.BgpSettings != nil {
@@ -564,34 +562,64 @@ func expandArmVirtualNetworkGatewaySku(d *schema.ResourceData) *network.VirtualN
 }
 
 func flattenArmVirtualNetworkGatewayBgpSettings(settings *network.BgpSettings) []interface{} {
-	flat := make(map[string]interface{})
+	output := make([]interface{}, 0)
 
-	flat["asn"] = int(*settings.Asn)
-	flat["peering_address"] = *settings.BgpPeeringAddress
-	flat["peer_weight"] = int(*settings.PeerWeight)
+	if settings != nil {
+		flat := make(map[string]interface{})
 
-	return []interface{}{flat}
+		if asn := settings.Asn; asn != nil {
+			flat["asn"] = int(*asn)
+		}
+		if address := settings.BgpPeeringAddress; address != nil {
+			flat["peering_address"] = *address
+		}
+		if weight := settings.PeerWeight; weight != nil {
+			flat["peer_weight"] = int(*weight)
+		}
+
+		output = append(output, flat)
+	}
+
+	return output
 }
 
 func flattenArmVirtualNetworkGatewayIPConfigurations(ipConfigs *[]network.VirtualNetworkGatewayIPConfiguration) []interface{} {
-	flat := make([]interface{}, 0, len(*ipConfigs))
+	flat := make([]interface{}, 0)
 
-	for _, cfg := range *ipConfigs {
-		props := cfg.VirtualNetworkGatewayIPConfigurationPropertiesFormat
-		v := make(map[string]interface{})
+	if ipConfigs != nil {
+		for _, cfg := range *ipConfigs {
+			props := cfg.VirtualNetworkGatewayIPConfigurationPropertiesFormat
+			v := make(map[string]interface{})
 
-		v["name"] = *cfg.Name
-		v["private_ip_address_allocation"] = string(props.PrivateIPAllocationMethod)
-		v["subnet_id"] = *props.Subnet.ID
-		v["public_ip_address_id"] = *props.PublicIPAddress.ID
+			if name := cfg.Name; name != nil {
+				v["name"] = *name
+			}
+			v["private_ip_address_allocation"] = string(props.PrivateIPAllocationMethod)
 
-		flat = append(flat, v)
+			if subnet := props.Subnet; subnet != nil {
+				if id := subnet.ID; id != nil {
+					v["subnet_id"] = *id
+				}
+			}
+
+			if pip := props.PublicIPAddress; pip != nil {
+				if id := pip.ID; id != nil {
+					v["public_ip_address_id"] = *id
+				}
+			}
+
+			flat = append(flat, v)
+		}
 	}
 
 	return flat
 }
 
 func flattenArmVirtualNetworkGatewayVpnClientConfig(cfg *network.VpnClientConfiguration) []interface{} {
+	if cfg == nil {
+		return []interface{}{}
+	}
+
 	flat := make(map[string]interface{})
 
 	addressSpace := make([]interface{}, 0)

--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -141,17 +141,6 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"vpn_client_protocols": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateFunc: validation.StringInSlice([]string{
-									string(network.IkeV2),
-									string(network.SSTP),
-								}, true),
-							},
-						},
 						"root_certificate": {
 							Type:     schema.TypeSet,
 							Optional: true,
@@ -210,6 +199,17 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 							ConflictsWith: []string{
 								"vpn_client_configuration.0.root_certificate",
 								"vpn_client_configuration.0.revoked_certificate",
+							},
+						},
+						"vpn_client_protocols": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(network.IkeV2),
+									string(network.SSTP),
+								}, true),
 							},
 						},
 					},

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -84,6 +84,15 @@ The `vpn_client_configuration` block supports:
 * `revoked_certificate` - One or more `revoked_certificate` blocks which
     are defined below.
 
+* `radius_server_address` - (Optional) The address of the Radius server.
+    This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
+
+* `radius_server_secret` - (Optional) The secret used by the Radius server.
+    This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
+
+* `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
+    The supported values are `SSTP` and `IkeV2`.
+
 The `bgp_settings` block supports:
 
 * `asn` - The Autonomous System Number (ASN) to use as part of the BGP.

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -169,10 +169,6 @@ The `vpn_client_configuration` block supports:
 * `address_space` - (Required) The address space out of which ip addresses for
     vpn clients will be taken. You can provide more than one address space, e.g.
     in CIDR notation.
-
-* `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
-    The supported values are "SSTP" and "IkeV2".
-
 * `root_certificate` - (Optional) One or more `root_certificate` blocks which are
     defined below. These root certificates are used to sign the client certificate
     used by the VPN clients to connect to the gateway.
@@ -187,6 +183,9 @@ The `vpn_client_configuration` block supports:
 
 * `radius_server_secret` - (Optional) The secret used by the Radius server.
     This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
+
+* `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
+    The supported values are `SSTP` and `IkeV2`.
 
 The `bgp_settings` block supports:
 


### PR DESCRIPTION
Adds support for the `radius_server_address`, `radius_server_secret` and `vpn_client_protocols` fields to the Data Source - introduced to the Resource in #946

This also moves the flatten functions into the Data Source and clears up a few crash points

Fixes #1496