### PR TITLE
New resource & data source 'azurerm_azuread_group'

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -109,6 +109,7 @@ type ArmClient struct {
 	roleDefinitionsClient   authorization.RoleDefinitionsClient
 	applicationsClient      graphrbac.ApplicationsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
+	groupsClient            graphrbac.GroupsClient
 
 	// Autoscale Settings
 	autoscaleSettingsClient insights.AutoscaleSettingsClient
@@ -509,6 +510,13 @@ func (c *ArmClient) registerAuthentication(endpoint, graphEndpoint, subscription
 	servicePrincipalsClient.Sender = sender
 	servicePrincipalsClient.SkipResourceProviderRegistration = c.skipProviderRegistration
 	c.servicePrincipalsClient = servicePrincipalsClient
+
+	groupsClient := graphrbac.NewGroupsClientWithBaseURI(graphEndpoint, tenantId)
+	setUserAgent(&groupsClient.Client)
+	groupsClient.Authorizer = graphAuth
+	groupsClient.Sender = sender
+	groupsClient.SkipResourceProviderRegistration = c.skipProviderRegistration
+	c.groupsClient = groupsClient
 }
 
 func (c *ArmClient) registerCDNClients(endpoint, subscriptionId string, auth autorest.Authorizer, sender autorest.Sender) {

--- a/azurerm/data_source_azuread_group.go
+++ b/azurerm/data_source_azuread_group.go
@@ -60,7 +60,7 @@ func dataSourceArmAzureADGroupRead(d *schema.ResourceData, meta interface{}) err
 
 		// use the name to find the Azure AD group
 		name := d.Get("name").(string)
-		filter := "displayName eq '" + name + "'"
+		filter := fmt.Sprintf("displayName eq '%s'", name)
 		log.Printf("[DEBUG] [data_source_azuread_group] Using filter %q", filter)
 
 		resp, err := client.ListComplete(ctx, filter)

--- a/azurerm/data_source_azuread_group.go
+++ b/azurerm/data_source_azuread_group.go
@@ -2,11 +2,13 @@ package azurerm
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 	"log"
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmAzureADGroup() *schema.Resource {
@@ -17,18 +19,19 @@ func dataSourceArmAzureADGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"object_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ConflictsWith: []string{"name"},
-			},
-
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"object_id"},
+			},
+
+			"object_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name"},
+				ValidateFunc:  validate.UUID,
 			},
 		},
 	}

--- a/azurerm/data_source_azuread_group.go
+++ b/azurerm/data_source_azuread_group.go
@@ -1,0 +1,94 @@
+package azurerm
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"log"
+	"strings"
+)
+
+func dataSourceArmAzureADGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmAzureADGroupRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name"},
+			},
+
+			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_id"},
+			},
+		},
+	}
+}
+
+func dataSourceArmAzureADGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	var adgroup graphrbac.ADGroup
+	var groupObj *graphrbac.ADGroup
+
+	if oId, ok := d.GetOk("object_id"); ok {
+		// use the object_id to find the Azure AD group
+
+		objectId := oId.(string)
+		resp, err := client.Get(ctx, objectId)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Error: AzureAD Group with ID %q was not found", objectId)
+			}
+
+			return fmt.Errorf("Error making Read request on AzureAD Group with ID %q: %+v", objectId, err)
+		}
+
+		adgroup = resp
+
+	} else {
+
+		// use the name to find the Azure AD group
+		name := d.Get("name").(string)
+		filter := "displayName eq '" + name + "'"
+		log.Printf("[DEBUG] [data_source_azuread_group] Using filter %q", filter)
+
+		resp, err := client.ListComplete(ctx, filter)
+		if err != nil {
+			return fmt.Errorf("Error listing Azure AD groups: %+v", err)
+		}
+
+		for _, v := range *resp.Response().Value {
+			if v.DisplayName != nil {
+				if strings.EqualFold(*v.DisplayName, name) {
+					log.Printf("[DEBUG] [data_source_azuread_group] %q (API result) matches %q (given value). The group has the objectId: %q", *v.DisplayName, name, *v.ObjectID)
+					groupObj = &v
+					break
+				} else {
+					log.Printf("[DEBUG] [data_source_azuread_group] %q (API result) does not match %q (given value)", *v.DisplayName, name)
+				}
+			}
+		}
+		if groupObj == nil {
+			return fmt.Errorf("Couldn't locate a Azure AD group with a name of %q", name)
+		}
+
+		adgroup = *groupObj
+	}
+
+	d.SetId(*adgroup.ObjectID)
+	d.Set("object_id", adgroup.ObjectID)
+	d.Set("name", adgroup.DisplayName)
+
+	return nil
+}

