### PR TITLE
Update Go version to 1.11.x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ General Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.10 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.11.x (to build the provider plugin)
 
 Windows Specific Requirements
 -----------------------------


### PR DESCRIPTION
This PR is a follow up on #2229 in README file.