### PR TITLE
[API Management] Fixed regex validation of Publisher Name

### DIFF
--- a/azurerm/helpers/validate/api_management.go
+++ b/azurerm/helpers/validate/api_management.go
@@ -18,7 +18,7 @@ func ApiManagementServiceName(v interface{}, k string) (ws []string, es []error)
 func ApiManagementServicePublisherName(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^[\S ]{1,100}$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^.{1,100}$`).Match([]byte(value)); !matched {
 		es = append(es, fmt.Errorf("%q may only be up to 100 characters in length", k))
 	}
 

--- a/azurerm/helpers/validate/api_management.go
+++ b/azurerm/helpers/validate/api_management.go
@@ -18,7 +18,7 @@ func ApiManagementServiceName(v interface{}, k string) (ws []string, es []error)
 func ApiManagementServicePublisherName(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^[\S*]{1,100}$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^[\S ]{1,100}$`).Match([]byte(value)); !matched {
 		es = append(es, fmt.Errorf("%q may only be up to 100 characters in length", k))
 	}
 

--- a/azurerm/helpers/validate/api_management_test.go
+++ b/azurerm/helpers/validate/api_management_test.go
@@ -43,3 +43,55 @@ func TestAzureRMApiManagementServiceName_validation(t *testing.T) {
 		}
 	}
 }
+
+func TestAzureRMApiManagementPublisherName_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+		{
+			Value:    "a",
+			ErrCount: 0,
+		},
+		{
+			Value:    "abc",
+			ErrCount: 0,
+		},
+		{
+			Value:    "api1",
+			ErrCount: 0,
+		},
+		{
+			Value:    "company-api",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hello_world",
+			ErrCount: 0,
+		},
+		{
+			Value:    "helloworld21!",
+			ErrCount: 0,
+		},
+		{
+			Value:    "company api",
+			ErrCount: 0,
+		},
+		{
+			Value:    "alsdkjflasjkdflajsdlfjkalsdfjkalskdjflajksdflkjasdlfkjasldkfjalksdjflakjsdfljkasdlkfjalskdjfalksdjfdd",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := ApiManagementServicePublisherName(tc.Value, "azurerm_api_management")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Api Management Service Publisher Name to trigger a validation error for '%s'", tc.Value)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2068

Fixed validation to allow all chars and only limit by length. The only limitation in the Azure API is that the length should not be greater than 100. Added test to validate publisher name.