### PR TITLE
Deprecating the Scheduler resources

### DIFF
--- a/azurerm/data_source_scheduler_job_collection.go
+++ b/azurerm/data_source_scheduler_job_collection.go
@@ -11,6 +11,8 @@ func dataSourceArmSchedulerJobCollection() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceArmSchedulerJobCollectionRead,
 
+		DeprecationMessage: "Scheduler Job Collection has been deprecated in favour of Logic Apps - more information can be found at https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps",
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/azurerm/resource_arm_scheduler_job.go
+++ b/azurerm/resource_arm_scheduler_job.go
@@ -30,6 +30,8 @@ func resourceArmSchedulerJob() *schema.Resource {
 		Update: resourceArmSchedulerJobCreateUpdate,
 		Delete: resourceArmSchedulerJobDelete,
 
+		DeprecationMessage: "Scheduler Job's have been deprecated in favour of Logic Apps - more information can be found at https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps",
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/resource_arm_scheduler_job_collection.go
+++ b/azurerm/resource_arm_scheduler_job_collection.go
@@ -22,6 +22,8 @@ func resourceArmSchedulerJobCollection() *schema.Resource {
 		Update: resourceArmSchedulerJobCollectionCreateUpdate,
 		Delete: resourceArmSchedulerJobCollectionDelete,
 
+		DeprecationMessage: "Scheduler Job Collection has been deprecated in favour of Logic Apps - more information can be found at https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps",
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/website/docs/d/scheduler_job_collection.html.markdown
+++ b/website/docs/d/scheduler_job_collection.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to access information about an existing Scheduler Job Collection.
 
+~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this data source as a part of version 2.0 of the AzureRM Provider.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/container_service.html.markdown
+++ b/website/docs/r/container_service.html.markdown
@@ -10,8 +10,10 @@ description: |-
 
 Manages an Azure Container Service Instance
 
-~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text.
+~> **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+~> **NOTE:** You may wish to consider using [Azure Kubernetes Service (AKS)](kubernetes_cluster.html) for new deployments.
 
 ## Example Usage (DCOS)
 

--- a/website/docs/r/scheduler_job.html.markdown
+++ b/website/docs/r/scheduler_job.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Scheduler Job.
 
+~> **NOTE:** Support for Scheduler Job has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+
 ## Example Usage (single web get now)
 
 ```hcl

--- a/website/docs/r/scheduler_job_collection.html.markdown
+++ b/website/docs/r/scheduler_job_collection.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Scheduler Job Collection.
 
+~> **NOTE:** Support for Scheduler Job Collections has been deprecated by Microsoft in favour of Logic Apps ([more information can be found at this link](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such we plan to remove support for this resource as a part of version 2.0 of the AzureRM Provider.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
The independent scheduler resources have been deprecated in favour of Logic Apps - this PR deprecates those resources and adds disclaimers to the docs for them.

I've also added a disclaimer to the ACS page since [this page](https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-walkthrough) notes that future development will be in AKS (and thus folks may wish to consider using AKS instead)