### PR TITLE
New Data Source: `azurerm_management_group`

### DIFF
--- a/azurerm/data_source_management_group.go
+++ b/azurerm/data_source_management_group.go
@@ -1,0 +1,109 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2018-03-01-preview/management"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmManagementGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmManagementGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"parent_management_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"subscription_ids": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func dataSourceArmManagementGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).managementGroupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	groupId := d.Get("group_id").(string)
+
+	recurse := true
+	resp, err := client.Get(ctx, groupId, "children", &recurse, "", managementGroupCacheControl)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Management Group %q doesn't exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error reading Management Group %q: %+v", d.Id(), err)
+	}
+
+	d.SetId(*resp.ID)
+	d.Set("group_id", groupId)
+
+	if props := resp.Properties; props != nil {
+		d.Set("display_name", props.DisplayName)
+
+		subscriptionIds, err := flattenArmManagementGroupDataSourceSubscriptionIds(props.Children)
+		if err != nil {
+			return fmt.Errorf("Error flattening `subscription_ids`: %+v", err)
+		}
+		d.Set("subscription_ids", subscriptionIds)
+
+		parentId := ""
+		if details := props.Details; details != nil {
+			if parent := details.Parent; parent != nil {
+				if pid := parent.ID; pid != nil {
+					parentId = *pid
+				}
+			}
+		}
+		d.Set("parent_management_group_id", parentId)
+
+	}
+
+	return nil
+}
+
+func flattenArmManagementGroupDataSourceSubscriptionIds(input *[]managementgroups.ChildInfo) (*schema.Set, error) {
+	subscriptionIds := &schema.Set{F: schema.HashString}
+	if input == nil {
+		return subscriptionIds, nil
+	}
+
+	for _, child := range *input {
+		if child.ID == nil {
+			continue
+		}
+
+		id, err := parseManagementGroupSubscriptionID(*child.ID)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse child subscription ID %+v", err)
+		}
+
+		if id != nil {
+			subscriptionIds.Add(id.subscriptionId)
+		}
+	}
+
+	return subscriptionIds, nil
+}

--- a/azurerm/data_source_management_group.go
+++ b/azurerm/data_source_management_group.go
@@ -2,7 +2,6 @@ package azurerm
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2018-03-01-preview/management"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -49,9 +48,7 @@ func dataSourceArmManagementGroupRead(d *schema.ResourceData, meta interface{}) 
 	resp, err := client.Get(ctx, groupId, "children", &recurse, "", managementGroupCacheControl)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] Management Group %q doesn't exist - removing from state", d.Id())
-			d.SetId("")
-			return nil
+			return fmt.Errorf("Management Group %q was not found", groupId)
 		}
 
 		return fmt.Errorf("Error reading Management Group %q: %+v", d.Id(), err)

--- a/azurerm/data_source_management_group_test.go
+++ b/azurerm/data_source_management_group_test.go
@@ -1,0 +1,40 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceArmManagementGroup_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_management_group.test"
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceArmManagementGroup_basic(ri),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "display_name", fmt.Sprintf("acctestmg-%d", ri)),
+					resource.TestCheckResourceAttr(dataSourceName, "subscription_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceArmManagementGroup_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "azurerm_management_group" "test" {
+  display_name = "acctestmg-%d"
+}
+
+data "azurerm_management_group" "test" {
+  group_id = "${azurerm_management_group.test.group_id}"
+}
+`, rInt)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -99,6 +99,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_log_analytics_workspace":               dataSourceLogAnalyticsWorkspace(),
 			"azurerm_logic_app_workflow":                    dataSourceArmLogicAppWorkflow(),
 			"azurerm_managed_disk":                          dataSourceArmManagedDisk(),
+			"azurerm_management_group":                      dataSourceArmManagementGroup(),
 			"azurerm_network_interface":                     dataSourceArmNetworkInterface(),
 			"azurerm_network_security_group":                dataSourceArmNetworkSecurityGroup(),
 			"azurerm_notification_hub":                      dataSourceNotificationHub(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -120,6 +120,10 @@
                     <a href="/docs/providers/azurerm/d/managed_disk.html">azurerm_managed_disk</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-management-group") %>>
+                    <a href="/docs/providers/azurerm/d/management_group.html">azurerm_management_group</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-network-interface") %>>
                     <a href="/docs/providers/azurerm/d/network_interface.html">azurerm_network_interface</a>
                 </li>

--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_management_group"
+sidebar_current: "docs-azurerm-datasource-management-group"
+description: |-
+  Get information about the specified Management Group.
+---
+
+# Data Source: azurerm_management_group
+
+Use this data source to access the properties of a Management Group.
+
+## Example Usage
+
+```hcl
+data "azurerm_management_group" "test" {
+  group_id = "00000000-0000-0000-0000-000000000000"
+}
+
+output "display_name" {
+  value = "${data.azurerm_management_group.test.display_name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Required) Specifies the UUID of this Management Group.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Management Group.
+
+* `display_name` - A friendly name for the Management Group.
+
+* `parent_management_group_id` - The ID of any Parent Management Group.
+
+* `subscription_ids` - A list of Subscription ID's which are assigned to the Management Group.
+

--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `display_name` - (Optional) A friendly name for this Management Group. If not specified, this'll be the same as the `group_id`.
 
-* `parent_management_group_id` - (Required) The ID of the Parent Management Group. Changing this forces a new resource to be created.
+* `parent_management_group_id` - (Optional) The ID of the Parent Management Group. Changing this forces a new resource to be created.
 
 * `subscription_ids` - (Optional) A list of Subscription ID's which should be assigned to the Management Group.
 


### PR DESCRIPTION
Tests pass:

```
$ acctests azurerm TestAccDataSourceArmManagementGroup_basic
=== RUN   TestAccDataSourceArmManagementGroup_basic
--- PASS: TestAccDataSourceArmManagementGroup_basic (57.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	57.713s
```