--- a/azurerm/data_source_azuread_group_test.go
+++ b/azurerm/data_source_azuread_group_test.go
@@ -1,0 +1,79 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMAzureADGroup_byObjectId(t *testing.T) {
+	dataSourceName := "data.azurerm_azuread_group.test"
+	id := uuid.New().String()
+	config := testAccDataSourceAzureRMAzureADGroup_objectId(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMActiveDirectoryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMActiveDirectoryGroup(id),
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMActiveDirectoryGroupExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMAzureADGroup_byName(t *testing.T) {
+	dataSourceName := "data.azurerm_azuread_group.test"
+	id := uuid.New().String()
+	config := testAccDataSourceAzureRMAzureADGroup_name(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMActiveDirectoryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMActiveDirectoryGroup(id),
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMActiveDirectoryGroupExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMAzureADGroup_objectId(id string) string {
+	template := testAccAzureRMActiveDirectoryGroup(id)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_azuread_group" "test" {
+  object_id = "${azurerm_azuread_group.test.id}"
+}
+`, template)
+}
+
+func testAccDataSourceAzureRMAzureADGroup_name(id string) string {
+	template := testAccAzureRMActiveDirectoryGroup(id)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_azuread_group" "test" {
+  name = "${azurerm_azuread_group.test.name}"
+}
+`, template)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -79,8 +79,8 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"azurerm_azuread_application":                   dataSourceArmAzureADApplication(),
-			"azurerm_azuread_service_principal":             dataSourceArmActiveDirectoryServicePrincipal(),
 			"azurerm_azuread_group":                         dataSourceArmAzureADGroup(),
+			"azurerm_azuread_service_principal":             dataSourceArmActiveDirectoryServicePrincipal(),
 			"azurerm_application_security_group":            dataSourceArmApplicationSecurityGroup(),
 			"azurerm_app_service":                           dataSourceArmAppService(),
 			"azurerm_app_service_plan":                      dataSourceAppServicePlan(),
@@ -125,9 +125,9 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"azurerm_azuread_application":                     resourceArmActiveDirectoryApplication(),
+			"azurerm_azuread_group":                           resourceArmActiveDirectoryGroup(),
 			"azurerm_azuread_service_principal":               resourceArmActiveDirectoryServicePrincipal(),
 			"azurerm_azuread_service_principal_password":      resourceArmActiveDirectoryServicePrincipalPassword(),
-			"azurerm_azuread_group":                           resourceArmActiveDirectoryGroup(),
 			"azurerm_application_gateway":                     resourceArmApplicationGateway(),
 			"azurerm_application_insights":                    resourceArmApplicationInsights(),
 			"azurerm_application_security_group":              resourceArmApplicationSecurityGroup(),

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -80,6 +80,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"azurerm_azuread_application":                   dataSourceArmAzureADApplication(),
 			"azurerm_azuread_service_principal":             dataSourceArmActiveDirectoryServicePrincipal(),
+			"azurerm_azuread_group":                         dataSourceArmAzureADGroup(),
 			"azurerm_application_security_group":            dataSourceArmApplicationSecurityGroup(),
 			"azurerm_app_service":                           dataSourceArmAppService(),
 			"azurerm_app_service_plan":                      dataSourceAppServicePlan(),
@@ -126,6 +127,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_azuread_application":                     resourceArmActiveDirectoryApplication(),
 			"azurerm_azuread_service_principal":               resourceArmActiveDirectoryServicePrincipal(),
 			"azurerm_azuread_service_principal_password":      resourceArmActiveDirectoryServicePrincipalPassword(),
+			"azurerm_azuread_group":                           resourceArmActiveDirectoryGroup(),
 			"azurerm_application_gateway":                     resourceArmApplicationGateway(),
 			"azurerm_application_insights":                    resourceArmApplicationInsights(),
 			"azurerm_application_security_group":              resourceArmApplicationSecurityGroup(),

--- a/azurerm/resource_arm_azuread_group.go
+++ b/azurerm/resource_arm_azuread_group.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -19,15 +20,11 @@ func resourceArmActiveDirectoryGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"object_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
 			},
 		},
 	}
@@ -52,7 +49,6 @@ func resourceArmActiveDirectoryGroupCreate(d *schema.ResourceData, meta interfac
 	}
 
 	d.SetId(*group.ObjectID)
-	d.Set("object_id", group.ObjectID)
 
 	return resourceArmActiveDirectoryGroupRead(d, meta)
 }
