### PR TITLE
Allow storage account container access type change without recreation

### DIFF
--- a/azurerm/resource_arm_storage_container.go
+++ b/azurerm/resource_arm_storage_container.go
@@ -19,6 +19,7 @@ func resourceArmStorageContainer() *schema.Resource {
 		Create:        resourceArmStorageContainerCreate,
 		Read:          resourceArmStorageContainerRead,
 		Delete:        resourceArmStorageContainerDelete,
+		Update:        resourceArmStorageContainerCreate,
 		MigrateState:  resourceStorageContainerMigrateState,
 		SchemaVersion: 1,
 		Importer: &schema.ResourceImporter{
@@ -41,7 +42,6 @@ func resourceArmStorageContainer() *schema.Resource {
 			"container_access_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Default:      "private",
 				ValidateFunc: validateArmStorageContainerAccessType,
 			},

--- a/azurerm/resource_arm_storage_container.go
+++ b/azurerm/resource_arm_storage_container.go
@@ -16,10 +16,10 @@ import (
 
 func resourceArmStorageContainer() *schema.Resource {
 	return &schema.Resource{
-		Create:        resourceArmStorageContainerCreate,
+		Create:        resourceArmStorageContainerCreateUpdate,
 		Read:          resourceArmStorageContainerRead,
 		Delete:        resourceArmStorageContainerDelete,
-		Update:        resourceArmStorageContainerCreate,
+		Update:        resourceArmStorageContainerCreateUpdate,
 		MigrateState:  resourceStorageContainerMigrateState,
 		SchemaVersion: 1,
 		Importer: &schema.ResourceImporter{
@@ -87,7 +87,7 @@ func validateArmStorageContainerAccessType(v interface{}, k string) (ws []string
 	return
 }
 
-func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmStorageContainerCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	armClient := meta.(*ArmClient)
 	ctx := armClient.StopContext
 

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -46,8 +46,8 @@ func TestAccAzureRMStorageContainer_update(t *testing.T) {
 
 	ri := acctest.RandInt()
 	rs := strings.ToLower(acctest.RandString(11))
-	at1 := "Private"
-	at2 := "Container"
+	at1 := "private"
+	at2 := "container"
 	initconfig := testAccAzureRMStorageContainer_update(ri, rs, testLocation(), at1)
 	updateconfig := testAccAzureRMStorageContainer_update(ri, rs, testLocation(), at2)
 
@@ -60,16 +60,14 @@ func TestAccAzureRMStorageContainer_update(t *testing.T) {
 				Config: initconfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageContainerExists(resourceName, &c),
-					// testCheckAzureRMStorageContainerAccessType(&c, initconfig),
-					resource.TestCheckResourceAttr(resourceName, "container_access_type", initconfig),
+					resource.TestCheckResourceAttr(resourceName, "container_access_type", at1),
 				),
 			},
 			{
 				Config: updateconfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageContainerExists(resourceName, &c),
-					// testCheckAzureRMStorageContainerAccessType(&c, updateconfig),
-					resource.TestCheckResourceAttr(resourceName, "container_access_type", updateconfig),
+					resource.TestCheckResourceAttr(resourceName, "container_access_type", at2),
 				),
 			},
 			{
@@ -182,15 +180,6 @@ func testCheckAzureRMStorageContainerExists(name string, c *storage.Container) r
 
 		return nil
 	}
-}
-
-func testCheckAzureRMStorageContainerAccessType(c *storage.Container, accessType string) resource.TestCheckFunc {
-    return func(s *terraform.State) error {
-        if *c.container_access_type != accessType {
-            return fmt.Errorf("bad access type, expected \"%s\", got: %#v", accessType, *c.container_access_type)
-        }
-        return nil
-    }
 }
 
 func testAccARMStorageContainerDisappears(name string, c *storage.Container) resource.TestCheckFunc {

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `storage_account_name` - (Required) Specifies the storage account in which to create the storage container.
  Changing this forces a new resource to be created.
 
-* `container_access_type` - (Optional) The 'interface' for access the container provides. Can be either `blob`, `container` or `private`. Defaults to `private`. Changing this forces a new resource to be created.
+* `container_access_type` - (Optional) The 'interface' for access the container provides. Can be either `blob`, `container` or `private`. Defaults to `private`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This should fix issue #1686. The fix was quite small as it only needed to have an update function added, which the create function is fully capable of handling.