### PR TITLE
Aks node resource group

### DIFF
--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -38,6 +38,11 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"node_resource_group": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"kube_config": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -233,6 +238,7 @@ func dataSourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}
 		d.Set("dns_prefix", props.DNSPrefix)
 		d.Set("fqdn", props.Fqdn)
 		d.Set("kubernetes_version", props.KubernetesVersion)
+		d.Set("node_resource_group", props.NodeResourceGroup)
 
 		linuxProfile := flattenKubernetesClusterDataSourceLinuxProfile(props.LinuxProfile)
 		if err := d.Set("linux_profile", linuxProfile); err != nil {

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -399,7 +399,7 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("dns_prefix", props.DNSPrefix)
 		d.Set("fqdn", props.Fqdn)
 		d.Set("kubernetes_version", props.KubernetesVersion)
-		d.Set("node_resource_group", props.nodeResourceGroup)
+		d.Set("node_resource_group", props.NodeResourceGroup)
 
 		linuxProfile := flattenAzureRmKubernetesClusterLinuxProfile(props.LinuxProfile)
 		if err := d.Set("linux_profile", linuxProfile); err != nil {

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -75,6 +75,11 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"node_resource_group": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"kube_config": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -394,6 +399,7 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("dns_prefix", props.DNSPrefix)
 		d.Set("fqdn", props.Fqdn)
 		d.Set("kubernetes_version", props.KubernetesVersion)
+		d.Set("node_resource_group", props.nodeResourceGroup)
 
 		linuxProfile := flattenAzureRmKubernetesClusterLinuxProfile(props.LinuxProfile)
 		if err := d.Set("linux_profile", linuxProfile); err != nil {

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -41,7 +41,7 @@ The following attributes are exported:
 
 * `kube_config_raw` - Base64 encoded Kubernetes configuration.
 
-* `node_resource_group` - Auto-generated Resource Group for AKS Cluster resources.
+* `node_resource_group` - Auto-generated Resource Group containing AKS Cluster resources.
 
 * `kube_config` - A `kube_config` block as defined below.
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -41,6 +41,8 @@ The following attributes are exported:
 
 * `kube_config_raw` - Base64 encoded Kubernetes configuration.
 
+* `node_resource_group` - Auto-generated Resource Group for AKS Cluster resources.
+
 * `kube_config` - A `kube_config` block as defined below.
 
 * `location` - The Azure Region in which the managed Kubernetes Cluster exists.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -267,7 +267,7 @@ The following attributes are exported:
 
 * `fqdn` - The FQDN of the Azure Kubernetes Managed Cluster.
 
-* `node_resource_group` - Auto-generated Resource Group for AKS Cluster resources.
+* `node_resource_group` - Auto-generated Resource Group containing AKS Cluster resources.
 
 * `kube_config_raw` - Base64 encoded Kubernetes configuration
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -267,6 +267,8 @@ The following attributes are exported:
 
 * `fqdn` - The FQDN of the Azure Kubernetes Managed Cluster.
 
+* `node_resource_group` - Auto-generated Resource Group for AKS Cluster resources.
+
 * `kube_config_raw` - Base64 encoded Kubernetes configuration
 
 * `kube_config` - Kubernetes configuration, sub-attributes defined below:


### PR DESCRIPTION
This adds support for the node_resource_group output which is auto-generated when an AKS cluster is provisioned. Related to https://github.com/terraform-providers/terraform-provider-azurerm/issues/1276#issuecomment-396453612