### PR TITLE
Add `enable_builtin_logging` to `azurerm_function_app`

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -66,7 +66,7 @@ func resourceArmFunctionApp() *schema.Resource {
 				Optional: true,
 			},
 
-			"built_in_logging_enabled": {
+			"enable_builtin_logging": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
@@ -459,7 +459,7 @@ func resourceArmFunctionAppRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("version", appSettings["FUNCTIONS_EXTENSION_VERSION"])
 
 	dashboard, ok := appSettings["AzureWebJobsDashboard"]
-	d.Set("built_in_logging_enabled", ok && dashboard != "")
+	d.Set("enable_builtin_logging", ok && dashboard != "")
 
 	delete(appSettings, "AzureWebJobsDashboard")
 	delete(appSettings, "AzureWebJobsStorage")
@@ -537,7 +537,7 @@ func getBasicFunctionAppAppSettings(d *schema.ResourceData, appServiceTier strin
 		{Name: &functionVersionPropName, Value: &functionVersion},
 	}
 
-	if d.Get("built_in_logging_enabled").(bool) {
+	if d.Get("enable_builtin_logging").(bool) {
 		basicSettings = append(basicSettings, web.NameValuePair{
 			Name:  &dashboardPropName,
 			Value: &storageConnection,

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -66,6 +66,12 @@ func resourceArmFunctionApp() *schema.Resource {
 				Optional: true,
 			},
 
+			"built_in_logging_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"connection_string": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -452,6 +458,9 @@ func resourceArmFunctionAppRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("storage_connection_string", appSettings["AzureWebJobsStorage"])
 	d.Set("version", appSettings["FUNCTIONS_EXTENSION_VERSION"])
 
+	dashboard, ok := appSettings["AzureWebJobsDashboard"]
+	d.Set("built_in_logging_enabled", ok && dashboard != "")
+
 	delete(appSettings, "AzureWebJobsDashboard")
 	delete(appSettings, "AzureWebJobsStorage")
 	delete(appSettings, "FUNCTIONS_EXTENSION_VERSION")
@@ -524,9 +533,15 @@ func getBasicFunctionAppAppSettings(d *schema.ResourceData, appServiceTier strin
 	contentShare := strings.ToLower(d.Get("name").(string)) + "-content"
 
 	basicSettings := []web.NameValuePair{
-		{Name: &dashboardPropName, Value: &storageConnection},
 		{Name: &storagePropName, Value: &storageConnection},
 		{Name: &functionVersionPropName, Value: &functionVersion},
+	}
+
+	if d.Get("built_in_logging_enabled").(bool) {
+		basicSettings = append(basicSettings, web.NameValuePair{
+			Name:  &dashboardPropName,
+			Value: &storageConnection,
+		})
 	}
 
 	consumptionSettings := []web.NameValuePair{

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -455,6 +455,73 @@ func TestAccAzureRMFunctionApp_updateIdentity(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFunctionApp_loggingDisabled(t *testing.T) {
+	resourceName := "azurerm_function_app.test"
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := testAccAzureRMFunctionApp_loggingDisabled(ri, rs, testLocation())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFunctionAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					testCheckAzureRMFunctionAppHasNoContentShare(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMFunctionApp_updateLogging(t *testing.T) {
+	resourceName := "azurerm_function_app.test"
+	ri := acctest.RandInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	location := testLocation()
+
+	enabledConfig := testAccAzureRMFunctionApp_basic(ri, rs, location)
+	disabledConfig := testAccAzureRMFunctionApp_loggingDisabled(ri, rs, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFunctionAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: enabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "true"),
+				),
+			},
+			{
+				Config: disabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "false"),
+				),
+			},
+			{
+				Config: enabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMFunctionAppDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
@@ -1125,4 +1192,39 @@ resource "azurerm_function_app" "test" {
   }
 }
 `, rInt, location, storage)
+}
+
+func testAccAzureRMFunctionApp_loggingDisabled(rInt int, storage string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+	name     = "acctestRG-%[1]d"
+	location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+	name                     = "acctestsa%[3]s"
+	resource_group_name      = "${azurerm_resource_group.test.name}"
+	location                 = "${azurerm_resource_group.test.location}"
+	account_tier             = "Standard"
+	account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+	name                = "acctestASP-%[1]d"
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+	sku {
+		tier = "Standard"
+		size = "S1"
+	}
+}
+
+resource "azurerm_function_app" "test" {
+	name                      = "acctest-%[1]d-func"
+	location                  = "${azurerm_resource_group.test.location}"
+	resource_group_name       = "${azurerm_resource_group.test.name}"
+	app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+	storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+	built_in_logging_enabled  = false
+}`, rInt, location, storage)
 }

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -471,7 +471,7 @@ func TestAccAzureRMFunctionApp_loggingDisabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFunctionAppExists(resourceName),
 					testCheckAzureRMFunctionAppHasNoContentShare(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_builtin_logging", "false"),
 				),
 			},
 			{
@@ -501,21 +501,21 @@ func TestAccAzureRMFunctionApp_updateLogging(t *testing.T) {
 				Config: enabledConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_builtin_logging", "true"),
 				),
 			},
 			{
 				Config: disabledConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFunctionAppExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_builtin_logging", "false"),
 				),
 			},
 			{
 				Config: enabledConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "built_in_logging_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_builtin_logging", "true"),
 				),
 			},
 		},
@@ -1197,34 +1197,34 @@ resource "azurerm_function_app" "test" {
 func testAccAzureRMFunctionApp_loggingDisabled(rInt int, storage string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-	name     = "acctestRG-%[1]d"
-	location = "%[2]s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-	name                     = "acctestsa%[3]s"
-	resource_group_name      = "${azurerm_resource_group.test.name}"
-	location                 = "${azurerm_resource_group.test.location}"
-	account_tier             = "Standard"
-	account_replication_type = "LRS"
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_app_service_plan" "test" {
-	name                = "acctestASP-%[1]d"
-	location            = "${azurerm_resource_group.test.location}"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	sku {
-		tier = "Standard"
-		size = "S1"
-	}
+  name                = "acctestASP-%[1]d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
 }
 
 resource "azurerm_function_app" "test" {
-	name                      = "acctest-%[1]d-func"
-	location                  = "${azurerm_resource_group.test.location}"
-	resource_group_name       = "${azurerm_resource_group.test.name}"
-	app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
-	storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
-	built_in_logging_enabled  = false
+  name                      = "acctest-%[1]d-func"
+  location                  = "${azurerm_resource_group.test.location}"
+  resource_group_name       = "${azurerm_resource_group.test.name}"
+  app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+  storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+  enable_builtin_logging    = false
 }`, rInt, location, storage)
 }

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -99,6 +99,8 @@ The following arguments are supported:
 
 * `app_settings` - (Optional) A key-value pair of App Settings.
 
+* `enable_builtin_logging` - (Optional) Should the built-in logging of this Function App be enabled? Defaults to `true`.
+
 * `connection_string` - (Optional) An `connection_string` block as defined below.
 
 * `client_affinity_enabled` - (Optional) Should the Function App send session affinity cookies, which route client requests in the same session to the same instance?


### PR DESCRIPTION
This PR fulfills the request in #1979.
The method used in the implementation is documented here: https://docs.microsoft.com/en-us/azure/azure-functions/functions-monitoring#disable-built-in-logging.

(fixes #1979)