### PR TITLE
Fix the Go Fmt issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- "1.10.x"
+- "1.11.x"
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ General Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.10 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
 
 Windows Specific Requirements
 -----------------------------

--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -489,7 +489,7 @@ func flattenKubernetesClusterDataSourceAddonProfiles(profile map[string]*contain
 		}
 
 		output := map[string]interface{}{
-			"enabled": enabled,
+			"enabled":                            enabled,
 			"http_application_routing_zone_name": zoneName,
 		}
 		routes = append(routes, output)

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -126,9 +126,9 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 	appServicePlan := web.AppServicePlan{
 		Location:                 &location,
 		AppServicePlanProperties: properties,
-		Kind: &kind,
-		Tags: expandTags(tags),
-		Sku:  &sku,
+		Kind:                     &kind,
+		Tags:                     expandTags(tags),
+		Sku:                      &sku,
 	}
 
 	createFuture, err := client.CreateOrUpdate(ctx, resGroup, name, appServicePlan)

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -743,9 +743,9 @@ func resourceArmApplicationGatewayCreateUpdate(d *schema.ResourceData, meta inte
 	}
 
 	gateway := network.ApplicationGateway{
-		Name:     utils.String(name),
-		Location: utils.String(location),
-		Tags:     expandTags(tags),
+		Name:                               utils.String(name),
+		Location:                           utils.String(location),
+		Tags:                               expandTags(tags),
 		ApplicationGatewayPropertiesFormat: &properties,
 	}
 

--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -82,11 +82,11 @@ func resourceArmApplicationInsightsCreateOrUpdate(d *schema.ResourceData, meta i
 	}
 
 	insightProperties := insights.ApplicationInsightsComponent{
-		Name:     &name,
-		Location: &location,
-		Kind:     &applicationType,
+		Name:                                   &name,
+		Location:                               &location,
+		Kind:                                   &applicationType,
 		ApplicationInsightsComponentProperties: &applicationInsightsComponentProperties,
-		Tags: expandTags(tags),
+		Tags:                                   expandTags(tags),
 	}
 
 	resp, err := client.CreateOrUpdate(ctx, resGroup, name, insightProperties)

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -876,7 +876,7 @@ func flattenAzureRmKubernetesClusterAddonProfiles(profile map[string]*containers
 		}
 
 		output := map[string]interface{}{
-			"enabled": enabled,
+			"enabled":                            enabled,
 			"http_application_routing_zone_name": zoneName,
 		}
 		routes = append(routes, output)

--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -158,10 +158,10 @@ func resourceArmLoadBalancerCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	loadBalancer := network.LoadBalancer{
-		Name:     utils.String(name),
-		Location: utils.String(location),
-		Tags:     expandedTags,
-		Sku:      &sku,
+		Name:                         utils.String(name),
+		Location:                     utils.String(location),
+		Tags:                         expandedTags,
+		Sku:                          &sku,
 		LoadBalancerPropertiesFormat: &properties,
 	}
 
@@ -309,9 +309,9 @@ func expandAzureRmLoadBalancerFrontendIpConfigurations(d *schema.ResourceData) *
 		name := data["name"].(string)
 		zones := expandZones(data["zones"].([]interface{}))
 		frontEndConfig := network.FrontendIPConfiguration{
-			Name: &name,
+			Name:                                    &name,
 			FrontendIPConfigurationPropertiesFormat: &properties,
-			Zones: zones,
+			Zones:                                   zones,
 		}
 
 		frontEndConfigs = append(frontEndConfigs, frontEndConfig)

--- a/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -293,7 +293,7 @@ func expandAzureRmLoadBalancerNatPool(d *schema.ResourceData, lb *network.LoadBa
 	}
 
 	return &network.InboundNatPool{
-		Name: utils.String(d.Get("name").(string)),
+		Name:                           utils.String(d.Get("name").(string)),
 		InboundNatPoolPropertiesFormat: &properties,
 	}, nil
 }

--- a/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -307,7 +307,7 @@ func expandAzureRmLoadBalancerNatRule(d *schema.ResourceData, lb *network.LoadBa
 	}
 
 	natRule := network.InboundNatRule{
-		Name: utils.String(d.Get("name").(string)),
+		Name:                           utils.String(d.Get("name").(string)),
 		InboundNatRulePropertiesFormat: &properties,
 	}
 

