### PR TITLE
Update start_ip_address documentation

### DIFF
--- a/website/docs/r/postgresql_firewall_rule.html.markdown
+++ b/website/docs/r/postgresql_firewall_rule.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.
 
-* `start_ip_address` - (Required) Specifies the Charset for the PostgreSQL Database. Changing this forces a new resource to be created.
+* `start_ip_address` - (Required) Specifies the Start IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
 
 * `end_ip_address` - (Required) Specifies the End IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
It looks like the documentation for `start_ip_address` was errantly copied from a different field. Update it with the correct documentation.