### PR TITLE
azurerm_virtual_network_gateway: Add OpenVPN as a client protocol option

### DIFF
--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -216,6 +216,7 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{
 									string(network.IkeV2),
+									string(network.OpenVPN),
 									string(network.SSTP),
 								}, true),
 							},

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -91,7 +91,7 @@ The `vpn_client_configuration` block supports:
     This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
 
 * `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
-    The supported values are `SSTP` and `IkeV2`.
+    The supported values are `SSTP`, `IkeV2` and `OpenVPN`.
 
 The `bgp_settings` block supports:
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -186,7 +186,7 @@ The `vpn_client_configuration` block supports:
     This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
 
 * `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
-    The supported values are `SSTP` and `IkeV2`.
+    The supported values are `SSTP`, `IkeV2` and `OpenVPN`. **NOTE**: The OpenVPN protocol is currently in Public Preview. You need to [opt in to be able to use OpenVPN as an option](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-openvpn).
 
 The `bgp_settings` block supports:
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -186,7 +186,7 @@ The `vpn_client_configuration` block supports:
     This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
 
 * `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
-    The supported values are `SSTP`, `IkeV2` and `OpenVPN`. **NOTE**: The OpenVPN protocol is currently in Public Preview. You need to [opt in to be able to use OpenVPN as an option](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-openvpn).
+    The supported values are `SSTP`, `IkeV2` and `OpenVPN`. **NOTE**: The OpenVPN protocol is currently in Public Preview. You need to [opt in your subscription and the gateway itself after its creation to be able to use OpenVPN as an option](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-openvpn).
 
 The `bgp_settings` block supports:
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -186,7 +186,7 @@ The `vpn_client_configuration` block supports:
     This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
 
 * `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
-    The supported values are `SSTP`, `IkeV2` and `OpenVPN`. **NOTE**: The OpenVPN protocol is currently in Public Preview. You need to [opt in your subscription and the gateway itself after its creation to be able to use OpenVPN as an option](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-openvpn).
+    The supported values are `SSTP`, `IkeV2` and `OpenVPN`. **NOTE**: The OpenVPN protocol is currently in Public Preview. You need to [opt in to be able to use OpenVPN as an option](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-openvpn).
 
 The `bgp_settings` block supports:
 


### PR DESCRIPTION
This patch allows setting _OpenVPN_ as a VPN Gateway client protocol (currently in Public Preview). 

Annoucement: https://azure.microsoft.com/en-us/updates/openvpn-support-for-azure-vpn-gateways/
Docs: https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-howto-openvpn