### PR TITLE
update TestAccAzureRMPublicIpDynamic_basic_withIPv6 to check for lowercase ip version

### DIFF
--- a/azurerm/resource_arm_public_ip_test.go
+++ b/azurerm/resource_arm_public_ip_test.go
@@ -160,7 +160,7 @@ func TestAccAzureRMPublicIpDynamic_basic_withIPv6(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "ip_version", "IPv6"),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "ipv6"), //api returns all lowercase
 				),
 			},
 			{


### PR DESCRIPTION
turn a 

```
------- Stdout: -------
=== RUN   TestAccAzureRMPublicIpDynamic_basic_withIPv6
--- FAIL: TestAccAzureRMPublicIpDynamic_basic_withIPv6 (61.57s)
	testing.go:513: Step 0 error: Check failed: Check 2/2 error: azurerm_public_ip.test: Attribute 'ip_version' expected "IPv6", got "ipv6"
FAIL
```

into a

```
=== RUN   TestAccAzureRMPublicIpDynamic_basic_withIPv6
--- PASS: TestAccAzureRMPublicIpDynamic_basic_withIPv6 (71.55s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	71.583s
```