### PR TITLE
Update azurerm_nsg port ranges notation

### DIFF
--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -29,13 +29,25 @@ resource "azurerm_network_security_group" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   security_rule {
-    name                       = "test123"
+    name                       = "ssh"
     priority                   = 100
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "ldap"
+    priority                   = 101
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_ranges    = [ "636-636", "389-389" ]
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
@@ -71,11 +83,11 @@ The `security_rule` block supports:
 
 * `source_port_range` - (Optional) Source Port or Range. Integer or range between `0` and `65535` or `*` to match any. This is required if `source_port_ranges` is not specified.
 
-* `source_port_ranges` - (Optional) List of source ports or port ranges. This is required if `source_port_range` is not specified.
+* `source_port_ranges` - (Optional) List of source port ranges. To specify multiple single ports, each port must be expressed as an element in a list with its own range. This is required if `source_port_range` is not specified.
 
 * `destination_port_range` - (Optional) Destination Port or Range. Integer or range between `0` and `65535` or `*` to match any. This is required if `destination_port_ranges` is not specified.
 
-* `destination_port_ranges` - (Optional) List of destination ports or port ranges. This is required if `destination_port_range` is not specified.
+* `destination_port_ranges` - (Optional) List of source port ranges. To specify multiple single ports, each port must be expressed as an element in a list with its own range. This is required if `source_port_range` is not specified.
 
 * `source_address_prefix` - (Optional) CIDR or source IP range or * to match any IP. Tags such as ‘VirtualNetwork’, ‘AzureLoadBalancer’ and ‘Internet’ can also be used. This is required if `source_address_prefixes` is not specified.
 


### PR DESCRIPTION
Azure will return an error when specifying a list of individual ports in destination_port_ranges that aren't expressed as ranges.
```
* azurerm_network_security_group.ldap_nsg: Error creating/updating NSG "smenatest_nsg" (Resource Group "smenatest"): network.SecurityGroupsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="SecurityRuleInvalidPortRange" Message="Security rule has invalid Port range. Value provided: 636, 389. Value should be an integer OR integer range with '-' delimiter. Valid range 0-65535." Details=[]
```
This is successful if done as in the added example security rule.