### PR TITLE
Add .go-version into .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ website/vendor
 !command/test-fixtures/**/.terraform/
 
 .env.sh
+
+# goenv version file
+.go-version


### PR DESCRIPTION
Add .go-version genereated by `goenv` tool into list.