### PR TITLE
Update TimeSpan documentation in Service Bus Queue/Topic

### DIFF
--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -40,21 +40,24 @@ func resourceArmServiceBusQueue() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"auto_delete_on_idle": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIso8601Duration(),
 			},
 
 			"default_message_ttl": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIso8601Duration(),
 			},
 
 			"duplicate_detection_history_time_window": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIso8601Duration(),
 			},
 
 			"enable_express": {

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -244,10 +244,10 @@ func TestAccAzureRMServiceBusQueue_isoTimeSpanAttributes(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceBusQueueExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "auto_delete_on_idle", "00:10:00"),
-					resource.TestCheckResourceAttr(resourceName, "default_message_ttl", "00:30:00"),
+					resource.TestCheckResourceAttr(resourceName, "auto_delete_on_idle", "PT10M"),
+					resource.TestCheckResourceAttr(resourceName, "default_message_ttl", "PT30M"),
 					resource.TestCheckResourceAttr(resourceName, "requires_duplicate_detection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "duplicate_detection_history_time_window", "00:15:00"),
+					resource.TestCheckResourceAttr(resourceName, "duplicate_detection_history_time_window", "PT15M"),
 				),
 			},
 		},
@@ -544,10 +544,10 @@ resource "azurerm_servicebus_queue" "test" {
     name                         = "acctestservicebusqueue-%d"
     resource_group_name          = "${azurerm_resource_group.test.name}"
     namespace_name               = "${azurerm_servicebus_namespace.test.name}"
-    auto_delete_on_idle          = "00:10:00"
-    default_message_ttl          = "00:30:00"
+    auto_delete_on_idle          = "PT10M"
+    default_message_ttl          = "PT30M"
     requires_duplicate_detection = true
-    duplicate_detection_history_time_window = "00:15:00"
+    duplicate_detection_history_time_window = "PT15M"
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_servicebus_topic.go
+++ b/azurerm/resource_arm_servicebus_topic.go
@@ -53,21 +53,24 @@ func resourceArmServiceBusTopic() *schema.Resource {
 			},
 
 			"auto_delete_on_idle": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIso8601Duration(),
 			},
 
 			"default_message_ttl": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIso8601Duration(),
 			},
 
 			"duplicate_detection_history_time_window": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateIso8601Duration(),
 			},
 
 			"enable_batched_operations": {

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -215,10 +215,10 @@ func TestAccAzureRMServiceBusTopic_isoTimeSpanAttributes(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceBusTopicExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "auto_delete_on_idle", "00:10:00"),
-					resource.TestCheckResourceAttr(resourceName, "default_message_ttl", "00:30:00"),
+					resource.TestCheckResourceAttr(resourceName, "auto_delete_on_idle", "PT10M"),
+					resource.TestCheckResourceAttr(resourceName, "default_message_ttl", "PT30M"),
 					resource.TestCheckResourceAttr(resourceName, "requires_duplicate_detection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "duplicate_detection_history_time_window", "00:15:00"),
+					resource.TestCheckResourceAttr(resourceName, "duplicate_detection_history_time_window", "PT15M"),
 				),
 			},
 		},