@@ -81,8 +77,7 @@ func resourceArmActiveDirectoryGroupDelete(d *schema.ResourceData, meta interfac
 	client := meta.(*ArmClient).groupsClient
 	ctx := meta.(*ArmClient).StopContext
 
-	resp, err := client.Delete(ctx, d.Id())
-	if err != nil {
+	if resp, err := client.Delete(ctx, d.Id()); err != nil {
 		if !utils.ResponseWasNotFound(resp) {
 			return fmt.Errorf("Error Deleting Azure AD Group with ID %q: %+v", d.Id(), err)
 		}

--- a/azurerm/resource_arm_azuread_group.go
+++ b/azurerm/resource_arm_azuread_group.go
@@ -1,0 +1,92 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmActiveDirectoryGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmActiveDirectoryGroupCreate,
+		Read:   resourceArmActiveDirectoryGroupRead,
+		Delete: resourceArmActiveDirectoryGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceArmActiveDirectoryGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+
+	properties := graphrbac.GroupCreateParameters{
+		DisplayName:     &name,
+		MailEnabled:     utils.Bool(false),
+		MailNickname:    &name,
+		SecurityEnabled: utils.Bool(true),
+	}
+
+	group, err := client.Create(ctx, properties)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*group.ObjectID)
+	d.Set("object_id", group.ObjectID)
+
+	return resourceArmActiveDirectoryGroupRead(d, meta)
+}
+
+func resourceArmActiveDirectoryGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resp, err := client.Get(ctx, d.Id())
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] [resource_arm_azuread_group] Azure AD group with id %q was not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Azure AD Group with ID %q: %+v", d.Id(), err)
+	}
+
+	d.Set("name", resp.DisplayName)
+
+	return nil
+}
+
+func resourceArmActiveDirectoryGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).groupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resp, err := client.Delete(ctx, d.Id())
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error Deleting Azure AD Group with ID %q: %+v", d.Id(), err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_azuread_group_test.go
+++ b/azurerm/resource_arm_azuread_group_test.go
@@ -1,0 +1,107 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMActiveDirectoryGroup_basic(t *testing.T) {
+	resourceName := "azurerm_azuread_group.test"
+	id := uuid.New().String()
+	config := testAccAzureRMActiveDirectoryGroup(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMActiveDirectoryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMActiveDirectoryGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMActiveDirectoryGroup_complete(t *testing.T) {
+	resourceName := "azurerm_azuread_group.test"
+	id := uuid.New().String()
+	config := testAccAzureRMActiveDirectoryGroup(id)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMActiveDirectoryGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMActiveDirectoryGroupExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest%s", id)),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMActiveDirectoryGroupExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %q", name)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).groupsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, rs.Primary.ID)
+
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Azure AD Group %q does not exist", rs.Primary.ID)
+			}
+			return fmt.Errorf("Bad: Get on Azure AD groupsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMActiveDirectoryGroupDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_azuread_group" {
+			continue
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).groupsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, rs.Primary.ID)
+
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return err
+		}
+
+		return fmt.Errorf("Azure AD group still exists:\n%#v", resp)
+	}
+
+	return nil
+}
+
+func testAccAzureRMActiveDirectoryGroup(id string) string {
+	return fmt.Sprintf(`
+resource "azurerm_azuread_group" "test" {
+  name = "acctest%s"
+}
+`, id)
+}

--- a/azurerm/resource_arm_azuread_group_test.go
+++ b/azurerm/resource_arm_azuread_group_test.go
@@ -27,6 +27,11 @@ func TestAccAzureRMActiveDirectoryGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest%s", id)),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -47,6 +52,11 @@ func TestAccAzureRMActiveDirectoryGroup_complete(t *testing.T) {
 					testCheckAzureRMActiveDirectoryGroupExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("acctest%s", id)),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -47,6 +47,10 @@
                   <a href="/docs/providers/azurerm/d/azuread_service_principal.html">azurerm_azuread_service_principal</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-azuread-group") %>>
+                  <a href="/docs/providers/azurerm/d/azuread_group.html">azurerm_azuread_group</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-builtin-role-definition") %>>
                     <a href="/docs/providers/azurerm/d/builtin_role_definition.html">azurerm_builtin_role_definition</a>
                 </li>
@@ -250,6 +254,9 @@
               <ul class="nav nav-visible">
                 <li<%= sidebar_current("docs-azurerm-resource-azuread-application") %>>
                   <a href="/docs/providers/azurerm/r/azuread_application.html">azurerm_azuread_application</a>
+                </li>
+                <li<%= sidebar_current("docs-azurerm-resource-azuread-group") %>>
+                  <a href="/docs/providers/azurerm/r/azuread_group.html">azurerm_azuread_group</a>
                 </li>
                 <li<%= sidebar_current("docs-azurerm-resource-azuread-service-principal-x") %>>
                   <a href="/docs/providers/azurerm/r/azuread_service_principal.html">azurerm_azuread_service_principal</a>

