### PR TITLE
Added support for EventHub compatible EndPoints and Paths

### DIFF
--- a/azurerm/resource_arm_iothub.go
+++ b/azurerm/resource_arm_iothub.go
@@ -87,6 +87,24 @@ func resourceArmIotHub() *schema.Resource {
 				Computed: true,
 			},
 
+			"event_hub_events_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"event_hub_operations_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"event_hub_events_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"event_hub_operations_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"shared_access_policy": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -206,6 +224,29 @@ func resourceArmIotHubRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if properties := hub.Properties; properties != nil {
+
+		for k, v := range properties.EventHubEndpoints {
+			if v == nil {
+				continue
+			}
+			if k == "events" {
+				if v.Endpoint != nil {
+					d.Set("event_hub_events_endpoint", *v.Endpoint)
+				}
+				if v.Path != nil {
+					d.Set("event_hub_events_path", *v.Path)
+				}
+			} else if k == "operationsMonitoringEvents" {
+				if v.Endpoint != nil {
+					d.Set("event_hub_operations_endpoint", *v.Endpoint)
+				}
+				if v.Path != nil {
+					d.Set("event_hub_operations_path", *v.Path)
+				}
+			}
+
+		}
+
 		d.Set("hostname", properties.HostName)
 	}
 

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -68,6 +68,10 @@ The following attributes are exported:
 
 * `shared_access_policy` - One or more `shared_access_policy` blocks as defined below.
 
+* `event_hub_[events|operations]_endpoint` -  The EventHub compatible endpoint for either the events or operational data (in conjunction with the path and share access policy, can be used to build a connection string)
+
+* `event_hub_[events|operations]_path` -  The EventHub compatible path for either the events or operational data (in conjunction with the endpoint and share access policy, can be used to build a connection string).
+
 ---
 
 A `shared access policy` block contains the following:

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -64,13 +64,16 @@ The following attributes are exported:
 
 * `id` - The ID of the IoTHub.
 
+* `event_hub_events_endpoint` -  The EventHub compatible endpoint for events data
+* `event_hub_events_path` -  The EventHub compatible path for events data
+* `event_hub_operations_endpoint` -  The EventHub compatible endpoint for operational data
+* `event_hub_operations_path` -  The EventHub compatible path for operational data
+
+-> **NOTE:** These fields can be used in conjunction with the `shared_access_policy` block to build a connection string
+
 * `hostname` - The hostname of the IotHub Resource.
 
 * `shared_access_policy` - One or more `shared_access_policy` blocks as defined below.
-
-* `event_hub_[events|operations]_endpoint` -  The EventHub compatible endpoint for either the events or operational data (in conjunction with the path and share access policy, can be used to build a connection string)
-
-* `event_hub_[events|operations]_path` -  The EventHub compatible path for either the events or operational data (in conjunction with the endpoint and share access policy, can be used to build a connection string).
 
 ---
 


### PR DESCRIPTION
Hello I am looking for feedback on this pull request.
The PR is the fulfill this feature request: https://github.com/terraform-providers/terraform-provider-azurerm/issues/1743

It's a simple pull request whose objective is to expose the `Endpoint` and `Path` properties of each Endpoint in the Events Hub Compatible endpoints that the IoT Gateway exposes.

I created 4 new properties:
```
event_hub_events_endpoint
event_hub_events_path
event_hub_operations_endpoint
event_hub_operations_path
```

Fixes #1743