### PR TITLE
Expose ID of an embedded subnet defined in azurerm_virtual_network

### DIFF
--- a/azurerm/resource_arm_virtual_network.go
+++ b/azurerm/resource_arm_virtual_network.go
@@ -70,6 +70,10 @@ func resourceArmVirtualNetwork() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 				Set: resourceAzureSubnetHash,
@@ -296,6 +300,10 @@ func flattenVirtualNetworkSubnets(input *[]network.Subnet) *schema.Set {
 	if subnets := input; subnets != nil {
 		for _, subnet := range *input {
 			output := map[string]interface{}{}
+
+			if id := subnet.ID; id != nil {
+				output["id"] = *id
+			}
 
 			if name := subnet.Name; name != nil {
 				output["name"] = *name

--- a/azurerm/resource_arm_virtual_network_test.go
+++ b/azurerm/resource_arm_virtual_network_test.go
@@ -92,6 +92,8 @@ func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "subnet.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet.0.id"),
 				),
 			},
 		},
@@ -136,10 +138,10 @@ func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(resourceName, "subnet.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
 					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
 				),
 			},
@@ -147,10 +149,10 @@ func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists(resourceName),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(
-						resourceName, "tags.environment", "staging"),
+					resource.TestCheckResourceAttr(resourceName, "subnet.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet.0.id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_virtual_network_test.go
+++ b/azurerm/resource_arm_virtual_network_test.go
@@ -93,7 +93,7 @@ func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "subnet.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "subnet.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet.1472110187.id"),
 				),
 			},
 		},
@@ -139,7 +139,7 @@ func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "subnet.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "subnet.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet.1472110187.id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
 					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
@@ -150,7 +150,7 @@ func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualNetworkExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "subnet.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "subnet.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet.1472110187.id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
 				),

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -56,10 +56,6 @@ resource "azurerm_virtual_network" "test" {
     environment = "Production"
   }
 }
-
-output "id_of_subnet2" {
-  value = "${azurerm_virtual_network.test.subnet.2796830261.id}"
-}
 ```
 
 ## Argument Reference
@@ -85,6 +81,8 @@ The following arguments are supported:
     subnets. Each `subnet` block supports fields documented below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
 
 The `subnet` block supports:
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -31,9 +31,9 @@ resource "azurerm_network_security_group" "test" {
 
 resource "azurerm_virtual_network" "test" {
   name                = "virtualNetwork1"
+  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   address_space       = ["10.0.0.0/16"]
-  location            = "West US"
   dns_servers         = ["10.0.0.4", "10.0.0.5"]
 
   subnet {
@@ -55,6 +55,10 @@ resource "azurerm_virtual_network" "test" {
   tags {
     environment = "Production"
   }
+}
+
+output "id_of_subnet2" {
+  value = "${azurerm_virtual_network.test.subnet.2796830261.id}"
 }
 ```
 
@@ -104,6 +108,12 @@ The following attributes are exported:
 * `location` - The location/region where the virtual network is created
 
 * `address_space` - The address space that is used the virtual network.
+
+* `subnet` - Set of multiple subnets defined in this virtual network. Each `subnet` block supports the fields documented below.
+
+The `subnet` block supports:
+
+* `id` - The ID of this subnet.
 
 
 ## Import

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -109,9 +109,11 @@ The following attributes are exported:
 
 * `address_space` - The address space that is used the virtual network.
 
-* `subnet` - Set of multiple subnets defined in this virtual network. Each `subnet` block supports the fields documented below.
+* `subnet`- One or more `subnet` blocks as defined below.
 
-The `subnet` block supports:
+---
+
+The `subnet` block exports:
 
 * `id` - The ID of this subnet.
 


### PR DESCRIPTION
* Add test cases to verify ID is actually set
* Add documentation and sample code to explain how to reference the subnet ID
* Expose the subnet ID in azurerm_virtual_network resource

Actually it is hard to reference a specific subnet element in the current implementation because of the hash function. But that is a different story and requires state migration as well. So I just keep it as a small change in this PR.

The PR enables user referencing the subnet ID defined in `azurerm_virtual_network` resource mentioned in issue #666 .

Fixes #666