@@ -468,10 +468,10 @@ resource "azurerm_servicebus_topic" "test" {
     name                         = "acctestservicebustopic-%d"
     namespace_name               = "${azurerm_servicebus_namespace.test.name}"
     resource_group_name          = "${azurerm_resource_group.test.name}"
-    auto_delete_on_idle          = "00:10:00"
-    default_message_ttl          = "00:30:00"
+    auto_delete_on_idle          = "PT10M"
+    default_message_ttl          = "PT30M"
     requires_duplicate_detection = true
-    duplicate_detection_history_time_window = "00:15:00"
+    duplicate_detection_history_time_window = "PT15M"
 }
 `, rInt, location, rInt, rInt)
 }

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -63,16 +63,14 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group in which to
     create the namespace. Changing this forces a new resource to be created.
 
-* `auto_delete_on_idle` - (Optional) The idle interval after which the
-    Queue is automatically deleted, minimum of 5 minutes. Provided in the [TimeSpan](#timespan-format)
-    format.
+* `auto_delete_on_idle` - (Optional) The ISO 8601 timespan duration of the idle interval after which the
+    Queue is automatically deleted, minimum of 5 minutes.
 
-* `default_message_ttl` - (Optional) The TTL of messages sent to this queue. This is the default value
-    used when TTL is not set on message itself. Provided in the [TimeSpan](#timespan-format)
-    format.
+* `default_message_ttl` - (Optional) The ISO 8601 timespan duration of the TTL of messages sent to this
+    queue. This is the default value used when TTL is not set on message itself.
 
-* `duplicate_detection_history_time_window` - (Optional) The duration during which
-    duplicates can be detected. Default value is 10 minutes. Provided in the [TimeSpan](#timespan-format) format.
+* `duplicate_detection_history_time_window` - (Optional) The ISO 8601 timespan duration during which
+    duplicates can be detected. Default value is 10 minutes. (`PT10M`)
 
 * `enable_express` - (Optional) Boolean flag which controls whether Express Entities
     are enabled. An express queue holds a message in memory temporarily before writing
@@ -104,11 +102,6 @@ The following arguments are supported:
     Changing this forces a new resource to be created. Defaults to `false`.
 
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls whether the Queue has dead letter support when a message expires. Defaults to `false`.
-    
-### TimeSpan Format
-
-Some arguments for this resource are required in the TimeSpan format which is
-used to represent a length of time. The supported format is documented [here](https://msdn.microsoft.com/en-us/library/se73z7b9(v=vs.110).aspx#Anchor_2)
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -63,16 +63,14 @@ The following arguments are supported:
 
 * `status` - (Optional) The Status of the Service Bus Topic. Acceptable values are `Active` or `Disabled`. Defaults to `Active`.
 
-* `auto_delete_on_idle` - (Optional) The idle interval after which the
-    Topic is automatically deleted, minimum of 5 minutes. Provided in the [TimeSpan](#timespan-format)
-    format.
+* `auto_delete_on_idle` - (Optional) The ISO 8601 timespan duration of the idle interval after which the
+    Topic is automatically deleted, minimum of 5 minutes.
 
-* `default_message_ttl` - (Optional) The TTL of messages sent to this topic if no
-    TTL value is set on the message itself. Provided in the [TimeSpan](#timespan-format)
-    format.
+* `default_message_ttl` - (Optional) The ISO 8601 timespan duration of TTL of messages sent to this topic if no
+    TTL value is set on the message itself.
 
-* `duplicate_detection_history_time_window` - (Optional) The duration during which
-    duplicates can be detected. Provided in the [TimeSpan](#timespan-format) format. Defaults to 10 minutes (`00:10:00`)
+* `duplicate_detection_history_time_window` - (Optional) The ISO 8601 timespan duration during which
+    duplicates can be detected. Defaults to 10 minutes. (`PT10M`)
 
 * `enable_batched_operations` - (Optional) Boolean flag which controls if server-side
     batched operations are enabled. Defaults to false.
@@ -97,11 +95,6 @@ The following arguments are supported:
 
 * `support_ordering` - (Optional) Boolean flag which controls whether the Topic
     supports ordering. Defaults to false.
-
-### TimeSpan Format
-
-Some arguments for this resource are required in the TimeSpan format which is
-used to represent a lengh of time. The supported format is documented [here](https://msdn.microsoft.com/en-us/library/se73z7b9(v=vs.110).aspx#Anchor_2)
 
 ## Attributes Reference
 


### PR DESCRIPTION
The original documentation regarding `auto_delete_on_idle`, `default_message_ttl` and `duplicate_detection_history_time_window` is not correct any more. Azure REST APIs have replaced all [C# TimeSpan format](https://docs.microsoft.com/en-us/dotnet/api/system.timespan.parse?redirectedfrom=MSDN&view=netframework-4.7.2#System_TimeSpan_Parse_System_String_) with the new [ISO8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations). This change is also caught in #646 .

In this PR:
- Update the documentation to use the latest ISO8601 duration format
- Add test cases in order to catch such problems as soon as possible in the future
- Add `ValidateFunc` so user could see the error before applying