### PR TITLE
r/application_gateway: clarify default value of require_sni in an http_listener

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -286,7 +286,7 @@ The `http_listener` block supports:
 * `require_sni` - (Optional) Applicable only if protocol is https. Enables SNI for multi-hosting.
   Valid values are:
 * true
-* false
+* false (default)
 
 The `probe` block supports:
 


### PR DESCRIPTION
Is there any reason we can't just make the default for `require_sni` to be `true` when the listener is HTTPS?