### PR TITLE
'dev_test_virtual_machine' simple code fix

### DIFF
--- a/website/docs/r/dev_test_linux_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_linux_virtual_machine.html.markdown
@@ -33,7 +33,6 @@ resource "azurerm_dev_test_virtual_network" "test" {
   name                = "example-network"
   lab_name            = "${azurerm_dev_test_lab.test.name}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
 
   subnet {
     use_public_ip_address           = "Allow"

--- a/website/docs/r/dev_test_windows_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_windows_virtual_machine.html.markdown
@@ -32,7 +32,6 @@ resource "azurerm_dev_test_virtual_network" "test" {
   name                = "example-network"
   lab_name            = "${azurerm_dev_test_lab.test.name}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
 
   subnet {
     use_public_ip_address           = "Allow"


### PR DESCRIPTION
**Relate:**
azurerm_dev_test_linux_virtual_machine
azurerm_dev_test_windows_virtual_machine

**Details**
There is no location field in dev_test_virtual_network, so I removed this filed in depends simple code.