### PR TITLE
App Service/App Service Slots - adding support for min TLS version

### DIFF
--- a/azurerm/data_source_app_service_test.go
+++ b/azurerm/data_source_app_service_test.go
@@ -165,6 +165,25 @@ func TestAccDataSourceAzureRMAppService_http2Enabled(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMAppService_minTls(t *testing.T) {
+	dataSourceName := "data.azurerm_app_service.test"
+	rInt := acctest.RandInt()
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppService_minTls(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "site_config.0.min_tls_version", "1.1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAppService_basic(rInt int, location string) string {
 	config := testAccAzureRMAppService_basic(rInt, location)
 	return fmt.Sprintf(`
@@ -251,6 +270,18 @@ data "azurerm_app_service" "test" {
 
 func testAccDataSourceAppService_http2Enabled(rInt int, location string) string {
 	config := testAccAzureRMAppService_http2Enabled(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_app_service" "test" {
+  name                = "${azurerm_app_service.test.name}"
+  resource_group_name = "${azurerm_app_service.test.resource_group_name}"
+}
+`, config)
+}
+
+func testAccDataSourceAppService_minTls(rInt int, location string) string {
+	config := testAccAzureRMAppService_minTls(rInt, location, "1.1")
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/helpers/schema/app_service.go
+++ b/azurerm/helpers/schema/app_service.go
@@ -184,6 +184,17 @@ func AppServiceSiteConfigSchema() *schema.Schema {
 					Optional: true,
 					Computed: true,
 				},
+
+				"min_tls_version": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(web.OneFullStopZero),
+						string(web.OneFullStopOne),
+						string(web.OneFullStopTwo),
+					}, false),
+				},
 			},
 		},
 	}
@@ -305,6 +316,10 @@ func ExpandAppServiceSiteConfig(input interface{}) web.SiteConfig {
 		siteConfig.FtpsState = web.FtpsState(v.(string))
 	}
 
+	if v, ok := config["min_tls_version"]; ok {
+		siteConfig.MinTLSVersion = web.SupportedTLSVersions(v.(string))
+	}
+
 	return siteConfig
 }
 
@@ -409,6 +424,7 @@ func FlattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 
 	result["scm_type"] = string(input.ScmType)
 	result["ftps_state"] = string(input.FtpsState)
+	result["min_tls_version"] = string(input.MinTLSVersion)
 
 	return append(results, result)
 }

--- a/azurerm/import_arm_app_service_slot_test.go
+++ b/azurerm/import_arm_app_service_slot_test.go
@@ -29,3 +29,26 @@ func TestAccAzureRMAppServiceSlot_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMAppServiceSlot_importMinTls(t *testing.T) {
+	resourceName := "azurerm_app_service_slot.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppServiceSlot_minTls(ri, testLocation(), "1.1")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/import_arm_app_service_test.go
+++ b/azurerm/import_arm_app_service_test.go
@@ -489,3 +489,26 @@ func TestAccAzureRMAppService_importWebSockets(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMAppService_importMinTls(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_minTls(ri, testLocation(), "1.1")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -852,6 +852,35 @@ func TestAccAzureRMAppService_linuxFxVersion(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_minTls(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_minTls(ri, testLocation(), "1.0")
+	updatedConfig := testAccAzureRMAppService_minTls(ri, testLocation(), "1.1")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.min_tls_version", "1.0"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.min_tls_version", "1.1"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMAppServiceDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
@@ -1804,4 +1833,35 @@ resource "azurerm_app_service" "test" {
   }
 }
 `, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_minTls(rInt int, location string, tlsVersion string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    min_tls_version = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, tlsVersion)
 }

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -85,6 +85,8 @@ output "app_service_id" {
 
 * `managed_pipeline_mode` - The Managed Pipeline Mode used in this App Service.
 
+* `min_tls_version` - The minimum supported TLS version for this App Service.
+
 * `php_version` - The version of PHP used in this App Service.
 
 * `python_version` - The version of Python used in this App Service.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -167,6 +167,7 @@ The following arguments are supported:
 ~> **NOTE:** MySQL In App is not intended for production environments and will not scale beyond a single instance. Instead you may wish [to use Azure Database for MySQL](/docs/providers/azurerm/r/mysql_database.html).
 
 * `managed_pipeline_mode` - (Optional) The Managed Pipeline Mode. Possible values are `Integrated` and `Classic`. Defaults to `Integrated`.
+* `min_tls_version` - (Optional) The minimum supported TLS version for the app service. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new app services.
 * `php_version` - (Optional) The version of PHP to use in this App Service. Possible values are `5.5`, `5.6`, `7.0` and `7.1`.
 * `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7` and `3.4`.
 * `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -196,6 +196,7 @@ The following arguments are supported:
 ~> **NOTE:** MySQL In App is not intended for production environments and will not scale beyond a single instance. Instead you may wish [to use Azure Database for MySQL](/docs/providers/azurerm/r/mysql_database.html).
 
 * `managed_pipeline_mode` - (Optional) The Managed Pipeline Mode. Possible values are `Integrated` and `Classic`. Defaults to `Integrated`.
+* `min_tls_version` - (Optional) The minimum supported TLS version for the app service. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new app services.
 * `php_version` - (Optional) The version of PHP to use in this App Service Slot. Possible values are `5.5`, `5.6`, `7.0` and `7.1`.
 * `python_version` - (Optional) The version of Python to use in this App Service Slot. Possible values are `2.7` and `3.4`.
 * `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.


### PR DESCRIPTION
- Add support for the minimum TLS version used for clients connecting to
an app service or slot
- Add tests for app service and slot resources, data source, and import