### PR TITLE
Change the log analytics workspace sku to the new default

### DIFF
--- a/examples/log-analytics-container-monitoring/main.tf
+++ b/examples/log-analytics-container-monitoring/main.tf
@@ -16,7 +16,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   name                = "k8s-workspace-${random_id.workspace.hex}"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Free"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_log_analytics_solution" "test" {

--- a/website/docs/r/log_analytics_solution.html.markdown
+++ b/website/docs/r/log_analytics_solution.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   name                = "k8s-workspace-${random_id.workspace.hex}"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Free"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_log_analytics_solution" "test" {

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_log_analytics_workspace" "test" {
   name                = "acctest-01"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Standard"
+  sku                 = "PerGB2018"
   retention_in_days   = 30
 }
 ```


### PR DESCRIPTION
Change the log analytics workspace sku to the new default for the example and docs to avoid issues for users who have not used Log Analytics before April 2018