### PR TITLE
[WIP] New data source 'azurerm_azuread_group'

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -104,6 +104,7 @@ type ArmClient struct {
 	roleDefinitionsClient   authorization.RoleDefinitionsClient
 	applicationsClient      graphrbac.ApplicationsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
+	groupsClient            graphrbac.GroupsClient
 
 	// CDN
 	cdnCustomDomainsClient cdn.CustomDomainsClient
@@ -482,6 +483,13 @@ func (c *ArmClient) registerAuthentication(endpoint, graphEndpoint, subscription
 	servicePrincipalsClient.Sender = sender
 	servicePrincipalsClient.SkipResourceProviderRegistration = c.skipProviderRegistration
 	c.servicePrincipalsClient = servicePrincipalsClient
+
+	groupsClient := graphrbac.NewGroupsClientWithBaseURI(graphEndpoint, tenantId)
+	setUserAgent(&groupsClient.Client)
+	groupsClient.Authorizer = graphAuth
+	groupsClient.Sender = sender
+	groupsClient.SkipResourceProviderRegistration = c.skipProviderRegistration
+	c.groupsClient = groupsClient
 }
 
 func (c *ArmClient) registerCDNClients(endpoint, subscriptionId string, auth autorest.Authorizer, sender autorest.Sender) {

--- a/azurerm/data_source_azuread_group.go
+++ b/azurerm/data_source_azuread_group.go
@@ -1,0 +1,94 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceArmAzureADGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmAzureADGroupRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"display_name"},
+			},
+
+			"display_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_id"},
+			},
+
+			"security_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceArmAzureADGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	var adgroup graphrbac.ADGroup
+	var groupObj *graphrbac.ADGroup
+
+	if oId, ok := d.GetOk("object_id"); ok {
+		// use the object_id to find the Azure AD group
+		resp, err := client.List(ctx, "")
+		if err != nil {
+			return fmt.Errorf("Error listing Azure AD groups: %+v", err)
+		}
+
+		for _, v := range *resp.Response().Value {
+			if v.ObjectID != nil {
+				if *v.ObjectID == oId {
+					groupObj = &v
+					break
+				}
+			}
+		}
+		if groupObj == nil {
+			return fmt.Errorf("Couldn't locate a Azure AD group with the id %q", oId)
+		}
+	} else {
+		// use the name to find the Azure AD group
+		resp, err := client.ListComplete(ctx, "")
+		if err != nil {
+			return fmt.Errorf("Error listing Azure AD groups: %+v", err)
+		}
+
+		name := d.Get("display_name").(string)
+		for _, v := range *resp.Response().Value {
+			if v.DisplayName != nil {
+				if *v.DisplayName == name {
+					groupObj = &v
+					break
+				}
+			}
+		}
+		if groupObj == nil {
+			return fmt.Errorf("Couldn't locate a Azure AD group with a name of %q", name)
+		}
+	}
+
+	adgroup = *groupObj
+
+	d.SetId(*adgroup.ObjectID)
+	d.Set("object_id", adgroup.ObjectID)
+	d.Set("display_name", adgroup.DisplayName)
+	d.Set("security_enabled", adgroup.SecurityEnabled)
+
+	return nil
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -79,6 +79,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"azurerm_azuread_application":                   dataSourceArmAzureADApplication(),
+			"azurerm_azuread_group":                         dataSourceArmAzureADGroup(),
 			"azurerm_application_security_group":            dataSourceArmApplicationSecurityGroup(),
 			"azurerm_app_service":                           dataSourceArmAppService(),
 			"azurerm_app_service_plan":                      dataSourceAppServicePlan(),

--- a/website/docs/d/azuread_group.html.markdown
+++ b/website/docs/d/azuread_group.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_azuread_group"
+sidebar_current: "docs-azurerm-datasource-azuread-group"
+description: |-
+  Gets information about a group object within the Azure Active Directory.
+
+---
+
+# Data Source: azurerm_azuread_group
+
+Gets information about a Group object within the Azure Active Directory.
+
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read directory data` within the `Windows Azure Active Directory` API.
+
+## Example Usage (by Object ID)
+
+```hcl
+data "azurerm_azuread_group" "test_group" {
+  object_id = "78722cfc-8946-11e8-95f1-2200ec79ad01"
+}
+```
+
+## Example Usage (by Group Display Name)
+
+```hcl
+data "azurerm_azuread_group" "test_group" {
+  display_name = "MyTestGroup"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `object_id` - (Optional) The ID of the Azure AD Group we want to lookup.
+
+* `display_name` - (Optional) The ID of the Azure AD Group we want to loopup.
+
+-> **NOTE:** At least one of `display_name` or `object_id` must be specified.
+
+-> **WARNING:** `display_name` is not unique within Azure Active Directory. The data source will only return the first Group found.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Object ID for the Azure AD Group.
+* `display_name` - The Display Name for the Azure AD Group.
+* `security_enabled` - True or False depending if the Azure AD Group is security enabled.


### PR DESCRIPTION
This PR adds a new data source for 'azurerm_azuread_group'.

- [x] New data source
- [x] Add markdown documentation
- [ ] Add tests (as these are my first steps with Go, I'm not yet sure how to do this.)

## Example Usage (by Object ID)

```hcl
data "azurerm_azuread_group" "test_group" {
  object_id = "78722cfc-8946-11e8-95f1-2200ec79ad01"
}
```

## Example Usage (by Group Display Name)

```hcl
data "azurerm_azuread_group" "test_group" {
  display_name = "MyTestGroup"
}
```

The following attributes are exported:

* `id` - The Object ID for the Azure AD Group.
* `display_name` - The Display Name for the Azure AD Group.
* `security_enabled` - True or False depending if the Azure AD Group is security enabled.