### PR TITLE
docs/kubernetes_cluster: Fix inaccurate kube_config_raw description

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -269,7 +269,9 @@ The following attributes are exported:
 
 * `node_resource_group` - Auto-generated Resource Group containing AKS Cluster resources.
 
-* `kube_config_raw` - Base64 encoded Kubernetes configuration
+* `kube_config_raw` - Raw Kubernetes config to be used by
+    [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/) and
+    other compatible tools
 
 * `kube_config` - Kubernetes configuration, sub-attributes defined below:
 


### PR DESCRIPTION
The config we expose actually isn't base64 encoded as demonstrated below:

```
$ echo 'azurerm_kubernetes_cluster.test.kube_config_raw' | terraform console
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data:
...
```

Whether it should be encoded is a separate discussion I'm happy to engage in, but the aim here is to at least bring docs up to date 😉 