### PR TITLE
Remove mention of `Premium` SKU from redis_firewall_rule

### DIFF
--- a/website/docs/r/redis_firewall_rule.html.markdown
+++ b/website/docs/r/redis_firewall_rule.html.markdown
@@ -3,15 +3,13 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_redis_firewall_rule"
 sidebar_current: "docs-azurerm-resource-redis-firewall-rule"
 description: |-
-  Manages a Firewall Rule associated with a Premium Redis Cache.
+  Manages a Firewall Rule associated with a Redis Cache.
 
 ---
 
 # azurerm_redis_firewall_rule
 
-Manages a Firewall Rule associated with a Premium Redis Cache.
-
-~> **Note:** Redis Firewall Rules can only be assigned to a Redis Cache with a `Premium` SKU.
+Manages a Firewall Rule associated with a Redis Cache.
 
 ## Example Usage
 


### PR DESCRIPTION
I've updated the documentation for `azurerm_redis_firewall_rule` to remove the note that explains that it can only be used with a Premium tier cache, since that is no-longer the case.

Fixes #2012