### PR TITLE
Role Definition: support for Data Actions

### DIFF
--- a/azurerm/resource_arm_role_definition.go
+++ b/azurerm/resource_arm_role_definition.go
@@ -64,6 +64,20 @@ func resourceArmRoleDefinition() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"data_actions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"not_data_actions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 					},
 				},
 			},
@@ -194,12 +208,26 @@ func expandRoleDefinitionPermissions(d *schema.ResourceData) []authorization.Per
 		}
 		permission.Actions = &actionsOutput
 
+		dataActionsOutput := make([]string, 0)
+		dataActions := input["data_actions"].([]interface{})
+		for _, a := range dataActions {
+			dataActionsOutput = append(dataActionsOutput, a.(string))
+		}
+		permission.DataActions = &dataActionsOutput
+
 		notActionsOutput := make([]string, 0)
 		notActions := input["not_actions"].([]interface{})
 		for _, a := range notActions {
 			notActionsOutput = append(notActionsOutput, a.(string))
 		}
 		permission.NotActions = &notActionsOutput
+
+		notDataActionsOutput := make([]string, 0)
+		notDataActions := input["not_data_actions"].([]interface{})
+		for _, a := range notDataActions {
+			notDataActionsOutput = append(notDataActionsOutput, a.(string))
+		}
+		permission.NotDataActions = &notDataActionsOutput
 
 		output = append(output, permission)
 	}
@@ -232,6 +260,14 @@ func flattenRoleDefinitionPermissions(input *[]authorization.Permission) []inter
 		}
 		output["actions"] = actions
 
+		dataActions := make([]string, 0)
+		if permission.DataActions != nil {
+			for _, dataAction := range *permission.DataActions {
+				dataActions = append(dataActions, dataAction)
+			}
+		}
+		output["data_actions"] = dataActions
+
 		notActions := make([]string, 0)
 		if permission.NotActions != nil {
 			for _, action := range *permission.NotActions {
@@ -239,6 +275,14 @@ func flattenRoleDefinitionPermissions(input *[]authorization.Permission) []inter
 			}
 		}
 		output["not_actions"] = notActions
+
+		notDataActions := make([]string, 0)
+		if permission.NotDataActions != nil {
+			for _, dataAction := range *permission.NotDataActions {
+				notDataActions = append(notDataActions, dataAction)
+			}
+		}
+		output["not_data_actions"] = notDataActions
 
 		permissions = append(permissions, output)
 	}

--- a/azurerm/resource_arm_role_definition.go
+++ b/azurerm/resource_arm_role_definition.go
@@ -65,18 +65,20 @@ func resourceArmRoleDefinition() *schema.Resource {
 							},
 						},
 						"data_actions": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+							Set: schema.HashString,
 						},
 						"not_data_actions": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+							Set: schema.HashString,
 						},
 					},
 				},
@@ -209,8 +211,8 @@ func expandRoleDefinitionPermissions(d *schema.ResourceData) []authorization.Per
 		permission.Actions = &actionsOutput
 
 		dataActionsOutput := make([]string, 0)
-		dataActions := input["data_actions"].([]interface{})
-		for _, a := range dataActions {
+		dataActions := input["data_actions"].(*schema.Set)
+		for _, a := range dataActions.List() {
 			dataActionsOutput = append(dataActionsOutput, a.(string))
 		}
 		permission.DataActions = &dataActionsOutput
@@ -223,8 +225,8 @@ func expandRoleDefinitionPermissions(d *schema.ResourceData) []authorization.Per
 		permission.NotActions = &notActionsOutput
 
 		notDataActionsOutput := make([]string, 0)
-		notDataActions := input["not_data_actions"].([]interface{})
-		for _, a := range notDataActions {
+		notDataActions := input["not_data_actions"].(*schema.Set)
+		for _, a := range notDataActions.List() {
 			notDataActionsOutput = append(notDataActionsOutput, a.(string))
 		}
 		permission.NotDataActions = &notDataActionsOutput
@@ -260,13 +262,13 @@ func flattenRoleDefinitionPermissions(input *[]authorization.Permission) []inter
 		}
 		output["actions"] = actions
 
-		dataActions := make([]string, 0)
+		dataActions := make([]interface{}, 0)
 		if permission.DataActions != nil {
 			for _, dataAction := range *permission.DataActions {
 				dataActions = append(dataActions, dataAction)
 			}
 		}
-		output["data_actions"] = dataActions
+		output["data_actions"] = schema.NewSet(schema.HashString, dataActions)
 
 		notActions := make([]string, 0)
 		if permission.NotActions != nil {
@@ -276,13 +278,13 @@ func flattenRoleDefinitionPermissions(input *[]authorization.Permission) []inter
 		}
 		output["not_actions"] = notActions
 
-		notDataActions := make([]string, 0)
+		notDataActions := make([]interface{}, 0)
 		if permission.NotDataActions != nil {
 			for _, dataAction := range *permission.NotDataActions {
 				notDataActions = append(notDataActions, dataAction)
 			}
 		}
-		output["not_data_actions"] = notDataActions
+		output["not_data_actions"] = schema.NewSet(schema.HashString, notDataActions)
 
 		permissions = append(permissions, output)
 	}

--- a/azurerm/resource_arm_role_definition_test.go
+++ b/azurerm/resource_arm_role_definition_test.go
@@ -191,8 +191,10 @@ resource "azurerm_role_definition" "test" {
   description        = "Acceptance Test Role Definition"
 
   permissions {
-    actions     = ["*"]
-    not_actions = ["Microsoft.Authorization/*/read"]
+    actions          = ["*"]
+    data_actions     = ["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read"]
+    not_actions      = ["Microsoft.Authorization/*/read"]
+    not_data_actions = []
   }
 
   assignable_scopes = [

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -50,9 +50,13 @@ The following arguments are supported:
 
 A `permissions` block as the following properties:
 
-* `action` - (Optional) One or more Allowed Actions, such as `*`, `Microsoft.Resources/subscriptions/resourceGroups/read`. See ['Azure Resource Manager resource provider operations'](https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations) for details. 
+* `action` - (Optional) One or more Allowed Actions, such as `*`, `Microsoft.Resources/subscriptions/resourceGroups/read`. See ['Azure Resource Manager resource provider operations'](https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations) for details.
+
+* `data_action` - (Optional) One or more Allowed Data Actions, such as `*`, `Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read`. See ['Azure Resource Manager resource provider operations'](https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations) for details.
 
 * `not_action` - (Optional) One or more Disallowed Actions, such as `*`, `Microsoft.Resources/subscriptions/resourceGroups/read`. See ['Azure Resource Manager resource provider operations'](https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations) for details.
+
+* `not_data_action` - (Optional) One or more Disallowed Data Actions, such as `*`, `Microsoft.Resources/subscriptions/resourceGroups/read`. See ['Azure Resource Manager resource provider operations'](https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations) for details.
 
 ## Attributes Reference
 


### PR DESCRIPTION
```
$ acctests azurerm TestAccAzureRMRoleDefinition_complete
=== RUN   TestAccAzureRMRoleDefinition_complete
--- PASS: TestAccAzureRMRoleDefinition_complete (46.46s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	47.349s
```

Fixes #1538