### PR TITLE
`azurerm_application_insights` - support for the MobileCenter kind

### DIFF
--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -41,6 +41,7 @@ func resourceArmApplicationInsights() *schema.Resource {
 					"web",
 					"other",
 					"java",
+					"MobileCenter",
 					"phone",
 					"store",
 					"ios",

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -52,6 +52,27 @@ func TestAccAzureRMApplicationInsights_basicJava(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApplicationInsights_basicMobileCenter(t *testing.T) {
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMApplicationInsights_basic(ri, testLocation(), "MobileCenter")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsExists("azurerm_application_insights.test"),
+					resource.TestCheckResourceAttr("azurerm_application_insights.test", "application_type", "MobileCenter"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMApplicationInsights_basicOther(t *testing.T) {
 
 	ri := acctest.RandInt()

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `Web`, `Java`, `Phone`, `Store`, `iOS` and `Other`.
+* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `Java`, `iOS`, `MobileCenter`, `Other`, `Phone`, `Store` and `Web`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
```
$ acctests azurerm TestAccAzureRMApplicationInsights_basicMobileCenter
=== RUN   TestAccAzureRMApplicationInsights_basicMobileCenter
--- PASS: TestAccAzureRMApplicationInsights_basicMobileCenter (76.28s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	76.616s
```

Fixes #1815