### PR TITLE
[WIP] New data source "azurerm_azuread_user"

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -109,6 +109,7 @@ type ArmClient struct {
 	roleDefinitionsClient   authorization.RoleDefinitionsClient
 	applicationsClient      graphrbac.ApplicationsClient
 	servicePrincipalsClient graphrbac.ServicePrincipalsClient
+	usersClient             graphrbac.UsersClient
 
 	// Autoscale Settings
 	autoscaleSettingsClient insights.AutoscaleSettingsClient
@@ -483,6 +484,10 @@ func (c *ArmClient) registerAuthentication(endpoint, graphEndpoint, subscription
 	servicePrincipalsClient := graphrbac.NewServicePrincipalsClientWithBaseURI(graphEndpoint, tenantId)
 	c.configureClient(&servicePrincipalsClient.Client, graphAuth)
 	c.servicePrincipalsClient = servicePrincipalsClient
+
+	usersClient := graphrbac.NewUsersClientWithBaseURI(graphEndpoint, tenantId)
+	c.configureClient(&usersClient.Client, graphAuth)
+	c.usersClient = usersClient
 }
 
 func (c *ArmClient) registerCDNClients(endpoint, subscriptionId string, auth autorest.Authorizer, sender autorest.Sender) {

--- a/azurerm/data_source_azuread_user.go
+++ b/azurerm/data_source_azuread_user.go
@@ -1,0 +1,69 @@
+package azurerm
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"log"
+)
+
+func dataSourceArmAzureADUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmAzureADUserRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"object_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"user_principal_name"},
+			},
+
+			"user_principal_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"object_id"},
+			},
+		},
+	}
+}
+
+func dataSourceArmAzureADUserRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).usersClient
+	ctx := meta.(*ArmClient).StopContext
+
+	var user graphrbac.User
+	var queryString string
+
+	if oId, ok := d.GetOk("object_id"); ok {
+
+		// use the object_id to find the Azure AD user
+		queryString = oId.(string)
+	} else {
+
+		// use the user_principal_name to find the Azure AD user
+		queryString = d.Get("user_principal_name").(string)
+	}
+
+	log.Printf("[DEBUG] [data_source_azuread_user] Using Get with upnOrObjectId: %q", queryString)
+	resp, err := client.Get(ctx, queryString)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: AzureAD User with ID or userPrincipalName %q not found", queryString)
+		}
+		return fmt.Errorf("Error making Read request on AzureAD User with ID or userPrincipalName %q: %+v", queryString, err)
+	}
+
+	user = resp
+
+	d.SetId(*user.ObjectID)
+	d.Set("object_id", user.ObjectID)
+	d.Set("user_principal_name", user.UserPrincipalName)
+
+	return nil
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -80,6 +80,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"azurerm_azuread_application":                   dataSourceArmAzureADApplication(),
 			"azurerm_azuread_service_principal":             dataSourceArmActiveDirectoryServicePrincipal(),
+			"azurerm_azuread_user":                          dataSourceArmAzureADUser(),
 			"azurerm_application_security_group":            dataSourceArmApplicationSecurityGroup(),
 			"azurerm_app_service":                           dataSourceArmAppService(),
 			"azurerm_app_service_plan":                      dataSourceAppServicePlan(),


### PR DESCRIPTION
This PR adds a new data source for Azure Active Directory users.

- [x] New data source 'azurerm_azuread_user'
- [ ] Add markdown documentation
- [ ] Add tests

## Example Usage

```hcl
// This queries an Azure AD user by ID
data "azurerm_azuread_user" "my_user_by_id" {
  object_id = "b2c800cc-b059-11e8-8d7f-47eeee7848b0"
}

// This queries an Azure AD user by userPrincipalName
data "azurerm_azuread_user" "my_user_by_upn" {
  user_principal_name = "john.doe@terraform.io"
}
```

The following attributes are exported:

* `id` - The Object ID of the Azure AD User.
* `object_id` - The Object ID of the Azure AD User.
* `user_principal_name` - The User Principal Name of the Azure AD User.