### PR TITLE
resource/container_group: parse command as sh

### DIFF
--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/flynn-archive/go-shlex"
+
 	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-04-01/containerinstance"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -206,7 +208,11 @@ func resourceArmContainerGroupCreate(d *schema.ResourceData, meta interface{}) e
 	tags := d.Get("tags").(map[string]interface{})
 	restartPolicy := d.Get("restart_policy").(string)
 
-	containers, containerGroupPorts, containerGroupVolumes := expandContainerGroupContainers(d)
+	containers, containerGroupPorts, containerGroupVolumes, err := expandContainerGroupContainers(d)
+	if err != nil {
+		return err
+	}
+
 	containerGroup := containerinstance.ContainerGroup{
 		Name:     &name,
 		Location: &location,
@@ -227,7 +233,7 @@ func resourceArmContainerGroupCreate(d *schema.ResourceData, meta interface{}) e
 		containerGroup.ContainerGroupProperties.IPAddress.DNSNameLabel = &dnsNameLabel
 	}
 
-	_, err := containerGroupsClient.CreateOrUpdate(ctx, resGroup, name, containerGroup)
+	_, err = containerGroupsClient.CreateOrUpdate(ctx, resGroup, name, containerGroup)
 	if err != nil {
 		return err
 	}
@@ -443,7 +449,7 @@ func flattenContainerVolumes(volumeMounts *[]containerinstance.VolumeMount, cont
 	return volumeConfigs
 }
 
-func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstance.Container, *[]containerinstance.Port, *[]containerinstance.Volume) {
+func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstance.Container, *[]containerinstance.Port, *[]containerinstance.Volume, error) {
 	containersConfig := d.Get("container").([]interface{})
 	containers := make([]containerinstance.Container, 0, len(containersConfig))
 	containerGroupPorts := make([]containerinstance.Port, 0, len(containersConfig))
@@ -498,7 +504,10 @@ func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstanc
 		}
 
 		if v, _ := data["command"]; v != "" {
-			command := strings.Split(v.(string), " ")
+			command, err := shlex.Split(v.(string))
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("Error parsing as sh `container.command`: %+v", err)
+			}
 			container.Command = &command
 		}
 
@@ -513,7 +522,7 @@ func expandContainerGroupContainers(d *schema.ResourceData) (*[]containerinstanc
 		containers = append(containers, container)
 	}
 
