### PR TITLE
Remove tags validate in preConfig of TestAccAzureRMKeyVault_update

### DIFF
--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -125,6 +125,7 @@ func TestAccAzureRMKeyVault_update(t *testing.T) {
 					testCheckAzureRMKeyVaultExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "access_policy.0.key_permissions.0", "create"),
 					resource.TestCheckResourceAttr(resourceName, "access_policy.0.secret_permissions.0", "set"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -125,7 +125,6 @@ func TestAccAzureRMKeyVault_update(t *testing.T) {
 					testCheckAzureRMKeyVaultExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "access_policy.0.key_permissions.0", "create"),
 					resource.TestCheckResourceAttr(resourceName, "access_policy.0.secret_permissions.0", "set"),
-					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
 				),
 			},
 			{


### PR DESCRIPTION
There are no tags block in preConfig method, so we should remove validate tags in the fitst step of this test: TestAccAzureRMKeyVault_update