### PR TITLE
Expose the UserAssignedIdentity auto-generated ClientID property.

### DIFF
--- a/azurerm/resource_arm_user_assigned_identity.go
+++ b/azurerm/resource_arm_user_assigned_identity.go
@@ -38,6 +38,11 @@ func resourceArmUserAssignedIdentity() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"client_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -104,6 +109,12 @@ func resourceArmUserAssignedIdentityRead(d *schema.ResourceData, meta interface{
 	if props := resp.IdentityProperties; props != nil {
 		if principalId := props.PrincipalID; principalId != nil {
 			d.Set("principal_id", principalId.String())
+		}
+	}
+
+	if props := resp.IdentityProperties; props != nil {
+		if clientId := props.ClientID; clientId != nil {
+			d.Set("client_id", clientId.String())
 		}
 	}
 

--- a/azurerm/resource_arm_user_assigned_identity.go
+++ b/azurerm/resource_arm_user_assigned_identity.go
@@ -110,9 +110,7 @@ func resourceArmUserAssignedIdentityRead(d *schema.ResourceData, meta interface{
 		if principalId := props.PrincipalID; principalId != nil {
 			d.Set("principal_id", principalId.String())
 		}
-	}
 
-	if props := resp.IdentityProperties; props != nil {
 		if clientId := props.ClientID; clientId != nil {
 			d.Set("client_id", clientId.String())
 		}

--- a/azurerm/resource_arm_user_assigned_identity_test.go
+++ b/azurerm/resource_arm_user_assigned_identity_test.go
@@ -28,12 +28,6 @@ func TestAccAzureRMUserAssignedIdentity_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMUserAssignedIdentityExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "principal_id", regexp.MustCompile(generatedUuidRegex)),
-				),
-			},
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMUserAssignedIdentityExists(resourceName),
 					resource.TestMatchResourceAttr(resourceName, "client_id", regexp.MustCompile(generatedUuidRegex)),
 				),
 			},

--- a/azurerm/resource_arm_user_assigned_identity_test.go
+++ b/azurerm/resource_arm_user_assigned_identity_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccAzureRMUserAssignedIdentity_basic(t *testing.T) {
-	principalIdRegex := "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
+	generatedUuidRegex := "^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$"
 	resourceName := "azurerm_user_assigned_identity.test"
 	ri := acctest.RandInt()
 	rs := acctest.RandString(14)
@@ -27,7 +27,14 @@ func TestAccAzureRMUserAssignedIdentity_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMUserAssignedIdentityExists(resourceName),
-					resource.TestMatchResourceAttr(resourceName, "principal_id", regexp.MustCompile(principalIdRegex)),
+					resource.TestMatchResourceAttr(resourceName, "principal_id", regexp.MustCompile(generatedUuidRegex)),
+				),
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMUserAssignedIdentityExists(resourceName),
+					resource.TestMatchResourceAttr(resourceName, "client_id", regexp.MustCompile(generatedUuidRegex)),
 				),
 			},
 		},

--- a/website/docs/r/user_assigned_identity.markdown
+++ b/website/docs/r/user_assigned_identity.markdown
@@ -49,6 +49,8 @@ The following attributes are exported:
 
 * `principal_id` - Service Principal ID associated with the user assigned identity.
 
+* `client_id` - Client ID associated with the user assigned identity.
+
 ## Import
 
 User Assigned Identitites can be imported using the `resource id`, e.g.


### PR DESCRIPTION
The UserAssignedIdentity resources don't currently expose the ClientId property which is needed to request MSI access tokens. This PR aims to correct that.

One example of when this property is required is here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/tutorial-windows-vm-ua-arm


I'm not sure if I need to change anything else... I've not submitted a terraform patch before. Please let me know and I'll amend.


Thanks
