### PR TITLE
Build - add new target for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,9 @@ install:
 - bash scripts/gogetcookie.sh
 - go get github.com/kardianos/govendor
 
+# Any step fails will stop the Travis CI from running.
 script:
-- make test
-- make vendor-status
-- make vet
-- make website-test
+- make ci-test
 
 branches:
   only:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,8 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=azurerm
 
+ci-test: vendor-status vet test website-test
+
 default: build
 
 build: fmtcheck


### PR DESCRIPTION
The original `make` commands defined in `script` section of .travis.yml don't support fast fail, which wasted time in executing the left commands even previous failed.

This PR introduces a new target, ci-test, which supports fast fail and benefits end user to run it locally before sending out for PR.