### PR TITLE
Storage: Import Support

### DIFF
--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -218,8 +218,8 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	// gives us https://example.core.windows.net/container/file.vhd
-	id := fmt.Sprintf("https://%s.%s/%s/%s", storageAccountName, env.StorageEndpointSuffix, cont, name)
+	// gives us https://example.blob.core.windows.net/container/file.vhd
+	id := fmt.Sprintf("https://%s.blob.%s/%s/%s", storageAccountName, env.StorageEndpointSuffix, cont, name)
 	d.SetId(id)
 	return resourceArmStorageBlobRead(d, meta)
 }
@@ -735,7 +735,7 @@ func parseStorageBlobID(input string, environment azure.Environment) (*storageBl
 		return nil, fmt.Errorf("Expected number of segments in the path to be < 2 but got %d", len(segments))
 	}
 
-	storageAccountName := strings.Replace(uri.Host, fmt.Sprintf(".%s", environment.StorageEndpointSuffix), "", 1)
+	storageAccountName := strings.Replace(uri.Host, fmt.Sprintf(".blob.%s", environment.StorageEndpointSuffix), "", 1)
 	containerName := segments[0]
 	blobName := strings.TrimPrefix(uri.Path, fmt.Sprintf("/%s/", containerName))
 

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -27,6 +27,9 @@ func resourceArmStorageBlob() *schema.Resource {
 		Delete:        resourceArmStorageBlobDelete,
 		MigrateState:  resourceStorageBlobMigrateState,
 		SchemaVersion: 1,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/resource_arm_storage_blob_migration.go
+++ b/azurerm/resource_arm_storage_blob_migration.go
@@ -1,0 +1,40 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceStorageBlobMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AzureRM Storage Blob State v0; migrating to v1")
+		return migrateStorageBlobStateV0toV1(is, meta)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateStorageBlobStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] ARM Storage Blob Attributes before Migration: %#v", is.Attributes)
+
+	environment := meta.(*ArmClient).environment
+
+	blobName := is.Attributes["name"]
+	containerName := is.Attributes["storage_container_name"]
+	storageAccountName := is.Attributes["storage_account_name"]
+	newID := fmt.Sprintf("https://%s.%s/%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName, blobName)
+	is.Attributes["id"] = newID
+	is.ID = newID
+
+	log.Printf("[DEBUG] ARM Storage Blob Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/azurerm/resource_arm_storage_blob_migration.go
+++ b/azurerm/resource_arm_storage_blob_migration.go
@@ -30,7 +30,7 @@ func migrateStorageBlobStateV0toV1(is *terraform.InstanceState, meta interface{}
 	blobName := is.Attributes["name"]
 	containerName := is.Attributes["storage_container_name"]
 	storageAccountName := is.Attributes["storage_account_name"]
-	newID := fmt.Sprintf("https://%s.%s/%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName, blobName)
+	newID := fmt.Sprintf("https://%s.blob.%s/%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName, blobName)
 	is.Attributes["id"] = newID
 	is.ID = newID
 

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -1,0 +1,67 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
+// as we want to run this depending on the cloud we're in.
+func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
+	config := testGetAzureConfig(t)
+	if config == nil {
+		t.SkipNow()
+		return
+	}
+
+	client, err := getArmClient(config)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
+		return
+	}
+
+	client.StopContext = testAccProvider.StopContext()
+
+	suffix := client.environment.StorageEndpointSuffix
+
+	cases := map[string]struct {
+		StateVersion       int
+		ID                 string
+		InputAttributes    map[string]string
+		ExpectedAttributes map[string]string
+	}{
+		"v0_1_without_value": {
+			StateVersion: 0,
+			ID:           "some_id",
+			InputAttributes: map[string]string{
+				"name": "blob.vhd",
+				"storage_container_name": "container",
+				"storage_account_name":   "example",
+			},
+			ExpectedAttributes: map[string]string{
+				"id": fmt.Sprintf("https://example.%s/container/blob.vhd", suffix),
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.InputAttributes,
+		}
+		is, err := resourceStorageBlobMigrateState(tc.StateVersion, is, client)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.ExpectedAttributes {
+			actual := is.Attributes[k]
+			if actual != v {
+				t.Fatalf("Bad Storage Blob Migrate for %q: %q\n\n expected: %q", k, actual, v)
+			}
+		}
+	}
+}

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 				"storage_account_name":   "example",
 			},
 			ExpectedAttributes: map[string]string{
-				"id": fmt.Sprintf("https://example.%s/container/blob.vhd", suffix),
+				"id": fmt.Sprintf("https://example.blob.%s/container/blob.vhd", suffix),
 			},
 		},
 	}

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -144,6 +144,7 @@ func TestResourceAzureRMStorageBlobAttempts_validation(t *testing.T) {
 }
 
 func TestAccAzureRMStorageBlob_basic(t *testing.T) {
+	resourceName := "azurerm_storage_blob.test"
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
 	config := testAccAzureRMStorageBlob_basic(ri, rs, testLocation())
@@ -156,14 +157,20 @@ func TestAccAzureRMStorageBlob_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageBlobExists("azurerm_storage_blob.test"),
+					testCheckAzureRMStorageBlobExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
+	resourceName := "azurerm_storage_blob.test"
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
 	config := testAccAzureRMStorageBlob_basic(ri, rs, testLocation())
@@ -176,8 +183,8 @@ func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageBlobExists("azurerm_storage_blob.test"),
-					testCheckAzureRMStorageBlobDisappears("azurerm_storage_blob.test"),
+					testCheckAzureRMStorageBlobExists(resourceName),
+					testCheckAzureRMStorageBlobDisappears(resourceName),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -221,6 +228,7 @@ func TestAccAzureRMStorageBlobBlock_source(t *testing.T) {
 }
 
 func TestAccAzureRMStorageBlobPage_source(t *testing.T) {
+	resourceName := "azurerm_storage_blob.source"
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
 	sourceBlob, err := ioutil.TempFile("", "")
@@ -272,14 +280,20 @@ func TestAccAzureRMStorageBlobPage_source(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageBlobMatchesFile("azurerm_storage_blob.source", storage.BlobTypePage, sourceBlob.Name()),
+					testCheckAzureRMStorageBlobMatchesFile(resourceName, storage.BlobTypePage, sourceBlob.Name()),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccAzureRMStorageBlob_source_uri(t *testing.T) {
+	resourceName := "azurerm_storage_blob.destination"
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
 	sourceBlob, err := ioutil.TempFile("", "")
@@ -307,8 +321,13 @@ func TestAccAzureRMStorageBlob_source_uri(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageBlobMatchesFile("azurerm_storage_blob.destination", storage.BlobTypeBlock, sourceBlob.Name()),
+					testCheckAzureRMStorageBlobMatchesFile(resourceName, storage.BlobTypeBlock, sourceBlob.Name()),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -161,9 +161,10 @@ func TestAccAzureRMStorageBlob_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "type"},
 			},
 		},
 	})
@@ -283,11 +284,6 @@ func TestAccAzureRMStorageBlobPage_source(t *testing.T) {
 					testCheckAzureRMStorageBlobMatchesFile(resourceName, storage.BlobTypePage, sourceBlob.Name()),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -325,9 +321,10 @@ func TestAccAzureRMStorageBlob_source_uri(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "type"},
 			},
 		},
 	})