--- a/website/docs/d/azuread_group.html.markdown
+++ b/website/docs/d/azuread_group.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_azuread_group"
+sidebar_current: "docs-azurerm-datasource-azuread-group"
+description: |-
+  Gets information about a group object within the Azure Active Directory.
+
+---
+
+# Data Source: azurerm_azuread_group
+
+Gets information about a Group object within the Azure Active Directory.
+
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read directory data` within the `Windows Azure Active Directory` API.
+
+## Example Usage (by Object ID)
+
+```hcl
+data "azurerm_azuread_group" "test_group" {
+  object_id = "78722cfc-8946-11e8-95f1-2200ec79ad01"
+}
+```
+
+## Example Usage (by Group Display Name)
+
+```hcl
+data "azurerm_azuread_group" "test_group" {
+  name = "MyTestGroup"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `object_id` - (Optional) The ID of the Azure AD Group we want to lookup.
+
+* `name` - (Optional) The ID of the Azure AD Group we want to loopup.
+
+-> **NOTE:** At least one of `name` or `object_id` must be specified.
+
+-> **WARNING:** `name` is not unique within Azure Active Directory. The data source will only return the first Group found.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Object ID for the Azure AD Group.
+* `object_id` - The Object ID for the Azure AD Group.
+* `name` - The Display Name for the Azure AD Group.

--- a/website/docs/d/azuread_group.html.markdown
+++ b/website/docs/d/azuread_group.html.markdown
@@ -3,13 +3,13 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_group"
 sidebar_current: "docs-azurerm-datasource-azuread-group"
 description: |-
-  Gets information about a group object within the Azure Active Directory.
+  Gets information about an Azure Active Directory group.
 
 ---
 
 # Data Source: azurerm_azuread_group
 
-Gets information about a Group object within the Azure Active Directory.
+Gets information about an Azure Active Directory group.
 
 -> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to both `Read directory data` within the `Windows Azure Active Directory` API.
 

--- a/website/docs/r/azuread_group.html.markdown
+++ b/website/docs/r/azuread_group.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `object_id` - The Object ID of the Group.
+* `id` - The Object ID of the Group.
 
 * `name` - The Display Name of the Group.
 

--- a/website/docs/r/azuread_group.html.markdown
+++ b/website/docs/r/azuread_group.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_azuread_group"
+sidebar_current: "docs-azurerm-resource-azuread-group"
+description: |-
+  Manages a Group within Azure Active Directory.
+
+---
+
+# azurerm_azuread_group
+
+Manages a Group within Azure Active Directory.
+
+-> **NOTE:** If you're authenticating using a Service Principal then it must have permissions to `Read and write all groups` within the `Windows Azure Active Directory` API.
+
+-> **NOTE:** Additionally, due to a limitation within the API, you have to assign **one** of the following Azure Active Directory Roles to the Service Principal to be able to delete Groups:
+
+* User Account Administrator
+* Company Administrator
+
+You can assign one of the required Azure Active Directory Roles with PowerShell. Please refer to [this documentation](https://docs.microsoft.com/en-us/powershell/module/azuread/add-azureaddirectoryrolemember) for more details.
+
+## Example Usage
+
+```hcl
+resource "azurerm_azuread_group" "my_group" {
+  name = "MyGroup"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The display name for the Group.
+
+-> **NOTE:** Group names are not unique within Azure Active Directory.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `object_id` - The Object ID of the Group.
+
+* `name` - The Display Name of the Group.
+
+## Import
+
+Azure Active Directory Groups can be imported using the `object id`, e.g.
+
+```shell
+terraform import azurerm_azuread_group.my_group 00000000-0000-0000-0000-000000000000
+```


### PR DESCRIPTION
This replaces PR #1585.

This PR adds a new resource and data source for Azure Active Directory groups.

- [x] New data source 'azurerm_azuread_group'
- [x] New resource 'azurerm_azuread_group'
- [x] Add markdown documentation
- [x] Add tests

## Example Usage

```hcl

// This creates a new Azure AD group with the display name "my_group"
resource "azurerm_azuread_group" "my_group" {
 name = "my_group"
}

// This queries an Azure AD group by ID
data "azurerm_azuread_group" "my_group_by_id" {
  object_id = "78722cfc-8946-11e8-95f1-2200ec79ad01"
}

// This queries an Azure AD group by Name
data "azurerm_azuread_group" "my_group_by_name" {
  name = "my_group"
}
```

The following attributes are exported:

* `id` - The Object ID for the Azure AD Group.
* `object_id` - The Object ID for the Azure AD Group.
* `name` - The Display Name for the Azure AD Group.