### PR TITLE
Add `compute` attribute for `route_table_id` and `network_security_group` in `azurerm_subnet`

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -44,12 +44,14 @@ func resourceArmSubnet() *schema.Resource {
 			"network_security_group_id": {
 				Type:       schema.TypeString,
 				Optional:   true,
+				Computed:   true,
 				Deprecated: "Use the `azurerm_subnet_network_security_group_association` resource instead.",
 			},
 
 			"route_table_id": {
 				Type:       schema.TypeString,
 				Optional:   true,
+				Computed:   true,
 				Deprecated: "Use the `azurerm_subnet_route_table_association` resource instead.",
 			},
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -52,11 +52,11 @@ The following arguments are supported:
 
 * `network_security_group_id` - (Optional / **Deprecated**) The ID of the Network Security Group to associate with the subnet.
 
--> **NOTE:** At this time Subnet <-> Network Security Group associations need to be configured both using this field (which is now Deprecated) and/or using the `azurerm_subnet_network_security_group_association` resource. This field field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
+-> **NOTE:** At this time Subnet `<->` Network Security Group associations need to be configured both using this field (which is now Deprecated) and/or using the `azurerm_subnet_network_security_group_association` resource. This field field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
 
 * `route_table_id` - (Optional / **Deprecated**) The ID of the Route Table to associate with the subnet.
 
--> **NOTE:** At this time Subnet <-> Route Table associations need to be configured both using this field (which is now Deprecated) and/or using the `azurerm_subnet_route_table_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
+-> **NOTE:** At this time Subnet `<->` Route Table associations need to be configured both using this field (which is now Deprecated) and/or using the `azurerm_subnet_route_table_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
 
 * `service_endpoints` - (Optional) The list of Service endpoints to associate with the subnet. Possible values include: `Microsoft.AzureActiveDirectory`, `Microsoft.AzureCosmosDB`, `Microsoft.EventHub`, `Microsoft.KeyVault`, `Microsoft.ServiceBus`, `Microsoft.Sql` and `Microsoft.Storage`.
 

--- a/website/docs/r/subnet_network_security_group_association.html.markdown
+++ b/website/docs/r/subnet_network_security_group_association.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Associates a [Network Security Group](network_security_group.html) with a [Subnet](subnet.html) within a [Virtual Network](virtual_network.html).
 
--> **NOTE:** Subnet <-> Network Security Group associations currently need to be configured on both this resource and using the `network_security_group_id` field on the `azurerm_subnet` resource. The next major version of the AzureRM Provider (2.0) will remove the `network_security_group_id` field from the `azurerm_subnet` resource such that this resource is used to link resources in future.
+-> **NOTE:** Subnet `<->` Network Security Group associations currently need to be configured on both this resource and using the `network_security_group_id` field on the `azurerm_subnet` resource. The next major version of the AzureRM Provider (2.0) will remove the `network_security_group_id` field from the `azurerm_subnet` resource such that this resource is used to link resources in future.
 
 ## Example Usage
 
@@ -76,7 +76,7 @@ The following attributes are exported:
 
 ## Import
 
-Subnet <-> Network Security Group Associations can be imported using the `resource id` of the Subnet, e.g.
+Subnet `<->` Network Security Group Associations can be imported using the `resource id` of the Subnet, e.g.
 
 ```shell
 terraform import azurerm_subnet_network_security_group_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/virtualNetworks/myvnet1/subnets/mysubnet1

--- a/website/docs/r/subnet_route_table_association.html.markdown
+++ b/website/docs/r/subnet_route_table_association.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Associates a [Route Table](route_table.html) with a [Subnet](subnet.html) within a [Virtual Network](virtual_network.html).
 
--> **NOTE:** Subnet <-> Route Table associations currently need to be configured on both this resource and using the `route_table_id` field on the `azurerm_subnet` resource. The next major version of the AzureRM Provider (2.0) will remove the `route_table_id` field from the `azurerm_subnet` resource such that this resource is used to link resources in future.
+-> **NOTE:** Subnet `<->` Route Table associations currently need to be configured on both this resource and using the `route_table_id` field on the `azurerm_subnet` resource. The next major version of the AzureRM Provider (2.0) will remove the `route_table_id` field from the `azurerm_subnet` resource such that this resource is used to link resources in future.
 
 ## Example Usage
 


### PR DESCRIPTION
This PR added `computed` for `route_table_id` and `network_security_group` in `azurerm_subnet`, so that rerun of `terraform plan` will not report unexpected change.

The `<->` is broken in the `Note` part of both pages:
https://www.terraform.io/docs/providers/azurerm/r/subnet_route_table_association.html
https://www.terraform.io/docs/providers/azurerm/r/subnet_network_security_group_association.html