@@ -702,31 +699,32 @@ resource "azurerm_storage_account" "source" {
 }
 
 resource "azurerm_storage_container" "source" {
-    name = "source"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_name = "${azurerm_storage_account.source.name}"
-    container_access_type = "blob"
+  name = "source"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  storage_account_name = "${azurerm_storage_account.source.name}"
+  container_access_type = "blob"
 }
 
 resource "azurerm_storage_blob" "source" {
-    name = "source.vhd"
+  name = "source.vhd"
 
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_name = "${azurerm_storage_account.source.name}"
-    storage_container_name = "${azurerm_storage_container.source.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  storage_account_name = "${azurerm_storage_account.source.name}"
+  storage_container_name = "${azurerm_storage_container.source.name}"
 
-    type = "block"
-    source = "%s"
-    parallelism = 4
-    attempts = 2
+  type = "block"
+  source = "%s"
+  parallelism = 4
+  attempts = 2
 }
 
 resource "azurerm_storage_blob" "destination" {
-    name = "destination.vhd"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_name = "${azurerm_storage_account.source.name}"
-    storage_container_name = "${azurerm_storage_container.source.name}"
-    source_uri = "${azurerm_storage_blob.source.url}"
+  name = "destination.vhd"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  storage_account_name = "${azurerm_storage_account.source.name}"
+  storage_container_name = "${azurerm_storage_container.source.name}"
+  source_uri = "${azurerm_storage_blob.source.url}"
+  type = "block"
 }
 `, rInt, location, rString, sourceBlobName)
 }

--- a/azurerm/resource_arm_storage_container.go
+++ b/azurerm/resource_arm_storage_container.go
@@ -129,7 +129,7 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error setting permissions for container %s in storage account %s: %+v", name, storageAccountName, err)
 	}
 
-	id := fmt.Sprintf("https://%s.%s/%s", storageAccountName, armClient.environment.StorageEndpointSuffix, name)
+	id := fmt.Sprintf("https://%s.blob.%s/%s", storageAccountName, armClient.environment.StorageEndpointSuffix, name)
 	d.SetId(id)
 	return resourceArmStorageContainerRead(d, meta)
 }
@@ -310,7 +310,7 @@ func parseStorageContainerID(input string, environment azure.Environment) (*stor
 		return nil, fmt.Errorf("Expected number of segments in the path to be < 1 but got %d", len(segments))
 	}
 
-	storageAccountName := strings.Replace(uri.Host, fmt.Sprintf(".%s", environment.StorageEndpointSuffix), "", 1)
+	storageAccountName := strings.Replace(uri.Host, fmt.Sprintf(".blob.%s", environment.StorageEndpointSuffix), "", 1)
 	containerName := segments[0]
 
 	id := storageContainerId{

--- a/azurerm/resource_arm_storage_container.go
+++ b/azurerm/resource_arm_storage_container.go
@@ -22,6 +22,9 @@ func resourceArmStorageContainer() *schema.Resource {
 		Delete:        resourceArmStorageContainerDelete,
 		MigrateState:  resourceStorageContainerMigrateState,
 		SchemaVersion: 1,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/resource_arm_storage_container.go
+++ b/azurerm/resource_arm_storage_container.go
@@ -3,22 +3,25 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
-	"regexp"
-
 	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func resourceArmStorageContainer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmStorageContainerCreate,
-		Read:   resourceArmStorageContainerRead,
-		Exists: resourceArmStorageContainerExists,
-		Delete: resourceArmStorageContainerDelete,
+		Create:        resourceArmStorageContainerCreate,
+		Read:          resourceArmStorageContainerRead,
+		Exists:        resourceArmStorageContainerExists,
+		Delete:        resourceArmStorageContainerDelete,
+		MigrateState:  resourceStorageContainerMigrateState,
+		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -40,6 +43,7 @@ func resourceArmStorageContainer() *schema.Resource {
 				Default:      "private",
 				ValidateFunc: validateArmStorageContainerAccessType,
 			},
+
 			"properties": {
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -122,8 +126,157 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error setting permissions for container %s in storage account %s: %+v", name, storageAccountName, err)
 	}
 
-	d.SetId(name)
+	id := fmt.Sprintf("https://%s.%s/%s", storageAccountName, armClient.environment.StorageEndpointSuffix, name)
+	d.SetId(id)
 	return resourceArmStorageContainerRead(d, meta)
+}
+
+// resourceAzureStorageContainerRead does all the necessary API calls to
+// read the status of the storage container off Azure.
+func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+	ctx := armClient.StopContext
+
+	id, err := parseStorageContainerID(d.Id(), armClient.environment)
+	if err != nil {
+		return err
+	}
+
+	resourceGroup, err := determineResourceGroupForStorageAccount(id.storageAccountName, armClient)
+	if err != nil {
+		return err
+	}
+	if resourceGroup == nil {
+		log.Printf("Cannot locate Resource Group for Storage Account %q (presuming it's gone) - removing from state", id.storageAccountName)
+		d.SetId("")
+		return nil
+	}
+
+	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
+	if err != nil {
+		return err
+	}
+	if !accountExists {
+		log.Printf("[DEBUG] Storage account %q not found, removing container %q from state", id.storageAccountName, d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	containers, err := blobClient.ListContainers(storage.ListContainersParameters{
+		Prefix:  id.containerName,
+		Timeout: 90,
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve storage containers in account %q: %s", id.containerName, err)
+	}
+
+	var container *storage.Container
+	for _, cont := range containers.Containers {
+		if cont.Name == id.containerName {
+			container = &cont
+			break
+		}
+	}
+
+	if container == nil {
+		log.Printf("[INFO] Storage container %q does not exist in account %q, removing from state...", id.containerName, id.storageAccountName)
+		d.SetId("")
+		return nil
+	}
+
+	output := make(map[string]interface{})
+
+	output["last_modified"] = container.Properties.LastModified
+	output["lease_status"] = container.Properties.LeaseStatus
+	output["lease_state"] = container.Properties.LeaseState
+	output["lease_duration"] = container.Properties.LeaseDuration
+
+	if err := d.Set("properties", output); err != nil {
+		return fmt.Errorf("Error flattening `properties`: %+v", err)
+	}
+
+	return nil
+}
+
+func resourceArmStorageContainerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	armClient := meta.(*ArmClient)
+	ctx := armClient.StopContext
+
+	id, err := parseStorageContainerID(d.Id(), armClient.environment)
+	if err != nil {
+		return false, err
+	}
+
+	resourceGroup, err := determineResourceGroupForStorageAccount(id.storageAccountName, armClient)
+	if err != nil {
+		return false, err
+	}
+	if resourceGroup == nil {
+		log.Printf("Cannot locate Resource Group for Storage Account %q (presuming it's gone) - removing from state", id.storageAccountName)
+		return false, nil
+	}
+
+	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
+	if err != nil {
+		return false, err
+	}
+	if !accountExists {
+		log.Printf("[DEBUG] Storage account %q not found, removing container %q from state", id.storageAccountName, d.Id())
+		d.SetId("")
+		return false, nil
+	}
+
+	log.Printf("[INFO] Checking existence of storage container %q in storage account %q", id.containerName, id.storageAccountName)
+	reference := blobClient.GetContainerReference(id.containerName)
+	exists, err := reference.Exists()
+	if err != nil {
+		return false, fmt.Errorf("Error querying existence of storage container %q in storage account %q: %s", id.containerName, id.storageAccountName, err)
+	}
+
+	if !exists {
+		log.Printf("[INFO] Storage container %q does not exist in account %q, removing from state...", id.containerName, id.storageAccountName)
+	}
+
+	return exists, nil
+}
+
+// resourceAzureStorageContainerDelete does all the necessary API calls to
+// delete a storage container off Azure.
+func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{}) error {
+	armClient := meta.(*ArmClient)
+	ctx := armClient.StopContext
+
+	id, err := parseStorageContainerID(d.Id(), armClient.environment)
+	if err != nil {
+		return err
+	}
+
+	resourceGroup, err := determineResourceGroupForStorageAccount(id.storageAccountName, armClient)
+	if err != nil {
+		return err
+	}
+	if resourceGroup == nil {
+		log.Printf("Cannot locate Resource Group for Storage Account %q (presuming it's gone) - removing from state", id.storageAccountName)
+		return nil
+	}
+
+	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
+	if err != nil {
+		return err
+	}
+	if !accountExists {
+		log.Printf("[INFO] Storage Account %q doesn't exist so the container won't exist", id.storageAccountName)
+		return nil
+	}
+
+	log.Printf("[INFO] Deleting storage container %q in account %q", id.containerName, id.storageAccountName)
+	reference := blobClient.GetContainerReference(id.containerName)
+	deleteOptions := &storage.DeleteContainerOptions{}
+	if _, err := reference.DeleteIfExists(deleteOptions); err != nil {
+		return fmt.Errorf("Error deleting storage container %q from storage account %q: %s", id.containerName, id.storageAccountName, err)
+	}
+
+	return nil
 }
 
 func checkContainerIsCreated(reference *storage.Container) func() *resource.RetryError {
@@ -138,118 +291,28 @@ func checkContainerIsCreated(reference *storage.Container) func() *resource.Retr
 	}
 }
 
-// resourceAzureStorageContainerRead does all the necessary API calls to
-// read the status of the storage container off Azure.
-func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) error {
-	armClient := meta.(*ArmClient)
-	ctx := armClient.StopContext
-
-	resourceGroupName := d.Get("resource_group_name").(string)
-	storageAccountName := d.Get("storage_account_name").(string)
-
-	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroupName, storageAccountName)
-	if err != nil {
-		return err
-	}
-	if !accountExists {
-		log.Printf("[DEBUG] Storage account %q not found, removing container %q from state", storageAccountName, d.Id())
-		d.SetId("")
-		return nil
-	}
-
-	name := d.Get("name").(string)
-	containers, err := blobClient.ListContainers(storage.ListContainersParameters{
-		Prefix:  name,
-		Timeout: 90,
-	})
-	if err != nil {
-		return fmt.Errorf("Failed to retrieve storage containers in account %q: %s", name, err)
-	}
-
-	var found bool
-	for _, cont := range containers.Containers {
-		if cont.Name == name {
-			found = true
-
-			props := make(map[string]interface{})
-			props["last_modified"] = cont.Properties.LastModified
-			props["lease_status"] = cont.Properties.LeaseStatus
-			props["lease_state"] = cont.Properties.LeaseState
-			props["lease_duration"] = cont.Properties.LeaseDuration
-
-			d.Set("properties", props)
-		}
-	}
-
-	if !found {
-		log.Printf("[INFO] Storage container %q does not exist in account %q, removing from state...", name, storageAccountName)
-		d.SetId("")
-	}
-
-	return nil
+type storageContainerId struct {
+	storageAccountName string
+	containerName      string
 }
 
-func resourceArmStorageContainerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	armClient := meta.(*ArmClient)
-	ctx := armClient.StopContext
-
-	resourceGroupName := d.Get("resource_group_name").(string)
-	storageAccountName := d.Get("storage_account_name").(string)
-
-	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroupName, storageAccountName)
+func parseStorageContainerID(input string, environment azure.Environment) (*storageContainerId, error) {
+	uri, err := url.Parse(input)
 	if err != nil {
-		return false, err
-	}
-	if !accountExists {
-		log.Printf("[DEBUG] Storage account %q not found, removing container %q from state", storageAccountName, d.Id())
-		d.SetId("")
-		return false, nil
+		return nil, fmt.Errorf("Error parsing %q as URI: %+v", input, err)
 	}
 
-	name := d.Get("name").(string)
-
-	log.Printf("[INFO] Checking existence of storage container %q in storage account %q", name, storageAccountName)
-	reference := blobClient.GetContainerReference(name)
-	exists, err := reference.Exists()
-	if err != nil {
-		return false, fmt.Errorf("Error querying existence of storage container %q in storage account %q: %s", name, storageAccountName, err)
+	segments := strings.Split(uri.Path, "/")
+	if len(segments) < 1 {
+		return nil, fmt.Errorf("Expected number of segments in the path to be < 1 but got %d", len(segments))
 	}
 
-	if !exists {
-		log.Printf("[INFO] Storage container %q does not exist in account %q, removing from state...", name, storageAccountName)
-		d.SetId("")
+	storageAccountName := strings.Replace(uri.Host, fmt.Sprintf(".%s", environment.StorageEndpointSuffix), "", 1)
+	containerName := segments[0]
+
+	id := storageContainerId{
+		storageAccountName: storageAccountName,
+		containerName:      containerName,
 	}
-
-	return exists, nil
-}
-
-// resourceAzureStorageContainerDelete does all the necessary API calls to
-// delete a storage container off Azure.
-func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{}) error {
-	armClient := meta.(*ArmClient)
-	ctx := armClient.StopContext
-
-	resourceGroupName := d.Get("resource_group_name").(string)
-	storageAccountName := d.Get("storage_account_name").(string)
-
-	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroupName, storageAccountName)
-	if err != nil {
-		return err
-	}
-	if !accountExists {
-		log.Printf("[INFO]Storage Account %q doesn't exist so the container won't exist", storageAccountName)
-		return nil
-	}
-
-	name := d.Get("name").(string)
-
-	log.Printf("[INFO] Deleting storage container %q in account %q", name, storageAccountName)
-	reference := blobClient.GetContainerReference(name)
-	deleteOptions := &storage.DeleteContainerOptions{}
-	if _, err := reference.DeleteIfExists(deleteOptions); err != nil {
-		return fmt.Errorf("Error deleting storage container %q from storage account %q: %s", name, storageAccountName, err)
-	}
-
-	d.SetId("")
-	return nil
+	return &id, nil
 }

--- a/azurerm/resource_arm_storage_container_migration.go
+++ b/azurerm/resource_arm_storage_container_migration.go
@@ -29,7 +29,7 @@ func migrateStorageContainerStateV0toV1(is *terraform.InstanceState, meta interf
 
 	containerName := is.Attributes["name"]
 	storageAccountName := is.Attributes["storage_account_name"]
-	newID := fmt.Sprintf("https://%s.%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName)
+	newID := fmt.Sprintf("https://%s.blob.%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName)
 	is.Attributes["id"] = newID
 	is.ID = newID
 

--- a/azurerm/resource_arm_storage_container_migration.go
+++ b/azurerm/resource_arm_storage_container_migration.go
@@ -1,0 +1,39 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceStorageContainerMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AzureRM Storage Container State v0; migrating to v1")
+		return migrateStorageContainerStateV0toV1(is, meta)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateStorageContainerStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] ARM Storage Container Attributes before Migration: %#v", is.Attributes)
+
+	environment := meta.(*ArmClient).environment
+
+	containerName := is.Attributes["name"]
+	storageAccountName := is.Attributes["storage_account_name"]
+	newID := fmt.Sprintf("https://%s.%s/%s", storageAccountName, environment.StorageEndpointSuffix, containerName)
+	is.Attributes["id"] = newID
+	is.ID = newID
+
+	log.Printf("[DEBUG] ARM Storage Container Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 				"storage_account_name": "example",
 			},
 			ExpectedAttributes: map[string]string{
-				"id": fmt.Sprintf("https://example.%s/container", suffix),
+				"id": fmt.Sprintf("https://example.blob.%s/container", suffix),
 			},
 		},
 	}

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -1,0 +1,66 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
+// as we want to run this depending on the cloud we're in.
+func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
+	config := testGetAzureConfig(t)
+	if config == nil {
+		t.SkipNow()
+		return
+	}
+
+	client, err := getArmClient(config)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
+		return
+	}
+
+	client.StopContext = testAccProvider.StopContext()
+
+	suffix := client.environment.StorageEndpointSuffix
+
+	cases := map[string]struct {
+		StateVersion       int
+		ID                 string
+		InputAttributes    map[string]string
+		ExpectedAttributes map[string]string
+	}{
+		"v0_1_without_value": {
+			StateVersion: 0,
+			ID:           "some_id",
+			InputAttributes: map[string]string{
+				"name":                 "container",
+				"storage_account_name": "example",
+			},
+			ExpectedAttributes: map[string]string{
+				"id": fmt.Sprintf("https://example.%s/container", suffix),
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.InputAttributes,
+		}
+		is, err := resourceStorageContainerMigrateState(tc.StateVersion, is, client)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.ExpectedAttributes {
+			actual := is.Attributes[k]
+			if actual != v {
+				t.Fatalf("Bad Storage Blob Migrate for %q: %q\n\n expected: %q", k, actual, v)
+			}
+		}
+	}
+}

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccAzureRMStorageContainer_basic(t *testing.T) {
+	resourceName := "azurerm_storage_container.test"
 	var c storage.Container
 
 	ri := acctest.RandInt()
@@ -27,8 +28,13 @@ func TestAccAzureRMStorageContainer_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageContainerExists("azurerm_storage_container.test", &c),
+					testCheckAzureRMStorageContainerExists(resourceName, &c),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -59,6 +65,7 @@ func TestAccAzureRMStorageContainer_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMStorageContainer_root(t *testing.T) {
+	resourceName := "azurerm_storage_container.test"
 	var c storage.Container
 
 	ri := acctest.RandInt()
@@ -73,9 +80,14 @@ func TestAccAzureRMStorageContainer_root(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageContainerExists("azurerm_storage_container.test", &c),
-					resource.TestCheckResourceAttr("azurerm_storage_container.test", "name", "$root"),
+					testCheckAzureRMStorageContainerExists(resourceName, &c),
+					resource.TestCheckResourceAttr(resourceName, "name", "$root"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azurerm/resource_arm_storage_queue.go
+++ b/azurerm/resource_arm_storage_queue.go
@@ -201,7 +201,8 @@ func parseStorageQueueID(input string) (*storageQueueId, error) {
 	segments := strings.Split(uri.Host, ".")
 	if len(segments) > 0 {
 		storageAccountName := segments[0]
-		queue := strings.Replace(uri.Path, "/", "", 1)
+		// remove the leading `/`
+		queue := strings.TrimPrefix(uri.Path, "/")
 		id := storageQueueId{
 			storageAccountName: storageAccountName,
 			queueName:          queue,

--- a/azurerm/resource_arm_storage_queue.go
+++ b/azurerm/resource_arm_storage_queue.go
@@ -201,7 +201,6 @@ func parseStorageQueueID(input string) (*storageQueueId, error) {
 	segments := strings.Split(uri.Host, ".")
 	if len(segments) > 0 {
 		storageAccountName := segments[0]
-		// remove the
 		queue := strings.Replace(uri.Path, "/", "", 1)
 		id := storageQueueId{
 			storageAccountName: storageAccountName,

--- a/azurerm/resource_arm_storage_queue_migration.go
+++ b/azurerm/resource_arm_storage_queue_migration.go
@@ -1,0 +1,40 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceStorageQueueMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AzureRM Storage Queue State v0; migrating to v1")
+		return migrateStorageQueueStateV0toV1(is, meta)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateStorageQueueStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] ARM Storage Queue Attributes before Migration: %#v", is.Attributes)
+
+	environment := meta.(*ArmClient).environment
+
+	queueName := is.Attributes["name"]
+	storageAccountName := is.Attributes["storage_account_name"]
+	newID := fmt.Sprintf("https://%s.queue.%s/%s", storageAccountName, environment.StorageEndpointSuffix, queueName)
+	is.Attributes["id"] = newID
+	is.ID = newID
+
+	log.Printf("[DEBUG] ARM Storage Queue Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/azurerm/resource_arm_storage_queue_migration_test.go
+++ b/azurerm/resource_arm_storage_queue_migration_test.go
@@ -9,7 +9,7 @@ import (
 
 // NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
 // as we want to run this depending on the cloud we're in.
-func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
+func TestAccAzureRMStorageQueueMigrateState(t *testing.T) {
 	config := testGetAzureConfig(t)
 	if config == nil {
 		t.SkipNow()
@@ -36,11 +36,11 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 			StateVersion: 0,
 			ID:           "some_id",
 			InputAttributes: map[string]string{
-				"name":                 "container",
+				"name":                 "queue",
 				"storage_account_name": "example",
 			},
 			ExpectedAttributes: map[string]string{
-				"id": fmt.Sprintf("https://example.blob.%s/container", suffix),
+				"id": fmt.Sprintf("https://example.queue.%s/queue", suffix),
 			},
 		},
 	}
@@ -50,7 +50,7 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 			ID:         tc.ID,
 			Attributes: tc.InputAttributes,
 		}
-		is, err := resourceStorageContainerMigrateState(tc.StateVersion, is, client)
+		is, err := resourceStorageQueueMigrateState(tc.StateVersion, is, client)
 
 		if err != nil {
 			t.Fatalf("bad: %s, err: %#v", tn, err)
@@ -59,7 +59,7 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 		for k, v := range tc.ExpectedAttributes {
 			actual := is.Attributes[k]
 			if actual != v {
-				t.Fatalf("Bad Storage Container Migrate for %q: %q\n\n expected: %q", k, actual, v)
+				t.Fatalf("Bad Storage Queue Migrate for %q: %q\n\n expected: %q", k, actual, v)
 			}
 		}
 	}

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -51,6 +51,7 @@ func TestResourceAzureRMStorageQueueName_Validation(t *testing.T) {
 }
 
 func TestAccAzureRMStorageQueue_basic(t *testing.T) {
+	resourceName := "azurerm_storage_queue.test"
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
 	config := testAccAzureRMStorageQueue_basic(ri, rs, testLocation())
@@ -63,8 +64,13 @@ func TestAccAzureRMStorageQueue_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageQueueExists("azurerm_storage_queue.test"),
+					testCheckAzureRMStorageQueueExists(resourceName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -202,7 +202,6 @@ func parseStorageTableID(input string) (*storageTableId, error) {
 	segments := strings.Split(uri.Host, ".")
 	if len(segments) > 0 {
 		storageAccountName := segments[0]
-		// remove the
 		table := strings.Replace(uri.Path, "/", "", 1)
 		id := storageTableId{
 			storageAccountName: storageAccountName,

--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -3,7 +3,9 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -14,6 +16,11 @@ func resourceArmStorageTable() *schema.Resource {
 		Create: resourceArmStorageTableCreate,
 		Read:   resourceArmStorageTableRead,
 		Delete: resourceArmStorageTableDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		SchemaVersion: 1,
+		MigrateState:  resourceStorageTableMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -51,7 +58,9 @@ func validateArmStorageTableName(v interface{}, k string) (ws []string, errors [
 func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) error {
 	armClient := meta.(*ArmClient)
 	ctx := armClient.StopContext
+	environment := armClient.environment
 
+	name := d.Get("name").(string)
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
@@ -63,7 +72,6 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Storage Account %q Not Found", storageAccountName)
 	}
 
-	name := d.Get("name").(string)
 	table := tableClient.GetTableReference(name)
 
 	log.Printf("[INFO] Creating table %q in storage account %q.", name, storageAccountName)
@@ -75,8 +83,8 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error creating table %q in storage account %q: %s", name, storageAccountName, err)
 	}
 
-	d.SetId(name)
-
+	id := fmt.Sprintf("https://%s.table.%s/%s", storageAccountName, environment.StorageEndpointSuffix, name)
+	d.SetId(id)
 	return resourceArmStorageTableRead(d, meta)
 }
 
@@ -84,40 +92,57 @@ func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error
 	armClient := meta.(*ArmClient)
 	ctx := armClient.StopContext
 
-	resourceGroupName := d.Get("resource_group_name").(string)
-	storageAccountName := d.Get("storage_account_name").(string)
-
-	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, resourceGroupName, storageAccountName)
+	id, err := parseStorageTableID(d.Id())
 	if err != nil {
 		return err
 	}
-	if !accountExists {
-		log.Printf("[DEBUG] Storage account %q not found, removing table %q from state", storageAccountName, d.Id())
+
+	resourceGroup, err := determineResourceGroupForStorageAccount(id.storageAccountName, armClient)
+	if err != nil {
+		return err
+	}
+
+	if resourceGroup == nil {
+		log.Printf("Unable to determine Resource Group for Storage Account %q (assuming removed)", id.storageAccountName)
 		d.SetId("")
 		return nil
 	}
 
-	name := d.Get("name").(string)
+	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
+	if err != nil {
+		return err
+	}
+
+	if !accountExists {
+		log.Printf("[DEBUG] Storage account %q not found, removing table %q from state", id.storageAccountName, id.tableName)
+		d.SetId("")
+		return nil
+	}
+
 	metaDataLevel := storage.MinimalMetadata
 	options := &storage.QueryTablesOptions{}
 	tables, err := tableClient.QueryTables(metaDataLevel, options)
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve storage tables in account %q: %s", name, err)
+		return fmt.Errorf("Failed to retrieve Tables in Storage Account %q: %s", id.tableName, err)
 	}
 
-	var found bool
+	var storageTable *storage.Table
 	for _, table := range tables.Tables {
-		tableName := string(table.Name)
-		if tableName == name {
-			found = true
-			d.Set("name", tableName)
+		if string(table.Name) == id.tableName {
+			storageTable = &table
+			break
 		}
 	}
 
-	if !found {
-		log.Printf("[INFO] Storage table %q does not exist in account %q, removing from state...", name, storageAccountName)
+	if storageTable == nil {
+		log.Printf("[INFO] Table %q does not exist in Storage Account %q, removing from state...", id.tableName, id.storageAccountName)
 		d.SetId("")
+		return nil
 	}
+
+	d.Set("name", id.tableName)
+	d.Set("storage_account_name", id.storageAccountName)
+	d.Set("resource_group_name", resourceGroup)
 
 	return nil
 }
@@ -126,28 +151,65 @@ func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) err
 	armClient := meta.(*ArmClient)
 	ctx := armClient.StopContext
 
-	resourceGroupName := d.Get("resource_group_name").(string)
-	storageAccountName := d.Get("storage_account_name").(string)
+	id, err := parseStorageTableID(d.Id())
+	if err != nil {
+		return err
+	}
 
-	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, resourceGroupName, storageAccountName)
+	resourceGroup, err := determineResourceGroupForStorageAccount(id.storageAccountName, armClient)
+	if err != nil {
+		return err
+	}
+
+	if resourceGroup == nil {
+		log.Printf("Unable to determine Resource Group for Storage Account %q (assuming removed)", id.storageAccountName)
+		return nil
+	}
+
+	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
 	if err != nil {
 		return err
 	}
 	if !accountExists {
-		log.Printf("[INFO] Storage Account %q doesn't exist so the table won't exist", storageAccountName)
+		log.Printf("[INFO] Storage Account %q doesn't exist so the table won't exist", id.storageAccountName)
 		return nil
 	}
 
-	name := d.Get("name").(string)
-	table := tableClient.GetTableReference(name)
+	table := tableClient.GetTableReference(id.tableName)
 	timeout := uint(60)
 	options := &storage.TableOptions{}
 
-	log.Printf("[INFO] Deleting storage table %q in account %q", name, storageAccountName)
+	log.Printf("[INFO] Deleting Table %q in Storage Account %q", id.tableName, id.storageAccountName)
 	if err := table.Delete(timeout, options); err != nil {
-		return fmt.Errorf("Error deleting storage table %q from storage account %q: %s", name, storageAccountName, err)
+		return fmt.Errorf("Error deleting table %q from Storage Account %q: %s", id.tableName, id.storageAccountName, err)
 	}
 
-	d.SetId("")
 	return nil
+}
+
+type storageTableId struct {
+	storageAccountName string
+	tableName          string
+}
+
+func parseStorageTableID(input string) (*storageTableId, error) {
+	// https://myaccount.table.core.windows.net/table1
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing %q as a URI: %+v", input, err)
+	}
+
+	segments := strings.Split(uri.Host, ".")
+	if len(segments) > 0 {
+		storageAccountName := segments[0]
+		// remove the
+		table := strings.Replace(uri.Path, "/", "", 1)
+		id := storageTableId{
+			storageAccountName: storageAccountName,
+			tableName:          table,
+		}
+		return &id, nil
+	}
+
+	return nil, nil
 }

--- a/azurerm/resource_arm_storage_table_migration.go
+++ b/azurerm/resource_arm_storage_table_migration.go
@@ -1,0 +1,40 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceStorageTableMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AzureRM Storage Table State v0; migrating to v1")
+		return migrateStorageTableStateV0toV1(is, meta)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateStorageTableStateV0toV1(is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] ARM Storage Table Attributes before Migration: %#v", is.Attributes)
+
+	environment := meta.(*ArmClient).environment
+
+	tableName := is.Attributes["name"]
+	storageAccountName := is.Attributes["storage_account_name"]
+	newID := fmt.Sprintf("https://%s.table.%s/%s", storageAccountName, environment.StorageEndpointSuffix, tableName)
+	is.Attributes["id"] = newID
+	is.ID = newID
+
+	log.Printf("[DEBUG] ARM Storage Table Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/azurerm/resource_arm_storage_table_migration_test.go
+++ b/azurerm/resource_arm_storage_table_migration_test.go
@@ -1,0 +1,66 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
+// as we want to run this depending on the cloud we're in.
+func TestAccAzureRMStorageTableMigrateState(t *testing.T) {
+	config := testGetAzureConfig(t)
+	if config == nil {
+		t.SkipNow()
+		return
+	}
+
+	client, err := getArmClient(config)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
+		return
+	}
+
+	client.StopContext = testAccProvider.StopContext()
+
+	suffix := client.environment.StorageEndpointSuffix
+
+	cases := map[string]struct {
+		StateVersion       int
+		ID                 string
+		InputAttributes    map[string]string
+		ExpectedAttributes map[string]string
+	}{
+		"v0_1_without_value": {
+			StateVersion: 0,
+			ID:           "some_id",
+			InputAttributes: map[string]string{
+				"name":                 "table1",
+				"storage_account_name": "example",
+			},
+			ExpectedAttributes: map[string]string{
+				"id": fmt.Sprintf("https://example.table.%s/table1", suffix),
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.InputAttributes,
+		}
+		is, err := resourceStorageTableMigrateState(tc.StateVersion, is, client)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.ExpectedAttributes {
+			actual := is.Attributes[k]
+			if actual != v {
+				t.Fatalf("Bad Storage Table Migrate for %q: %q\n\n expected: %q", k, actual, v)
+			}
+		}
+	}
+}

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccAzureRMStorageTable_basic(t *testing.T) {
+	resourceName := "azurerm_storage_table.test"
 	var table storage.Table
 
 	ri := acctest.RandInt()
@@ -27,8 +28,13 @@ func TestAccAzureRMStorageTable_basic(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageTableExists("azurerm_storage_table.test", &table),
+					testCheckAzureRMStorageTableExists(resourceName, &table),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The storage blob Resource ID.
+* `id` - The ID of the Storage Blob.
 * `url` - The URL of the blob
 
 ## Import

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -87,5 +87,5 @@ The following attributes are exported in addition to the arguments listed above:
 Storage Blob's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_storage_blob.blob1 https://example.core.windows.net/container/blob.vhd
+terraform import azurerm_storage_blob.blob1 https://example.blob.core.windows.net/container/blob.vhd
 ```

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -81,3 +81,11 @@ The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The storage blob Resource ID.
 * `url` - The URL of the blob
