### PR TITLE
Check if error is retryable before returning that it is

### DIFF
--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -3,10 +3,12 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -182,6 +184,12 @@ func validateRoleDefinitionName(i interface{}, k string) ([]string, []error) {
 }
 
 func retryRoleAssignmentsClient(scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}) func() *resource.RetryError {
+	urlErrorIsRetryable := func(err *url.Error) bool {
+		if err.Temporary() || err.Timeout() {
+			return true
+		}
+		return false
+	}
 
 	return func() *resource.RetryError {
 		roleAssignmentsClient := meta.(*ArmClient).roleAssignmentsClient
@@ -190,7 +198,18 @@ func retryRoleAssignmentsClient(scope string, name string, properties authorizat
 		_, err := roleAssignmentsClient.Create(ctx, scope, name, properties)
 
 		if err != nil {
-			return resource.RetryableError(err)
+			// Error is retryable only if it is a temporary error or timeout
+			switch e := err.(type) {
+			case autorest.DetailedError:
+				if ue, ok := e.Original.(*url.Error); ok && urlErrorIsRetryable(ue) {
+					return resource.RetryableError(err)
+				}
+			case *url.Error:
+				if urlErrorIsRetryable(e) {
+					return resource.RetryableError(err)
+				}
+			}
+			return resource.NonRetryableError(err)
 		}
 		return nil
 

--- a/azurerm/utils/response.go
+++ b/azurerm/utils/response.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net"
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -12,6 +13,21 @@ func ResponseWasConflict(resp autorest.Response) bool {
 
 func ResponseWasNotFound(resp autorest.Response) bool {
 	return responseWasStatusCode(resp, http.StatusNotFound)
+}
+
+func ResponseErrorIsRetryable(err error) bool {
+	if arerr, ok := err.(autorest.DetailedError); ok {
+		err = arerr.Original
+	}
+
+	switch e := err.(type) {
+	case net.Error:
+		if e.Temporary() || e.Timeout() {
+			return true
+		}
+	}
+
+	return false
 }
 
 func responseWasStatusCode(resp autorest.Response, statusCode int) bool {

--- a/azurerm/utils/response_test.go
+++ b/azurerm/utils/response_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -34,6 +35,43 @@ func TestResponseNotFound_StatusCodes(t *testing.T) {
 		if test.expectedResult != result {
 			t.Fatalf("Expected '%+v' for status code '%d' - got '%+v'",
 				test.expectedResult, test.statusCode, result)
+		}
+	}
+}
+
+type testNetError struct {
+	timeout   bool
+	temporary bool
+}
+
+// testNetError fulfills net.Error interface
+func (e testNetError) Error() string   { return "testError" }
+func (e testNetError) Timeout() bool   { return e.timeout }
+func (e testNetError) Temporary() bool { return e.temporary }
+
+func TestResponseErrorIsRetryable(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		err            error
+		expectedResult bool
+	}{
+		{"Unhandled error types are not retryable", fmt.Errorf("Some other error"), false},
+		{"Temporary AND timeout errors are retryable", testNetError{true, true}, true},
+		{"Timeout errors are retryable", testNetError{true, false}, true},
+		{"Temporary errors are retryable", testNetError{false, true}, true},
+		{"net.Errors that are neither temporary nor timeouts are not retryable", testNetError{false, false}, false},
+		{"Retryable error nested in autorest.DetailedError is retryable", autorest.DetailedError{
+			Original: testNetError{true, true}}, true},
+		{"Unhandled error nested in autorest.DetailedError is not retryable", autorest.DetailedError{
+			Original: fmt.Errorf("Some other error")}, false},
+		{"nil is handled as non-retryable", nil, false},
+	}
+
+	for _, test := range testCases {
+		result := ResponseErrorIsRetryable(test.err)
+		if test.expectedResult != result {
+			t.Errorf("Expected '%v' for case '%s' - got '%v'",
+				test.expectedResult, test.desc, result)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1757.

This PR checks if errors returned in `resource_arm_role_assignment` are actually retryable, rather than always retrying. If the approach is ok, it should also be applied to `resource_arm_storage_container`, which uses the same "always retry" logic.
Currently, I just check if the error (or nested error) is a `*url.Error` and if so if it is a temporary or timeout error. Anything else is deemed non-retryable. Are there other cases that should be retried?