### PR TITLE
Example has a type

### DIFF
--- a/website/docs/r/security_center_workspace.markdown
+++ b/website/docs/r/security_center_workspace.markdown
@@ -29,7 +29,7 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_security_center_contact" "example" {
+resource "azurerm_security_center_workspace" "example" {
   scope        = "/subscriptions/00000000-0000-0000-0000-000000000000"
   workspace_id = "${azurerm_log_analytics_workspace.example.id}"
 }

--- a/website/docs/r/security_center_workspace.markdown
+++ b/website/docs/r/security_center_workspace.markdown
@@ -40,13 +40,14 @@ resource "azurerm_security_center_workspace" "example" {
 The following arguments are supported:
 
 * `scope` - (Required) The scope of VMs to send their security data to the desired workspace, unless overridden by a setting with more specific scope.
-* `workspace_id` - (Required) The resource ID of the log analytics workspace to save the data in.
+
+* `workspace_id` - (Required) The ID of the Log Analytics Workspace to save the data in.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The Security Center Contact ID.
+* `id` - The Security Center Workspace ID.
 
 ## Import
 


### PR DESCRIPTION
I think the example has a typo, should be azurerm_security_center_workspace and not azurerm_security_center_contact.

(fixes #2148)