### PR TITLE
Modify Update and Delete azurerm_role_definition

### DIFF
--- a/azurerm/resource_arm_role_definition.go
+++ b/azurerm/resource_arm_role_definition.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/hashicorp/go-uuid"
@@ -82,8 +83,8 @@ func resourceArmRoleDefinitionCreateUpdate(d *schema.ResourceData, meta interfac
 	client := meta.(*ArmClient).roleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
-	roleDefinitionId := d.Get("role_definition_id").(string)
-	if roleDefinitionId == "" {
+	roleDefinitionId := filepath.Base(d.Id())
+	if roleDefinitionId == "." {
 		uuid, err := uuid.GenerateUUID()
 		if err != nil {
 			return fmt.Errorf("Error generating UUID for Role Assignment: %+v", err)
@@ -163,16 +164,15 @@ func resourceArmRoleDefinitionDelete(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*ArmClient).roleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
-	roleDefinitionId := d.Get("role_definition_id").(string)
 	scope := d.Get("scope").(string)
 
-	resp, err := client.Delete(ctx, scope, roleDefinitionId)
+	resp, err := client.Delete(ctx, scope, filepath.Base(d.Id()))
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting Role Definition %q: %+v", roleDefinitionId, err)
+		return fmt.Errorf("Error deleting Role Definition %q: %+v", filepath.Base(d.Id()), err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_role_definition.go
+++ b/azurerm/resource_arm_role_definition.go
@@ -85,12 +85,15 @@ func resourceArmRoleDefinitionCreateUpdate(d *schema.ResourceData, meta interfac
 
 	roleDefinitionId := filepath.Base(d.Id())
 	if roleDefinitionId == "." {
-		uuid, err := uuid.GenerateUUID()
-		if err != nil {
-			return fmt.Errorf("Error generating UUID for Role Assignment: %+v", err)
-		}
+		roleDefinitionId = d.Get("role_definition_id").(string)
+		if roleDefinitionId == "" {
+			uuid, err := uuid.GenerateUUID()
+			if err != nil {
+				return fmt.Errorf("Error generating UUID for Role Assignment: %+v", err)
+			}
 
-		roleDefinitionId = uuid
+			roleDefinitionId = uuid
+		}
 	}
 
 	name := d.Get("name").(string)

--- a/azurerm/resource_arm_role_definition_test.go
+++ b/azurerm/resource_arm_role_definition_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
@@ -117,11 +118,11 @@ func testCheckAzureRMRoleDefinitionExists(name string) resource.TestCheckFunc {
 		}
 
 		scope := rs.Primary.Attributes["scope"]
-		roleDefinitionId := rs.Primary.Attributes["role_definition_id"]
+		roleDefinitionId := rs.Primary.Attributes["id"]
 
 		client := testAccProvider.Meta().(*ArmClient).roleDefinitionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		resp, err := client.Get(ctx, scope, roleDefinitionId)
+		resp, err := client.Get(ctx, scope, filepath.Base(roleDefinitionId))
 
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
@@ -141,11 +142,11 @@ func testCheckAzureRMRoleDefinitionDestroy(s *terraform.State) error {
 		}
 
 		scope := rs.Primary.Attributes["scope"]
-		roleDefinitionId := rs.Primary.Attributes["role_definition_id"]
+		roleDefinitionId := rs.Primary.Attributes["id"]
 
 		client := testAccProvider.Meta().(*ArmClient).roleDefinitionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		resp, err := client.Get(ctx, scope, roleDefinitionId)
+		resp, err := client.Get(ctx, scope, filepath.Base(roleDefinitionId))
 
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {

--- a/azurerm/resource_arm_role_definition_test.go
+++ b/azurerm/resource_arm_role_definition_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAccAzureRMRoleDefinition_basic(t *testing.T) {
+	resourceName := "azurerm_role_definition.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMRoleDefinition_basic(uuid.New().String(), ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,9 +22,13 @@ func TestAccAzureRMRoleDefinition_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMRoleDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAzureRMRoleDefinition_basic(uuid.New().String(), ri),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRoleDefinitionExists("azurerm_role_definition.test"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0.actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0.actions.0", "*"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0.not_actions.#", "0"),
 				),
 			},
 		},
@@ -32,8 +36,8 @@ func TestAccAzureRMRoleDefinition_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRoleDefinition_complete(t *testing.T) {
+	resourceName := "azurerm_role_definition.test"
 	ri := acctest.RandInt()
-	config := testAccAzureRMRoleDefinition_complete(uuid.New().String(), ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -41,9 +45,14 @@ func TestAccAzureRMRoleDefinition_complete(t *testing.T) {
 		CheckDestroy: testCheckAzureRMRoleDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAzureRMRoleDefinition_complete(uuid.New().String(), ri),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRoleDefinitionExists("azurerm_role_definition.test"),
+					testCheckAzureRMRoleDefinitionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0.actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0.actions.0", "*"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0.not_actions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0.not_actions.0", "Microsoft.Authorization/*/read"),
 				),
 			},
 		},
@@ -90,7 +99,6 @@ func TestAccAzureRMRoleDefinition_update(t *testing.T) {
 
 func TestAccAzureRMRoleDefinition_emptyName(t *testing.T) {
 	resourceName := "azurerm_role_definition.test"
-
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This pull request addresses the issue described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/1540 where the azurerm_role_definition was unable to be updated or deleted.

Changes to Delete:
Changes have been made to get the path of the resource and pull the id from the end.

Changes to CreateOrUpdate:
Now retrieves the id from the end of the path if it exists or generates one if the resource path is empty.

(fixes #1540)