### PR TITLE
updated test and example vm size from Standard_A0 -> Standard_F2

### DIFF
--- a/azurerm/resource_arm_container_service_test.go
+++ b/azurerm/resource_arm_container_service_test.go
@@ -186,7 +186,7 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent%d"
-    vm_size    = "Standard_A0"
+    vm_size    = "Standard_F2"
   }
 
   diagnostics_profile {
@@ -226,7 +226,7 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent%d"
-    vm_size    = "Standard_A0"
+    vm_size    = "Standard_F2"
   }
 
   service_principal {
@@ -271,7 +271,7 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent%d"
-    vm_size    = "Standard_A0"
+    vm_size    = "Standard_F2"
   }
 
   service_principal {
@@ -320,7 +320,7 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent%d"
-    vm_size    = "Standard_A0"
+    vm_size    = "Standard_F2"
   }
 
   diagnostics_profile {

--- a/azurerm/resource_arm_snapshot_test.go
+++ b/azurerm/resource_arm_snapshot_test.go
@@ -512,7 +512,7 @@ resource "azurerm_virtual_machine" "test" {
   location              = "${azurerm_resource_group.test.location}"
   resource_group_name   = "${azurerm_resource_group.test.name}"
   network_interface_ids = ["${azurerm_network_interface.test.id}"]
-  vm_size               = "Standard_A0"
+  vm_size               = "Standard_F2"
   delete_os_disk_on_termination = true
 
   storage_image_reference {

--- a/azurerm/resource_arm_virtual_machine_extension_test.go
+++ b/azurerm/resource_arm_virtual_machine_extension_test.go
@@ -196,7 +196,7 @@ resource "azurerm_virtual_machine" "test" {
     location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     network_interface_ids = ["${azurerm_network_interface.test.id}"]
-    vm_size = "Standard_A0"
+    vm_size = "Standard_F2"
 
     storage_image_reference {
 		publisher = "Canonical"
@@ -302,7 +302,7 @@ resource "azurerm_virtual_machine" "test" {
     location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     network_interface_ids = ["${azurerm_network_interface.test.id}"]
-    vm_size = "Standard_A0"
+    vm_size = "Standard_F2"
 
     storage_image_reference {
 		publisher = "Canonical"
@@ -409,7 +409,7 @@ resource "azurerm_virtual_machine" "test" {
     location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     network_interface_ids = ["${azurerm_network_interface.test.id}"]
-    vm_size = "Standard_A0"
+    vm_size = "Standard_F2"
 
     storage_image_reference {
 	publisher = "Canonical"
@@ -527,7 +527,7 @@ resource "azurerm_virtual_machine" "test" {
     location = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
     network_interface_ids = ["${azurerm_network_interface.test.id}"]
-    vm_size = "Standard_A0"
+    vm_size = "Standard_F2"
 
     storage_image_reference {
 	publisher = "Canonical"

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -1849,7 +1849,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Automatic"
 
   sku {
-    name     = "Standard_A0"
+    name     = "Standard_F2"
     tier     = "Standard"
     capacity = "1"
   }
@@ -1963,7 +1963,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Automatic"
 
   sku {
-    name     = "Standard_A0"
+    name     = "Standard_F2"
     tier     = "Standard"
     capacity = "1"
   }
@@ -2081,7 +2081,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Automatic"
 
   sku {
-    name     = "Standard_A0"
+    name     = "Standard_F2"
     tier     = "Standard"
     capacity = "1"
   }
@@ -3530,7 +3530,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Manual"
 
   sku {
-    name     = "Standard_A0"
+    name     = "Standard_F2"
     tier     = "Standard"
     capacity = 1
   }
@@ -3625,7 +3625,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Manual"
 
   sku {
-    name     = "Standard_A0"
+    name     = "Standard_F2"
     tier     = "standard"
     capacity = 2
   }

--- a/examples/encrypt-running-linux-vm/variables.tf
+++ b/examples/encrypt-running-linux-vm/variables.tf
@@ -33,7 +33,7 @@ variable "storage_replication_type" {
 
 variable "vm_size" {
   description = "Specifies the size of the virtual machine. This must be the same as the vm image from which you are copying."
-  default     = "Standard_A0"
+  default     = "Standard_F2"
 }
 
 variable "image_publisher" {

--- a/examples/freebsd-jumpbox/variables.tf
+++ b/examples/freebsd-jumpbox/variables.tf
@@ -52,7 +52,7 @@ variable "storage_replication_type" {
 
 variable "vm_size" {
   description = "Specifies the size of the virtual machine."
-  default     = "Standard_A0"
+  default     = "Standard_F2"
 }
 
 variable "image_publisher" {

--- a/examples/vm-simple-linux-managed-disk/variables.tf
+++ b/examples/vm-simple-linux-managed-disk/variables.tf
@@ -47,7 +47,7 @@ variable "storage_replication_type" {
 
 variable "vm_size" {
   description = "Specifies the size of the virtual machine."
-  default     = "Standard_A0"
+  default     = "Standard_F2"
 }
 
 variable "image_publisher" {

--- a/website/docs/r/container_service.html.markdown
+++ b/website/docs/r/container_service.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent1"
-    vm_size    = "Standard_A0"
+    vm_size    = "Standard_F2"
   }
 
   diagnostics_profile {
@@ -88,7 +88,7 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent1"
-    vm_size    = "Standard_A0"
+    vm_size    = "Standard_F2"
   }
 
   service_principal {
@@ -137,7 +137,7 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent1"
-    vm_size    = "Standard_A0"
+    vm_size    = "Standard_F2"
   }
 
   diagnostics_profile {

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -83,7 +83,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Manual"
 
   sku {
-    name     = "Standard_A0"
+    name     = "Standard_F2"
     tier     = "Standard"
     capacity = 2
   }
@@ -190,7 +190,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   upgrade_policy_mode = "Manual"
 
   sku {
-    name     = "Standard_A0"
+    name     = "Standard_F2"
     tier     = "Standard"
     capacity = 2
   }


### PR DESCRIPTION
speed up tests by using the faster vm size `Standard_F2`