### PR TITLE
azurerm_lb_probe: backport azurestack review comments

### DIFF
--- a/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -23,9 +25,10 @@ func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"location": deprecatedLocationSchema(),
@@ -33,23 +36,30 @@ func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"loadbalancer_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
 			},
 
 			"backend_ip_configurations": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
+				},
+				Set: schema.HashString,
 			},
 
 			"load_balancing_rules": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
+				},
+				Set: schema.HashString,
 			},
 		},
 	}

--- a/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -49,7 +50,7 @@ func resourceArmLoadBalancerNatRule() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				StateFunc:        ignoreCaseStateFunc,
-				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(network.TransportProtocolAll),
 					string(network.TransportProtocolTCP),

--- a/azurerm/resource_arm_loadbalancer_probe.go
+++ b/azurerm/resource_arm_loadbalancer_probe.go
@@ -217,7 +217,9 @@ func resourceArmLoadBalancerProbeRead(d *schema.ResourceData, meta interface{}) 
 				}
 			}
 		}
-		d.Set("load_balancer_rules", load_balancer_rules)
+		if err := d.Set("load_balancer_rules", load_balancer_rules); err != nil {
+			return fmt.Errorf("Error setting `load_balancer_rules` (Load Balancer Probe %q): %+v", name, err)
+		}
 	}
 
 	return nil

--- a/azurerm/resource_arm_loadbalancer_probe.go
+++ b/azurerm/resource_arm_loadbalancer_probe.go
@@ -9,14 +9,18 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func resourceArmLoadBalancerProbe() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmLoadBalancerProbeCreate,
+		Create: resourceArmLoadBalancerProbeCreateUpdate,
 		Read:   resourceArmLoadBalancerProbeRead,
-		Update: resourceArmLoadBalancerProbeCreate,
+		Update: resourceArmLoadBalancerProbeCreateUpdate,
 		Delete: resourceArmLoadBalancerProbeDelete,
 		Importer: &schema.ResourceImporter{
 			State: loadBalancerSubResourceStateImporter,
@@ -24,9 +28,10 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"location": deprecatedLocationSchema(),
@@ -34,9 +39,10 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"loadbalancer_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
 			},
 
 			"protocol": {
@@ -44,12 +50,18 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 				Computed:         true,
 				Optional:         true,
 				StateFunc:        ignoreCaseStateFunc,
-				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.ProbeProtocolHTTP),
+					string(network.ProbeProtocolHTTPS),
+					string(network.ProbeProtocolTCP),
+				}, true),
 			},
 
 			"port": {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validate.PortNumber,
 			},
 
 			"request_path": {
@@ -58,9 +70,10 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 			},
 
 			"interval_in_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  15,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      15,
+				ValidateFunc: validation.IntAtLeast(5),
 			},
 
 			"number_of_probes": {
@@ -72,14 +85,17 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 			"load_balancer_rules": {
 				Type:     schema.TypeSet,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.NoZeroValues,
+				},
+				Set: schema.HashString,
 			},
 		},
 	}
 }
 
-func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmLoadBalancerProbeCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).loadBalancerClient
 	ctx := meta.(*ArmClient).StopContext
 
@@ -97,11 +113,7 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 
-	newProbe, err := expandAzureRmLoadBalancerProbe(d, loadBalancer)
-	if err != nil {
-		return fmt.Errorf("Error Expanding Probe: %+v", err)
-	}
-
+	newProbe := expandAzureRmLoadBalancerProbe(d)
 	probes := append(*loadBalancer.LoadBalancerPropertiesFormat.Probes, *newProbe)
 
 	existingProbe, existingProbeIndex, exists := findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
@@ -189,19 +201,24 @@ func resourceArmLoadBalancerProbeRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("name", config.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("protocol", config.ProbePropertiesFormat.Protocol)
-	d.Set("interval_in_seconds", config.ProbePropertiesFormat.IntervalInSeconds)
-	d.Set("number_of_probes", config.ProbePropertiesFormat.NumberOfProbes)
-	d.Set("port", config.ProbePropertiesFormat.Port)
-	d.Set("request_path", config.ProbePropertiesFormat.RequestPath)
 
-	var load_balancer_rules []string
-	if config.ProbePropertiesFormat.LoadBalancingRules != nil {
-		for _, ruleConfig := range *config.ProbePropertiesFormat.LoadBalancingRules {
-			load_balancer_rules = append(load_balancer_rules, *ruleConfig.ID)
+	if properties := config.ProbePropertiesFormat; properties != nil {
+		d.Set("protocol", properties.Protocol)
+		d.Set("interval_in_seconds", properties.IntervalInSeconds)
+		d.Set("number_of_probes", properties.NumberOfProbes)
+		d.Set("port", properties.Port)
+		d.Set("request_path", properties.RequestPath)
+
+		var load_balancer_rules []string
+		if rules := properties.LoadBalancingRules; rules != nil {
+			for _, ruleConfig := range *rules {
+				if id := ruleConfig.ID; id != nil {
+					load_balancer_rules = append(load_balancer_rules, *id)
+				}
+			}
 		}
+		d.Set("load_balancer_rules", load_balancer_rules)
 	}
-	d.Set("load_balancer_rules", load_balancer_rules)
 
 	return nil
 }
@@ -258,7 +275,7 @@ func resourceArmLoadBalancerProbeDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func expandAzureRmLoadBalancerProbe(d *schema.ResourceData, lb *network.LoadBalancer) (*network.Probe, error) {
+func expandAzureRmLoadBalancerProbe(d *schema.ResourceData) *network.Probe {
 
 	properties := network.ProbePropertiesFormat{
 		NumberOfProbes:    utils.Int32(int32(d.Get("number_of_probes").(int))),
@@ -274,10 +291,8 @@ func expandAzureRmLoadBalancerProbe(d *schema.ResourceData, lb *network.LoadBala
 		properties.RequestPath = utils.String(v.(string))
 	}
 
-	probe := network.Probe{
+	return &network.Probe{
 		Name: utils.String(d.Get("name").(string)),
 		ProbePropertiesFormat: &properties,
 	}
-
-	return &probe, nil
 }

--- a/website/docs/r/loadbalancer_probe.html.markdown
+++ b/website/docs/r/loadbalancer_probe.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_lb_probe
 
-Create a LoadBalancer Probe Resource.
+Manages a LoadBalancer Probe Resource.
 
 ~> **NOTE** When using this resource, the LoadBalancer needs to have a FrontEnd IP Configuration Attached
 
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Probe.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule.
-* `protocol` - (Optional) Specifies the protocol of the end point. Possible values are `Http` or `Tcp`. If Tcp is specified, a received ACK is required for the probe to be successful. If Http is specified, a 200 OK response from the specified URI is required for the probe to be successful.
+* `protocol` - (Optional) Specifies the protocol of the end point. Possible values are `Http`, `Https` or `Tcp`. If Tcp is specified, a received ACK is required for the probe to be successful. If Http is specified, a 200 OK response from the specified URI is required for the probe to be successful.
 * `port` - (Required) Port on which the Probe queries the backend endpoint. Possible values range from 1 to 65535, inclusive.
 * `request_path` - (Optional) The URI used for requesting health status from the backend endpoint. Required if protocol is set to Http. Otherwise, it is not allowed.
 * `interval_in_seconds` - (Optional) The interval, in seconds between probes to the backend endpoint for health status. The default value is 15, the minimum value is 5.


### PR DESCRIPTION
backport of issues found in [this pr](https://github.com/terraform-providers/terraform-provider-azurestack/pull/23)

also explicitly adds `Https` support to `protocol` property.

