### PR TITLE
`azurerm_key_vault_key` - handling the parent Key Vault being deleted

### DIFF
--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -326,6 +326,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 
 	if err != nil {
 		if utils.ResponseWasNotFound(cert.Response) {
+			log.Printf("[DEBUG] Certificate %q was not found in Key Vault at URI %q - removing from state", id.Name, id.KeyVaultBaseUrl)
 			d.SetId("")
 			return nil
 		}

--- a/azurerm/resource_arm_key_vault_key.go
+++ b/azurerm/resource_arm_key_vault_key.go
@@ -175,6 +175,7 @@ func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error 
 	resp, err := client.GetKey(ctx, id.KeyVaultBaseUrl, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Key %q was not found in Key Vault at URI %q - removing from state", id.Name, id.KeyVaultBaseUrl)
 			d.SetId("")
 			return nil
 		}

--- a/azurerm/resource_arm_key_vault_key.go
+++ b/azurerm/resource_arm_key_vault_key.go
@@ -174,6 +174,11 @@ func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error 
 
 	resp, err := client.GetKey(ctx, id.KeyVaultBaseUrl, id.Name, "")
 	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 

--- a/azurerm/resource_arm_key_vault_secret.go
+++ b/azurerm/resource_arm_key_vault_secret.go
@@ -155,6 +155,7 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 	resp, err := client.GetSecret(ctx, id.KeyVaultBaseUrl, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Secret %q was not found in Key Vault at URI %q - removing from state", id.Name, id.KeyVaultBaseUrl)
 			d.SetId("")
 			return nil
 		}

--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -82,6 +83,28 @@ func TestAccAzureRMKeyVault_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKeyVaultExists("azurerm_key_vault.test"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMKeyVault_disappears(t *testing.T) {
+	resourceName := "azurerm_key_vault.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMKeyVault_basic(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKeyVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKeyVaultExists(resourceName),
+					testCheckAzureRMKeyVaultDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -193,6 +216,36 @@ func testCheckAzureRMKeyVaultExists(name string) resource.TestCheckFunc {
 			}
 
 			return fmt.Errorf("Bad: Get on keyVaultClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMKeyVaultDisappears(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		vaultName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for vault: %s", vaultName)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).keyVaultClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := client.Delete(ctx, resourceGroup, vaultName)
+		if err != nil {
+			if response.WasNotFound(resp.Response) {
+				return nil
+			}
+
+			return fmt.Errorf("Bad: Delete on keyVaultClient: %+v", err)
 		}
 
 		return nil


### PR DESCRIPTION
Currently Key Vault Key's don't detect that the parent Key Vault has been deleted during the refresh, and so they fail:

```
* azurerm_key_vault_key.dckey: azurerm_key_vault_key.dckey: keyvault.BaseClient#GetKey: Failure sending request: StatusCode=0 -- Original Error: Get https://east2-kv.vault.azure.net/keys/DCKey/?api-version=2016-10-01: dial tcp: lookup east2-kv.vault.azure.net: no such host
```

Fixes #1240


Key Vault tests pass:

```
$ acctests azurerm TestAccAzureRMKeyVault_disappears
=== RUN   TestAccAzureRMKeyVault_disappears
--- PASS: TestAccAzureRMKeyVault_disappears (193.03s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	193.059s
```

Key Vault Certificate tests pass:

```
$ acctests azurerm TestAccAzureRMKeyVaultCertificate_disappears

=== RUN   TestAccAzureRMKeyVaultCertificate_disappears
--- PASS: TestAccAzureRMKeyVaultCertificate_disappears (234.06s)
=== RUN   TestAccAzureRMKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted
--- PASS: TestAccAzureRMKeyVaultCertificate_disappearsWhenParentKeyVaultDeleted (214.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	448.453s
```

Key Vault Key tests pass:

```
$ acctests azurerm TestAccAzureRMKeyVaultKey_disappears

=== RUN   TestAccAzureRMKeyVaultKey_disappears
--- PASS: TestAccAzureRMKeyVaultKey_disappears (201.67s)
=== RUN   TestAccAzureRMKeyVaultKey_disappearsWhenParentKeyVaultDeleted
--- PASS: TestAccAzureRMKeyVaultKey_disappearsWhenParentKeyVaultDeleted (197.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	398.835s
```

Key Vault Secret tests pass:

```
$ acctests azurerm TestAccAzureRMKeyVaultSecret_disappears
=== RUN   TestAccAzureRMKeyVaultSecret_disappears
--- PASS: TestAccAzureRMKeyVaultSecret_disappears (196.76s)
=== RUN   TestAccAzureRMKeyVaultSecret_disappearsWhenParentKeyVaultDeleted
--- PASS: TestAccAzureRMKeyVaultSecret_disappearsWhenParentKeyVaultDeleted (196.75s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	393.541s
```
