### PR TITLE
Monitor Activity Log Alert: add missing criteria fields

### DIFF
--- a/azurerm/resource_arm_monitor_activity_log_alert.go
+++ b/azurerm/resource_arm_monitor_activity_log_alert.go
@@ -66,9 +66,8 @@ func resourceArmMonitorActivityLogAlert() *schema.Resource {
 							}, false),
 						},
 						"operation_name": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.NoZeroValues,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"caller": {
 							Type:     schema.TypeString,
@@ -84,6 +83,18 @@ func resourceArmMonitorActivityLogAlert() *schema.Resource {
 								"Error",
 								"Critical",
 							}, false),
+						},
+						"resource_provider": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"resource_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"resource_group": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 						"resource_id": {
 							Type:         schema.TypeString,
@@ -273,6 +284,24 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) *insights.Activi
 			Equals: utils.String(level),
 		})
 	}
+	if resourceProvider := v["resource_provider"].(string); resourceProvider != "" {
+		conditions = append(conditions, insights.ActivityLogAlertLeafCondition{
+			Field:  utils.String("resourceProvider"),
+			Equals: utils.String(resourceProvider),
+		})
+	}
+	if resourceType := v["resource_type"].(string); resourceType != "" {
+		conditions = append(conditions, insights.ActivityLogAlertLeafCondition{
+			Field:  utils.String("resourceType"),
+			Equals: utils.String(resourceType),
+		})
+	}
+	if resourceGroup := v["resource_group"].(string); resourceGroup != "" {
+		conditions = append(conditions, insights.ActivityLogAlertLeafCondition{
+			Field:  utils.String("resourceGroup"),
+			Equals: utils.String(resourceGroup),
+		})
+	}
 	if id := v["resource_id"].(string); id != "" {
 		conditions = append(conditions, insights.ActivityLogAlertLeafCondition{
 			Field:  utils.String("resourceId"),
@@ -330,6 +359,12 @@ func flattenMonitorActivityLogAlertCriteria(input *insights.ActivityLogAlertAllO
 			switch strings.ToLower(*condition.Field) {
 			case "operationname":
 				result["operation_name"] = *condition.Equals
+			case "resourceprovider":
+				result["resource_provider"] = *condition.Equals
+			case "resourcetype":
+				result["resource_type"] = *condition.Equals
+			case "resourcegroup":
+				result["resource_group"] = *condition.Equals
 			case "resourceid":
 				result["resource_id"] = *condition.Equals
 			case "substatus":

--- a/azurerm/resource_arm_monitor_activity_log_alert_test.go
+++ b/azurerm/resource_arm_monitor_activity_log_alert_test.go
@@ -28,7 +28,6 @@ func TestAccAzureRMMonitorActivityLogAlert_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "scopes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "criteria.0.operation_name", "Microsoft.Storage/storageAccounts/write"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.category", "Recommendation"),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "0"),
 				),
@@ -96,6 +95,9 @@ func TestAccAzureRMMonitorActivityLogAlert_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "criteria.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.operation_name", "Microsoft.Storage/storageAccounts/write"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.category", "Recommendation"),
+					resource.TestCheckResourceAttr(resourceName, "criteria.0.resource_provider", "Microsoft.Storage"),
+					resource.TestCheckResourceAttr(resourceName, "criteria.0.resource_type", "Microsoft.Storage/storageAccounts"),
+					resource.TestCheckResourceAttrSet(resourceName, "criteria.0.resource_group"),
 					resource.TestCheckResourceAttrSet(resourceName, "criteria.0.resource_id"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.caller", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.level", "Error"),
@@ -133,7 +135,6 @@ func TestAccAzureRMMonitorActivityLogAlert_basicAndCompleteUpdate(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "scopes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "criteria.0.operation_name", "Microsoft.Storage/storageAccounts/write"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.category", "Recommendation"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.resource_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.caller", ""),
@@ -152,6 +153,9 @@ func TestAccAzureRMMonitorActivityLogAlert_basicAndCompleteUpdate(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "criteria.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.operation_name", "Microsoft.Storage/storageAccounts/write"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.category", "Recommendation"),
+					resource.TestCheckResourceAttr(resourceName, "criteria.0.resource_provider", "Microsoft.Storage"),
+					resource.TestCheckResourceAttr(resourceName, "criteria.0.resource_type", "Microsoft.Storage/storageAccounts"),
+					resource.TestCheckResourceAttrSet(resourceName, "criteria.0.resource_group"),
 					resource.TestCheckResourceAttrSet(resourceName, "criteria.0.resource_id"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.caller", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.level", "Error"),
@@ -167,7 +171,6 @@ func TestAccAzureRMMonitorActivityLogAlert_basicAndCompleteUpdate(t *testing.T) 
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "scopes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "criteria.0.operation_name", "Microsoft.Storage/storageAccounts/write"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.category", "Recommendation"),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.resource_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "criteria.0.caller", ""),
@@ -193,7 +196,6 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   scopes              = ["${azurerm_resource_group.test.id}"]
 
   criteria {
-    operation_name = "Microsoft.Storage/storageAccounts/write"
     category       = "Recommendation"
   }
 }
@@ -278,11 +280,14 @@ resource "azurerm_monitor_activity_log_alert" "test" {
 
   criteria {
     operation_name = "Microsoft.Storage/storageAccounts/write"
-    category       = "Recommendation"
-    resource_id    = "${azurerm_storage_account.test.id}"
-    caller         = "user@example.com"
-    level          = "Error"
-    status         = "Failed"
+    category       		= "Recommendation"
+    resource_provider = "Microsoft.Storage"
+    resource_type  		= "Microsoft.Storage/storageAccounts"
+    resource_group 		= "${azurerm_resource_group.test.name}"
+    resource_id    		= "${azurerm_storage_account.test.id}"
+    caller         		= "user@example.com"
+    level        		  = "Error"
+    status        		= "Failed"
   }
 
   action {

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -84,11 +84,14 @@ An `action` block supports the following:
 A `criteria` block supports the following:
 
 * `category` - (Required) The category of the operation. Possible values are `Administrative`, `Autoscale`, `Policy`, `Recommendation`, `Security` and `Service Health`.
-* `operation_name` - (Required) The Resource Manager Role-Based Access Control operation name. Supported operation should be of the form: `<resourceProvider>/<resourceType>/<operation>`.
+* `operation_name` - (Optional) The Resource Manager Role-Based Access Control operation name. Supported operation should be of the form: `<resourceProvider>/<resourceType>/<operation>`.
+* `resource_provider` - (Optional) The name of the resource provider monitored by the activity log alert.
+* `resource_type` - (Optional) The resource type monitored by the activity log alert.
+* `resource_group` - (Optional) The name of resource group monitored by the activity log alert.
 * `resource_id` - (Optional) The specific resource monitored by the activity log alert. It should be within one of the `scopes`.
 * `caller` - (Optional) The email address or Azure Active Directory identifier of the user who performed the operation.
 * `level` - (Optional) The severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
-* `status` - (Optional) The status of the event. for example, `Started`, `Failed`, or `Succeeded`.
+* `status` - (Optional) The status of the event. For example, `Started`, `Failed`, or `Succeeded`.
 * `sub_status` - (Optional) The sub status of the event.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR addresses https://github.com/terraform-providers/terraform-provider-azurerm/issues/2140 by providing support for additional criteria fields. `criteria.operation_name` is now optional as it's not a required field for the API call.

Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/2140

Test results:
```bash
~/go/src/github.com/terraform-providers/terraform-provider-azurerm on activity-log-alert-criteria*
λ TESTARGS="-run TestAccAzureRMMonitorActivityLogAlert -count=1" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccAzureRMMonitorActivityLogAlert -count=1 -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
?       github.com/terraform-providers/terraform-provider-azurerm       [no test files]
=== RUN   TestAccAzureRMMonitorActivityLogAlert_basic
--- PASS: TestAccAzureRMMonitorActivityLogAlert_basic (62.71s)
=== RUN   TestAccAzureRMMonitorActivityLogAlert_singleResource
--- PASS: TestAccAzureRMMonitorActivityLogAlert_singleResource (98.70s)
=== RUN   TestAccAzureRMMonitorActivityLogAlert_complete
--- PASS: TestAccAzureRMMonitorActivityLogAlert_complete (101.31s)
=== RUN   TestAccAzureRMMonitorActivityLogAlert_basicAndCompleteUpdate
--- PASS: TestAccAzureRMMonitorActivityLogAlert_basicAndCompleteUpdate (135.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       398.322s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/authentication        0.021s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure 0.036s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/kubernetes    0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response      0.027s [no tests to run]
?       github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/set   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress      0.036s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate      0.022s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils 0.029s [no tests to run]
?       github.com/terraform-providers/terraform-provider-azurerm/version       [no test files]
```