### PR TITLE
Prevent potential crash due to empty name in VNet data source

### DIFF
--- a/azurerm/data_source_virtual_network.go
+++ b/azurerm/data_source_virtual_network.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -13,14 +14,12 @@ func dataSourceArmVirtualNetwork() *schema.Resource {
 		Read: dataSourceArmVnetRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
 			},
 
-			"resource_group_name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
 
 			"address_spaces": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
* Add non-empty check for `name` field
* Replace `resource_group_name` with common definition to match best practice

This PR resolves #966 .