### PR TITLE
Stripping the Authorization Header from the Logs

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -331,12 +331,24 @@ func (c *ArmClient) configureClient(client *autorest.Client, auth autorest.Autho
 func withRequestLogging() autorest.SendDecorator {
 	return func(s autorest.Sender) autorest.Sender {
 		return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {
+			// strip the authorization header prior to printing
+			authHeaderName := "Authorization"
+			auth := r.Header.Get(authHeaderName)
+			if auth != "" {
+				r.Header.Del(authHeaderName)
+			}
+
 			// dump request to wire format
 			if dump, err := httputil.DumpRequestOut(r, true); err == nil {
 				log.Printf("[DEBUG] AzureRM Request: \n%s\n", dump)
 			} else {
 				// fallback to basic message
 				log.Printf("[DEBUG] AzureRM Request: %s to %s\n", r.Method, r.URL)
+			}
+
+			// add the auth header back
+			if auth != "" {
+				r.Header.Add(authHeaderName, auth)
 			}
 
 			resp, err := s.Do(r)


### PR DESCRIPTION
This PR ensures that the active Authorization header isn't printed out to the local debug logs (when `TF_LOG` is specified) by stripping it from the request prior to printing and then adding it back in when printing's completed