### PR TITLE
Update application_gateway.html.markdown

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -131,7 +131,7 @@ resource "azurerm_application_gateway" "network" {
   url_path_map {
     name = "pbr.contoso.com"
     default_backend_address_pool_name = "${azurerm_virtual_network.vnet.name}-beap-fallback"
-    default_backend_http_settings_name = ${azurerm_virtual_network.vnet.name}-be-htst"
+    default_backend_http_settings_name = "${azurerm_virtual_network.vnet.name}-be-htst"
 
     path_rule {
       name = "pbr.contoso.com_first"


### PR DESCRIPTION
Missing double quote in the example default_backend_http_settings_name assignment.