### PR TITLE
New Data Source: `azurerm_key_vault_key`

### DIFF
--- a/azurerm/data_source_key_vault_key.go
+++ b/azurerm/data_source_key_vault_key.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -20,8 +21,9 @@ func dataSourceArmKeyVaultKey() *schema.Resource {
 			},
 
 			"vault_uri": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.URLIsHTTPS,
 			},
 
 			"key_type": {

--- a/azurerm/data_source_key_vault_key.go
+++ b/azurerm/data_source_key_vault_key.go
@@ -1,0 +1,117 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmKeyVaultKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmKeyVaultKeyRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azure.ValidateKeyVaultChildName,
+			},
+
+			"vault_uri": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"key_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"key_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"key_opts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"n": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"e": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsForDataSourceSchema(),
+		},
+	}
+}
+
+func dataSourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).keyVaultManagementClient
+	ctx := meta.(*ArmClient).StopContext
+
+	vaultUri := d.Get("vault_uri").(string)
+	name := d.Get("name").(string)
+
+	resp, err := client.GetKey(ctx, vaultUri, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Key %q was not found in Key Vault at URI %q", name, vaultUri)
+		}
+
+		return err
+	}
+
+	id := *resp.Key.Kid
+	parsedId, err := azure.ParseKeyVaultChildID(id)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id)
+	if key := resp.Key; key != nil {
+		d.Set("key_type", string(key.Kty))
+
+		options := flattenKeyVaultKeyDataSourceOptions(key.KeyOps)
+		if err := d.Set("key_opts", options); err != nil {
+			return err
+		}
+
+		d.Set("n", key.N)
+		d.Set("e", key.E)
+	}
+
+	d.Set("version", parsedId.Version)
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}
+
+func flattenKeyVaultKeyDataSourceOptions(input *[]string) []interface{} {
+	results := make([]interface{}, 0)
+
+	if input != nil {
+		for _, option := range *input {
+			results = append(results, option)
+		}
+	}
+
+	return results
+}

--- a/azurerm/data_source_key_vault_key_test.go
+++ b/azurerm/data_source_key_vault_key_test.go
@@ -1,0 +1,43 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAzureRMKeyVaultKey_complete(t *testing.T) {
+	dataSourceName := "data.azurerm_key_vault_key.test"
+
+	rString := acctest.RandString(8)
+	location := testLocation()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceKeyVaultKey_complete(rString, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "key_type", "RSA"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.hello", "world"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceKeyVaultKey_complete(rString string, location string) string {
+	resource := testAccAzureRMKeyVaultKey_complete(rString, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_key_vault_key" "test" {
+  name 		= "${azurerm_key_vault_key.test.name}"
+  vault_uri = "${azurerm_key_vault_key.test.vault_uri}"
+}
+`, resource)
+}

--- a/azurerm/data_source_key_vault_secret.go
+++ b/azurerm/data_source_key_vault_secret.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -14,15 +15,17 @@ func dataSourceArmKeyVaultSecret() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateKeyVaultChildName,
 			},
 
 			"vault_uri": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.URLIsHTTPS,
 			},
 
 			"value": {

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -89,6 +89,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_eventhub_namespace":                    dataSourceEventHubNamespace(),
 			"azurerm_image":                                 dataSourceArmImage(),
 			"azurerm_key_vault":                             dataSourceArmKeyVault(),
+			"azurerm_key_vault_key":                         dataSourceArmKeyVaultKey(),
 			"azurerm_key_vault_access_policy":               dataSourceArmKeyVaultAccessPolicy(),
 			"azurerm_key_vault_secret":                      dataSourceArmKeyVaultSecret(),
 			"azurerm_kubernetes_cluster":                    dataSourceArmKubernetesCluster(),

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -36,9 +37,10 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 			},
 
 			"vault_uri": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.URLIsHTTPS,
 			},
 
 			"certificate": {

--- a/azurerm/resource_arm_key_vault_key.go
+++ b/azurerm/resource_arm_key_vault_key.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -30,9 +31,10 @@ func resourceArmKeyVaultKey() *schema.Resource {
 			},
 
 			"vault_uri": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.URLIsHTTPS,
 			},
 
 			"key_type": {

--- a/azurerm/resource_arm_key_vault_secret.go
+++ b/azurerm/resource_arm_key_vault_secret.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -29,9 +30,10 @@ func resourceArmKeyVaultSecret() *schema.Resource {
 			},
 
 			"vault_uri": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.URLIsHTTPS,
 			},
 
 			"value": {

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -108,6 +108,10 @@
                     <a href="/docs/providers/azurerm/d/key_vault_access_policy.html">azurerm_key_vault_access_policy</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-key-vault-key") %>>
+                    <a href="/docs/providers/azurerm/d/key_vault_key.html">azurerm_key_vault_key</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-key-vault-secret") %>>
                     <a href="/docs/providers/azurerm/d/key_vault_secret.html">azurerm_key_vault_secret</a>
                 </li>

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_key"
+sidebar_current: "docs-azurerm-data-source-key-vault-key"
+description: |-
+  Gets information about an existing Key Vault Key.
+
+---
+
+# Data Source: azurerm_key_vault_key
+
+Use this data source to access information about an existing Key Vault Key.
+
+~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+data "azurerm_key_vault_key" "test" {
+  name      = "secret-sauce"
+  vault_uri = "https://rickslab.vault.azure.net/"
+}
+
+output "key_type" {
+  value = "${data.azurerm_key_vault_secret.test.key_type}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Key Vault Key.
+
+* `vault_uri` - (Required) Specifies the URI used to access the Key Vault instance, available on the `azurerm_key_vault` Data Source / Resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Key Vault Key.
+
+* `e` - The RSA public exponent of this Key Vault Key.
+
+* `key_type` - Specifies the Key Type of this Key Vault Key
+
+* `key_size` - Specifies the Size of this Key Vault Key.
+
+* `key_opts` - A list of JSON web key operations assigned to this Key Vault Key
+
+* `n` - The RSA modulus of this Key Vault Key.
+
+* `tags` - A mapping of tags assigned to this Key Vault Key.
+
+* `version` - The current version of the Key Vault Key.
+


### PR DESCRIPTION
_Probably_ dependent on #2229

Tests pass:

```
$ acctests azurerm TestAccDataSourceAzureRMKeyVaultKey_complete
=== RUN   TestAccDataSourceAzureRMKeyVaultKey_complete
--- PASS: TestAccDataSourceAzureRMKeyVaultKey_complete (274.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	275.408s
```

Fixes #1455