### PR TITLE
nic: deprecating the `internal_fqdn` field since it's deprecated

### DIFF
--- a/azurerm/data_source_network_interface.go
+++ b/azurerm/data_source_network_interface.go
@@ -118,8 +118,9 @@ func dataSourceArmNetworkInterface() *schema.Resource {
 			},
 
 			"internal_fqdn": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Deprecated: "This field has been removed by Azure",
+				Computed:   true,
 			},
 
 			/**

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -184,10 +184,10 @@ func resourceArmNetworkInterface() *schema.Resource {
 			},
 
 			"internal_fqdn": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.NoZeroValues,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "This field has been removed by Azure",
 			},
 
 			/**

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -404,25 +404,6 @@ func TestAccAzureRMNetworkInterface_applicationSecurityGroups(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMNetworkInterface_internalFQDN(t *testing.T) {
-	resourceName := "azurerm_network_interface.test"
-	rInt := acctest.RandInt()
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMNetworkInterface_internalFQDN(rInt, testLocation()),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMNetworkInterfaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "internal_fqdn", fmt.Sprintf("acctestnic-%d.example.com", rInt)),
-				),
-			},
-		},
-	})
-}
-
 func TestAccAzureRMNetworkInterface_importPublicIP(t *testing.T) {
 	resourceName := "azurerm_network_interface.test"
 	rInt := acctest.RandInt()
@@ -1361,42 +1342,6 @@ resource "azurerm_network_interface" "test" {
     subnet_id                      = "${azurerm_subnet.test.id}"
     private_ip_address_allocation  = "dynamic"
     application_security_group_ids = ["${azurerm_application_security_group.test.id}"]
-  }
-}
-`, rInt, location, rInt, rInt, rInt)
-}
-
-func testAccAzureRMNetworkInterface_internalFQDN(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-rg-%d"
-  location = "%s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctestvn-%d"
-  address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "testsubnet"
-  resource_group_name  = "${azurerm_resource_group.test.name}"
-  virtual_network_name = "${azurerm_virtual_network.test.name}"
-  address_prefix       = "10.0.2.0/24"
-}
-
-resource "azurerm_network_interface" "test" {
-  name                = "acctestnic-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  internal_fqdn       = "acctestnic-%d.example.com"
-
-  ip_configuration {
-    name                          = "testconfiguration1"
-    subnet_id                     = "${azurerm_subnet.test.id}"
-    private_ip_address_allocation = "dynamic"
   }
 }
 `, rInt, location, rInt, rInt, rInt)

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -37,7 +37,6 @@ output "network_interface_id" {
 * `enable_ip_forwarding` - Indicate if IP forwarding is set on the specified Network Interface.
 * `dns_servers` - The list of DNS servers used by the specified Network Interface.
 * `internal_dns_name_label` - The internal dns name label of the specified Network Interface.
-* `internal_fqdn` - The internal FQDN associated to the specified Network Interface.
 * `ip_configuration` - One or more `ip_configuration` blocks as defined below.
 * `location` - The location of the specified Network Interface.
 * `mac_address` - The MAC address used by the specified Network Interface.

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -113,7 +113,6 @@ The following attributes are exported:
 * `private_ip_address` - The private ip address of the network interface.
 * `virtual_machine_id` - Reference to a VM with which this NIC has been associated.
 * `applied_dns_servers` - If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are part of the Availability Set
-* `internal_fqdn` - Fully qualified DNS name supporting internal communications between VMs in the same VNet
 
 ## Import
 


### PR DESCRIPTION
The `internal_fqdn` field has been removed/deprecated from the Azure API - so this PR deprecates it / removes the test