### PR TITLE
azurerm_network_interface - ip_configuration - private_ip_address_allocation - types correction in documentation

### DIFF
--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -54,7 +54,7 @@ A `ip_configuration` block contains:
 * `name` - The name of the IP Configuration.
 * `subnet_id` - The ID of the Subnet which the Network Interface is connected to.
 * `private_ip_address` - The Private IP Address assigned to this Network Interface.
-* `private_ip_address_allocation` - The IP Address allocation type for the Private address, such as `Dynamic` or `Standard`.
+* `private_ip_address_allocation` - The IP Address allocation type for the Private address, such as `Dynamic` or `Static`.
 * `public_ip_address_id` - The ID of the Public IP Address which is connected to this Network Interface.
 * `application_gateway_backend_address_pools_ids` - A list of Backend Address Pool ID's within a Application Gateway that this Network Interface is connected to.
 * `load_balancer_backend_address_pools_ids` - A list of Backend Address Pool ID's within a Load Balancer that this Network Interface is connected to.


### PR DESCRIPTION
At present the documentation states that `ip_configuration`.`private_ip_address_allocation` can have have a value of `Dynamic` or `Standard`.

`Standard` is incorrect, `Static` is correct.