### PR TITLE
docs/r/management_lock: Fix typo: note -> notes

### DIFF
--- a/website/docs/r/management_lock.html.markdown
+++ b/website/docs/r/management_lock.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 ~> **Note:** `CanNotDelete` means authorized users are able to read and modify the resources, but not delete. `ReadOnly` means authorized users can only read from a resource, but they can't modify or delete it.
 
-* `note` - (Optional) Specifies some notes about the lock. Maximum of 512 characters. Changing this forces a new resource to be created.
+* `notes` - (Optional) Specifies some notes about the lock. Maximum of 512 characters. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Cf. https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/resource_arm_management_lock.go#L48