### PR TITLE
Data Disk Attachment: obtaining a basic view of the VM rather than the Instance View

### DIFF
--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
@@ -92,7 +92,7 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 	azureRMLockByName(virtualMachineName, virtualMachineResourceName)
 	defer azureRMUnlockByName(virtualMachineName, virtualMachineResourceName)
 
-	virtualMachine, err := client.Get(ctx, resourceGroup, virtualMachineName, compute.InstanceView)
+	virtualMachine, err := client.Get(ctx, resourceGroup, virtualMachineName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(virtualMachine.Response) {
 			return fmt.Errorf("Virtual Machine %q (Resource Group %q) was not found", virtualMachineName, resourceGroup)


### PR DESCRIPTION
This matches the usages across the Provider which I _believe_ should should fix #1600 - but I've been unable to reliably reproduce that issue. Additional context is in this comment: https://github.com/terraform-providers/terraform-provider-azurerm/issues/1600#issuecomment-413839706