### PR TITLE
Removing the Client ID since it breaks networking api's

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -288,7 +288,7 @@ func clientRequestID() string {
 func (c *ArmClient) configureClient(client *autorest.Client, auth autorest.Authorizer) {
 	setUserAgent(client)
 	client.Authorizer = auth
-	client.RequestInspector = azure.WithClientID(clientRequestID())
+	//client.RequestInspector = azure.WithClientID(clientRequestID())
 	client.Sender = autorest.CreateSender(withRequestLogging())
 	client.SkipResourceProviderRegistration = c.skipProviderRegistration
 	client.PollingDuration = 60 * time.Minute


### PR DESCRIPTION
Apparently setting the Client ID means the Networking API's (LB's/Firewall etc) no longer return the ID of nested resources - meaning any Nested Resources no longer works.

@metacpp is going to investigate this - but we're reverting this change for the moment