### PR TITLE
resource/application_Gateway: Add minimum_servers to probe resource

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -458,6 +458,12 @@ func resourceArmApplicationGateway() *schema.Resource {
 							Required: true,
 						},
 
+						"minimum_servers": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+
 						"match": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -1172,6 +1178,7 @@ func expandApplicationGatewayProbes(d *schema.ResourceData) *[]network.Applicati
 		interval := int32(data["interval"].(int))
 		timeout := int32(data["timeout"].(int))
 		unhealthyThreshold := int32(data["unhealthy_threshold"].(int))
+		minServers := int32(data["minimum_servers"].(int))
 
 		setting := network.ApplicationGatewayProbe{
 			Name: &name,
@@ -1182,6 +1189,7 @@ func expandApplicationGatewayProbes(d *schema.ResourceData) *[]network.Applicati
 				Interval:           &interval,
 				Timeout:            &timeout,
 				UnhealthyThreshold: &unhealthyThreshold,
+				MinServers:         &minServers,
 			},
 		}
 
@@ -1646,6 +1654,10 @@ func flattenApplicationGatewayProbes(input *[]network.ApplicationGatewayProbe) [
 
 				if threshold := props.UnhealthyThreshold; threshold != nil {
 					settings["unhealthy_threshold"] = int(*threshold)
+				}
+
+				if minServers := props.MinServers; minServers != nil {
+					settings["minimum_healthy"] = int(*minServers)
 				}
 
 				if match := props.Match; match != nil {

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -1657,7 +1657,7 @@ func flattenApplicationGatewayProbes(input *[]network.ApplicationGatewayProbe) [
 				}
 
 				if minServers := props.MinServers; minServers != nil {
-					settings["minimum_healthy"] = int(*minServers)
+					settings["minimum_servers"] = int(*minServers)
 				}
 
 				if match := props.Match; match != nil {

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -1498,7 +1498,7 @@ resource "azurerm_application_gateway" "test" {
     timeout             = 120
     interval            = 300
     unhealthy_threshold = 8
-    minimum_healthy     = 2
+    minimum_servers     = 2
     match               = {
       body              = "*"
       status_code       = [

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -1498,6 +1498,7 @@ resource "azurerm_application_gateway" "test" {
     timeout             = 120
     interval            = 300
     unhealthy_threshold = 8
+    minimum_healthy     = 2
     match               = {
       body              = "*"
       status_code       = [

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -262,6 +262,8 @@ The `probe` block supports:
 
 * `unhealthy_threshold` - (Required) Probe retry count. Backend server is marked down after consecutive probe failure count reaches UnhealthyThreshold. Minimum 1 second and Maximum 20.
 
+* `minimum_servers` - (Optional) Minimum number of servers that are always marked healthy. Default value is 0.
+
 * `match` - (Optional) Probe health response match. 
 
   * `body` - (Optional) Body that must be contained in the health response. Defaults to "*"


### PR DESCRIPTION
This was missing from the original implementation and is required if
you want to manually mark servers as active