### PR TITLE
App Service Custom Hostname Binding: support for multiple bindings

### DIFF
--- a/azurerm/import_arm_app_service_hostname_binding_test.go
+++ b/azurerm/import_arm_app_service_hostname_binding_test.go
@@ -13,8 +13,9 @@ func TestAccAzureRMAppServiceCustomHostnameBinding(t *testing.T) {
 	// the app service name being shared (so the tests don't conflict with each other)
 	testCases := map[string]map[string]func(t *testing.T){
 		"basic": {
-			"basic":  testAccAzureRMAppServiceCustomHostnameBinding_basic,
-			"import": testAccAzureRMAppServiceCustomHostnameBinding_import,
+			"basic":    testAccAzureRMAppServiceCustomHostnameBinding_basic,
+			"multiple": testAccAzureRMAppServiceCustomHostnameBinding_multiple,
+			"import":   testAccAzureRMAppServiceCustomHostnameBinding_import,
 		},
 	}
 

--- a/azurerm/resource_arm_app_service_custom_hostname_binding.go
+++ b/azurerm/resource_arm_app_service_custom_hostname_binding.go
@@ -9,6 +9,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+var appServiceCustomHostnameBindingResourceName = "azurerm_app_service_custom_hostname_binding"
+
 func resourceArmAppServiceCustomHostnameBinding() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmAppServiceCustomHostnameBindingCreate,
@@ -45,6 +47,9 @@ func resourceArmAppServiceCustomHostnameBindingCreate(d *schema.ResourceData, me
 	resourceGroup := d.Get("resource_group_name").(string)
 	appServiceName := d.Get("app_service_name").(string)
 	hostname := d.Get("hostname").(string)
+
+	azureRMLockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
+	defer azureRMUnlockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
 
 	properties := web.HostNameBinding{
 		HostNameBindingProperties: &web.HostNameBindingProperties{
@@ -109,6 +114,9 @@ func resourceArmAppServiceCustomHostnameBindingDelete(d *schema.ResourceData, me
 	resGroup := id.ResourceGroup
 	appServiceName := id.Path["sites"]
 	hostname := id.Path["hostNameBindings"]
+
+	azureRMLockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
+	defer azureRMUnlockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
 
 	log.Printf("[DEBUG] Deleting App Service Hostname Binding %q (App Service %q / Resource Group %q)", hostname, appServiceName, resGroup)
 


### PR DESCRIPTION
The Azure API only allows a single hostname to be added/removed at once. This PR adds a lock to ensure this is the case

before this change:

```
$ ARM_TEST_APP_SERVICE=tomdevacctest12345 ARM_TEST_DOMAIN=REDACTED ARM_ALT_TEST_DOMAIN=REDACTED acctests azurerm TestAccAzureRMAppServiceCustomHostnameBinding

=== RUN   TestAccAzureRMAppServiceCustomHostnameBinding
=== RUN   TestAccAzureRMAppServiceCustomHostnameBinding/basic
=== RUN   TestAccAzureRMAppServiceCustomHostnameBinding/basic/basic
=== RUN   TestAccAzureRMAppServiceCustomHostnameBinding/basic/import
--- PASS: TestAccAzureRMAppServiceCustomHostnameBinding (299.70s)
    --- PASS: TestAccAzureRMAppServiceCustomHostnameBinding/basic (299.70s)
        --- PASS: TestAccAzureRMAppServiceCustomHostnameBinding/basic/basic (135.97s)
        --- PASS: TestAccAzureRMAppServiceCustomHostnameBinding/basic/import (163.72s)
=== RUN   TestAccAzureRMAppServiceCustomHostnameBinding_multiple
--- FAIL: TestAccAzureRMAppServiceCustomHostnameBinding_multiple (112.01s)
	testing.go:573: Error destroying resource! WARNING: Dangling resources
		may exist. The full state and error is shown below.

		Error: Error applying: 1 error(s) occurred:

		* azurerm_app_service_custom_hostname_binding.test2 (destroy): 1 error(s) occurred:

		* azurerm_app_service_custom_hostname_binding.test2: web.AppsClient#DeleteHostNameBinding: Failure sending request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=<nil> <nil>
```

after this change:

```
$ ARM_TEST_APP_SERVICE=tomdevacctest12345 ARM_TEST_DOMAIN=REDACTED ARM_ALT_TEST_DOMAIN=REDACTED acctests azurerm TestAccAzureRMAppServiceCustomHostnameBinding_multiple
=== RUN   TestAccAzureRMAppServiceCustomHostnameBinding_multiple
--- PASS: TestAccAzureRMAppServiceCustomHostnameBinding_multiple (157.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	158.148s
```


Fixes #1968