### PR TITLE
Add support for vnet rules to CosmosDB accounts.

### DIFF
--- a/azurerm/data_source_cosmos_db_account.go
+++ b/azurerm/data_source_cosmos_db_account.go
@@ -225,13 +225,7 @@ func dataSourceArmCosmosDBAccountRead(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("Error setting `capabilities`: %+v", err)
 		}
 
-		virtualNetworkRules := make([]map[string]interface{}, len(*props.VirtualNetworkRules))
-		for i, r := range *props.VirtualNetworkRules {
-			virtualNetworkRules[i] = map[string]interface{}{
-				"id": *r.ID,
-			}
-		}
-		if err := d.Set("virtual_network_rule", virtualNetworkRules); err != nil {
+		if err := d.Set("virtual_network_rule", flattenAzureRmCosmosDBAccountVirtualNetworkRulesAsList(props.VirtualNetworkRules)); err != nil {
 			return fmt.Errorf("Error setting `virtual_network_rule`: %+v", err)
 		}
 
@@ -284,4 +278,18 @@ func flattenAzureRmCosmosDBAccountCapabilitiesAsList(capabilities *[]documentdb.
 	}
 
 	return &slice
+}
+
+func flattenAzureRmCosmosDBAccountVirtualNetworkRulesAsList(rules *[]documentdb.VirtualNetworkRule) []map[string]interface{} {
+	if rules == nil {
+		return []map[string]interface{}{}
+	}
+
+	virtualNetworkRules := make([]map[string]interface{}, len(*rules))
+	for i, r := range *rules {
+		virtualNetworkRules[i] = map[string]interface{}{
+			"id": *r.ID,
+		}
+	}
+	return virtualNetworkRules
 }

--- a/azurerm/data_source_cosmos_db_account.go
+++ b/azurerm/data_source_cosmos_db_account.go
@@ -105,6 +105,24 @@ func dataSourceArmCosmosDBAccount() *schema.Resource {
 				},
 			},
 
+			"is_virtual_network_filter_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"virtual_network_rule": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -183,6 +201,7 @@ func dataSourceArmCosmosDBAccountRead(d *schema.ResourceData, meta interface{}) 
 		d.Set("offer_type", string(props.DatabaseAccountOfferType))
 		d.Set("ip_range_filter", props.IPRangeFilter)
 		d.Set("endpoint", props.DocumentEndpoint)
+		d.Set("is_virtual_network_filter_enabled", resp.IsVirtualNetworkFilterEnabled)
 		d.Set("enable_automatic_failover", resp.EnableAutomaticFailover)
 
 		if err := d.Set("consistency_policy", flattenAzureRmCosmosDBAccountConsistencyPolicy(resp.ConsistencyPolicy)); err != nil {
@@ -204,6 +223,16 @@ func dataSourceArmCosmosDBAccountRead(d *schema.ResourceData, meta interface{}) 
 
 		if err := d.Set("capabilities", flattenAzureRmCosmosDBAccountCapabilitiesAsList(resp.Capabilities)); err != nil {
 			return fmt.Errorf("Error setting `capabilities`: %+v", err)
+		}
+
+		virtualNetworkRules := make([]map[string]interface{}, len(*props.VirtualNetworkRules))
+		for i, r := range *props.VirtualNetworkRules {
+			virtualNetworkRules[i] = map[string]interface{}{
+				"id": *r.ID,
+			}
+		}
+		if err := d.Set("virtual_network_rule", virtualNetworkRules); err != nil {
+			return fmt.Errorf("Error setting `virtual_network_rule`: %+v", err)
 		}
 
 		readEndpoints := make([]string, 0)

--- a/azurerm/data_source_cosmos_db_account_test.go
+++ b/azurerm/data_source_cosmos_db_account_test.go
@@ -53,6 +53,28 @@ func TestAccDataSourceAzureRMCosmosDBAccount_geoReplicated_customId(t *testing.T
 	})
 }
 
