### PR TITLE
Update validation logic for kubenet network plugin.

### DIFF
--- a/azurerm/data_source_kubernetes_cluster_test.go
+++ b/azurerm/data_source_kubernetes_cluster_test.go
@@ -145,9 +145,7 @@ data "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzure(rInt int, clientId string, clientSecret string, location string) string {
-	resource := testAccAzureRMKubernetesCluster_advancedNetworking(
-		rInt, clientId, clientSecret, location,
-		"azure", "", "", "")
+	resource := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(rInt, clientId, clientSecret, location, "azure")
 	return fmt.Sprintf(`
 %s
 
@@ -159,9 +157,7 @@ data "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenet(rInt int, clientId string, clientSecret string, location string) string {
-	resource := testAccAzureRMKubernetesCluster_advancedNetworking(
-		rInt, clientId, clientSecret, location,
-		"kubenet", "", "", "")
+	resource := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(rInt, clientId, clientSecret, location, "kubenet")
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/data_source_kubernetes_cluster_test.go
+++ b/azurerm/data_source_kubernetes_cluster_test.go
@@ -91,6 +91,35 @@ func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzure(t *testin
 	})
 }
 
+func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t *testing.T) {
+	dataSourceName := "data.azurerm_kubernetes_cluster.test"
+	ri := acctest.RandInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	location := testLocation()
+	config := testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureComplete(ri, clientId, clientSecret, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agent_pool_profile.0.vnet_subnet_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_profile.0.network_plugin", "azure"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.network_plugin"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.dns_service_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.docker_bridge_cidr"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.service_cidr"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenet(t *testing.T) {
 	dataSourceName := "data.azurerm_kubernetes_cluster.test"
 	ri := acctest.RandInt()
@@ -98,6 +127,35 @@ func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenet(t *test
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
 	location := testLocation()
 	config := testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenet(ri, clientId, clientSecret, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agent_pool_profile.0.vnet_subnet_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_profile.0.network_plugin", "kubenet"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.network_plugin"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.dns_service_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.docker_bridge_cidr"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.service_cidr"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(t *testing.T) {
+	dataSourceName := "data.azurerm_kubernetes_cluster.test"
+	ri := acctest.RandInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	location := testLocation()
+	config := testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(ri, clientId, clientSecret, location)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -145,7 +203,19 @@ data "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzure(rInt int, clientId string, clientSecret string, location string) string {
-	resource := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(rInt, clientId, clientSecret, location, "azure")
+	resource := testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location, "azure")
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = "${azurerm_kubernetes_cluster.test.name}"
+  resource_group_name = "${azurerm_kubernetes_cluster.test.resource_group_name}"
+}
+`, resource)
+}
+
+func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureComplete(rInt int, clientId string, clientSecret string, location string) string {
+	resource := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(rInt, clientId, clientSecret, location, "azure")
 	return fmt.Sprintf(`
 %s
 
@@ -157,6 +227,18 @@ data "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenet(rInt int, clientId string, clientSecret string, location string) string {
+	resource := testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location, "kubenet")
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = "${azurerm_kubernetes_cluster.test.name}"
+  resource_group_name = "${azurerm_kubernetes_cluster.test.resource_group_name}"
+}
+`, resource)
+}
+
+func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(rInt int, clientId string, clientSecret string, location string) string {
 	resource := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(rInt, clientId, clientSecret, location, "kubenet")
 	return fmt.Sprintf(`
 %s

--- a/azurerm/data_source_kubernetes_cluster_test.go
+++ b/azurerm/data_source_kubernetes_cluster_test.go
@@ -145,7 +145,9 @@ data "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzure(rInt int, clientId string, clientSecret string, location string) string {
-	resource := testAccAzureRMKubernetesCluster_advancedNetworkingAzure(rInt, clientId, clientSecret, location)
+	resource := testAccAzureRMKubernetesCluster_advancedNetworking(
+		rInt, clientId, clientSecret, location,
+		"azure", "", "", "")
 	return fmt.Sprintf(`
 %s
 
@@ -157,7 +159,9 @@ data "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingKubenet(rInt int, clientId string, clientSecret string, location string) string {
-	resource := testAccAzureRMKubernetesCluster_advancedNetworkingKubenet(rInt, clientId, clientSecret, location)
+	resource := testAccAzureRMKubernetesCluster_advancedNetworking(
+		rInt, clientId, clientSecret, location,
+		"kubenet", "", "", "")
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -41,7 +41,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 					serviceCidr := profile["service_cidr"].(string)
 
 					if !((dockerBridgeCidr == "" && dnsServiceIP == "" && serviceCidr == "") ||
-					     (dockerBridgeCidr != "" && dnsServiceIP != "" && serviceCidr != "")) {
+						(dockerBridgeCidr != "" && dnsServiceIP != "" && serviceCidr != "")) {
 						return fmt.Errorf("`docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or neither should be empty.")
 					}
 				}

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -42,7 +42,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 
 					if !((dockerBridgeCidr == "" && dnsServiceIP == "" && serviceCidr == "") ||
 						(dockerBridgeCidr != "" && dnsServiceIP != "" && serviceCidr != "")) {
-						return fmt.Errorf("`docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or neither should be empty.")
+						return fmt.Errorf("`docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or all should be set.")
 					}
 				}
 			}

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -35,16 +35,25 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				profile := rawProfiles[0].(map[string]interface{})
 				networkPlugin := profile["network_plugin"].(string)
 
