### PR TITLE
Remove default from vmss "priority" property

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -128,7 +128,6 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  string(compute.Regular),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(compute.Low),
 					string(compute.Regular),


### PR DESCRIPTION
We have a large number of virtual machine scale sets that were created before priority was an option on them. In those cases the priority property is not returned from ARM and it has no value. By setting a default on this property that "" gets changed to "Regular" and all existing scalesets are marked to be recreated. It appears in my testing that simply removing this default allows existing scalesets to function without this property and adding a value for it in the manifests generate the appropriate diffs.