### PR TITLE
resource/servicebus_subscription: Allow the setting of default_message_ttl

### DIFF
--- a/azurerm/resource_arm_servicebus_subscription.go
+++ b/azurerm/resource_arm_servicebus_subscription.go
@@ -135,6 +135,10 @@ func resourceArmServiceBusSubscriptionCreate(d *schema.ResourceData, meta interf
 		parameters.SBSubscriptionProperties.ForwardTo = &forwardTo
 	}
 
+	if defaultMessageTtl := d.Get("default_message_ttl").(string); defaultMessageTtl != "" {
+		parameters.DefaultMessageTimeToLive = &defaultMessageTtl
+	}
+
 	_, err := client.CreateOrUpdate(ctx, resourceGroup, namespaceName, topicName, name, parameters)
 	if err != nil {
 		return err

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -30,6 +30,26 @@ func TestAccAzureRMServiceBusSubscription_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMServiceBusSubscription_defaultTtl(t *testing.T) {
+	ri := acctest.RandInt()
+	config := testAccAzureRMServiceBusSubscription_withDefaultTtl(ri, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusSubscriptionExists("azurerm_servicebus_subscription.test"),
+					resource.TestCheckResourceAttr("azurerm_servicebus_subscription.test", "default_message_ttl", "PT1H"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMServiceBusSubscription_updateEnableBatched(t *testing.T) {
 	resourceName := "azurerm_servicebus_subscription.test"
 	ri := acctest.RandInt()
@@ -209,6 +229,11 @@ resource "azurerm_servicebus_subscription" "test" {
 
 func testAccAzureRMServiceBusSubscription_basic(rInt int, location string) string {
 	return fmt.Sprintf(testAccAzureRMServiceBusSubscription_tfTemplate, rInt, location, rInt, rInt, rInt, "")
+}
+
+func testAccAzureRMServiceBusSubscription_withDefaultTtl(rInt int, location string) string {
+	return fmt.Sprintf(testAccAzureRMServiceBusSubscription_tfTemplate, rInt, location, rInt, rInt, rInt,
+		"default_message_ttl = \"PT1H\"\n")
 }
 
 func testAccAzureRMServiceBusSubscription_updateEnableBatched(rInt int, location string) string {


### PR DESCRIPTION
Fixes: #1566

This wasn't being passed to the Create func even though the user could
define it

```
▶ acctests azurerm TestAccAzureRMServiceBusSubscription_
=== RUN   TestAccAzureRMServiceBusSubscription_importBasic
--- PASS: TestAccAzureRMServiceBusSubscription_importBasic (243.63s)
=== RUN   TestAccAzureRMServiceBusSubscription_basic
--- PASS: TestAccAzureRMServiceBusSubscription_basic (223.77s)
=== RUN   TestAccAzureRMServiceBusSubscription_defaultTtl
--- PASS: TestAccAzureRMServiceBusSubscription_defaultTtl (217.08s)
=== RUN   TestAccAzureRMServiceBusSubscription_updateEnableBatched
--- PASS: TestAccAzureRMServiceBusSubscription_updateEnableBatched (281.08s)
=== RUN   TestAccAzureRMServiceBusSubscription_updateRequiresSession
--- PASS: TestAccAzureRMServiceBusSubscription_updateRequiresSession (397.46s)
=== RUN   TestAccAzureRMServiceBusSubscription_updateForwardTo
--- PASS: TestAccAzureRMServiceBusSubscription_updateForwardTo (208.94s)
PASS
ok	github.com/terraform-providers/terraform-provider-azurerm/azurerm	1354.925s
```