### PR TITLE
service_bus_queue: support for `max_delivery_count`

### DIFF
--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -241,6 +241,7 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 		d.Set("requires_session", props.RequiresSession)
 		d.Set("dead_lettering_on_message_expiration", props.DeadLetteringOnMessageExpiration)
+		d.Set("max_delivery_count", props.MaxDeliveryCount)
 
 		if maxSizeMB := props.MaxSizeInMegabytes; maxSizeMB != nil {
 			maxSize := int(*maxSizeMB)

--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -119,9 +119,10 @@ func resourceArmServiceBusQueue() *schema.Resource {
 			},
 
 			"max_delivery_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  10,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      10,
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 		},
 	}

--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/servicebus/mgmt/2017-04-01/servicebus"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )

--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -117,6 +117,12 @@ func resourceArmServiceBusQueue() *schema.Resource {
 				Optional:   true,
 				Deprecated: "This field has been removed by Azure.",
 			},
+
+			"max_delivery_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  10,
+			},
 		},
 	}
 }
@@ -133,6 +139,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 	enableExpress := d.Get("enable_express").(bool)
 	enablePartitioning := d.Get("enable_partitioning").(bool)
 	maxSize := int32(d.Get("max_size_in_megabytes").(int))
+	maxDeliveryCount := int32(d.Get("max_delivery_count").(int))
 	requiresDuplicateDetection := d.Get("requires_duplicate_detection").(bool)
 	requiresSession := d.Get("requires_session").(bool)
 	deadLetteringOnMessageExpiration := d.Get("dead_lettering_on_message_expiration").(bool)
@@ -143,6 +150,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 			EnableExpress:                    &enableExpress,
 			EnablePartitioning:               &enablePartitioning,
 			MaxSizeInMegabytes:               &maxSize,
+			MaxDeliveryCount:                 &maxDeliveryCount,
 			RequiresDuplicateDetection:       &requiresDuplicateDetection,
 			RequiresSession:                  &requiresSession,
 			DeadLetteringOnMessageExpiration: &deadLetteringOnMessageExpiration,

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -587,22 +587,22 @@ resource "azurerm_servicebus_queue" "test" {
 func testAccAzureRMServiceBusQueue_maxDeliveryCount(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
+    name     = "acctestRG-%d"
     location = "%s"
 }
 
 resource "azurerm_servicebus_namespace" "test" {
-    name = "acctestservicebusnamespace-%d"
+    name                = "acctestservicebusnamespace-%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "${azurerm_resource_group.test.location}"
-    sku = "standard"
+    location            = "${azurerm_resource_group.test.location}"
+    sku                 = "standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
-    name = "acctestservicebusqueue-%d"
+    name                = "acctestservicebusqueue-%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    namespace_name = "${azurerm_servicebus_namespace.test.name}"
-    max_delivery_count = 20
+    namespace_name      = "${azurerm_servicebus_namespace.test.name}"
+    max_delivery_count  = 20
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -597,7 +597,7 @@ resource "azurerm_servicebus_queue" "test" {
     name = "acctestservicebusqueue-%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
     namespace_name = "${azurerm_servicebus_namespace.test.name}"
-    maxDeliveryCount = 20
+    max_delivery_count = 20
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -59,6 +59,11 @@ func TestAccAzureRMServiceBusQueue_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_size_in_megabytes", "2048"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -96,12 +96,14 @@ The following arguments are supported:
     the Queue requires duplicate detection. Changing this forces
     a new resource to be created. Defaults to `false`.
 
-* `requires_session` - (Optional) Boolean flag which controls whether the Queue requires sessions. 
-    This will allow ordered handling of unbounded sequences of related messages. With sessions enabled 
-    a queue can guarantee first-in-first-out delivery of messages. 
+* `requires_session` - (Optional) Boolean flag which controls whether the Queue requires sessions.
+    This will allow ordered handling of unbounded sequences of related messages. With sessions enabled
+    a queue can guarantee first-in-first-out delivery of messages.
     Changing this forces a new resource to be created. Defaults to `false`.
 
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls whether the Queue has dead letter support when a message expires. Defaults to `false`.
+
+* `max_delivery_count` - (Optional) Integer value which controls when a message is automatically deadlettered. Defaults to `10`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This change adds `max_delivery_count` to the service bus queue's schema so that it is configurable.

See #1977 