### PR TITLE
Fix typo in the azurerm_cosmosdb_account page heading

### DIFF
--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages a CosmosDB (formally DocumentDB) Account.
 ---
 
-# azurerm_cosmos_db_account
+# azurerm_cosmosdb_account
 
 Manages a CosmosDB (formally DocumentDB) Account.
 


### PR DESCRIPTION
There's an extra underscore in the header/title, and it doesn't match the actual name of the resource.