### PR TITLE
resouce/app_insights: Allow different application_type deployments

### DIFF
--- a/azurerm/import_arm_application_insights_test.go
+++ b/azurerm/import_arm_application_insights_test.go
@@ -11,7 +11,7 @@ func TestAccAzureRMApplicationInsights_importBasicWeb(t *testing.T) {
 	resourceName := "azurerm_application_insights.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicWeb(ri, testLocation())
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "web")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccAzureRMApplicationInsights_importBasicOther(t *testing.T) {
 	resourceName := "azurerm_application_insights.test"
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicWeb(ri, testLocation())
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "web")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -38,8 +38,12 @@ func resourceArmApplicationInsights() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(insights.Web),
-					string(insights.Other),
+					"web",
+					"other",
+					"java",
+					"phone",
+					"store",
+					"ios",
 				}, true),
 			},
 

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccAzureRMApplicationInsights_basicWeb(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicWeb(ri, testLocation())
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "web")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,6 +24,28 @@ func TestAccAzureRMApplicationInsights_basicWeb(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApplicationInsightsExists("azurerm_application_insights.test"),
+					resource.TestCheckResourceAttr("azurerm_application_insights.test", "application_type", "web"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApplicationInsights_basicJava(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "java")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsExists("azurerm_application_insights.test"),
+					resource.TestCheckResourceAttr("azurerm_application_insights.test", "application_type", "java"),
 				),
 			},
 		},
@@ -33,7 +55,7 @@ func TestAccAzureRMApplicationInsights_basicWeb(t *testing.T) {
 func TestAccAzureRMApplicationInsights_basicOther(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := testAccAzureRMApplicationInsights_basicOther(ri, testLocation())
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "other")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,6 +66,70 @@ func TestAccAzureRMApplicationInsights_basicOther(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApplicationInsightsExists("azurerm_application_insights.test"),
+					resource.TestCheckResourceAttr("azurerm_application_insights.test", "application_type", "other"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApplicationInsights_basicPhone(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "phone")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsExists("azurerm_application_insights.test"),
+					resource.TestCheckResourceAttr("azurerm_application_insights.test", "application_type", "phone"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApplicationInsights_basicStore(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "store")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsExists("azurerm_application_insights.test"),
+					resource.TestCheckResourceAttr("azurerm_application_insights.test", "application_type", "store"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApplicationInsights_basiciOS(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "ios")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsExists("azurerm_application_insights.test"),
+					resource.TestCheckResourceAttr("azurerm_application_insights.test", "application_type", "ios"),
 				),
 			},
 		},
@@ -106,7 +192,7 @@ func testCheckAzureRMApplicationInsightsExists(name string) resource.TestCheckFu
 	}
 }
 
-func testAccAzureRMApplicationInsights_basicWeb(rInt int, location string) string {
+func testAccAzureRMApplicationInsights_basic(rInt int, location string, applicationType string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -117,23 +203,7 @@ resource "azurerm_application_insights" "test" {
   name                = "acctestappinsights-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  application_type    = "web"
+  application_type    = "%s"
 }
-`, rInt, location, rInt)
-}
-
-func testAccAzureRMApplicationInsights_basicOther(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_application_insights" "test" {
-  name                = "acctestappinsights-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  application_type    = "other"
-}
-`, rInt, location, rInt)
+`, rInt, location, rInt, applicationType)
 }

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `Web` and `Other`.
+* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `Web`, `Java`, `Phone`, `Store`, `iOS` and `Other`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Fixes: #822

This follows the work in the API to allow types like web, other, java,
store, phone and ios

```
▶ acctests azurerm TestAccAzureRMApplicationInsights_
=== RUN   TestAccAzureRMApplicationInsights_importBasicWeb
--- PASS: TestAccAzureRMApplicationInsights_importBasicWeb (99.07s)
=== RUN   TestAccAzureRMApplicationInsights_importBasicOther
--- PASS: TestAccAzureRMApplicationInsights_importBasicOther (96.48s)
=== RUN   TestAccAzureRMApplicationInsights_basicWeb
--- PASS: TestAccAzureRMApplicationInsights_basicWeb (84.27s)
=== RUN   TestAccAzureRMApplicationInsights_basicJava
--- PASS: TestAccAzureRMApplicationInsights_basicJava (79.28s)
=== RUN   TestAccAzureRMApplicationInsights_basicOther
--- PASS: TestAccAzureRMApplicationInsights_basicOther (73.29s)
=== RUN   TestAccAzureRMApplicationInsights_basicPhone
--- PASS: TestAccAzureRMApplicationInsights_basicPhone (73.88s)
=== RUN   TestAccAzureRMApplicationInsights_basicStore
--- PASS: TestAccAzureRMApplicationInsights_basicStore (68.69s)
=== RUN   TestAccAzureRMApplicationInsights_basiciOS
--- PASS: TestAccAzureRMApplicationInsights_basiciOS (76.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	651.307s
```