-				if networkPlugin == "kubenet" || networkPlugin == "azure" {
-					dockerBridgeCidr := profile["docker_bridge_cidr"].(string)
-					dnsServiceIP := profile["dns_service_ip"].(string)
-					serviceCidr := profile["service_cidr"].(string)
-
-					if !((dockerBridgeCidr == "" && dnsServiceIP == "" && serviceCidr == "") ||
-						(dockerBridgeCidr != "" && dnsServiceIP != "" && serviceCidr != "")) {
-						return fmt.Errorf("`docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or all should be set.")
-					}
+				if networkPlugin != "kubenet" && networkPlugin != "azure" {
+					return nil
 				}
+
+				dockerBridgeCidr := profile["docker_bridge_cidr"].(string)
+				dnsServiceIP := profile["dns_service_ip"].(string)
+				serviceCidr := profile["service_cidr"].(string)
+
+				// All empty values.
+				if dockerBridgeCidr == "" && dnsServiceIP == "" && serviceCidr == "" {
+					return nil
+				}
+
+				// All set values.
+				if dockerBridgeCidr != "" && dnsServiceIP != "" && serviceCidr != "" {
+					return nil
+				}
+
+				return fmt.Errorf("`docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or all should be set.")
 			}
 
 			return nil

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -23,30 +23,6 @@ func resourceArmKubernetesCluster() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		CustomizeDiff: func(diff *schema.ResourceDiff, v interface{}) error {
-			if v, exists := diff.GetOk("network_profile"); exists {
-				rawProfiles := v.([]interface{})
-				if len(rawProfiles) == 0 {
-					return nil
-				}
-
-				// then ensure the conditionally-required fields are set
-				profile := rawProfiles[0].(map[string]interface{})
-				networkPlugin := profile["network_plugin"].(string)
-
-				if networkPlugin == "kubenet" {
-					dockerBridgeCidr := profile["docker_bridge_cidr"].(string)
-					dnsServiceIP := profile["dns_service_ip"].(string)
-					serviceCidr := profile["service_cidr"].(string)
-
-					if dockerBridgeCidr == "" || dnsServiceIP == "" || serviceCidr == "" {
-						return fmt.Errorf("If the `network_plugin` is set to `kubenet` then the fields `docker_bridge_cidr`, `dns_service_ip` and `service_cidr` must not be empty.")
-					}
-				}
-			}
-
-			return nil
-		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -183,7 +183,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(),"kubenet")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(), "kubenet")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -206,7 +206,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(t *testin
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(ri, clientId, clientSecret, testLocation(),"kubenet")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(ri, clientId, clientSecret, testLocation(), "kubenet")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -229,7 +229,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzure(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(),"azure")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(), "azure")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -252,7 +252,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t *testing.
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(ri, clientId, clientSecret, testLocation(),"azure")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(ri, clientId, clientSecret, testLocation(), "azure")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -491,7 +491,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(rInt int, clientId string, clientSecret string, location string, networkPlugin string) string {
-	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location,  `
+	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location, `
   network_profile {
     network_plugin = "%s"
   }
@@ -499,7 +499,7 @@ func testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(rInt int, clientI
 }
 
 func testAccAzureRMKubernetesCluster_advancedNetworkingComplete(rInt int, clientId string, clientSecret string, location string, networkPlugin string) string {
-	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location,  `
+	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location, `
   network_profile {
     network_plugin = "%s"
     dns_service_ip     = "10.10.0.10"

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -183,7 +183,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(), "kubenet")
+	config := testAccAzureRMKubernetesCluster_advancedNetworking(ri, clientId, clientSecret, testLocation(), "kubenet")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -229,7 +229,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzure(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(), "azure")
+	config := testAccAzureRMKubernetesCluster_advancedNetworking(ri, clientId, clientSecret, testLocation(), "azure")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -433,7 +433,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, rInt, location, rInt, rInt, rInt, clientId, clientSecret)
 }
 
