### PR TITLE
resource/function_app: Add support for outputting site_credentials

### DIFF
--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -107,6 +107,7 @@ func TestAccAzureRMFunctionApp_appSettings(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFunctionAppExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "app_settings.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "site_credential.#", "1"),
 				),
 			},
 			{

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -153,6 +153,8 @@ The following attributes are exported:
 
 * `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this App Service.
 
+* `site_credential` - A `site_credential` block as defined below, which contains the site-level credentials used to publish to this App Service.
+
 ---
 
 `identity` exports the following:
@@ -160,6 +162,12 @@ The following attributes are exported:
 * `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
+
+
+`site_credential` exports the following:
+
+* `username` - The username which can be used to publish to this App Service
+* `password` - The password associated with the username, which can be used to publish to this App Service.
 
 
 ## Import


### PR DESCRIPTION
Fixes: #1328

Modelled on that of app_service

```
▶ acctests azurerm TestAccAzureRMFunctionApp_
=== RUN   TestAccAzureRMFunctionApp_importBasic
--- PASS: TestAccAzureRMFunctionApp_importBasic (121.08s)
=== RUN   TestAccAzureRMFunctionApp_importTags
--- PASS: TestAccAzureRMFunctionApp_importTags (118.88s)
=== RUN   TestAccAzureRMFunctionApp_importAppSettings
--- PASS: TestAccAzureRMFunctionApp_importAppSettings (140.97s)
=== RUN   TestAccAzureRMFunctionApp_basic
--- PASS: TestAccAzureRMFunctionApp_basic (149.64s)
=== RUN   TestAccAzureRMFunctionApp_tags
--- PASS: TestAccAzureRMFunctionApp_tags (135.59s)
=== RUN   TestAccAzureRMFunctionApp_tagsUpdate
--- PASS: TestAccAzureRMFunctionApp_tagsUpdate (188.66s)
=== RUN   TestAccAzureRMFunctionApp_appSettings
--- PASS: TestAccAzureRMFunctionApp_appSettings (276.09s)
=== RUN   TestAccAzureRMFunctionApp_siteConfig
--- PASS: TestAccAzureRMFunctionApp_siteConfig (129.07s)
=== RUN   TestAccAzureRMFunctionApp_connectionStrings
--- PASS: TestAccAzureRMFunctionApp_connectionStrings (154.03s)
=== RUN   TestAccAzureRMFunctionApp_siteConfigMulti
--- PASS: TestAccAzureRMFunctionApp_siteConfigMulti (321.31s)
=== RUN   TestAccAzureRMFunctionApp_updateVersion
--- PASS: TestAccAzureRMFunctionApp_updateVersion (217.87s)
=== RUN   TestAccAzureRMFunctionApp_3264bit
--- PASS: TestAccAzureRMFunctionApp_3264bit (176.06s)
=== RUN   TestAccAzureRMFunctionApp_httpsOnly
--- PASS: TestAccAzureRMFunctionApp_httpsOnly (149.35s)
=== RUN   TestAccAzureRMFunctionApp_consumptionPlan
--- PASS: TestAccAzureRMFunctionApp_consumptionPlan (146.26s)
=== RUN   TestAccAzureRMFunctionApp_createIdentity
--- PASS: TestAccAzureRMFunctionApp_createIdentity (126.58s)
=== RUN   TestAccAzureRMFunctionApp_updateIdentity
--- PASS: TestAccAzureRMFunctionApp_updateIdentity (129.65s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	2681.121s
```