### PR TITLE
Virtual Machine: Handling `disk.ManagedDisk.ID` being nil

### DIFF
--- a/azurerm/resource_arm_image.go
+++ b/azurerm/resource_arm_image.go
@@ -347,7 +347,7 @@ func flattenAzureRmImageDataDisks(diskImages *[]compute.ImageDataDisk) []interfa
 				l["size_gb"] = *disk.DiskSizeGB
 			}
 			l["lun"] = *disk.Lun
-			if disk.ManagedDisk != nil {
+			if disk.ManagedDisk != nil && disk.ManagedDisk.ID != nil {
 				l["managed_disk_id"] = *disk.ManagedDisk.ID
 			}
 

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -850,12 +850,16 @@ func resourceArmVirtualMachineDelete(d *schema.ResourceData, meta interface{}) e
 		}
 
 		if osDisk.Vhd != nil {
-			if err = resourceArmVirtualMachineDeleteVhd(*osDisk.Vhd.URI, meta); err != nil {
-				return fmt.Errorf("Error deleting OS Disk VHD: %+v", err)
+			if osDisk.Vhd.URI != nil {
+				if err = resourceArmVirtualMachineDeleteVhd(*osDisk.Vhd.URI, meta); err != nil {
+					return fmt.Errorf("Error deleting OS Disk VHD: %+v", err)
+				}
 			}
 		} else if osDisk.ManagedDisk != nil {
-			if err = resourceArmVirtualMachineDeleteManagedDisk(*osDisk.ManagedDisk.ID, meta); err != nil {
-				return fmt.Errorf("Error deleting OS Managed Disk: %+v", err)
+			if osDisk.ManagedDisk.ID != nil {
+				if err = resourceArmVirtualMachineDeleteManagedDisk(*osDisk.ManagedDisk.ID, meta); err != nil {
+					return fmt.Errorf("Error deleting OS Managed Disk: %+v", err)
+				}
 			}
 		} else {
 			return fmt.Errorf("Unable to locate OS managed disk properties from %s", name)
@@ -1078,7 +1082,9 @@ func flattenAzureRmVirtualMachineDataDisk(disks *[]compute.DataDisk, disksInfo [
 		}
 		if disk.ManagedDisk != nil {
 			l["managed_disk_type"] = string(disk.ManagedDisk.StorageAccountType)
-			l["managed_disk_id"] = *disk.ManagedDisk.ID
+			if disk.ManagedDisk.ID != nil {
+				l["managed_disk_id"] = *disk.ManagedDisk.ID
+			}
 		}
 		l["create_option"] = disk.CreateOption
 		l["caching"] = string(disk.Caching)


### PR DESCRIPTION
Ensuring we nil-check `ManagedDisk.ID` before accessing it - which fixes #1941