### PR TITLE
Update resource_arm_logic_app_trigger_http_request.go

### DIFF
--- a/azurerm/resource_arm_logic_app_trigger_http_request.go
+++ b/azurerm/resource_arm_logic_app_trigger_http_request.go
@@ -191,9 +191,9 @@ func resourceArmLogicAppTriggerHttpRequestDelete(d *schema.ResourceData, meta in
 func validateLogicAppTriggerHttpRequestRelativePath(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 
-	r, _ := regexp.Compile("^[A-Za-z0-9_]+$")
+	r, _ := regexp.Compile("^[A-Za-z0-9_/}{]+$")
 	if !r.MatchString(value) {
-		errors = append(errors, fmt.Errorf("Relative Path can only contain alphanumeric characters and underscores."))
+		errors = append(errors, fmt.Errorf("Relative Path can only contain alphanumeric characters, underscores, forward slashes and curly braces."))
 	}
 
 	return

--- a/azurerm/resource_arm_logic_app_trigger_http_request_test.go
+++ b/azurerm/resource_arm_logic_app_trigger_http_request_test.go
@@ -82,7 +82,7 @@ func TestAccAzureRMLogicAppTriggerHttpRequest_relativePath(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLogicAppTriggerExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "method", "POST"),
-					resource.TestCheckResourceAttr(resourceName, "relative_path", "hello_there"),
+					resource.TestCheckResourceAttr(resourceName, "relative_path", "customers/{id}"),
 				),
 			},
 		},
@@ -178,7 +178,7 @@ resource "azurerm_logic_app_trigger_http_request" "test" {
   logic_app_id  = "${azurerm_logic_app_workflow.test.id}"
   schema        = "{}"
   method        = "POST"
-  relative_path = "hello_there"
+  relative_path = "customers/{id}"
 }
 `, template)
 }


### PR DESCRIPTION
Fixes #1917 to allow http triggers with params in the relative path. See https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-http-endpoint#accept-parameters-through-your-http-endpoint-url for an example