### PR TITLE
update DataLakeAnalyticsFirewallRule basic test to not occasinaly panic

### DIFF
--- a/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
+++ b/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
@@ -183,5 +183,5 @@ resource "azurerm_data_lake_analytics_firewall_rule" "test" {
   start_ip_address    = "%[4]s"
   end_ip_address      = "%[5]s"
 }
-`, rInt, location, strconv.Itoa(rInt)[0:15], startIP, endIP)
+`, rInt, location, strconv.Itoa(rInt)[0:10], startIP, endIP)
 }


### PR DESCRIPTION
It uses a slice of the rInt as a string, sometimes that string is not 15 digits long. Changed the slice to be only 10.