+
+## Import
+
+Storage Blob's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_blob.blob1 https://example.core.windows.net/container/blob.vhd
+```

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -64,5 +64,5 @@ The following attributes are exported in addition to the arguments listed above:
 Storage Containers can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_storage_container.container1 https://example.core.windows.net/container
+terraform import azurerm_storage_container.container1 https://example.blob.core.windows.net/container
 ```

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The storage container Resource ID.
+* `id` - The ID of the Storage Container.
 * `properties` - Key-value definition of additional properties associated to the storage container
 
 ## Import

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -58,3 +58,11 @@ The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The storage container Resource ID.
 * `properties` - Key-value definition of additional properties associated to the storage container
+
+## Import
+
+Storage Containers can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_container.container1 https://example.core.windows.net/container
+```

--- a/website/docs/r/storage_queue.html.markdown
+++ b/website/docs/r/storage_queue.html.markdown
@@ -49,4 +49,12 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The storage queue Resource ID.
+* `id` - The ID of the Storage Queue.
+
+## Import
+
+Storage Queue's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_queue.queue1 https://example.queue.core.windows.net/queue1
+```

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -49,4 +49,12 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The storage table Resource ID.
+* `id` - The ID of the Storage Table.
+
+## Import
+
+Storage Table's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_storage_table.table1 https://example.table.core.windows.net/table1
+```


### PR DESCRIPTION
This PR is a dependency for #1746 - and adds support for Import to the Storage Resources. In order to do this the ID's need changing to contain all of the necessary information - which requires a state migration, and will require appropriate changelog comments.

- [x] Import support for `azurerm_storage_blob`
- [x] Import support for `azurerm_storage_container`
- [x] Import support for `azurerm_storage_queue`
- [x] Import support for `azurerm_storage_table`

Fixes #1302
Fixes #1554
Fixes #1830