### PR TITLE
Removed validation from arm_function_app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ IMPROVEMENTS:
 * `azurerm_storage_container` - support for import [GH-1816]
 * `azurerm_storage_queue` - support for import [GH-1816]
 * `azurerm_storage_table` - support for import [GH-1816]
+* `azurerm_function_app` - support for specific versions [GH-1731]
 
 BUG FIXES:
 

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -52,10 +52,6 @@ func resourceArmFunctionApp() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "~1",
-				ValidateFunc: validation.StringInSlice([]string{
-					"~1",
-					"beta",
-				}, false),
 			},
 
 			"storage_connection_string": {

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -234,8 +234,8 @@ func TestAccAzureRMFunctionApp_updateVersion(t *testing.T) {
 	resourceName := "azurerm_function_app.test"
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	preConfig := testAccAzureRMFunctionApp_version(ri, rs, testLocation(), "beta")
-	postConfig := testAccAzureRMFunctionApp_version(ri, rs, testLocation(), "~1")
+	preConfig := testAccAzureRMFunctionApp_version(ri, rs, testLocation(), "~1")
+	postConfig := testAccAzureRMFunctionApp_version(ri, rs, testLocation(), "~2")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -246,7 +246,7 @@ func TestAccAzureRMFunctionApp_updateVersion(t *testing.T) {
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFunctionAppExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "version", "beta"),
+					resource.TestCheckResourceAttr(resourceName, "version", "~1"),
 				),
 			},
 			{

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -107,7 +107,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
-* `version` - (Optional) The runtime version associated with the Function App. Possible values are `~1` and `beta`. Defaults to `~1`.
+* `version` - (Optional) The runtime version associated with the Function App. Defaults to `~1`.
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 


### PR DESCRIPTION
As mentioned in [GH-1731](https://github.com/terraform-providers/terraform-provider-azurerm/issues/1731) There are times when you are required to pin the runtime version to a specific version. Also highlighted with this [breaking change](https://github.com/Azure/app-service-announcements/issues/112)

Validation has been removed from the version property on arm_function_app and tests updated to validated updating versions still work. 


Tests are passing and I have built it and run the provider with a .NET Standard 2 app with using pinned versions and V2.