### PR TITLE
disable WarnUnmatchedDirective to prevent nolint messages

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -32,5 +32,5 @@
     "line"
   ],
   "Vendor": true,
-  "WarnUnmatchedDirective": true
+  "WarnUnmatchedDirective": false
 }


### PR DESCRIPTION
Should prevent the `nolint` errors in CI