-	return &containers, &containerGroupPorts, &containerGroupVolumes
+	return &containers, &containerGroupPorts, &containerGroupVolumes, nil
 }
 
 func expandContainerEnvironmentVariables(input interface{}) *[]containerinstance.EnvironmentVariable {

--- a/vendor/github.com/flynn-archive/go-shlex/COPYING
+++ b/vendor/github.com/flynn-archive/go-shlex/COPYING
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/flynn-archive/go-shlex/Makefile
+++ b/vendor/github.com/flynn-archive/go-shlex/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2011 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include $(GOROOT)/src/Make.inc
+
+TARG=shlex
+GOFILES=\
+	shlex.go\
+
+include $(GOROOT)/src/Make.pkg

--- a/vendor/github.com/flynn-archive/go-shlex/README.md
+++ b/vendor/github.com/flynn-archive/go-shlex/README.md
@@ -1,0 +1,2 @@
+go-shlex is a simple lexer for go that supports shell-style quoting,
+commenting, and escaping.

--- a/vendor/github.com/flynn-archive/go-shlex/shlex.go
+++ b/vendor/github.com/flynn-archive/go-shlex/shlex.go
@@ -1,0 +1,457 @@
+/*
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shlex
+
+/*
+Package shlex implements a simple lexer which splits input in to tokens using
+shell-style rules for quoting and commenting.
+*/
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+/*
+A TokenType is a top-level token; a word, space, comment, unknown.
+*/
+type TokenType int
+
+/*
+A RuneTokenType is the type of a UTF-8 character; a character, quote, space, escape.
+*/
+type RuneTokenType int
+
+type lexerState int
+
+type Token struct {
+	tokenType TokenType
+	value     string
+}
+
+/*
+Two tokens are equal if both their types and values are equal. A nil token can
+never equal another token.
+*/
+func (a *Token) Equal(b *Token) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.tokenType != b.tokenType {
+		return false
+	}
+	return a.value == b.value
+}
+
+const (
+	RUNE_CHAR              string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-,/@$*()+=><:;&^%~|!?[]{}"
+	RUNE_SPACE             string = " \t\r\n"
+	RUNE_ESCAPING_QUOTE    string = "\""
+	RUNE_NONESCAPING_QUOTE string = "'"
+	RUNE_ESCAPE                   = "\\"
+	RUNE_COMMENT                  = "#"
+
+	RUNETOKEN_UNKNOWN           RuneTokenType = 0
+	RUNETOKEN_CHAR              RuneTokenType = 1
+	RUNETOKEN_SPACE             RuneTokenType = 2
+	RUNETOKEN_ESCAPING_QUOTE    RuneTokenType = 3
+	RUNETOKEN_NONESCAPING_QUOTE RuneTokenType = 4
+	RUNETOKEN_ESCAPE            RuneTokenType = 5
+	RUNETOKEN_COMMENT           RuneTokenType = 6
+	RUNETOKEN_EOF               RuneTokenType = 7
+
+	TOKEN_UNKNOWN TokenType = 0
+	TOKEN_WORD    TokenType = 1
+	TOKEN_SPACE   TokenType = 2
+	TOKEN_COMMENT TokenType = 3
+
+	STATE_START           lexerState = 0
+	STATE_INWORD          lexerState = 1
+	STATE_ESCAPING        lexerState = 2
+	STATE_ESCAPING_QUOTED lexerState = 3
+	STATE_QUOTED_ESCAPING lexerState = 4
+	STATE_QUOTED          lexerState = 5
+	STATE_COMMENT         lexerState = 6
+
+	INITIAL_TOKEN_CAPACITY int = 100
+)
+
+/*
+A type for classifying characters. This allows for different sorts of
+classifiers - those accepting extended non-ascii chars, or strict posix
+compatibility, for example.
+*/
+type TokenClassifier struct {
+	typeMap map[int32]RuneTokenType
+}
+
+func addRuneClass(typeMap *map[int32]RuneTokenType, runes string, tokenType RuneTokenType) {
+	for _, rune := range runes {
+		(*typeMap)[int32(rune)] = tokenType
+	}
+}
+
+/*
+Create a new classifier for basic ASCII characters.
+*/
+func NewDefaultClassifier() *TokenClassifier {
+	typeMap := map[int32]RuneTokenType{}
+	addRuneClass(&typeMap, RUNE_CHAR, RUNETOKEN_CHAR)
+	addRuneClass(&typeMap, RUNE_SPACE, RUNETOKEN_SPACE)
+	addRuneClass(&typeMap, RUNE_ESCAPING_QUOTE, RUNETOKEN_ESCAPING_QUOTE)
+	addRuneClass(&typeMap, RUNE_NONESCAPING_QUOTE, RUNETOKEN_NONESCAPING_QUOTE)
+	addRuneClass(&typeMap, RUNE_ESCAPE, RUNETOKEN_ESCAPE)
+	addRuneClass(&typeMap, RUNE_COMMENT, RUNETOKEN_COMMENT)
+	return &TokenClassifier{
+		typeMap: typeMap}
+}
+
+func (classifier *TokenClassifier) ClassifyRune(rune int32) RuneTokenType {
+	return classifier.typeMap[rune]
+}
+
+/*
+A type for turning an input stream in to a sequence of strings. Whitespace and
+comments are skipped.
+*/
+type Lexer struct {
+	tokenizer *Tokenizer
+}
+
+/*
+Create a new lexer.
+*/
+func NewLexer(r io.Reader) (*Lexer, error) {
+
+	tokenizer, err := NewTokenizer(r)
+	if err != nil {
+		return nil, err
+	}
+	lexer := &Lexer{tokenizer: tokenizer}
+	return lexer, nil
+}
+
+/*
+Return the next word, and an error value. If there are no more words, the error
+will be io.EOF.
+*/
+func (l *Lexer) NextWord() (string, error) {
+	var token *Token
+	var err error
+	for {
+		token, err = l.tokenizer.NextToken()
+		if err != nil {
+			return "", err
+		}
+		switch token.tokenType {
+		case TOKEN_WORD:
+			{
+				return token.value, nil
+			}
+		case TOKEN_COMMENT:
+			{
+				// skip comments
+			}
+		default:
+			{
+				panic(fmt.Sprintf("Unknown token type: %v", token.tokenType))
+			}
+		}
+	}
+	return "", io.EOF
+}
+
+/*
+A type for turning an input stream in to a sequence of typed tokens.
+*/
+type Tokenizer struct {
+	input      *bufio.Reader
+	classifier *TokenClassifier
+}
+
+/*
+Create a new tokenizer.
+*/
+func NewTokenizer(r io.Reader) (*Tokenizer, error) {
+	input := bufio.NewReader(r)
+	classifier := NewDefaultClassifier()
+	tokenizer := &Tokenizer{
+		input:      input,
+		classifier: classifier}
+	return tokenizer, nil
+}
+
+/*
+Scan the stream for the next token.
+
+This uses an internal state machine. It will panic if it encounters a character
+which it does not know how to handle.
+*/
+func (t *Tokenizer) scanStream() (*Token, error) {
+	state := STATE_START
+	var tokenType TokenType
+	value := make([]int32, 0, INITIAL_TOKEN_CAPACITY)
+	var (
+		nextRune     int32
+		nextRuneType RuneTokenType
+		err          error
+	)
+SCAN:
+	for {
+		nextRune, _, err = t.input.ReadRune()
+		nextRuneType = t.classifier.ClassifyRune(nextRune)
+		if err != nil {
+			if err == io.EOF {
+				nextRuneType = RUNETOKEN_EOF
+				err = nil
+			} else {
+				return nil, err
+			}
+		}
+		switch state {
+		case STATE_START: // no runes read yet
+			{
+				switch nextRuneType {
+				case RUNETOKEN_EOF:
+					{
+						return nil, io.EOF
+					}
+				case RUNETOKEN_CHAR:
+					{
+						tokenType = TOKEN_WORD
+						value = append(value, nextRune)
+						state = STATE_INWORD
+					}
+				case RUNETOKEN_SPACE:
+					{
+					}
+				case RUNETOKEN_ESCAPING_QUOTE:
+					{
+						tokenType = TOKEN_WORD
+						state = STATE_QUOTED_ESCAPING
+					}
+				case RUNETOKEN_NONESCAPING_QUOTE:
+					{
+						tokenType = TOKEN_WORD
+						state = STATE_QUOTED
+					}
+				case RUNETOKEN_ESCAPE:
+					{
+						tokenType = TOKEN_WORD
+						state = STATE_ESCAPING
+					}
+				case RUNETOKEN_COMMENT:
+					{
+						tokenType = TOKEN_COMMENT
+						state = STATE_COMMENT
+					}
+				default:
+					{
+						return nil, errors.New(fmt.Sprintf("Unknown rune: %v", nextRune))
+					}
+				}
+			}
+		case STATE_INWORD: // in a regular word
+			{
+				switch nextRuneType {
+				case RUNETOKEN_EOF:
+					{
+						break SCAN
+					}
+				case RUNETOKEN_CHAR, RUNETOKEN_COMMENT:
+					{
+						value = append(value, nextRune)
+					}
+				case RUNETOKEN_SPACE:
+					{
+						t.input.UnreadRune()
+						break SCAN
+					}
+				case RUNETOKEN_ESCAPING_QUOTE:
+					{
+						state = STATE_QUOTED_ESCAPING
+					}
+				case RUNETOKEN_NONESCAPING_QUOTE:
+					{
+						state = STATE_QUOTED
+					}
+				case RUNETOKEN_ESCAPE:
+					{
+						state = STATE_ESCAPING
+					}
+				default:
+					{
+						return nil, errors.New(fmt.Sprintf("Uknown rune: %v", nextRune))
+					}
+				}
+			}
+		case STATE_ESCAPING: // the next rune after an escape character
+			{
+				switch nextRuneType {
+				case RUNETOKEN_EOF:
+					{
+						err = errors.New("EOF found after escape character")
+						break SCAN
+					}
+				case RUNETOKEN_CHAR, RUNETOKEN_SPACE, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_NONESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT:
+					{
+						state = STATE_INWORD
+						value = append(value, nextRune)
+					}
+				default:
+					{
+						return nil, errors.New(fmt.Sprintf("Uknown rune: %v", nextRune))
+					}
+				}
+			}
+		case STATE_ESCAPING_QUOTED: // the next rune after an escape character, in double quotes
+			{
+				switch nextRuneType {
+				case RUNETOKEN_EOF:
+					{
+						err = errors.New("EOF found after escape character")
+						break SCAN
+					}
+				case RUNETOKEN_CHAR, RUNETOKEN_SPACE, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_NONESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT:
+					{
+						state = STATE_QUOTED_ESCAPING
+						value = append(value, nextRune)
+					}
+				default:
+					{
+						return nil, errors.New(fmt.Sprintf("Uknown rune: %v", nextRune))
+					}
+				}
+			}
+		case STATE_QUOTED_ESCAPING: // in escaping double quotes
+			{
+				switch nextRuneType {
+				case RUNETOKEN_EOF:
+					{
+						err = errors.New("EOF found when expecting closing quote.")
+						break SCAN
+					}
+				case RUNETOKEN_CHAR, RUNETOKEN_UNKNOWN, RUNETOKEN_SPACE, RUNETOKEN_NONESCAPING_QUOTE, RUNETOKEN_COMMENT:
+					{
+						value = append(value, nextRune)
+					}
+				case RUNETOKEN_ESCAPING_QUOTE:
+					{
+						state = STATE_INWORD
+					}
+				case RUNETOKEN_ESCAPE:
+					{
+						state = STATE_ESCAPING_QUOTED
+					}
+				default:
+					{
+						return nil, errors.New(fmt.Sprintf("Uknown rune: %v", nextRune))
+					}
+				}
+			}
+		case STATE_QUOTED: // in non-escaping single quotes
+			{
+				switch nextRuneType {
+				case RUNETOKEN_EOF:
+					{
+						err = errors.New("EOF found when expecting closing quote.")
+						break SCAN
+					}
+				case RUNETOKEN_CHAR, RUNETOKEN_UNKNOWN, RUNETOKEN_SPACE, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT:
+					{
+						value = append(value, nextRune)
+					}
+				case RUNETOKEN_NONESCAPING_QUOTE:
+					{
+						state = STATE_INWORD
+					}
+				default:
+					{
+						return nil, errors.New(fmt.Sprintf("Uknown rune: %v", nextRune))
+					}
+				}
+			}
+		case STATE_COMMENT:
+			{
+				switch nextRuneType {
+				case RUNETOKEN_EOF:
+					{
+						break SCAN
+					}
+				case RUNETOKEN_CHAR, RUNETOKEN_UNKNOWN, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT, RUNETOKEN_NONESCAPING_QUOTE:
+					{
+						value = append(value, nextRune)
+					}
+				case RUNETOKEN_SPACE:
+					{
+						if nextRune == '\n' {
+							state = STATE_START
+							break SCAN
+						} else {
+							value = append(value, nextRune)
+						}
+					}
+				default:
+					{
+						return nil, errors.New(fmt.Sprintf("Uknown rune: %v", nextRune))
+					}
+				}
+			}
+		default:
+			{
+				panic(fmt.Sprintf("Unexpected state: %v", state))
+			}
+		}
+	}
+	token := &Token{
+		tokenType: tokenType,
+		value:     string(value)}
+	return token, err
+}
+
+/*
+Return the next token in the stream, and an error value. If there are no more
+tokens available, the error value will be io.EOF.
+*/
+func (t *Tokenizer) NextToken() (*Token, error) {
+	return t.scanStream()
+}
+
+/*
+Split a string in to a slice of strings, based upon shell-style rules for
+quoting, escaping, and spaces.
+*/
+func Split(s string) ([]string, error) {
+	l, err := NewLexer(strings.NewReader(s))
+	if err != nil {
+		return nil, err
+	}
+	subStrings := []string{}
+	for {
+		word, err := l.NextWord()
+		if err != nil {
+			if err == io.EOF {
+				return subStrings, nil
+			}
+			return subStrings, err
+		}
+		subStrings = append(subStrings, word)
+	}
+	return subStrings, nil
+}

