### PR TITLE
azurerm_automation_schedule - Add missing properties for the advanced schedule

### DIFF
--- a/azurerm/resource_arm_automation_schedule.go
+++ b/azurerm/resource_arm_automation_schedule.go
@@ -126,6 +126,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 				Set:           set.HashStringIgnoreCase,
 				ConflictsWith: []string{"month_days", "monthly_occurrence"},
 			},
+
 			"month_days": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -423,33 +424,33 @@ func expandArmAutomationScheduleAdvanced(d *schema.ResourceData, isUpdate bool) 
 	return &expandedAdvancedSchedule, nil
 }
 
-func flattenArmAutomationScheduleAdvancedWeekDays(v *automation.AdvancedSchedule) *schema.Set {
+func flattenArmAutomationScheduleAdvancedWeekDays(s *automation.AdvancedSchedule) *schema.Set {
 	flattenedWeekDays := schema.NewSet(set.HashStringIgnoreCase, []interface{}{})
-	if v.WeekDays != nil {
-		for i := range *v.WeekDays {
-			flattenedWeekDays.Add((*v.WeekDays)[i])
+	if weekDays := s.WeekDays; weekDays != nil {
+		for _, v := range *weekDays {
+			flattenedWeekDays.Add(v)
 		}
 	}
 	return flattenedWeekDays
 }
 
-func flattenArmAutomationScheduleAdvancedMonthDays(v *automation.AdvancedSchedule) *schema.Set {
+func flattenArmAutomationScheduleAdvancedMonthDays(s *automation.AdvancedSchedule) *schema.Set {
 	flattenedMonthDays := schema.NewSet(set.HashInt, []interface{}{})
-	if v.MonthDays != nil {
-		for i := range *v.MonthDays {
-			flattenedMonthDays.Add(int(((*v.MonthDays)[i])))
+	if monthDays := s.MonthDays; monthDays != nil {
+		for _, v := range *monthDays {
+			flattenedMonthDays.Add(int(v))
 		}
 	}
 	return flattenedMonthDays
 }
 
-func flattenArmAutomationScheduleAdvancedMonthlyOccurrences(v *automation.AdvancedSchedule) []map[string]interface{} {
+func flattenArmAutomationScheduleAdvancedMonthlyOccurrences(s *automation.AdvancedSchedule) []map[string]interface{} {
 	flattenedMonthlyOccurrences := make([]map[string]interface{}, 0)
-	if v.MonthlyOccurrences != nil {
-		for i := range *v.MonthlyOccurrences {
+	if monthlyOccurrences := s.MonthlyOccurrences; monthlyOccurrences != nil {
+		for _, v := range *monthlyOccurrences {
 			f := make(map[string]interface{})
-			f["day"] = (*v.MonthlyOccurrences)[i].Day
-			f["occurrence"] = int(*(*v.MonthlyOccurrences)[i].Occurrence)
+			f["day"] = v.Day
+			f["occurrence"] = int(*v.Occurrence)
 			flattenedMonthlyOccurrences = append(flattenedMonthlyOccurrences, f)
 		}
 	}

--- a/azurerm/resource_arm_automation_schedule_test.go
+++ b/azurerm/resource_arm_automation_schedule_test.go
@@ -185,8 +185,8 @@ func TestAccAzureRMAutomationSchedule_weekly_advanced(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAutomationScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAutomationSchedule_recurring_advanced_week(ri, testLocation(), "Week", 1, "Monday"),
-				Check:  checkAccAzureRMAutomationSchedule_recurring_advanced_week(resourceName, "Week", 1, "Monday"),
+				Config: testAccAzureRMAutomationSchedule_recurring_advanced_week(ri, testLocation(), "Monday"),
+				Check:  checkAccAzureRMAutomationSchedule_recurring_advanced_week(resourceName, "Monday"),
 			},
 			{
 				ResourceName:      resourceName,
@@ -207,8 +207,8 @@ func TestAccAzureRMAutomationSchedule_monthly_advanced_by_day(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAutomationScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAutomationSchedule_recurring_advanced_month(ri, testLocation(), "Month", 1, 2),
-				Check:  checkAccAzureRMAutomationSchedule_recurring_advanced_month(resourceName, "Month", 1, 2),
+				Config: testAccAzureRMAutomationSchedule_recurring_advanced_month(ri, testLocation(), 2),
+				Check:  checkAccAzureRMAutomationSchedule_recurring_advanced_month(resourceName, 2),
 			},
 			{
 				ResourceName:      resourceName,
@@ -229,8 +229,8 @@ func TestAccAzureRMAutomationSchedule_monthly_advanced_by_week_day(t *testing.T)
 		CheckDestroy: testCheckAzureRMAutomationScheduleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(ri, testLocation(), "Month", 1, "Monday", 2),
-				Check:  checkAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(resourceName, "Month", 1, "Monday", 2),
+				Config: testAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(ri, testLocation(), "Monday", 2),
+				Check:  checkAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(resourceName, "Monday", 2),
 			},
 			{
 				ResourceName:      resourceName,
@@ -406,7 +406,7 @@ func checkAccAzureRMAutomationSchedule_recurring_basic(resourceName string, freq
 	)
 }
 
-func testAccAzureRMAutomationSchedule_recurring_advanced_week(rInt int, location, frequency string, interval int, weekDay string) string {
+func testAccAzureRMAutomationSchedule_recurring_advanced_week(rInt int, location string, weekDay string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -414,32 +414,29 @@ resource "azurerm_automation_schedule" "test" {
   name	 	              = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
-  frequency               = "%s"
-  interval                = "%d"
+  frequency               = "Week"
+  interval                = "1"
 
-  advanced_schedule {
-	week_days  = ["%s"]
-  }
+  week_days  = ["%s"]
 }	
-`, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, frequency, interval, weekDay)
+`, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, weekDay)
 }
 
-func checkAccAzureRMAutomationSchedule_recurring_advanced_week(resourceName string, frequency string, interval int, weekDay string) resource.TestCheckFunc {
+func checkAccAzureRMAutomationSchedule_recurring_advanced_week(resourceName string, weekDay string) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
 		testCheckAzureRMAutomationScheduleExists("azurerm_automation_schedule.test"),
 		resource.TestCheckResourceAttrSet(resourceName, "name"),
 		resource.TestCheckResourceAttrSet(resourceName, "resource_group_name"),
 		resource.TestCheckResourceAttrSet(resourceName, "automation_account_name"),
 		resource.TestCheckResourceAttrSet(resourceName, "start_time"),
-		resource.TestCheckResourceAttr(resourceName, "frequency", frequency),
-		resource.TestCheckResourceAttr(resourceName, "interval", strconv.Itoa(interval)),
+		resource.TestCheckResourceAttr(resourceName, "frequency", "Week"),
+		resource.TestCheckResourceAttr(resourceName, "interval", "1"),
 		resource.TestCheckResourceAttr(resourceName, "timezone", "UTC"),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.0.week_days.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "week_days.#", "1"),
 	)
 }
 
-func testAccAzureRMAutomationSchedule_recurring_advanced_month(rInt int, location, frequency string, interval int, monthDay int) string {
+func testAccAzureRMAutomationSchedule_recurring_advanced_month(rInt int, location string, monthDay int) string {
 	return fmt.Sprintf(`
 %s
 
@@ -447,33 +444,29 @@ resource "azurerm_automation_schedule" "test" {
   name	 	              = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
-  frequency               = "%s"
-  interval                = "%d"
+  frequency               = "Month"
+  interval                = "1"
 
-  advanced_schedule {
-	month_days  = [%d]
-  }
+  month_days  = [%d]
 }	
-`, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, frequency, interval, monthDay)
+`, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, monthDay)
 }
 
-func checkAccAzureRMAutomationSchedule_recurring_advanced_month(resourceName string, frequency string, interval int, monthDay int) resource.TestCheckFunc {
+func checkAccAzureRMAutomationSchedule_recurring_advanced_month(resourceName string, monthDay int) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
 		testCheckAzureRMAutomationScheduleExists("azurerm_automation_schedule.test"),
 		resource.TestCheckResourceAttrSet(resourceName, "name"),
 		resource.TestCheckResourceAttrSet(resourceName, "resource_group_name"),
 		resource.TestCheckResourceAttrSet(resourceName, "automation_account_name"),
 		resource.TestCheckResourceAttrSet(resourceName, "start_time"),
-		resource.TestCheckResourceAttr(resourceName, "frequency", frequency),
-		resource.TestCheckResourceAttr(resourceName, "interval", strconv.Itoa(interval)),
+		resource.TestCheckResourceAttr(resourceName, "frequency", "Month"),
+		resource.TestCheckResourceAttr(resourceName, "interval", "1"),
 		resource.TestCheckResourceAttr(resourceName, "timezone", "UTC"),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.0.month_days.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "month_days.#", "1"),
 	)
 }
 
-func testAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(rInt int, location, frequency string, interval int,
-	weekDay string, weekDayOccurrence int) string {
+func testAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(rInt int, location string, weekDay string, weekDayOccurrence int) string {
 
 	return fmt.Sprintf(`
 %s
@@ -482,36 +475,29 @@ resource "azurerm_automation_schedule" "test" {
   name	 	              = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
-  frequency               = "%s"
-  interval                = "%d"
+  frequency               = "Month"
+  interval                = "1"
 
-  advanced_schedule {
-
-	monthly_occurrence {
-		day        = "%s"
-		occurrence = "%d"
-	}
+  monthly_occurrence {
+	day        = "%s"
+	occurrence = "%d"
   }
 }	
-`, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, frequency, interval, weekDay, weekDayOccurrence)
+`, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, weekDay, weekDayOccurrence)
 }
 
-func checkAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(resourceName string, frequency string, interval int,
-	monthWeekDay string, monthWeekOccurrence int) resource.TestCheckFunc {
+func checkAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(resourceName string, monthWeekDay string, monthWeekOccurrence int) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(
 		testCheckAzureRMAutomationScheduleExists("azurerm_automation_schedule.test"),
 		resource.TestCheckResourceAttrSet(resourceName, "name"),
 		resource.TestCheckResourceAttrSet(resourceName, "resource_group_name"),
 		resource.TestCheckResourceAttrSet(resourceName, "automation_account_name"),
 		resource.TestCheckResourceAttrSet(resourceName, "start_time"),
-		resource.TestCheckResourceAttr(resourceName, "frequency", frequency),
-		resource.TestCheckResourceAttr(resourceName, "interval", strconv.Itoa(interval)),
+		resource.TestCheckResourceAttr(resourceName, "frequency", "Month"),
+		resource.TestCheckResourceAttr(resourceName, "interval", "1"),
 		resource.TestCheckResourceAttr(resourceName, "timezone", "UTC"),
-		resource.TestCheckResourceAttrSet(resourceName, "advanced_schedule.0.monthly_occurrence.0.day"),
-		resource.TestCheckResourceAttrSet(resourceName, "advanced_schedule.0.monthly_occurrence.0.occurrence"),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.0.monthly_occurrence.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.0.monthly_occurrence.0.day", monthWeekDay),
-		resource.TestCheckResourceAttr(resourceName, "advanced_schedule.0.monthly_occurrence.0.occurrence", strconv.Itoa(monthWeekOccurrence)),
+		resource.TestCheckResourceAttr(resourceName, "monthly_occurrence.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "monthly_occurrence.0.day", monthWeekDay),
+		resource.TestCheckResourceAttr(resourceName, "monthly_occurrence.0.occurrence", strconv.Itoa(monthWeekOccurrence)),
 	)
 }

--- a/azurerm/resource_arm_automation_schedule_test.go
+++ b/azurerm/resource_arm_automation_schedule_test.go
@@ -330,7 +330,7 @@ func testAccAzureRMAutomationSchedule_oneTime_basic(rInt int, location string) s
 %s
 
 resource "azurerm_automation_schedule" "test" {
-  name	 	              = "acctestAS-%d"
+  name                    = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
   frequency               = "OneTime"
@@ -355,7 +355,7 @@ func testAccAzureRMAutomationSchedule_oneTime_complete(rInt int, location, start
 %s
 
 resource "azurerm_automation_schedule" "test" {
-  name	 	              = "acctestAS-%d"
+  name                    = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
   frequency               = "OneTime"
@@ -384,7 +384,7 @@ func testAccAzureRMAutomationSchedule_recurring_basic(rInt int, location, freque
 %s
 
 resource "azurerm_automation_schedule" "test" {
-  name	 	              = "acctestAS-%d"
+  name                    = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
   frequency               = "%s"
@@ -411,13 +411,12 @@ func testAccAzureRMAutomationSchedule_recurring_advanced_week(rInt int, location
 %s
 
 resource "azurerm_automation_schedule" "test" {
-  name	 	              = "acctestAS-%d"
+  name                    = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
   frequency               = "Week"
   interval                = "1"
-
-  week_days  = ["%s"]
+  week_days               = ["%s"]
 }	
 `, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, weekDay)
 }
@@ -441,13 +440,12 @@ func testAccAzureRMAutomationSchedule_recurring_advanced_month(rInt int, locatio
 %s
 
 resource "azurerm_automation_schedule" "test" {
-  name	 	              = "acctestAS-%d"
+  name                    = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
   frequency               = "Month"
   interval                = "1"
-
-  month_days  = [%d]
+  month_days              = [%d]
 }	
 `, testAccAzureRMAutomationSchedule_prerequisites(rInt, location), rInt, monthDay)
 }
@@ -472,7 +470,7 @@ func testAccAzureRMAutomationSchedule_recurring_advanced_month_week_day(rInt int
 %s
 
 resource "azurerm_automation_schedule" "test" {
-  name	 	              = "acctestAS-%d"
+  name                    = "acctestAS-%d"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   automation_account_name = "${azurerm_automation_account.test.name}"
   frequency               = "Month"

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `description` -  (Optional) A description for this Schedule.
 
-* `interval` -  (Optional) The number of `frequency`s between runs. Only valid for `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
+* `interval` -  (Optional) The number of `frequency`s between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
 
 * `start_time` -  (Optional) Start time of the schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created.
 
@@ -65,17 +65,17 @@ The following arguments are supported:
 
 * `timezone` - (Optional) The timezone of the start time. Defaults to `UTC`. For possible values see: https://msdn.microsoft.com/en-us/library/ms912391(v=winembedded.11).aspx
 
-* `week_days` - (Optional) List of days of the week that the job should execute on. Only valid for `Week`.
+* `week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`.
 
-* `month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid for `Month`.
+* `month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month`.
 
-* `monthly_occurrence` - (Optional) List of occurrences of days within a month. Only valid for `Month`. The `monthly_occurrence` block supports fields documented below.
+* `monthly_occurrence` - (Optional) List of occurrences of days within a month. Only valid when frequency is `Month`. The `monthly_occurrence` block supports fields documented below.
 
 ---
 
 The `monthly_occurrence` block supports:
 
-* `day` - (Required) Day of the occurrence. Must be one of Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.
+* `day` - (Required) Day of the occurrence. Must be one of `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`.
 
 * `occurrence` - (Required) Occurrence of the week within the month. Must be between `1` and `5`. `-1` for last week within the month.
 

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -65,17 +65,11 @@ The following arguments are supported:
 
 * `timezone` - (Optional) The timezone of the start time. Defaults to `UTC`. For possible values see: https://msdn.microsoft.com/en-us/library/ms912391(v=winembedded.11).aspx
 
-* `advanced_schedule` - (Optional) Advanced fine-grained schedule frequency configuration. The `advanced_schedule` block supports fields documented below.
+* `week_days` - (Optional) List of days of the week that the job should execute on. Only valid for `Week`.
 
----
+* `month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid for `Month`.
 
-The `advanced_schedule` block supports:
-
-* `week_days` - (Optional) List of days of the week that the job should execute on.
-
-* `month_days` - (Optional) List of days of the month that the job should execute on. Must be between 1 and 31. 0 for last day of the month.
-
-* `monthly_occurrence` - (Optional) List of occurrences of days within a month. The `monthly_occurrence` block supports fields documented below.
+* `monthly_occurrence` - (Optional) List of occurrences of days within a month. Only valid for `Month`. The `monthly_occurrence` block supports fields documented below.
 
 ---
 
@@ -83,7 +77,7 @@ The `monthly_occurrence` block supports:
 
 * `day` - (Required) Day of the occurrence. Must be one of Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.
 
-* `occurrence` - (Required) Occurrence of the week within the month. Must be between 1 and 5.
+* `occurrence` - (Required) Occurrence of the week within the month. Must be between `1` and `5`. `-1` for last week within the month.
 
 ## Attributes Reference
 

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -31,11 +31,15 @@ resource "azurerm_automation_schedule" "example" {
   name                    = "tfex-automation-schedule"
   resource_group_name     = "${azurerm_resource_group.example.name}"
   automation_account_name = "${azurerm_automation_account.example.name}"
-  frequency               = "Hour"
+  frequency               = "Week"
   interval                = 1
   timezone                = "Central Europe Standard Time"
   start_time              = "2014-04-15T18:00:15+02:00"
   description             = "This is an example schedule"
+
+  advanced_schedule {
+    week_days = ["Friday"]
+  }
 }
 ```
 
@@ -60,6 +64,22 @@ The following arguments are supported:
 * `expiry_time` -  (Optional) The end time of the schedule.
 
 * `timezone` - (Optional) The timezone of the start time. Defaults to `UTC`. For possible values see: https://msdn.microsoft.com/en-us/library/ms912391(v=winembedded.11).aspx
+
+* `advanced_schedule` - (Optional) Advanced fine-grained schedule frequency configuration. The `advanced_schedule` block supports fields documented below.
+
+The `advanced_schedule` block supports:
+
+* `week_days` - (Optional) List of days of the week that the job should execute on.
+
+* `month_days` - (Optional) List of days of the month that the job should execute on. Must be between 1 and 31. 0 for last day of the month.
+
+* `monthly_occurrence` - (Optional) List of occurrences of days within a month. The `monthly_occurrence` block supports fields documented below.
+
+The `monthly_occurrence` block supports:
+
+* `day` - (Required) Day of the occurrence. Must be one of Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday.
+
+* `occurrence` - (Required) Occurrence of the week within the month. Must be between 1 and 5.
 
 ## Attributes Reference
 

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 * `advanced_schedule` - (Optional) Advanced fine-grained schedule frequency configuration. The `advanced_schedule` block supports fields documented below.
 
+---
+
 The `advanced_schedule` block supports:
 
 * `week_days` - (Optional) List of days of the week that the job should execute on.
@@ -74,6 +76,8 @@ The `advanced_schedule` block supports:
 * `month_days` - (Optional) List of days of the month that the job should execute on. Must be between 1 and 31. 0 for last day of the month.
 
 * `monthly_occurrence` - (Optional) List of occurrences of days within a month. The `monthly_occurrence` block supports fields documented below.
+
+---
 
 The `monthly_occurrence` block supports:
 


### PR DESCRIPTION
This pull request adds the missing properties in the `azurerm_automation_schedule` resource to configure the advanced schedule. Addresses issue #1392  