### PR TITLE
Authentication: Refreshing the Service Principal Token before using it

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -310,6 +310,12 @@ func getAuthorizationToken(c *authentication.Config, oauthConfig *adal.OAuthConf
 		return nil, err
 	}
 
+	err = spt.Refresh()
+
+	if err != nil {
+		return nil, fmt.Errorf("Error refreshing Service Principal Token: %+v", err)
+	}
+
 	auth := autorest.NewBearerAuthorizer(spt)
 	return auth, nil
 }


### PR DESCRIPTION
This fix was originally contributed by @sophos-jeff in #1349 but has been split-out

This allows Azure CLI auth to be used to accessing Key Vaults, which fixes #656.