### PR TITLE
Import Support for Container Groups

### DIFF
--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -35,6 +35,15 @@ func TestAccAzureRMContainerGroup_imageRegistryCredentials(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "image_registry_credential.1.password", "acrpassword"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"image_registry_credential.0.password",
+					"image_registry_credential.1.password",
+				},
+			},
 		},
 	})
 }
@@ -96,6 +105,15 @@ func TestAccAzureRMContainerGroup_linuxBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "container.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Linux"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"image_registry_credential.0.password",
+					"image_registry_credential.1.password",
+				},
 			},
 		},
 	})
@@ -159,6 +177,14 @@ func TestAccAzureRMContainerGroup_linuxComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "restart_policy", "OnFailure"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"container.0.volume.0.storage_account_key",
+				},
+			},
 		},
 	})
 }
@@ -181,6 +207,11 @@ func TestAccAzureRMContainerGroup_windowsBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "container.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Windows"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -209,6 +240,11 @@ func TestAccAzureRMContainerGroup_windowsComplete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "os_type", "Windows"),
 					resource.TestCheckResourceAttr(resourceName, "restart_policy", "Never"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -154,3 +154,11 @@ The following attributes are exported:
 * `ip_address` - The IP address allocated to the container group.
 
 * `fqdn` - The FQDN of the container group derived from `dns_name_label`.
+
+## Import
+
+Container Group's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_container_group.containerGroup1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ContainerInstance/containerGroups/myContainerGroup1
+```


### PR DESCRIPTION
This PR adds import support for container Groups

```
=== RUN   TestAccAzureRMContainerGroup_imageRegistryCredentials
--- PASS: TestAccAzureRMContainerGroup_imageRegistryCredentials (63.80s)
=== RUN   TestAccAzureRMContainerGroup_imageRegistryCredentialsUpdate
--- PASS: TestAccAzureRMContainerGroup_imageRegistryCredentialsUpdate (70.03s)
=== RUN   TestAccAzureRMContainerGroup_linuxBasic
--- PASS: TestAccAzureRMContainerGroup_linuxBasic (60.88s)
=== RUN   TestAccAzureRMContainerGroup_linuxBasicUpdate
--- PASS: TestAccAzureRMContainerGroup_linuxBasicUpdate (71.72s)
=== RUN   TestAccAzureRMContainerGroup_linuxComplete
--- PASS: TestAccAzureRMContainerGroup_linuxComplete (90.49s)
=== RUN   TestAccAzureRMContainerGroup_windowsBasic
--- PASS: TestAccAzureRMContainerGroup_windowsBasic (60.65s)
=== RUN   TestAccAzureRMContainerGroup_windowsComplete
--- PASS: TestAccAzureRMContainerGroup_windowsComplete (63.46s)
```