### PR TITLE
Remove `forcenew` for oms_agent.

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -340,18 +340,15 @@ func resourceArmKubernetesCluster() *schema.Resource {
 							Type:     schema.TypeList,
 							MaxItems: 1,
 							Optional: true,
-							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
 										Type:     schema.TypeBool,
 										Required: true,
-										ForceNew: true,
 									},
 									"log_analytics_workspace_id": {
 										Type:     schema.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},


### PR DESCRIPTION
After manual testing locally, oms_agent actually supports in-place update without recreating the AKS cluster. So I removed forcenew for oms_agent to support in-place update.