### PR TITLE
Insert attribute reference sku

### DIFF
--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -99,6 +99,7 @@ output "public_ip_address" {
 
 * `name` - (Required) Specifies the name of the public IP address.
 * `resource_group_name` - (Required) Specifies the name of the resource group.
+* `sku` - (Optional) The SKU of the Azure Public IP. Accepted values are Basic and Standard. Defaults to Basic.
 
 
 ## Attributes Reference


### PR DESCRIPTION
To use the standard LB it is necessary to pass the sku as an argument in azurerm_public_ip.

Example:
resource "azurerm_public_ip" "this" {
  name = "${var.prefix}-${terraform.workspace}-${var.module}-pip"
  resource_group_name = "${var.network_basic}"
  location = "${data.azurerm_resource_group.this.location}"
  resource_group_name = "${data.azurerm_resource_group.this.name}"
  public_ip_address_allocation = "static"
  sku = "standard"
}