### PR TITLE
Auto Scale: filter out the `$tags` tag

### DIFF
--- a/azurerm/resource_arm_autoscale_setting.go
+++ b/azurerm/resource_arm_autoscale_setting.go
@@ -432,7 +432,9 @@ func resourceArmAutoScaleSettingRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error setting `notification` of Autoscale Setting %q (resource group %q): %+v", name, resourceGroup, err)
 	}
 
-	flattenAndSetTags(d, resp.Tags)
+	// Return a new tag map filtered by the specified tag names.
+	tagMap := filterTags(resp.Tags, "$type")
+	flattenAndSetTags(d, tagMap)
 
 	return nil
 }

--- a/azurerm/resource_arm_autoscale_setting_test.go
+++ b/azurerm/resource_arm_autoscale_setting_test.go
@@ -31,6 +31,7 @@ func TestAccAzureRMAutoScaleSetting_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "profile.0.name", "metricRules"),
 					resource.TestCheckResourceAttr(resourceName, "profile.0.rule.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "notification.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "tags.$type"),
 				),
 			},
 		},


### PR DESCRIPTION
Prior to this change (with the acctest fix contained in this PR):

```
$ acctests azurerm TestAccAzureRMAutoScaleSetting_basic
=== RUN   TestAccAzureRMAutoScaleSetting_basic
--- FAIL: TestAccAzureRMAutoScaleSetting_basic (400.30s)
	testing.go:513: Step 0 error: Check failed: Check 7/7 error: azurerm_autoscale_setting.test: Attribute 'tags.$type' found when not expected
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	400.721s
```

Now:

```
$ acctests azurerm TestAccAzureRMAutoScaleSetting_basic
=== RUN   TestAccAzureRMAutoScaleSetting_basic
--- PASS: TestAccAzureRMAutoScaleSetting_basic (399.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	400.321s
```

Fixes #1661