### PR TITLE
Do not force new disk on source update

### DIFF
--- a/azurerm/resource_arm_managed_disk.go
+++ b/azurerm/resource_arm_managed_disk.go
@@ -67,7 +67,6 @@ func resourceArmManagedDisk() *schema.Resource {
 			"source_resource_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"image_reference_id": {


### PR DESCRIPTION
When a disk is created from a snapshot or a disk (Copy option), it
ends up recreating the disk if that source id changes.

I find that behavior inconveniant since I want to create many disks
from a single snapshot, and I want to refresh that snapshot onces
in a while without having the VMs being shut down of recreated.

By using the 'Copy from an existing disk' option, that's exactly
what happens it seems: it takes an internal snapshot, creates a disk
out of that snapshot and then throws the snapshot away.

Problem is that I would like to control when the snapshot occurs,
and I'm also suffering from a snapshot rate limitation that prevents
to create many VMs from a single existing disk.

I also can't think of something that would benefit from the existing
behavior, since it makes it quite hard to refresh a snapshot by
recreating it.