### PR TITLE
Adding retry functionality to role assignment

### DIFF
--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -180,17 +180,17 @@ func validateRoleDefinitionName(i interface{}, k string) ([]string, []error) {
 }
 
 func retryRoleAssignmentsClient(scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}) func() *resource.RetryError {
-	
+
 	return func() *resource.RetryError {
 		roleAssignmentsClient := meta.(*ArmClient).roleAssignmentsClient
 		ctx := meta.(*ArmClient).StopContext
-		
+
 		_, err := roleAssignmentsClient.Create(ctx, scope, name, properties)
 
 		if err != nil {
 			return resource.RetryableError(err)
 		}
 		return nil
-		
+
 	}
 }

--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -105,7 +107,7 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 		},
 	}
 
-	_, err := roleAssignmentsClient.Create(ctx, scope, name, properties)
+	err := resource.Retry(180*time.Second, retryRoleAssignmentsClient(scope, name, properties, meta))
 	if err != nil {
 		return err
 	}
@@ -175,4 +177,20 @@ func validateRoleDefinitionName(i interface{}, k string) ([]string, []error) {
 		return nil, []error{fmt.Errorf("Preview roles are not supported")}
 	}
 	return nil, nil
+}
+
+func retryRoleAssignmentsClient(scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}) func() *resource.RetryError {
+	
+	return func() *resource.RetryError {
+		roleAssignmentsClient := meta.(*ArmClient).roleAssignmentsClient
+		ctx := meta.(*ArmClient).StopContext
+		
+		_, err := roleAssignmentsClient.Create(ctx, scope, name, properties)
+
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		return nil
+		
+	}
 }

--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -107,7 +107,7 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 		},
 	}
 
-	err := resource.Retry(180*time.Second, retryRoleAssignmentsClient(scope, name, properties, meta))
+	err := resource.Retry(300*time.Second, retryRoleAssignmentsClient(scope, name, properties, meta))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a fix for #1635. It adds the retry functionality to the azurerm_role_assignment resource to take into account the time it takes for Azure to replicate the Principal ID to be usable by roles. Very similar to #1644  