--- a/azurerm/resource_arm_loadbalancer_probe.go
+++ b/azurerm/resource_arm_loadbalancer_probe.go
@@ -293,7 +293,7 @@ func expandAzureRmLoadBalancerProbe(d *schema.ResourceData) *network.Probe {
 	}
 
 	return &network.Probe{
-		Name: utils.String(d.Get("name").(string)),
+		Name:                  utils.String(d.Get("name").(string)),
 		ProbePropertiesFormat: &properties,
 	}
 }

--- a/azurerm/resource_arm_loadbalancer_rule.go
+++ b/azurerm/resource_arm_loadbalancer_rule.go
@@ -358,7 +358,7 @@ func expandAzureRmLoadBalancerRule(d *schema.ResourceData, lb *network.LoadBalan
 	}
 
 	return &network.LoadBalancingRule{
-		Name: utils.String(d.Get("name").(string)),
+		Name:                              utils.String(d.Get("name").(string)),
 		LoadBalancingRulePropertiesFormat: &properties,
 	}, nil
 }

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -298,7 +298,7 @@ func resourceArmNetworkInterfaceCreateUpdate(d *schema.ResourceData, meta interf
 		Name:                      &name,
 		Location:                  &location,
 		InterfacePropertiesFormat: &properties,
-		Tags: expandTags(tags),
+		Tags:                      expandTags(tags),
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, iface)
@@ -656,7 +656,7 @@ func expandAzureRmNetworkInterfaceIpConfigurations(d *schema.ResourceData) ([]ne
 
 		name := data["name"].(string)
 		ipConfig := network.InterfaceIPConfiguration{
-			Name: &name,
+			Name:                                     &name,
 			InterfaceIPConfigurationPropertiesFormat: &properties,
 		}
 

--- a/azurerm/resource_arm_network_security_group.go
+++ b/azurerm/resource_arm_network_security_group.go
@@ -363,7 +363,7 @@ func expandAzureRmSecurityRules(d *schema.ResourceData) ([]network.SecurityRule,
 		}
 
 		rules = append(rules, network.SecurityRule{
-			Name: &name,
+			Name:                         &name,
 			SecurityRulePropertiesFormat: &properties,
 		})
 	}

--- a/azurerm/resource_arm_public_ip.go
+++ b/azurerm/resource_arm_public_ip.go
@@ -153,12 +153,12 @@ func resourceArmPublicIpCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	publicIp := network.PublicIPAddress{
-		Name:     &name,
-		Location: &location,
-		Sku:      &sku,
+		Name:                            &name,
+		Location:                        &location,
+		Sku:                             &sku,
 		PublicIPAddressPropertiesFormat: &properties,
-		Tags:  expandTags(tags),
-		Zones: zones,
+		Tags:                            expandTags(tags),
+		Zones:                           zones,
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, publicIp)

--- a/azurerm/resource_arm_route_table.go
+++ b/azurerm/resource_arm_route_table.go
@@ -111,7 +111,7 @@ func resourceArmRouteTableCreateUpdate(d *schema.ResourceData, meta interface{})
 		Name:     &name,
 		Location: &location,
 		RouteTablePropertiesFormat: &network.RouteTablePropertiesFormat{
-			Routes: expandRouteTableRoutes(d),
+			Routes:                     expandRouteTableRoutes(d),
 			DisableBgpRoutePropagation: utils.Bool(d.Get("disable_bgp_route_propagation").(bool)),
 		},
 		Tags: expandTags(tags),

