### PR TITLE
azurerm_key_vault_certificate return thumbprint as hex

### DIFF
--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -358,14 +358,13 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 		d.Set("certificate_data", string(*contents))
 	}
 
-	x509Thumbprint, err := base64.RawURLEncoding.DecodeString(string(*cert.X509Thumbprint))
-	if err != nil {
-		return err
+	if v := cert.X509Thumbprint; v != nil {
+		x509Thumbprint, err := base64.RawURLEncoding.DecodeString(string(*v))
+		if err != nil {
+			return err
+		}
+		d.Set("thumbprint", strings.ToUpper(hex.EncodeToString(x509Thumbprint)))
 	}
-
-	x509ThumbprintHex := hex.EncodeToString(x509Thumbprint)
-
-	d.Set("thumbprint", strings.ToUpper(x509ThumbprintHex))
 
 	flattenAndSetTags(d, cert.Tags)
 

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -2,8 +2,11 @@ package azurerm
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
@@ -236,6 +239,11 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 				Computed: true,
 			},
 
+			"thumbprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -349,6 +357,16 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 	if contents := cert.Cer; contents != nil {
 		d.Set("certificate_data", string(*contents))
 	}
+
+	x509Thumbprint, err := base64.RawURLEncoding.DecodeString(string(*cert.X509Thumbprint))
+	if err != nil {
+		return err
+	}
+
+	x509ThumbprintHex := hex.EncodeToString(x509Thumbprint)
+
+	d.Set("thumbprint", strings.ToUpper(x509ThumbprintHex))
+
 	flattenAndSetTags(d, cert.Tags)
 
 	return nil

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -251,7 +251,8 @@ The following attributes are exported:
 * `id` - The Key Vault Certificate ID.
 * `secret_id` - The ID of the associated Key Vault Secret.
 * `version` - The current version of the Key Vault Certificate.
-* `certificate_data` - The raw Key Vault Certificate
+* `certificate_data` - The raw Key Vault Certificate.
+* `thumbprint` - The X509 Thumbprint of the Key Vault Certificate returned as hex string.
 
 
 ## Import


### PR DESCRIPTION
this is off the back of #1851 

will return the thumbprint in hex for certificates, much like the x509ThumbprintHex returned in the Azure CLI command:-

```
$ az keyvault certificate show --id ...
```

Can be used like:-

```
...

resource "azurerm_key_vault_certificate" "test" {
  name      = "generated-cert"
  vault_uri = "${azurerm_key_vault.test.vault_uri}"

  certificate_policy {
    issuer_parameters {
      name = "Self"
    }

    key_properties {
      exportable = true
      key_size   = 2048
      key_type   = "RSA"
      reuse_key  = true
    }

    lifetime_action {
      action {
        action_type = "AutoRenew"
      }

      trigger {
        days_before_expiry = 30
      }
    }

    secret_properties {
      content_type = "application/x-pkcs12"
    }

    x509_certificate_properties {
      key_usage = [
        "cRLSign",
        "dataEncipherment",
        "digitalSignature",
        "keyAgreement",
        "keyCertSign",
        "keyEncipherment",
      ]

      subject            = "CN=hello-world"
      validity_in_months = 12
    }
  }
}

output "thumbprint" {
  value = "${azurerm_key_vault_certificate.test.thumbprint}"
}
```

(fixes #1851)