### PR TITLE
[WIP] New Resource: Virtual Machine State

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -257,6 +257,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_virtual_machine_data_disk_attachment":    resourceArmVirtualMachineDataDiskAttachment(),
 			"azurerm_virtual_machine_extension":               resourceArmVirtualMachineExtensions(),
 			"azurerm_virtual_machine_scale_set":               resourceArmVirtualMachineScaleSet(),
+			"azurerm_virtual_machine_state":                   resourceArmVirtualMachineState(),
 			"azurerm_virtual_network":                         resourceArmVirtualNetwork(),
 			"azurerm_virtual_network_gateway":                 resourceArmVirtualNetworkGateway(),
 			"azurerm_virtual_network_gateway_connection":      resourceArmVirtualNetworkGatewayConnection(),

--- a/azurerm/resource_arm_virtual_machine_state.go
+++ b/azurerm/resource_arm_virtual_machine_state.go
@@ -33,8 +33,8 @@ func resourceArmVirtualMachineState() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"started",
-					"poweredoff",
+					"running",
+					"stopped",
 					"deallocated",
 				}, true),
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
@@ -55,7 +55,7 @@ func resourceArmVirtualMachineStateCreate(d *schema.ResourceData, meta interface
 
 	if vmState == "deallocated" {
 		err = resourceArmVirtualMachineStateDeallocate(resGroup, vmName, vmState, meta)
-	} else if vmState == "poweredoff" {
+	} else if vmState == "stopped" {
 		err = resourceArmVirtualMachineStatePowerOff(resGroup, vmName, vmState, meta)
 	} else if vmState == "started" {
 		err = resourceArmVirtualMachineStateStart(resGroup, vmName, vmState, meta)
@@ -93,12 +93,6 @@ func resourceArmVirtualMachineStateRead(d *schema.ResourceData, meta interface{}
 	}
 	resGroup := id.ResourceGroup
 	vmName := id.Path["virtualMachines"]
-
-	//vmName := d.Get("virtual_machine_name").(string)
-	//resGroup := d.Get("resource_group_name").(string)
-
-	//resp, err := client.InstanceView(ctx, resGroup, vmName)
-
 	vm, err := client.Get(ctx, resGroup, vmName, compute.InstanceView)
 	if err != nil {
 		if utils.ResponseWasNotFound(vm.Response) {
@@ -109,8 +103,6 @@ func resourceArmVirtualMachineStateRead(d *schema.ResourceData, meta interface{}
 
 	if vm.InstanceView != nil {
 		for _, statGet := range *vm.InstanceView.Statuses {
-			//d.Set("state", *statGet.Code)
-			//d.Set("state", strings.Split("/", *statGet.Code))
 			statusSplit := strings.Split(*statGet.Code, "/")
 			d.Set("state", statusSplit[1])
 		}

--- a/azurerm/resource_arm_virtual_machine_state.go
+++ b/azurerm/resource_arm_virtual_machine_state.go
@@ -1,0 +1,179 @@
+package azurerm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2017-12-01/compute"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmVirtualMachineState() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmVirtualMachineStateCreate,
+		Read:   resourceArmVirtualMachineStateRead,
+		Update: resourceArmVirtualMachineStateCreate,
+		Delete: resourceArmVirtualMachineStateRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"virtual_machine_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"started",
+					"poweredoff",
+					"deallocated",
+				}, true),
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+			},
+		},
+	}
+}
+
+func resourceArmVirtualMachineStateCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).vmClient
+	ctx := meta.(*ArmClient).StopContext
+
+	vmName := d.Get("virtual_machine_name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	vmState := d.Get("state").(string)
+
+	var err error
+
+	if vmState == "deallocated" {
+		err = resourceArmVirtualMachineStateDeallocate(resGroup, vmName, vmState, meta)
+	} else if vmState == "poweredoff" {
+		err = resourceArmVirtualMachineStatePowerOff(resGroup, vmName, vmState, meta)
+	} else if vmState == "started" {
+		err = resourceArmVirtualMachineStateStart(resGroup, vmName, vmState, meta)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	vm, err := client.Get(ctx, resGroup, vmName, compute.InstanceView)
+	if err != nil {
+		return err
+	}
+
+	if vm.InstanceView != nil {
+		for _, statGet := range *vm.InstanceView.Statuses {
+			fmt.Println(statGet.Level, *statGet.DisplayStatus)
+		}
+	} else {
+		return fmt.Errorf("Cannot read Virtual Machine State %s (resource group %s) ID", vmName, resGroup)
+	}
+
+	d.SetId(*vm.ID)
+
+	return resourceArmVirtualMachineStateRead(d, meta)
+}
+
+func resourceArmVirtualMachineStateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).vmClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	vmName := id.Path["virtualMachines"]
+
+	//vmName := d.Get("virtual_machine_name").(string)
+	//resGroup := d.Get("resource_group_name").(string)
+
+	//resp, err := client.InstanceView(ctx, resGroup, vmName)
+
+	vm, err := client.Get(ctx, resGroup, vmName, compute.InstanceView)
+	if err != nil {
+		if utils.ResponseWasNotFound(vm.Response) {
+			d.SetId("")
+			return nil
+		}
+	}
+
+	if vm.InstanceView != nil {
+		for _, statGet := range *vm.InstanceView.Statuses {
+			//d.Set("state", *statGet.Code)
+			//d.Set("state", strings.Split("/", *statGet.Code))
+			statusSplit := strings.Split(*statGet.Code, "/")
+			d.Set("state", statusSplit[1])
+		}
+	} else {
+		return fmt.Errorf("Cannot read Virtual Machine State %s (resource group %s) ID", vmName, resGroup)
+	}
+
+	d.Set("virtual_machine_name", vmName)
+	d.Set("resource_group_name", resGroup)
+
+	return nil
+}
+
+func resourceArmVirtualMachineStateDeallocate(resGroup string, vmName string, vmState string, meta interface{}) error {
+	client := meta.(*ArmClient).vmClient
+	ctx := meta.(*ArmClient).StopContext
+
+	future, err := client.Deallocate(ctx, resGroup, vmName)
+
+	if err != nil {
+		return err
+	}
+
+	err = future.WaitForCompletionRef(ctx, client.Client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceArmVirtualMachineStateStart(resGroup string, vmName string, vmState string, meta interface{}) error {
+	client := meta.(*ArmClient).vmClient
+	ctx := meta.(*ArmClient).StopContext
+
+	future, err := client.Start(ctx, resGroup, vmName)
+
+	if err != nil {
+		return err
+	}
+
+	err = future.WaitForCompletionRef(ctx, client.Client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceArmVirtualMachineStatePowerOff(resGroup string, vmName string, vmState string, meta interface{}) error {
+	client := meta.(*ArmClient).vmClient
+	ctx := meta.(*ArmClient).StopContext
+
+	future, err := client.PowerOff(ctx, resGroup, vmName)
+
+	if err != nil {
+		return err
+	}
+
+	err = future.WaitForCompletionRef(ctx, client.Client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/website/docs/r/virtual_machine_state.html.markdown
+++ b/website/docs/r/virtual_machine_state.html.markdown
@@ -3,7 +3,7 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_machine_state"
 sidebar_current: "docs-azurerm-resource-compute-virtualmachine-state"
 description: |-
-    Manages a Virtual Machine state to allow for a machine to be Started,
+    Manages a Virtual Machine state to allow for a machine to be Running,
     Powered Off and Deallocated without destroying/re-creating
 ---
 

--- a/website/docs/r/virtual_machine_state.html.markdown
+++ b/website/docs/r/virtual_machine_state.html.markdown
@@ -1,0 +1,157 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_virtual_machine_state"
+sidebar_current: "docs-azurerm-resource-compute-virtualmachine-state"
+description: |-
+    Manages a Virtual Machine state to allow for a machine to be Started,
+    Powered Off and Deallocated without destroying/re-creating
+---
+
+# azurerm_virtual_machine_state
+
+Manages a Virtual Machine Extension to provide post deployment configuration
+and run automated tasks.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG"
+  location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accsa"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine" "test" {
+  name                  = "acctvm"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.test.id}"]
+  vm_size               = "Standard_F2"
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "hostname"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  tags {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "test" {
+  name                 = "hostname"
+  location             = "${azurerm_resource_group.test.location}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_machine_name = "${azurerm_virtual_machine.test.name}"
+  publisher            = "Microsoft.Azure.Extensions"
+  type                 = "CustomScript"
+  type_handler_version = "2.0"
+
+  settings = <<SETTINGS
+	{
+		"commandToExecute": "hostname && uptime"
+	}
+SETTINGS
+
+  tags {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_virtual_machine_state" "test" {
+  virtual_machine_name = "${azurerm_virtual_machine.test.name}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  state = "Deallocated"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the virtual machine extension peering. Changing
+    this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the virtual network. Changing this forces a new resource to be
+    created.
+
+* `state` - (Required) The desired state of the Virtual Machine. Valid options are `running`,
+    `stopped` (stopped but will still incur costs) and `deallocated` (stopped and won't incur costs).
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The state of the virtual machine.
+
+## Import
+
+Virtual Machine States can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_virtual_machine_state.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/virtualMachines/myVM
+```


### PR DESCRIPTION
Here is a new resource which allows the control of the virtual machine state through Terraform.  It allows for a VM to be running/stopped/deallocated without the need to completely destroy the resource.  Where we leverage Azure IaaS components it isn't always realistic to destroy and recreate all the time and I don't want to have to grant permissions in the portal just so users can deallocate manually when the machine isn't being used.

I still need to finish writing the test cases but wanted to get an initial commit it. I've tested it locally and the scenarios so far seem to be working for me.

(It's my first full resource so be gentle :))