### PR TITLE
Fix shared image gallery name #2081

### DIFF
--- a/azurerm/helpers/validate/compute.go
+++ b/azurerm/helpers/validate/compute.go
@@ -7,10 +7,10 @@ import (
 
 func SharedImageGalleryName(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
-
-	r, _ := regexp.Compile("^[A-Za-z0-9._-]+$")
+	// Image gallery name accepts only alphanumeric, dots and underscores in the name (no dashes)
+	r, _ := regexp.Compile("^[A-Za-z0-9._]+$")
 	if !r.MatchString(value) {
-		es = append(es, fmt.Errorf("%s can only contain alphanumeric, full stops, underscores and dashes. Got %q.", k, value))
+		es = append(es, fmt.Errorf("%s can only contain alphanumeric, full stops and underscores. Got %q.", k, value))
 	}
 
 	length := len(value)
@@ -22,8 +22,20 @@ func SharedImageGalleryName(v interface{}, k string) (ws []string, es []error) {
 }
 
 func SharedImageName(v interface{}, k string) (ws []string, es []error) {
-	// same as Shared Image Gallery name, for now.
-	return SharedImageGalleryName(v, k)
+	// different from the shared image gallery name
+	value := v.(string)
+
+	r, _ := regexp.Compile("^[A-Za-z0-9._-]+$")
+	if !r.MatchString(value) {
+		es = append(es, fmt.Errorf("%s can only contain alphanumeric, full stops, dashes and underscores. Got %q.", k, value))
+	}
+
+	length := len(value)
+	if length >= 80 {
+		es = append(es, fmt.Errorf("%s can be up to 80 characters, currently %d.", k, length))
+	}
+
+	return
 }
 
 func SharedImageVersionName(v interface{}, k string) (ws []string, es []error) {

--- a/azurerm/helpers/validate/compute_test.go
+++ b/azurerm/helpers/validate/compute_test.go
@@ -37,7 +37,7 @@ func TestSharedImageGalleryName(t *testing.T) {
 		},
 		{
 			Input:       "hello-123",
-			ShouldError: false,
+			ShouldError: true,
 		},
 		{
 			Input:       acctest.RandString(79),

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_shared_image_gallery" "test" {
-  name                = "example-image-gallery"
+  name                = "example_image_gallery"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
   description         = "Shared images and things."

--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_shared_image_gallery" "test" {
-  name                = "example-image-gallery"
+  name                = "example_image_gallery"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
   description         = "Shared images and things."

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -23,7 +23,7 @@ data "azurerm_image" "existing" {
 
 data "azurerm_shared_image" "existing" {
   name                = "existing-image"
-  gallery_name        = "existing-gallery"
+  gallery_name        = "existing_gallery"
   resource_group_name = "existing-resources"
 }
 


### PR DESCRIPTION
Shared image gallery name can't have a dash in their name. 
![image](https://user-images.githubusercontent.com/6275375/47075641-983e4300-d21a-11e8-90c3-87fb42b07600.png)

Image definition can have underscore, dash, dot and alphanumeric.

![image](https://user-images.githubusercontent.com/6275375/47075630-91afcb80-d21a-11e8-8f00-e3a73bb6a197.png)


P.S. - Validated the length is 80 chars long for the names.

(fixes #2081)