### PR TITLE
Allow - in disk snapshot names

### DIFF
--- a/azurerm/resource_arm_snapshot.go
+++ b/azurerm/resource_arm_snapshot.go
@@ -216,10 +216,10 @@ func resourceArmSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func validateSnapshotName(v interface{}, k string) (ws []string, errors []error) {
-	// a-z, A-Z, 0-9 and _. The max name length is 80
+	// a-z, A-Z, 0-9, _ and -. The max name length is 80
 	value := v.(string)
 
-	r, _ := regexp.Compile("^[A-Za-z0-9_]+$")
+	r, _ := regexp.Compile("^[A-Za-z0-9_-]+$")
 	if !r.MatchString(value) {
 		errors = append(errors, fmt.Errorf("Snapshot Names can only contain alphanumeric characters and underscores."))
 	}

--- a/azurerm/resource_arm_snapshot_test.go
+++ b/azurerm/resource_arm_snapshot_test.go
@@ -30,11 +30,15 @@ func TestSnapshotName_validation(t *testing.T) {
 		},
 		{
 			Value:    "hello-world",
-			ErrCount: 1,
+			ErrCount: 0,
 		},
 		{
 			Value:    "hello_world",
 			ErrCount: 0,
+		},
+		{
+			Value:    "hello+world",
+			ErrCount: 1,
 		},
 		{
 			Value:    str,


### PR DESCRIPTION
It appears that - was omitted from the possible character in snapshot
names.

It doesn't seem like there is any issue when using - in the name, as
I was able to create snapshots with dashes both from the portal and
through this plugin (with this patch applied).