### PR TITLE
key_vault nework_acls block simple code update.

### DIFF
--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -47,8 +47,7 @@ resource "azurerm_key_vault" "test" {
 
   network_acls {
     default_action             = "Deny"
-    bypass                     = "None"
-    virtual_network_subnet_ids = ["${azurerm_subnet.test.id}"]
+    bypass                     = "AzureServices"
   }
 
   tags {


### PR DESCRIPTION
Fix reason:
1. When enabledForDiskEncryption is true, networkAcls.bypass must include "AzureServices". I changed bpass from 'None' to 'AzureServices' to make simple code pass.
2. No subnet_id in the context, so i removed this item.