--- a/vendor/github.com/flynn-archive/go-shlex/shlex_test.go
+++ b/vendor/github.com/flynn-archive/go-shlex/shlex_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2012 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shlex
+
+import (
+	"strings"
+	"testing"
+)
+
+func checkError(err error, t *testing.T) {
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestClassifier(t *testing.T) {
+	classifier := NewDefaultClassifier()
+	runeTests := map[int32]RuneTokenType{
+		'a':  RUNETOKEN_CHAR,
+		' ':  RUNETOKEN_SPACE,
+		'"':  RUNETOKEN_ESCAPING_QUOTE,
+		'\'': RUNETOKEN_NONESCAPING_QUOTE,
+		'#':  RUNETOKEN_COMMENT}
+	for rune, expectedType := range runeTests {
+		foundType := classifier.ClassifyRune(rune)
+		if foundType != expectedType {
+			t.Logf("Expected type: %v for rune '%c'(%v). Found type: %v.", expectedType, rune, rune, foundType)
+			t.Fail()
+		}
+	}
+}
+
+func TestTokenizer(t *testing.T) {
+	testInput := strings.NewReader("one two \"three four\" \"five \\\"six\\\"\" seven#eight # nine # ten\n eleven")
+	expectedTokens := []*Token{
+		&Token{
+			tokenType: TOKEN_WORD,
+			value:     "one"},
+		&Token{
+			tokenType: TOKEN_WORD,
+			value:     "two"},
+		&Token{
+			tokenType: TOKEN_WORD,
+			value:     "three four"},
+		&Token{
+			tokenType: TOKEN_WORD,
+			value:     "five \"six\""},
+		&Token{
+			tokenType: TOKEN_WORD,
+			value:     "seven#eight"},
+		&Token{
+			tokenType: TOKEN_COMMENT,
+			value:     " nine # ten"},
+		&Token{
+			tokenType: TOKEN_WORD,
+			value:     "eleven"}}
+
+	tokenizer, err := NewTokenizer(testInput)
+	checkError(err, t)
+	for _, expectedToken := range expectedTokens {
+		foundToken, err := tokenizer.NextToken()
+		checkError(err, t)
+		if !foundToken.Equal(expectedToken) {
+			t.Error("Expected token:", expectedToken, ". Found:", foundToken)
+		}
+	}
+}
+
+func TestLexer(t *testing.T) {
+	testInput := strings.NewReader("one")
+	expectedWord := "one"
+	lexer, err := NewLexer(testInput)
+	checkError(err, t)
+	foundWord, err := lexer.NextWord()
+	checkError(err, t)
+	if expectedWord != foundWord {
+		t.Error("Expected word:", expectedWord, ". Found:", foundWord)
+	}
+}
+
+func TestSplitSimple(t *testing.T) {
+	testInput := "one two three"
+	expectedOutput := []string{"one", "two", "three"}
+	foundOutput, err := Split(testInput)
+	if err != nil {
+		t.Error("Split returned error:", err)
+	}
+	if len(expectedOutput) != len(foundOutput) {
+		t.Error("Split expected:", len(expectedOutput), "results. Found:", len(foundOutput), "results")
+	}
+	for i := range foundOutput {
+		if foundOutput[i] != expectedOutput[i] {
+			t.Error("Item:", i, "(", foundOutput[i], ") differs from the expected value:", expectedOutput[i])
+		}
+	}
+}
+
+func TestSplitEscapingQuotes(t *testing.T) {
+	testInput := "one \"два ${three}\" four"
+	expectedOutput := []string{"one", "два ${three}", "four"}
+	foundOutput, err := Split(testInput)
+	if err != nil {
+		t.Error("Split returned error:", err)
+	}
+	if len(expectedOutput) != len(foundOutput) {
+		t.Error("Split expected:", len(expectedOutput), "results. Found:", len(foundOutput), "results")
+	}
+	for i := range foundOutput {
+		if foundOutput[i] != expectedOutput[i] {
+			t.Error("Item:", i, "(", foundOutput[i], ") differs from the expected value:", expectedOutput[i])
+		}
+	}
+}
+
+func TestGlobbingExpressions(t *testing.T) {
+	testInput := "onefile *file one?ile onefil[de]"
+	expectedOutput := []string{"onefile", "*file", "one?ile", "onefil[de]"}
+	foundOutput, err := Split(testInput)
+	if err != nil {
+		t.Error("Split returned error", err)
+	}
+	if len(expectedOutput) != len(foundOutput) {
+		t.Error("Split expected:", len(expectedOutput), "results. Found:", len(foundOutput), "results")
+	}
+	for i := range foundOutput {
+		if foundOutput[i] != expectedOutput[i] {
+			t.Error("Item:", i, "(", foundOutput[i], ") differs from the expected value:", expectedOutput[i])
+		}
+	}
+
+}
+
+func TestSplitNonEscapingQuotes(t *testing.T) {
+	testInput := "one 'два ${three}' four"
+	expectedOutput := []string{"one", "два ${three}", "four"}
+	foundOutput, err := Split(testInput)
+	if err != nil {
+		t.Error("Split returned error:", err)
+	}
+	if len(expectedOutput) != len(foundOutput) {
+		t.Error("Split expected:", len(expectedOutput), "results. Found:", len(foundOutput), "results")
+	}
+	for i := range foundOutput {
+		if foundOutput[i] != expectedOutput[i] {
+			t.Error("Item:", i, "(", foundOutput[i], ") differs from the expected value:", expectedOutput[i])
+		}
+	}
+}


### PR DESCRIPTION
[container_group.command](https://www.terraform.io/docs/providers/azurerm/r/container_group.html#command) is a `schema.TypeString` but on the [azure's doc](https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups/createorupdate#container), it is a `string[]`.
The current implementation take the command and split it on " ", and so, disallows having an argument containing a space.
In the long run, it would be best to move to a `schema.TypeList`, but this PR allows to keep the old schema and for complex command by taking it as a sh expression.