### PR TITLE
Automation Runbook: support for setting custom content

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -78,10 +78,11 @@ type ArmClient struct {
 
 	cosmosDBClient documentdb.DatabaseAccountsClient
 
-	automationAccountClient    automation.AccountClient
-	automationRunbookClient    automation.RunbookClient
-	automationCredentialClient automation.CredentialClient
-	automationScheduleClient   automation.ScheduleClient
+	automationAccountClient      automation.AccountClient
+	automationRunbookClient      automation.RunbookClient
+	automationCredentialClient   automation.CredentialClient
+	automationScheduleClient     automation.ScheduleClient
+	automationRunbookDraftClient automation.RunbookDraftClient
 
 	dnsClient   dns.RecordSetsClient
 	zonesClient dns.ZonesClient
@@ -472,6 +473,13 @@ func (c *ArmClient) registerAutomationClients(endpoint, subscriptionId string, a
 	scheduleClient := automation.NewScheduleClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&scheduleClient.Client, auth)
 	c.automationScheduleClient = scheduleClient
+
+	runbookDraftClient := automation.NewRunbookDraftClientWithBaseURI(endpoint, subscriptionId)
+	setUserAgent(&runbookDraftClient.Client)
+	runbookDraftClient.Authorizer = auth
+	runbookDraftClient.Sender = sender
+	runbookDraftClient.SkipResourceProviderRegistration = c.skipProviderRegistration
+	c.automationRunbookDraftClient = runbookDraftClient
 }
 
 func (c *ArmClient) registerAuthentication(endpoint, graphEndpoint, subscriptionId, tenantId string, auth, graphAuth autorest.Authorizer, sender autorest.Sender) {

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -475,10 +475,7 @@ func (c *ArmClient) registerAutomationClients(endpoint, subscriptionId string, a
 	c.automationScheduleClient = scheduleClient
 
 	runbookDraftClient := automation.NewRunbookDraftClientWithBaseURI(endpoint, subscriptionId)
-	setUserAgent(&runbookDraftClient.Client)
-	runbookDraftClient.Authorizer = auth
-	runbookDraftClient.Sender = sender
-	runbookDraftClient.SkipResourceProviderRegistration = c.skipProviderRegistration
+	c.configureClient(&runbookDraftClient.Client, auth)
 	c.automationRunbookDraftClient = runbookDraftClient
 }
 

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 
@@ -219,11 +220,16 @@ func resourceArmAutomationRunbookRead(d *schema.ResourceData, meta interface{}) 
 		flattenAndSetTags(d, tags)
 	}
 
-	content, err := client.GetContent(ctx, resGroup, accName, name)
+	response, err := client.GetContent(ctx, resGroup, accName, name)
 	if err != nil {
 		return err
 	}
-	d.Set("content", content)
+	if contentBytes := *response.Value; contentBytes != nil {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(contentBytes)
+		content := buf.String()
+		d.Set("content", content)
+	}
 
 	return nil
 }

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -219,6 +219,12 @@ func resourceArmAutomationRunbookRead(d *schema.ResourceData, meta interface{}) 
 		flattenAndSetTags(d, tags)
 	}
 
+	content, err := client.GetContent(ctx, resGroup, accName, name)
+	if err != nil {
+		return err
+	}
+	d.Set("content", content)
+
 	return nil
 }
 

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -73,6 +73,7 @@ func resourceArmAutomationRunbook() *schema.Resource {
 			"content": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"publish_content_link": {

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
@@ -155,8 +156,9 @@ func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta inter
 
 	if v, ok := d.GetOk("content"); ok {
 		content := v.(string)
+		reader := ioutil.NopCloser(bytes.NewBufferString(content))
 		draftClient := meta.(*ArmClient).automationRunbookDraftClient
-		_, err := draftClient.ReplaceContent(ctx, resGroup, accName, name, content)
+		_, err := draftClient.ReplaceContent(ctx, resGroup, accName, name, reader)
 		if err != nil {
 			return err
 		}

--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -233,12 +233,12 @@ func resourceArmKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("enabled_for_disk_encryption", props.EnabledForDiskEncryption)
 		d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
 		if err := d.Set("sku", flattenKeyVaultSku(props.Sku)); err != nil {
-			return fmt.Errorf("Error flattening `sku` for KeyVault %s: %+v", *resp.Name, err)
+			return fmt.Errorf("Error flattening `sku` for KeyVault %q: %+v", *resp.Name, err)
 		}
 
 		flattenedPolicies := azure.FlattenKeyVaultAccessPolicies(props.AccessPolicies)
 		if err := d.Set("access_policy", flattenedPolicies); err != nil {
-			return fmt.Errorf("Error flattening `access_policy` for KeyVault %s: %+v", *resp.Name, err)
+			return fmt.Errorf("Error flattening `access_policy` for KeyVault %q: %+v", *resp.Name, err)
 		}
 		d.Set("vault_uri", props.VaultURI)
 	}

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -42,6 +42,43 @@ resource "azurerm_automation_runbook" "example" {
 }
 ```
 
+## Example Usage - custom content
+
+```hcl
+resource "azurerm_resource_group" "example" {
+ name = "resourceGroup1"
+ location = "West Europe"
+}
+
+resource "azurerm_automation_account" "example" {
+  name                = "account1"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  sku {
+    name = "Basic"
+  }
+}
+
+data "local_file" "example" {
+  filename = "${path.module}/example.ps1"
+}
+
+resource "azurerm_automation_runbook" "example" {
+  name                = "Get-AzureVMTutorial"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  account_name        = "${azurerm_automation_account.example.name}"
+  log_verbose         = "true"
+  log_progress        = "true"
+  description         = "This is an example runbook"
+  runbook_type        = "PowerShell"
+  publish_content_link {
+    uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
+  }
+  content             = "${data.local_file.example.content}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 
 ~> **NOTE** The Azure API requires a `publish_content_link` to be supplied even when specifying your own `content`.
 
+~> **NOTE** Setting `content` to an empty string will revert the runbook to the `publish_content_link`.
+
 `publish_content_link` supports the following:
 
 * `uri` - (Required) The uri of the runbook content.

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -58,11 +58,15 @@ The following arguments are supported:
 
 * `log_progress` - (Required) Progress log option.
 
-* `log_verbose` -  (Required) Verbose log option.
+* `log_verbose` - (Required) Verbose log option.
 
 * `publish_content_link` - (Required) The published runbook content link.
 
-* `description` -  (Optional) A description for this credential.
+* `description` - (Optional) A description for this credential.
+
+* `content` - (Optional) The desired content of the runbook.
+
+~> **NOTE** The Azure API requires a `publish_content_link` to be supplied even when specifying your own `content`.
 
 `publish_content_link` supports the following:
 


### PR DESCRIPTION
Adds support for directly setting the content of a runbook.
This will require the (as yet unreleased) v20 of the azure-sdk-for-go to resolve [this issue](https://github.com/Azure/azure-sdk-for-go/issues/2350), so we need to wait for that before merging.