--- a/azurerm/resource_arm_sql_database_test.go
+++ b/azurerm/resource_arm_sql_database_test.go
@@ -137,7 +137,7 @@ func TestAccAzureRMSqlDatabase_restorePointInTime(t *testing.T) {
 		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: preConfig,
+				Config:                    preConfig,
 				PreventPostDestroyRefresh: true,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlDatabaseExists(resourceName),

--- a/azurerm/resource_arm_sql_elasticpool.go
+++ b/azurerm/resource_arm_sql_elasticpool.go
@@ -94,7 +94,7 @@ func resourceArmSqlElasticPoolCreate(d *schema.ResourceData, meta interface{}) e
 		Name:                  &name,
 		Location:              &location,
 		ElasticPoolProperties: getArmSqlElasticPoolProperties(d),
-		Tags: expandTags(tags),
+		Tags:                  expandTags(tags),
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, serverName, name, elasticPool)

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -809,7 +809,7 @@ func expandStorageAccountVirtualNetworks(networkRule map[string]interface{}) *[]
 		attrs := virtualNetworkConfig.(string)
 		virtualNetwork := storage.VirtualNetworkRule{
 			VirtualNetworkResourceID: utils.String(attrs),
-			Action: storage.Allow,
+			Action:                   storage.Allow,
 		}
 		virtualNetworks[i] = virtualNetwork
 	}

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 			StateVersion: 0,
 			ID:           "some_id",
 			InputAttributes: map[string]string{
-				"name": "blob.vhd",
+				"name":                   "blob.vhd",
 				"storage_container_name": "container",
 				"storage_account_name":   "example",
 			},

--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -124,7 +124,7 @@ func resourceArmSubnetCreate(d *schema.ResourceData, meta interface{}) error {
 	properties.ServiceEndpoints = &serviceEndpoints
 
 	subnet := network.Subnet{
-		Name: &name,
+		Name:                   &name,
 		SubnetPropertiesFormat: &properties,
 	}
 

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -629,8 +629,8 @@ func resourceArmVirtualMachineCreate(d *schema.ResourceData, meta interface{}) e
 		Name:                     &name,
 		Location:                 &location,
 		VirtualMachineProperties: &properties,
-		Tags:  expandedTags,
-		Zones: zones,
+		Tags:                     expandedTags,
+		Zones:                    zones,
 	}
 
 	if _, ok := d.GetOk("identity"); ok {

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -735,12 +735,12 @@ func resourceArmVirtualMachineScaleSetCreate(d *schema.ResourceData, meta interf
 	}
 
 	properties := compute.VirtualMachineScaleSet{
-		Name:     &name,
-		Location: &location,
-		Tags:     expandTags(tags),
-		Sku:      sku,
+		Name:                             &name,
+		Location:                         &location,
+		Tags:                             expandTags(tags),
+		Sku:                              sku,
 		VirtualMachineScaleSetProperties: &scaleSetProps,
-		Zones: zones,
+		Zones:                            zones,
 	}
 
 	if _, ok := d.GetOk("identity"); ok {

--- a/azurerm/resource_arm_virtual_network.go
+++ b/azurerm/resource_arm_virtual_network.go
@@ -99,7 +99,7 @@ func resourceArmVirtualNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		Name:                           &name,
 		Location:                       &location,
 		VirtualNetworkPropertiesFormat: vnetProperties,
-		Tags: expandTags(tags),
+		Tags:                           expandTags(tags),
 	}
 
 	networkSecurityGroupNames := make([]string, 0)

--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -279,9 +279,9 @@ func resourceArmVirtualNetworkGatewayCreateUpdate(d *schema.ResourceData, meta i
 	}
 
 	gateway := network.VirtualNetworkGateway{
-		Name:     &name,
-		Location: &location,
-		Tags:     expandTags(tags),
+		Name:                                  &name,
+		Location:                              &location,
+		Tags:                                  expandTags(tags),
 		VirtualNetworkGatewayPropertiesFormat: properties,
 	}
 

--- a/azurerm/resource_arm_virtual_network_peering.go
+++ b/azurerm/resource_arm_virtual_network_peering.go
@@ -83,7 +83,7 @@ func resourceArmVirtualNetworkPeeringCreate(d *schema.ResourceData, meta interfa
 	resGroup := d.Get("resource_group_name").(string)
 
 	peer := network.VirtualNetworkPeering{
-		Name: &name,
+		Name:                                  &name,
 		VirtualNetworkPeeringPropertiesFormat: getVirtualNetworkPeeringProperties(d),
 	}
 


### PR DESCRIPTION
This PR includes:
1. Upgrade the README and Travis CI to use Go 1.11, which will resolve the long path issue while running `go test` on Windows and benefit from new Go module system.
 2. The style changes after running of `make fmt` under Go v1.11.