### PR TITLE
r/Logic App: ensuring parameters are strings prior to setting

### DIFF
--- a/azurerm/resource_arm_logic_app_workflow.go
+++ b/azurerm/resource_arm_logic_app_workflow.go
@@ -256,7 +256,13 @@ func flattenLogicAppWorkflowParameters(input map[string]*logic.WorkflowParameter
 
 	for k, v := range input {
 		if v != nil {
-			output[k] = v.Value.(string)
+			// we only support string parameters at this time
+			val, ok := v.Value.(string)
+			if !ok {
+				log.Printf("[DEBUG] Skipping parameter %q since it's not a string", k)
+			}
+
+			output[k] = val
 		}
 	}
 


### PR DESCRIPTION
At this time the Logic App resource only supports setting String parameters - as such we should only set fields of this type.

Unfortunately adding an acceptance test for this is complicated (insofar as it requires a template which supports parameters of different types, which we don't support at this time) - but I can confirm via the portal this fix solves the crash #1841 [as it crashes on v1.13.0, but imports fine via this branch])

Fixes #1841