### PR TITLE
Rename `actionGroupsClient` to `monitorActionGroupsClient`

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -197,8 +197,8 @@ type ArmClient struct {
 	managementGroupsSubscriptionClient managementgroups.SubscriptionsClient
 
 	// Monitor
-	actionGroupsClient      insights.ActionGroupsClient
-	monitorAlertRulesClient insights.AlertRulesClient
+	monitorActionGroupsClient insights.ActionGroupsClient
+	monitorAlertRulesClient   insights.AlertRulesClient
 
 	// MSI
 	userAssignedIdentitiesClient msi.UserAssignedIdentitiesClient
@@ -825,9 +825,9 @@ func (c *ArmClient) registerLogicClients(endpoint, subscriptionId string, auth a
 }
 
 func (c *ArmClient) registerMonitorClients(endpoint, subscriptionId string, auth autorest.Authorizer, sender autorest.Sender) {
-	actionGroupsClient := insights.NewActionGroupsClientWithBaseURI(endpoint, subscriptionId)
-	c.configureClient(&actionGroupsClient.Client, auth)
-	c.actionGroupsClient = actionGroupsClient
+	agc := insights.NewActionGroupsClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&agc.Client, auth)
+	c.monitorActionGroupsClient = agc
 
 	arc := insights.NewAlertRulesClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&arc.Client, auth)

--- a/azurerm/resource_arm_monitor_action_group.go
+++ b/azurerm/resource_arm_monitor_action_group.go
@@ -110,7 +110,7 @@ func resourceArmMonitorActionGroup() *schema.Resource {
 }
 
 func resourceArmMonitorActionGroupCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).actionGroupsClient
+	client := meta.(*ArmClient).monitorActionGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -157,7 +157,7 @@ func resourceArmMonitorActionGroupCreateOrUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmMonitorActionGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).actionGroupsClient
+	client := meta.(*ArmClient).monitorActionGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -202,7 +202,7 @@ func resourceArmMonitorActionGroupRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmMonitorActionGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).actionGroupsClient
+	client := meta.(*ArmClient).monitorActionGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_monitor_action_group_test.go
+++ b/azurerm/resource_arm_monitor_action_group_test.go
@@ -449,7 +449,7 @@ resource "azurerm_monitor_action_group" "test" {
 }
 
 func testCheckAzureRMMonitorActionGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).actionGroupsClient
+	conn := testAccProvider.Meta().(*ArmClient).monitorActionGroupsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -488,12 +488,12 @@ func testCheckAzureRMMonitorActionGroupExists(name string) resource.TestCheckFun
 			return fmt.Errorf("Bad: no resource group found in state for Action Group Instance: %s", resourceName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).actionGroupsClient
+		conn := testAccProvider.Meta().(*ArmClient).monitorActionGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, resourceName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on actionGroupsClient: %+v", err)
+			return fmt.Errorf("Bad: Get on monitorActionGroupsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
The purpose of this refactoring PR is to align with exiting monitoring API client (`monitorAlertRulesClient`) as well as some future API clients (`monitorMetricAlertsClient`, `monitorActivityLogAlertsClient`).