### PR TITLE
Fix #502 - Terraform loses access token and requires az login

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -334,6 +334,13 @@ func getAuthorizationToken(c *authentication.Config, oauthConfig *adal.OAuthConf
 		return nil, err
 	}
 
+	// Set a callback which updates the azure cli refresh token on disk
+	if c.IsAzureCLI {
+		spt.SetRefreshCallbacks([]adal.TokenRefreshCallback{
+			c.AzureCLIRefreshCallback,
+		})
+	}
+
 	err = spt.Refresh()
 
 	if err != nil {

--- a/azurerm/helpers/authentication/access_token.go
+++ b/azurerm/helpers/authentication/access_token.go
@@ -29,8 +29,7 @@ func findValidAccessTokenForTenant(tokens []cli.Token, tenantId string) (*Access
 		}
 
 		if expirationDate.UTC().Before(time.Now().UTC()) {
-			log.Printf("[DEBUG] Token %q has expired", token.AccessToken)
-			continue
+			log.Printf("[DEBUG] Token %q has expired but will be renewed", token.AccessToken)
 		}
 
 		if !strings.Contains(accessToken.Resource, "management") {


### PR DESCRIPTION
This PR uses the callbacks present in the ADAL library along with a 'find and replace in file' function. These changes allow TF to use an expired token and persist the updated refresh token back to the AzureCLI file. 