+func TestAccDataSourceAzureRMCosmosDBAccount_virtualNetworkFilter(t *testing.T) {
+	ri := acctest.RandInt()
+	dataSourceName := "data.azurerm_cosmosdb_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMCosmosDBAccount_virtualNetworkFilter(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkAccAzureRMCosmosDBAccount_basic(dataSourceName, testLocation(), string(documentdb.BoundedStaleness), 1),
+					resource.TestCheckResourceAttr(dataSourceName, "is_virtual_network_filter_enabled", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "virtual_network_rule.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "virtual_network_rule.1.id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAzureRMCosmosDBAccount_complete(t *testing.T) {
 	ri := acctest.RandInt()
 	dataSourceName := "data.azurerm_cosmosdb_account.test"
@@ -109,4 +131,15 @@ data "azurerm_cosmosdb_account" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 `, testAccAzureRMCosmosDBAccount_complete(rInt, location, altLocation))
+}
+
+func testAccDataSourceAzureRMCosmosDBAccount_virtualNetworkFilter(rInt int, location string) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_cosmosdb_account" "test" {
+  name                = "${azurerm_cosmosdb_account.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, testAccAzureRMCosmosDBAccount_virtualNetworkFilter(rInt, location))
 }

--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -218,8 +219,9 @@ func resourceArmCosmosDBAccount() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: azure.ValidateResourceID,
 						},
 					},
 				},
@@ -924,11 +926,13 @@ func flattenAzureRmCosmosDBAccountVirtualNetworkRules(rules *[]documentdb.Virtua
 		F: resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash,
 	}
 
-	for _, r := range *rules {
-		rule := map[string]interface{}{
-			"id": *r.ID,
+	if rules != nil {
+		for _, r := range *rules {
+			rule := map[string]interface{}{
+				"id": *r.ID,
+			}
+			results.Add(rule)
 		}
-		results.Add(rule)
 	}
 
 	return &results

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -51,6 +51,10 @@ The following attributes are exported:
 
 * `capabilities` - Capabilities enabled on this Cosmos DB account.
 
+* `is_virtual_network_filter_enabled` - If virtual network filtering is enabled for this Cosmos DB account.
+
+* `virtual_network_rule` - Subnets that are allowed to access this CosmosDB account.
+
 `consistency_policy` The current consistency Settings for this CosmosDB account with the following properties:
 
 * `consistency_level` - The Consistency Level used by this CosmosDB Account. 
@@ -63,6 +67,10 @@ The following attributes are exported:
 * `id` - The ID of the location.
 * `location` - The name of the Azure region hosting replicated data.
 * `priority` - The locations fail over priority.
+
+`virtual_network_rule` The virtual network subnets allowed to access this Cosmos DB account with the following properties:
+
+* `id` - The ID of the virtual network subnet.
 
 * `endpoint` - The endpoint used to connect to the CosmosDB account.
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -77,6 +77,10 @@ The following arguments are supported:
 
 * `capabilities` - (Optional) Enable capabilities for this Cosmos DB account. Possible values are `EnableTable` and `EnableGremlin`.
 
+* `is_virtual_network_filter_enabled` - (Optional) Enables virtual network filtering for this Cosmos DB account.
+
+* `virtual_network_rule` - (Optional) Specifies a `virtual_network_rules` resource, used to define which subnets are allowed to access this CosmosDB account.
+
 `consistency_policy` Configures the database consistency and supports the following:
 
 * `consistency_level` - (Required) The Consistency Level to use for this CosmosDB Account - can be either `BoundedStaleness`, `Eventual`, `Session`, `Strong` or `ConsistentPrefix`.
@@ -92,6 +96,10 @@ The following arguments are supported:
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
 
 **NOTE:** The `prefix` and `failover_priority` fields of a location cannot be changed for the location with a failover priority of `0`.
+
+`virtual_network_rule` Configures the virtual network subnets allowed to access this Cosmos DB account and supports the following:
+
+* `id` - (Required) The ID of the virtual network subnet.
 
 ## Attributes Reference
 


### PR DESCRIPTION
These changes add support for virtual network filters to CosmosDB
accounts. Using these filters requires two new properties:
- `is_virtual_network_filter_enabled`, which enables virutal network
  filters for the account
- `virtual_network_rule`, which specifies the subnets that are allowed
  to access the account

Fixes #1342.