### PR TITLE
Additional checks for network_rules during read

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -701,7 +701,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		}
 
 		networkRules := props.NetworkRuleSet
-		if networkRules != nil && len(*networkRules.IPRules) > 0 && len(*networkRules.VirtualNetworkRules) > 0 {
+		if networkRules != nil {
 			if err := d.Set("network_rules", flattenStorageAccountNetworkRules(networkRules)); err != nil {
 				return fmt.Errorf("Error flattening `network_rules`: %+v", err)
 			}
@@ -829,6 +829,9 @@ func expandStorageAccountBypass(networkRule map[string]interface{}) storage.Bypa
 }
 
 func flattenStorageAccountNetworkRules(input *storage.NetworkRuleSet) []interface{} {
+	if len(*input.IPRules) == 0 && len(*input.VirtualNetworkRules) == 0 {
+		return []interface{}{}
+	}
 	networkRules := make(map[string]interface{}, 0)
 
 	networkRules["ip_rules"] = schema.NewSet(schema.HashString, flattenStorageAccountIPRules(input.IPRules))

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -843,8 +843,10 @@ func flattenStorageAccountNetworkRules(input *storage.NetworkRuleSet) []interfac
 
 func flattenStorageAccountIPRules(input *[]storage.IPRule) []interface{} {
 	ipRules := make([]interface{}, len(*input))
-	for i, ipRule := range *input {
-		ipRules[i] = *ipRule.IPAddressOrRange
+	if input != nil {
+		for i, ipRule := range *input {
+			ipRules[i] = *ipRule.IPAddressOrRange
+		}
 	}
 
 	return ipRules
@@ -852,8 +854,11 @@ func flattenStorageAccountIPRules(input *[]storage.IPRule) []interface{} {
 
 func flattenStorageAccountVirtualNetworks(input *[]storage.VirtualNetworkRule) []interface{} {
 	virtualNetworks := make([]interface{}, len(*input))
-	for i, virtualNetwork := range *input {
-		virtualNetworks[i] = *virtualNetwork.VirtualNetworkResourceID
+
+	if input != nil {
+		for i, virtualNetwork := range *input {
+			virtualNetworks[i] = *virtualNetwork.VirtualNetworkResourceID
+		}
 	}
 
 	return virtualNetworks


### PR DESCRIPTION
This PR address #1412. 

The plan from that users config will no return 
```
  ~ azurerm_storage_account.test
      network_rules.#:                                       "0" => "1"
      network_rules.0.bypass.#:                              "" => <computed>
      network_rules.0.virtual_network_subnet_ids.#:          "0" => "1"
      network_rules.0.virtual_network_subnet_ids.3418614067: "" => "/subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/resourceGroups/test-rg1412/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet"
```

Tests still pass 
```
=== RUN   TestAccAzureRMStorageAccount_networkRules
--- PASS: TestAccAzureRMStorageAccount_networkRules (123.25s)
=== RUN   TestAccAzureRMStorageAccount_networkRulesDeleted
--- PASS: TestAccAzureRMStorageAccount_networkRulesDeleted (109.85s)
```