### PR TITLE
Convert all names entered for Azure DNS resources to lowercase by default. 

### DIFF
--- a/azurerm/resource_arm_dns_a_record.go
+++ b/azurerm/resource_arm_dns_a_record.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceArmDnsARecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_aaaa_record.go
+++ b/azurerm/resource_arm_dns_aaaa_record.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceArmDnsAAAARecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_caa_record.go
+++ b/azurerm/resource_arm_dns_caa_record.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -27,6 +28,9 @@ func resourceArmDnsCaaRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_cname_record.go
+++ b/azurerm/resource_arm_dns_cname_record.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceArmDnsCNameRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_mx_record.go
+++ b/azurerm/resource_arm_dns_mx_record.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -27,6 +28,9 @@ func resourceArmDnsMxRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_ns_record.go
+++ b/azurerm/resource_arm_dns_ns_record.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceArmDnsNsRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_ptr_record.go
+++ b/azurerm/resource_arm_dns_ptr_record.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceArmDnsPtrRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_srv_record.go
+++ b/azurerm/resource_arm_dns_srv_record.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -26,6 +27,9 @@ func resourceArmDnsSrvRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_txt_record.go
+++ b/azurerm/resource_arm_dns_txt_record.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -24,6 +25,9 @@ func resourceArmDnsTxtRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameSchema(),

--- a/azurerm/resource_arm_dns_zone.go
+++ b/azurerm/resource_arm_dns_zone.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -25,6 +26,9 @@ func resourceArmDnsZone() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
 			},
 
 			"resource_group_name": resourceGroupNameDiffSuppressSchema(),


### PR DESCRIPTION
This PR converts all names entered for Azure DNS resources to lowercase by default. 

I've encountered a few colleagues with the same issue as the OP. While telling them to use only lowercase is possible, the fact remains that Azure is case insensitive and stores everything in lowercase.

Fixes #1229