### PR TITLE
Support for Data Disk Attachments on VM's with VM Extensions installed

### DIFF
--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
@@ -151,6 +151,9 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 
 	virtualMachine.StorageProfile.DataDisks = &disks
 
+	// fixes #1600
+	virtualMachine.Resources = nil
+
 	// if there's too many disks we get a 409 back with:
 	//   `The maximum number of data disks allowed to be attached to a VM of this size is 1.`
 	// which we're intentionally not wrapping, since the errors good.
@@ -260,6 +263,9 @@ func resourceArmVirtualMachineDataDiskAttachmentDelete(d *schema.ResourceData, m
 	}
 
 	virtualMachine.StorageProfile.DataDisks = &dataDisks
+
+	// fixes #1600
+	virtualMachine.Resources = nil
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, virtualMachineName, virtualMachine)
 	if err != nil {

--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
@@ -134,6 +134,30 @@ func TestAccAzureRMVirtualMachineDataDiskAttachment_updatingWriteAccelerator(t *
 	})
 }
 
+func TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_data_disk_attachment.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDataDiskAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtensionPrep(ri, location),
+			},
+			{
+				Config: testAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtensionComplete(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineDataDiskAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "virtual_machine_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_disk_id"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMVirtualMachineDataDiskAttachmentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -459,4 +483,130 @@ resource "azurerm_managed_disk" "test" {
   disk_size_gb         = 10
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtensionPrep(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "acctestpip%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
+}
+
+
+resource "azurerm_virtual_machine" "test" {
+  name                  = "acctestvm%d"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.test.id}"]
+  vm_size               = "Standard_F4"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_profile {
+    computer_name  = "testvm"
+    admin_username = "tfuser123"
+    admin_password = "Password1234!"
+  }
+
+  storage_os_disk {
+    name              = "myosdisk1"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  tags {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_virtual_machine_extension" "test" {
+  name                 = "random-script"
+  location             = "${azurerm_resource_group.test.location}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_machine_name = "${azurerm_virtual_machine.test.name}"
+  publisher            = "Microsoft.Azure.Extensions"
+  type                 = "CustomScript"
+  type_handler_version = "2.0"
+
+  settings = <<SETTINGS
+	{
+		"commandToExecute": "hostname"
+	}
+SETTINGS
+
+  tags {
+    environment = "Production"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtensionComplete(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtensionPrep(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctest%d"
+  location             = "${azurerm_resource_group.test.location}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = "${azurerm_managed_disk.test.id}"
+  virtual_machine_id = "${azurerm_virtual_machine.test.id}"
+  lun                = "11"
+  caching            = "ReadWrite"
+}
+`, template, rInt)
 }


### PR DESCRIPTION
This PR fixes an issue where the Virtual Machine Extension object cannot be posted back to the Virtual Machine API - which causes an issue when using the `azurerm_virtual_machine_data_disk_attachment resource on a Virtual Machine with a VM Extension configured.

Before this fix:

```
$ acctests azurerm TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension
=== RUN   TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension
--- FAIL: TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension (584.25s)
	testing.go:513: Step 1 error: Error applying: 1 error(s) occurred:

		* azurerm_virtual_machine_data_disk_attachment.test: 1 error(s) occurred:

		* azurerm_virtual_machine_data_disk_attachment.test: Error updating Virtual Machine "acctestvm1479430537935323945" (Resource Group "acctestrg1479430537935323945") with Disk "acctest1479430537935323945": compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidRequestContent" Message="The request content was invalid and could not be deserialized: 'Could not find member 'resources' on object of type 'ResourceDefinition'. Path 'resources', line 1, position 1655.'."
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	584.613s
```

After this fix:

```
$ acctests azurerm TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension
=== RUN   TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension
--- PASS: TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension (653.67s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	654.047s
```

Fixes #1600