### PR TITLE
[WIP] CosmosDB: Adding MongoDBv3.4 & mongoEnableDocLevelTTL capabilities

### DIFF
--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -197,8 +197,9 @@ func resourceArmCosmosDBAccount() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								"EnableTable",
 								"EnableGremlin",
-								`EnableCassandra`,
-								`MongoDBv3.4`,
+								"EnableCassandra",
+								"MongoDBv3.4",
+								"mongoEnableDocLevelTTL",
 							}, true),
 						},
 					},

--- a/azurerm/resource_arm_cosmos_db_account.go
+++ b/azurerm/resource_arm_cosmos_db_account.go
@@ -198,6 +198,7 @@ func resourceArmCosmosDBAccount() *schema.Resource {
 								"EnableTable",
 								"EnableGremlin",
 								`EnableCassandra`,
+								`MongoDBv3.4`,
 							}, true),
 						},
 					},

--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -361,6 +361,32 @@ func TestAccAzureRMCosmosDBAccount_capabilityMongo35(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMCosmosDBAccount_capabilityDocLevelTTL(t *testing.T) {
+	ri := acctest.RandInt()
+	resourceName := "azurerm_cosmosdb_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDBAccount_capabilityDocLevelTTL(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkAccAzureRMCosmosDBAccount_basic(resourceName, testLocation(), string(documentdb.BoundedStaleness), 1),
+					resource.TestCheckResourceAttr(resourceName, "kind", "MongoDB"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAbcAzureRMCosmosDBAccount_updatePropertiesAndLocation(t *testing.T) {
 	ri := acctest.RandInt()
 	resourceName := "azurerm_cosmosdb_account.test"
@@ -639,6 +665,16 @@ func testAccAzureRMCosmosDBAccount_capabilityMongo34(rInt int, location string) 
 
         capabilities = {
           name = "MongoDBv3.4"
+        }
+    `)
+}
+
+func testAccAzureRMCosmosDBAccount_capabilityDocLevelTTL(rInt int, location string) string {
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", `
+        kind = "MongoDB"
+
+        capabilities = {
+          name = "mongoEnableDocLevelTTL"
         }
     `)
 }

--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -262,7 +262,7 @@ func TestAccAzureRMCosmosDBAccount_mongoDB(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMCosmosDBAccount_gremlin(t *testing.T) {
+func TestAccAzureRMCosmosDBAccount_capabilityGremlin(t *testing.T) {
 	ri := acctest.RandInt()
 	resourceName := "azurerm_cosmosdb_account.test"
 
@@ -272,7 +272,7 @@ func TestAccAzureRMCosmosDBAccount_gremlin(t *testing.T) {
 		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMCosmosDBAccount_gremlin(ri, testLocation()),
+				Config: testAccAzureRMCosmosDBAccount_capabilityGremlin(ri, testLocation()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAccAzureRMCosmosDBAccount_basic(resourceName, testLocation(), string(documentdb.BoundedStaleness), 1),
 					resource.TestCheckResourceAttr(resourceName, "kind", "GlobalDocumentDB"),
@@ -287,7 +287,7 @@ func TestAccAzureRMCosmosDBAccount_gremlin(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMCosmosDBAccount_table(t *testing.T) {
+func TestAccAzureRMCosmosDBAccount_capabilityTable(t *testing.T) {
 	ri := acctest.RandInt()
 	resourceName := "azurerm_cosmosdb_account.test"
 
@@ -297,7 +297,7 @@ func TestAccAzureRMCosmosDBAccount_table(t *testing.T) {
 		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMCosmosDBAccount_table(ri, testLocation()),
+				Config: testAccAzureRMCosmosDBAccount_capabilityTable(ri, testLocation()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAccAzureRMCosmosDBAccount_basic(resourceName, testLocation(), string(documentdb.BoundedStaleness), 1),
 					resource.TestCheckResourceAttr(resourceName, "kind", "GlobalDocumentDB"),
@@ -312,6 +312,55 @@ func TestAccAzureRMCosmosDBAccount_table(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDBAccount_capabilityCassandra(t *testing.T) {
+	ri := acctest.RandInt()
+	resourceName := "azurerm_cosmosdb_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDBAccount_capabilityCassandra(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkAccAzureRMCosmosDBAccount_basic(resourceName, testLocation(), string(documentdb.BoundedStaleness), 1),
+					resource.TestCheckResourceAttr(resourceName, "kind", "GlobalDocumentDB"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMCosmosDBAccount_capabilityMongo35(t *testing.T) {
+	ri := acctest.RandInt()
+	resourceName := "azurerm_cosmosdb_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDBAccount_capabilityMongo34(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					checkAccAzureRMCosmosDBAccount_basic(resourceName, testLocation(), string(documentdb.BoundedStaleness), 1),
+					resource.TestCheckResourceAttr(resourceName, "kind", "MongoDB"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 func TestAbcAzureRMCosmosDBAccount_updatePropertiesAndLocation(t *testing.T) {
 	ri := acctest.RandInt()
 	resourceName := "azurerm_cosmosdb_account.test"
@@ -554,7 +603,7 @@ func testAccAzureRMCosmosDBAccount_mongoDB(rInt int, location string) string {
     `)
 }
 
-func testAccAzureRMCosmosDBAccount_gremlin(rInt int, location string) string {
+func testAccAzureRMCosmosDBAccount_capabilityGremlin(rInt int, location string) string {
 	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", `
         kind = "GlobalDocumentDB"
  
@@ -564,12 +613,32 @@ func testAccAzureRMCosmosDBAccount_gremlin(rInt int, location string) string {
     `)
 }
 
-func testAccAzureRMCosmosDBAccount_table(rInt int, location string) string {
+func testAccAzureRMCosmosDBAccount_capabilityTable(rInt int, location string) string {
 	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", `
         kind = "GlobalDocumentDB"
 
         capabilities = {
           name = "EnableTable"
+        }
+    `)
+}
+
+func testAccAzureRMCosmosDBAccount_capabilityCassandra(rInt int, location string) string {
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", `
+        kind = "GlobalDocumentDB"
+
+        capabilities = {
+          name = "EnableCassandra"
+        }
+    `)
+}
+
+func testAccAzureRMCosmosDBAccount_capabilityMongo34(rInt int, location string) string {
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", `
+        kind = "MongoDB"
+
+        capabilities = {
+          name = "MongoDBv3.4"
         }
     `)
 }


### PR DESCRIPTION
Added `MongoDBv3.4` & `mongoEnableDocLevelTTL` to capabilities

However the API doesn't seem to actually update the capabilities.

(relates to #1849, and broken in the same way)