### PR TITLE
Send provider version in user agent

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,7 +21,7 @@ test: fmtcheck
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
 debugacc: fmtcheck
 	TF_ACC=1 dlv test $(TEST) --headless --listen=:2345 --api-version=2 -- -test.v $(TESTARGS)

--- a/vendor/github.com/hashicorp/terraform/httpclient/client.go
+++ b/vendor/github.com/hashicorp/terraform/httpclient/client.go
@@ -1,0 +1,18 @@
+package httpclient
+
+import (
+	"net/http"
+
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+)
+
+// New returns the DefaultPooledClient from the cleanhttp
+// package that will also send a Terraform User-Agent string.
+func New() *http.Client {
+	cli := cleanhttp.DefaultPooledClient()
+	cli.Transport = &userAgentRoundTripper{
+		userAgent: UserAgentString(),
+		inner:     cli.Transport,
+	}
+	return cli
+}

--- a/vendor/github.com/hashicorp/terraform/httpclient/useragent.go
+++ b/vendor/github.com/hashicorp/terraform/httpclient/useragent.go
@@ -1,0 +1,40 @@
+package httpclient
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform/version"
+)
+
+const userAgentFormat = "Terraform/%s"
+const uaEnvVar = "TF_APPEND_USER_AGENT"
+
+func UserAgentString() string {
+	ua := fmt.Sprintf(userAgentFormat, version.Version)
+
+	if add := os.Getenv(uaEnvVar); add != "" {
+		add = strings.TrimSpace(add)
+		if len(add) > 0 {
+			ua += " " + add
+			log.Printf("[DEBUG] Using modified User-Agent: %s", ua)
+		}
+	}
+
+	return ua
+}
+
+type userAgentRoundTripper struct {
+	inner     http.RoundTripper
+	userAgent string
+}
+
+func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header.Set("User-Agent", rt.userAgent)
+	}
+	return rt.inner.RoundTrip(req)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1092,6 +1092,12 @@
 			"versionExact": "v0.11.3"
 		},
 		{
+			"checksumSHA1": "kD1ayilNruf2cES1LDfNZjYRscQ=",
+			"path": "github.com/hashicorp/terraform/httpclient",
+			"revision": "c96155cc68b1da43e49893ddc19a609f0085af19",
+			"revisionTime": "2018-10-04T21:23:31Z"
+		},
+		{
 			"checksumSHA1": "yFWmdS6yEJZpRJzUqd/mULqCYGk=",
 			"path": "github.com/hashicorp/terraform/moduledeps",
 			"revision": "3802b14260603f90c7a1faf55994dcc8933e2069",

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	// ProviderVersion is set during the release process to the release version of the binary
+	ProviderVersion = "dev"
+)


### PR DESCRIPTION
This fixes user agents to conform to the RFC, it also takes advantage
of a new build flag populating the binary version of the provider.

The version sent in the user agent without the flag will be
`terraform-provider-azurerm/dev` and for acceptance tests through
`make testacc` `terraform-provider-azurerm/acc`. The binary should
send a product in the user agent in the form of
`terraform-provider-azurerm/1.2.3`.