### PR TITLE
Typo on redis_configuration snippet

### DIFF
--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -170,7 +170,7 @@ resource "azurerm_redis_cache" "test" {
 
 ```hcl
 redis_configuration {
-  maxmemory_reserve  = 10
+  maxmemory_reserved = 10
   maxmemory_delta    = 2
   maxmemory_policy   = "allkeys-lru"
 }


### PR DESCRIPTION
Under 'Argument Reference', there is a typo on the redis_configuration snippet.