### PR TITLE
Update VMSS configs to reflect network_profile.*.ip_configuration.*.primary now being required

### DIFF
--- a/azurerm/resource_arm_autoscale_setting_test.go
+++ b/azurerm/resource_arm_autoscale_setting_test.go
@@ -764,6 +764,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
     ip_configuration {
       name      = "TestIPConfiguration"
       subnet_id = "${azurerm_subnet.test.id}"
+      primary   = true
     }
   }
 

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -1300,6 +1300,7 @@ resource "azurerm_virtual_machine_scale_set" "testdestination" {
     ip_configuration {
       name      = "TestIPConfiguration"
       subnet_id = "${azurerm_subnet.test.id}"
+      primary   = true
     }
   }
 

--- a/examples/traffic-manager-lb-scale-set/tf_modules/location.tf
+++ b/examples/traffic-manager-lb-scale-set/tf_modules/location.tf
@@ -134,6 +134,7 @@ resource "azurerm_virtual_machine_scale_set" "webserver_ss" {
       name                                   = "web_ss_ip_profile"
       subnet_id                              = "${azurerm_subnet.webservers_subnet.id}"
       load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.webservers_lb_backend.id}"]
+      primary                                = true
     }
   }
 

--- a/examples/vmss-ubuntu/main.tf
+++ b/examples/vmss-ubuntu/main.tf
@@ -109,6 +109,7 @@ resource "azurerm_virtual_machine_scale_set" "scaleset" {
       subnet_id                              = "${azurerm_subnet.subnet.id}"
       load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.backlb.id}"]
       load_balancer_inbound_nat_rules_ids    = ["${element(azurerm_lb_nat_pool.np.*.id, count.index)}"]
+      primary                                = true
     }
   }
 


### PR DESCRIPTION
That change in #2035 was not reflected in some tests configurations, this fixes them.