### PR TITLE
App Service Plan: refactoring / handling errors in flatten functions

### DIFF
--- a/azurerm/data_source_app_service_plan.go
+++ b/azurerm/data_source_app_service_plan.go
@@ -105,15 +105,17 @@ func dataSourceAppServicePlanRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if props := resp.AppServicePlanProperties; props != nil {
-		d.Set("properties", flattenAppServiceProperties(props))
+		if err := d.Set("properties", flattenAppServiceProperties(props)); err != nil {
+			return fmt.Errorf("Error flattening `properties`: %+v", err)
+		}
 
 		if props.MaximumNumberOfWorkers != nil {
 			d.Set("maximum_number_of_workers", int(*props.MaximumNumberOfWorkers))
 		}
 	}
 
-	if sku := resp.Sku; sku != nil {
-		d.Set("sku", flattenAppServicePlanSku(sku))
+	if err := d.Set("sku", flattenAppServicePlanSku(resp.Sku)); err != nil {
+		return fmt.Errorf("Error flattening `sku`: %+v", err)
 	}
 
 	flattenAndSetTags(d, resp.Tags)


### PR DESCRIPTION
Noticed a couple of test failures we need more info to fix:

```
* azurerm_app_service_plan.test: web.AppServicePlansClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> <nil>
```

Ended up doing some crash fixes/set error handling when passing through too