### PR TITLE
Fix indentation on application_gateway.html.markdown

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -285,8 +285,8 @@ The `http_listener` block supports:
 
 * `require_sni` - (Optional) Applicable only if protocol is https. Enables SNI for multi-hosting.
   Valid values are:
-* true
-* false (default)
+  * `true`
+  * `false` (default)
 
 The `probe` block supports:
 


### PR DESCRIPTION
The options for `require_sni` were not indented/formatted consistently with the rest of the page