### PR TITLE
sql server: excluding the not returned `admin_login_password` field

### DIFF
--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -78,9 +78,10 @@ func TestAccAzureRMSqlServer_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"administrator_login_password"},
 			},
 		},
 	})
@@ -135,9 +136,10 @@ func TestAccAzureRMSqlServer_withTags(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"administrator_login_password"},
 			},
 		},
 	})


### PR DESCRIPTION
Noticed this was failing due to the recent import test changes:

```
------- Stdout: -------
=== RUN   TestAccAzureRMSqlServer_basic
--- FAIL: TestAccAzureRMSqlServer_basic (183.19s)
	testing.go:538: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
		
		(map[string]string) {
		}
		
		
		(map[string]string) (len=1) {
		 (string) (len=28) "administrator_login_password": (string) (len=11) "thisIsDog11"
		}
		
FAIL
```