### PR TITLE
azurerm_builtin_role_definition: support for `data_actions` and `not_data_actions`

### DIFF
--- a/azurerm/data_source_azuread_application_test.go
+++ b/azurerm/data_source_azuread_application_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceAzureRMAzureADApplication_byObjectId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMActiveDirectoryApplicationExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
-					resource.TestCheckResourceAttr(dataSourceName, "homepage", fmt.Sprintf("http://acctest%s", id)),
+					resource.TestCheckResourceAttr(dataSourceName, "homepage", fmt.Sprintf("https://acctest%s", id)),
 					resource.TestCheckResourceAttr(dataSourceName, "identifier_uris.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "reply_urls.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "oauth2_allow_implicit_flow", "false"),
@@ -53,7 +53,7 @@ func TestAccDataSourceAzureRMAzureADApplication_byObjectIdComplete(t *testing.T)
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMActiveDirectoryApplicationExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
-					resource.TestCheckResourceAttr(dataSourceName, "homepage", fmt.Sprintf("http://homepage-%s", id)),
+					resource.TestCheckResourceAttr(dataSourceName, "homepage", fmt.Sprintf("https://homepage-%s", id)),
 					resource.TestCheckResourceAttr(dataSourceName, "identifier_uris.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "reply_urls.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "oauth2_allow_implicit_flow", "true"),
@@ -82,7 +82,7 @@ func TestAccDataSourceAzureRMAzureADApplication_byName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMActiveDirectoryApplicationExists(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "name", fmt.Sprintf("acctest%s", id)),
-					resource.TestCheckResourceAttr(dataSourceName, "homepage", fmt.Sprintf("http://acctest%s", id)),
+					resource.TestCheckResourceAttr(dataSourceName, "homepage", fmt.Sprintf("https://acctest%s", id)),
 					resource.TestCheckResourceAttr(dataSourceName, "identifier_uris.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "reply_urls.#", "0"),
 					resource.TestCheckResourceAttr(dataSourceName, "oauth2_allow_implicit_flow", "false"),

--- a/azurerm/data_source_builtin_role_definition.go
+++ b/azurerm/data_source_builtin_role_definition.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -42,6 +43,22 @@ func dataSourceArmBuiltInRoleDefinition() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+						},
+						"data_actions": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Set: schema.HashString,
+						},
+						"not_data_actions": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Set: schema.HashString,
 						},
 					},
 				},
@@ -88,16 +105,70 @@ func dataSourceArmBuiltInRoleDefinitionRead(d *schema.ResourceData, meta interfa
 		d.Set("description", props.Description)
 		d.Set("type", props.RoleType)
 
-		permissions := flattenRoleDefinitionPermissions(props.Permissions)
+		permissions := flattenRoleDefinitionDataSourcePermissions(props.Permissions)
 		if err := d.Set("permissions", permissions); err != nil {
 			return err
 		}
 
-		assignableScopes := flattenRoleDefinitionAssignableScopes(props.AssignableScopes)
+		assignableScopes := flattenRoleDefinitionDataSourceAssignableScopes(props.AssignableScopes)
 		if err := d.Set("assignable_scopes", assignableScopes); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func flattenRoleDefinitionDataSourcePermissions(input *[]authorization.Permission) []interface{} {
+	permissions := make([]interface{}, 0)
+
+	for _, permission := range *input {
+		output := make(map[string]interface{}, 0)
+
+		actions := make([]string, 0)
+		if permission.Actions != nil {
+			for _, action := range *permission.Actions {
+				actions = append(actions, action)
+			}
+		}
+		output["actions"] = actions
+
+		dataActions := make([]interface{}, 0)
+		if permission.DataActions != nil {
+			for _, dataAction := range *permission.DataActions {
+				dataActions = append(dataActions, dataAction)
+			}
+		}
+		output["data_actions"] = schema.NewSet(schema.HashString, dataActions)
+
+		notActions := make([]string, 0)
+		if permission.NotActions != nil {
+			for _, action := range *permission.NotActions {
+				notActions = append(notActions, action)
+			}
+		}
+		output["not_actions"] = notActions
+
+		notDataActions := make([]interface{}, 0)
+		if permission.NotDataActions != nil {
+			for _, dataAction := range *permission.NotDataActions {
+				notDataActions = append(notDataActions, dataAction)
+			}
+		}
+		output["not_data_actions"] = schema.NewSet(schema.HashString, notDataActions)
+
+		permissions = append(permissions, output)
+	}
+
+	return permissions
+}
+
+func flattenRoleDefinitionDataSourceAssignableScopes(input *[]string) []interface{} {
+	scopes := make([]interface{}, 0)
+
+	for _, scope := range *input {
+		scopes = append(scopes, scope)
+	}
+
+	return scopes
 }

--- a/azurerm/data_source_builtin_role_definition.go
+++ b/azurerm/data_source_builtin_role_definition.go
@@ -121,6 +121,9 @@ func dataSourceArmBuiltInRoleDefinitionRead(d *schema.ResourceData, meta interfa
 
 func flattenRoleDefinitionDataSourcePermissions(input *[]authorization.Permission) []interface{} {
 	permissions := make([]interface{}, 0)
+	if input == nil {
+		return permissions
+	}
 
 	for _, permission := range *input {
 		output := make(map[string]interface{}, 0)
@@ -165,6 +168,9 @@ func flattenRoleDefinitionDataSourcePermissions(input *[]authorization.Permissio
 
 func flattenRoleDefinitionDataSourceAssignableScopes(input *[]string) []interface{} {
 	scopes := make([]interface{}, 0)
+	if input == nil {
+		return scopes
+	}
 
 	for _, scope := range *input {
 		scopes = append(scopes, scope)

--- a/azurerm/resource_arm_role_definition.go
+++ b/azurerm/resource_arm_role_definition.go
@@ -250,6 +250,9 @@ func expandRoleDefinitionAssignableScopes(d *schema.ResourceData) []string {
 
 func flattenRoleDefinitionPermissions(input *[]authorization.Permission) []interface{} {
 	permissions := make([]interface{}, 0)
+	if input == nil {
+		return permissions
+	}
 
 	for _, permission := range *input {
 		output := make(map[string]interface{}, 0)
@@ -294,6 +297,9 @@ func flattenRoleDefinitionPermissions(input *[]authorization.Permission) []inter
 
 func flattenRoleDefinitionAssignableScopes(input *[]string) []interface{} {
 	scopes := make([]interface{}, 0)
+	if input == nil {
+		return scopes
+	}
 
 	for _, scope := range *input {
 		scopes = append(scopes, scope)

--- a/website/docs/d/builtin_role_definition.markdown
+++ b/website/docs/d/builtin_role_definition.markdown
@@ -38,4 +38,6 @@ output "contributor_role_definition_id" {
 A `permissions` block contains:
 
 * `actions` - a list of actions supported by this role
+* `data_actions` - a list of data actions supported by this role
 * `not_actions` - a list of actions which are denied by this role
+* `not_data_actions` - a list of data actions which are denied by this role


### PR DESCRIPTION
Noticed this was failing due to a bad set - this PR exposes the `data_actions` and `not_data_actions` fields on the `azurerm_builtin_role_definition` data source. This also fixes some broken tests in the AzureAD Application Data Source, where https is now required