-func testAccAzureRMKubernetesCluster_advancedNetworking(rInt int, clientId string, clientSecret string, location string, networkProfile string) string {
+func testAccAzureRMKubernetesCluster_advancedNetworking(rInt int, clientId string, clientSecret string, location string, networkPlugin string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -485,28 +485,73 @@ resource "azurerm_kubernetes_cluster" "test" {
     client_secret = "%s"
   }
 
-  %s
-}
-`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkProfile)
-}
-
-func testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(rInt int, clientId string, clientSecret string, location string, networkPlugin string) string {
-	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location, `
   network_profile {
     network_plugin = "%s"
   }
-`), networkPlugin)
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkPlugin)
 }
 
 func testAccAzureRMKubernetesCluster_advancedNetworkingComplete(rInt int, clientId string, clientSecret string, location string, networkPlugin string) string {
-	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location, `
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.1.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  tags {
+    environment = "Testing"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.1.0.0/24"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                   = "acctestaks%d"
+  location               = "${azurerm_resource_group.test.location}"
+  resource_group_name    = "${azurerm_resource_group.test.name}"
+  dns_prefix             = "acctestaks%d"
+  kubernetes_version     = "1.7.7"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  agent_pool_profile {
+    name           = "default"
+    count          = "2"
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  service_principal {
+    client_id     = "%s"
+    client_secret = "%s"
+  }
+
   network_profile {
-    network_plugin = "%s"
+    network_plugin     = "%s"
     dns_service_ip     = "10.10.0.10"
     docker_bridge_cidr = "172.18.0.1/16"
     service_cidr       = "10.10.0.0/16"
   }
-`), networkPlugin)
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkPlugin)
 }
 
 func testCheckAzureRMKubernetesClusterExists(name string) resource.TestCheckFunc {

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -183,9 +183,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworking(
-		ri, clientId, clientSecret, testLocation(),
-		"kubenet", "", "", "")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(),"kubenet")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -208,9 +206,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(t *testin
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworking(
-		ri, clientId, clientSecret, testLocation(),
-		"kubenet", "10.10.0.10", "172.18.0.1/16", "10.10.0.0/16")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(ri, clientId, clientSecret, testLocation(),"kubenet")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -233,9 +229,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzure(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworking(
-		ri, clientId, clientSecret, testLocation(),
-		"azure", "", "", "")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(ri, clientId, clientSecret, testLocation(),"azure")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -258,9 +252,7 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t *testing.
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworking(
-		ri, clientId, clientSecret, testLocation(),
-		"azure", "10.10.0.10", "172.18.0.1/16", "10.10.0.0/16")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(ri, clientId, clientSecret, testLocation(),"azure")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -441,9 +433,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, rInt, location, rInt, rInt, rInt, clientId, clientSecret)
 }
 
-func testAccAzureRMKubernetesCluster_advancedNetworking(rInt int, clientId string, clientSecret string, location string,
-	networkProfile string, dnsServiceIp string, dockerBridgeCidr string,
-	serviceCidr string) string {
+func testAccAzureRMKubernetesCluster_advancedNetworking(rInt int, clientId string, clientSecret string, location string, networkProfile string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -495,14 +485,28 @@ resource "azurerm_kubernetes_cluster" "test" {
     client_secret = "%s"
   }
 
-  network_profile {
-    network_plugin     = "%s"
-    dns_service_ip     = "%s"
-    docker_bridge_cidr = "%s"
-    service_cidr       = "%s"
-  }
+  %s
 }
-`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkProfile, dnsServiceIp, dockerBridgeCidr, serviceCidr)
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkProfile)
+}
+
+func testAccAzureRMKubernetesCluster_advancedNetworkingMinimum(rInt int, clientId string, clientSecret string, location string, networkPlugin string) string {
+	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location,  `
+  network_profile {
+    network_plugin = "%s"
+  }
+`), networkPlugin)
+}
+
+func testAccAzureRMKubernetesCluster_advancedNetworkingComplete(rInt int, clientId string, clientSecret string, location string, networkPlugin string) string {
+	return fmt.Sprintf(testAccAzureRMKubernetesCluster_advancedNetworking(rInt, clientId, clientSecret, location,  `
+  network_profile {
+    network_plugin = "%s"
+    dns_service_ip     = "10.10.0.10"
+    docker_bridge_cidr = "172.18.0.1/16"
+    service_cidr       = "10.10.0.0/16"
+  }
+`), networkPlugin)
 }
 
 func testCheckAzureRMKubernetesClusterExists(name string) resource.TestCheckFunc {

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAzureRMKubernetesCluster_agentPoolName(t *testing.T) {
+func TestAzureRMKubernetesCluster_agentPoolName(t *testing.T) {
 	cases := []struct {
 		Input       string
 		ExpectError bool

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -461,12 +461,9 @@ resource "azurerm_kubernetes_cluster" "test" {
     client_id     = "%s"
     client_secret = "%s"
   }
-	
+
   network_profile {
     network_plugin     = "kubenet"
-    dns_service_ip     = "10.10.0.10"
-    docker_bridge_cidr = "172.18.0.1/16"
-    service_cidr       = "10.10.0.0/16"
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
@@ -526,9 +523,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 	
   network_profile {
     network_plugin     = "kubenet"
-    dns_service_ip     = "10.10.0.10"
-    docker_bridge_cidr = "172.18.0.1/16"
-    service_cidr       = "10.10.0.0/16"
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
@@ -585,7 +579,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     client_id     = "%s"
     client_secret = "%s"
   }
-	
+
   network_profile {
     network_plugin = "azure"
   }

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -183,7 +183,9 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingKubenet(ri, clientId, clientSecret, testLocation())
+	config := testAccAzureRMKubernetesCluster_advancedNetworking(
+		ri, clientId, clientSecret, testLocation(),
+		"kubenet", "", "", "")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -206,7 +208,9 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(t *testin
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(ri, clientId, clientSecret, testLocation())
+	config := testAccAzureRMKubernetesCluster_advancedNetworking(
+		ri, clientId, clientSecret, testLocation(),
+		"kubenet", "10.10.0.10", "172.18.0.1/16", "10.10.0.0/16")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -229,7 +233,34 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzure(t *testing.T) {
 	ri := acctest.RandInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_advancedNetworkingAzure(ri, clientId, clientSecret, testLocation())
+	config := testAccAzureRMKubernetesCluster_advancedNetworking(
+		ri, clientId, clientSecret, testLocation(),
+		"azure", "", "", "")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "network_profile.0.network_plugin", "azure"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t *testing.T) {
+	resourceName := "azurerm_kubernetes_cluster.test"
+	ri := acctest.RandInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMKubernetesCluster_advancedNetworking(
+		ri, clientId, clientSecret, testLocation(),
+		"azure", "10.10.0.10", "172.18.0.1/16", "10.10.0.0/16")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -410,7 +441,9 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, rInt, location, rInt, rInt, rInt, clientId, clientSecret)
 }
 
-func testAccAzureRMKubernetesCluster_advancedNetworkingKubenet(rInt int, clientId string, clientSecret string, location string) string {
+func testAccAzureRMKubernetesCluster_advancedNetworking(rInt int, clientId string, clientSecret string, location string,
+														networkProfile string, dnsServiceIp string, dockerBridgeCidr string,
+														serviceCidr string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -463,128 +496,13 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 
   network_profile {
-    network_plugin     = "kubenet"
+    network_plugin     = "%s"
+    dns_service_ip     = "%s"
+    docker_bridge_cidr = "%s"
+    service_cidr       = "%s"
   }
 }
-`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
-}
-
-func testAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete(rInt int, clientId string, clientSecret string, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["10.1.0.0/16"]
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  tags {
-    environment = "Testing"
-  }
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
-  resource_group_name  = "${azurerm_resource_group.test.name}"
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
-  address_prefix       = "10.1.0.0/24"
-}
-
-resource "azurerm_kubernetes_cluster" "test" {
-  name                   = "acctestaks%d"
-  location               = "${azurerm_resource_group.test.location}"
-  resource_group_name    = "${azurerm_resource_group.test.name}"
-  dns_prefix             = "acctestaks%d"
-  kubernetes_version     = "1.7.7"
-
-  linux_profile {
-    admin_username = "acctestuser%d"
-
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
-  }
-
-  agent_pool_profile {
-    name           = "default"
-    count          = "2"
-    vm_size        = "Standard_DS2_v2"
-    vnet_subnet_id = "${azurerm_subnet.test.id}"
-  }
-
-  service_principal {
-    client_id     = "%s"
-    client_secret = "%s"
-  }
-	
-  network_profile {
-    network_plugin     = "kubenet"
-  }
-}
-`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
-}
-
-func testAccAzureRMKubernetesCluster_advancedNetworkingAzure(rInt int, clientId string, clientSecret string, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvirtnet%d"
-  address_space       = ["10.1.0.0/16"]
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  tags {
-    environment = "Testing"
-  }
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "acctestsubnet%d"
-  resource_group_name  = "${azurerm_resource_group.test.name}"
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
-  address_prefix       = "10.1.0.0/24"
-}
-
-resource "azurerm_kubernetes_cluster" "test" {
-  name                   = "acctestaks%d"
-  location               = "${azurerm_resource_group.test.location}"
-  resource_group_name    = "${azurerm_resource_group.test.name}"
-  dns_prefix             = "acctestaks%d"
-  kubernetes_version     = "1.7.7"
-
-  linux_profile {
-    admin_username = "acctestuser%d"
-
-    ssh_key {
-      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
-    }
-  }
-
-  agent_pool_profile {
-    name           = "default"
-    count          = "2"
-    vm_size        = "Standard_DS2_v2"
-    vnet_subnet_id = "${azurerm_subnet.test.id}"
-  }
-
-  service_principal {
-    client_id     = "%s"
-    client_secret = "%s"
-  }
-
-  network_profile {
-    network_plugin = "azure"
-  }
-}
-`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkProfile, dnsServiceIp, dockerBridgeCidr, serviceCidr)
 }
 
 func testCheckAzureRMKubernetesClusterExists(name string) resource.TestCheckFunc {

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -442,8 +442,8 @@ resource "azurerm_kubernetes_cluster" "test" {
 }
 
 func testAccAzureRMKubernetesCluster_advancedNetworking(rInt int, clientId string, clientSecret string, location string,
-														networkProfile string, dnsServiceIp string, dockerBridgeCidr string,
-														serviceCidr string) string {
+	networkProfile string, dnsServiceIp string, dockerBridgeCidr string,
+	serviceCidr string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -217,19 +217,19 @@ The following arguments are supported:
 
 `network_profile` supports the following:
 
-* `network_plugin` - (Required) Network plugin to use for networking. Currently supported values are 'azure' and 'kubenet'. Changing this forces a new resource to be created.
+* `network_plugin` - (Required) Network plugin to use for networking. Currently supported values are `azure` and `kubenet`. Changing this forces a new resource to be created.
 
 -> **NOTE:** When `network_plugin` is set to `azure` - the `vnet_subnet_id` field in the `agent_pool_profile` block must be set.
 
-* `service_cidr` - (Optional) The Network Range used by the Kubernetes service. This is required when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
+* `service_cidr` - (Optional) The Network Range used by the Kubernetes service. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This range should not be used by any network element on or connected to this VNet. Service address CIDR must be smaller than /12.
 
-* `dns_service_ip` - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). This is required when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
+* `dns_service_ip` - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). Changing this forces a new resource to be created.
 
-* `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. This is required when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
+* `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created.
 
-* `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. Changing this forces a new resource to be created.
+* `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. This field can only be set when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
 
 Here's an example of configuring the `kubenet` Networking Profile:
 
@@ -248,10 +248,6 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   network_profile {
     network_plugin     = "kubenet"
-    pod_cidr           = "10.244.0.0/24"
-    dns_service_ip     = "10.10.0.10"
-    docker_bridge_cidr = "172.17.0.1/16"
-    service_cidr       = "10.10.0.0/16"
   }
 }
 ```

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -221,13 +221,13 @@ The following arguments are supported:
 
 -> **NOTE:** When `network_plugin` is set to `azure` - the `vnet_subnet_id` field in the `agent_pool_profile` block must be set.
 
-* `service_cidr` - (Optional) The Network Range used by the Kubernetes service. Changing this forces a new resource to be created.
+* `service_cidr` - (Optional) The Network Range used by the Kubernetes service. This field can only be set together with `dns_service_ip` and `docker_bridge_cidr`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This range should not be used by any network element on or connected to this VNet. Service address CIDR must be smaller than /12.
 
-* `dns_service_ip` - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). Changing this forces a new resource to be created.
+* `dns_service_ip` - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). This field can only be set together with `service_cidr` and `docker_bridge_cidr`. Changing this forces a new resource to be created.
 
-* `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created.
+* `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. This field can only be set together with `service_cidr` and `dns_service_ip`. Changing this forces a new resource to be created.
 
 * `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. This field can only be set when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
1. After sync-up with AKS team, when network plugin is `kubenet`, `dockerBridgeCidr`, `dnsServiceIP `, and `serviceCidr`.
2. Update the test case for `kubenet` scenario.
3. Update the documentation for `azure` and `kubenet`.

The result of related acceptance tests (8/8/2018):
```
=== RUN   TestAccAzureRMKubernetesCluster_importBasic
--- PASS: TestAccAzureRMKubernetesCluster_importBasic (1347.68s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_basic
--- PASS: TestAccAzureRMKubernetesCluster_basic (1466.90s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_internalNetwork
--- PASS: TestAccAzureRMKubernetesCluster_internalNetwork (1505.84s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete (1509.45s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingAzure
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingAzure (1509.38s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingKubenet (1520.81s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete
--- PASS: TestAccAzureRMKubernetesCluster_advancedNetworkingKubenetComplete (1566.04s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_addAgent
--- PASS: TestAccAzureRMKubernetesCluster_addAgent (1966.13s)
PASS
=== RUN   TestAccAzureRMKubernetesCluster_upgradeConfig
--- PASS: TestAccAzureRMKubernetesCluster_upgradeConfig (2089.39s)
PASS
ok    ../azurerm/test-azurerm    2089.524s
```