### PR TITLE
azurerm_recovery_services_protected_vm can now be used when VM's are in a different resource group

### DIFF
--- a/azurerm/resource_arm_recovery_services_protected_vm.go
+++ b/azurerm/resource_arm_recovery_services_protected_vm.go
@@ -82,8 +82,8 @@ func resourceArmRecoveryServicesProtectedVmCreateUpdate(d *schema.ResourceData, 
 		return fmt.Errorf("[ERROR] parsed source_vm_id '%s' doesn't contain 'virtualMachines'", vmId)
 	}
 
-	protectedItemName := fmt.Sprintf("VM;iaasvmcontainerv2;%s;%s", resourceGroup, vmName)
-	containerName := fmt.Sprintf("iaasvmcontainer;iaasvmcontainerv2;%s;%s", resourceGroup, vmName)
+	protectedItemName := fmt.Sprintf("VM;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroup, vmName)
+	containerName := fmt.Sprintf("iaasvmcontainer;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroup, vmName)
 
 	log.Printf("[DEBUG] Creating/updating Recovery Service Protected VM %s (resource group %q)", protectedItemName, resourceGroup)
 

--- a/azurerm/resource_arm_recovery_services_protected_vm_test.go
+++ b/azurerm/resource_arm_recovery_services_protected_vm_test.go
@@ -41,6 +41,35 @@ func TestAccAzureRMRecoveryServicesProtectedVm_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMRecoveryServicesProtectedVm_separateResourceGroups(t *testing.T) {
+	resourceName := "azurerm_recovery_services_protected_vm.test"
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRecoveryServicesProtectedVmDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAbcAzureRMRecoveryServicesProtectedVm_separateResourceGroups(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRecoveryServicesProtectedVmExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "resource_group_name"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{ //vault cannot be deleted unless we unregister all backups
+				Config: testAbcAzureRMRecoveryServicesProtectedVm_additionalVault(ri, testLocation()),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMRecoveryServicesProtectedVmDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_recovery_services_protected_vm" {
@@ -49,10 +78,19 @@ func testCheckAzureRMRecoveryServicesProtectedVmDestroy(s *terraform.State) erro
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		vaultName := rs.Primary.Attributes["recovery_vault_name"]
-		vmName := rs.Primary.Attributes["source_vm_name"]
+		vmId := rs.Primary.Attributes["source_vm_id"]
 
-		protectedItemName := fmt.Sprintf("VM;iaasvmcontainerv2;%s;%s", resourceGroup, vmName)
-		containerName := fmt.Sprintf("iaasvmcontainer;iaasvmcontainerv2;%s;%s", resourceGroup, vmName)
+		parsedVmId, err := azure.ParseAzureResourceID(vmId)
+		if err != nil {
+			return fmt.Errorf("[ERROR] Unable to parse source_vm_id '%s': %+v", vmId, err)
+		}
+		vmName, hasName := parsedVmId.Path["virtualMachines"]
+		if !hasName {
+			return fmt.Errorf("[ERROR] parsed source_vm_id '%s' doesn't contain 'virtualMachines'", vmId)
+		}
+
+		protectedItemName := fmt.Sprintf("VM;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroup, vmName)
+		containerName := fmt.Sprintf("iaasvmcontainer;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroup, vmName)
 
 		client := testAccProvider.Meta().(*ArmClient).recoveryServicesProtectedItemsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -98,8 +136,8 @@ func testCheckAzureRMRecoveryServicesProtectedVmExists(resourceName string) reso
 			return fmt.Errorf("[ERROR] parsed source_vm_id '%s' doesn't contain 'virtualMachines'", vmId)
 		}
 
-		protectedItemName := fmt.Sprintf("VM;iaasvmcontainerv2;%s;%s", resourceGroup, vmName)
-		containerName := fmt.Sprintf("iaasvmcontainer;iaasvmcontainerv2;%s;%s", resourceGroup, vmName)
+		protectedItemName := fmt.Sprintf("VM;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroup, vmName)
+		containerName := fmt.Sprintf("iaasvmcontainer;iaasvmcontainerv2;%s;%s", parsedVmId.ResourceGroup, vmName)
 
 		client := testAccProvider.Meta().(*ArmClient).recoveryServicesProtectedItemsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -258,4 +296,52 @@ resource "azurerm_recovery_services_protected_vm" "test" {
 }
 
 `, testAccAzureRMRecoveryServicesProtectedVm_base(rInt, location))
+}
+
+func testAbcAzureRMRecoveryServicesProtectedVm_additionalVault(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG2-%[2]d"
+  location = "%[3]s"
+}
+
+resource "azurerm_recovery_services_vault" "test2" {
+  name                = "acctest2-%[2]d"
+  location            = "${azurerm_resource_group.test2.location}"
+  resource_group_name = "${azurerm_resource_group.test2.name}"
+  sku                 = "Standard"
+}
+
+resource "azurerm_recovery_services_protection_policy_vm" "test2" {
+  name                = "acctest2-%[2]d"
+  resource_group_name = "${azurerm_resource_group.test2.name}"
+  recovery_vault_name = "${azurerm_recovery_services_vault.test2.name}"
+
+  backup = {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily = {
+    count = 10
+  }
+}
+
+`, testAccAzureRMRecoveryServicesProtectedVm_base(rInt, location), rInt, location)
+}
+
+func testAbcAzureRMRecoveryServicesProtectedVm_separateResourceGroups(rInt int, location string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_recovery_services_protected_vm" "test" {
+  resource_group_name = "${azurerm_resource_group.test2.name}"
+  recovery_vault_name = "${azurerm_recovery_services_vault.test2.name}"
+  backup_policy_id    = "${azurerm_recovery_services_protection_policy_vm.test2.id}"
+  source_vm_id        = "${azurerm_virtual_machine.test.id}"
+}
+
+`, testAbcAzureRMRecoveryServicesProtectedVm_additionalVault(rInt, location))
 }

--- a/azurerm/resource_arm_recovery_services_protected_vm_test.go
+++ b/azurerm/resource_arm_recovery_services_protected_vm_test.go
@@ -51,7 +51,7 @@ func TestAccAzureRMRecoveryServicesProtectedVm_separateResourceGroups(t *testing
 		CheckDestroy: testCheckAzureRMRecoveryServicesProtectedVmDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAbcAzureRMRecoveryServicesProtectedVm_separateResourceGroups(ri, testLocation()),
+				Config: testAccAzureRMRecoveryServicesProtectedVm_separateResourceGroups(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRecoveryServicesProtectedVmExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_group_name"),
@@ -63,7 +63,7 @@ func TestAccAzureRMRecoveryServicesProtectedVm_separateResourceGroups(t *testing
 				ImportStateVerify: true,
 			},
 			{ //vault cannot be deleted unless we unregister all backups
-				Config: testAbcAzureRMRecoveryServicesProtectedVm_additionalVault(ri, testLocation()),
+				Config: testAccAzureRMRecoveryServicesProtectedVm_additionalVault(ri, testLocation()),
 				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
@@ -298,7 +298,7 @@ resource "azurerm_recovery_services_protected_vm" "test" {
 `, testAccAzureRMRecoveryServicesProtectedVm_base(rInt, location))
 }
 
-func testAbcAzureRMRecoveryServicesProtectedVm_additionalVault(rInt int, location string) string {
+func testAccAzureRMRecoveryServicesProtectedVm_additionalVault(rInt int, location string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -332,7 +332,7 @@ resource "azurerm_recovery_services_protection_policy_vm" "test2" {
 `, testAccAzureRMRecoveryServicesProtectedVm_base(rInt, location), rInt, location)
 }
 
-func testAbcAzureRMRecoveryServicesProtectedVm_separateResourceGroups(rInt int, location string) string {
+func testAccAzureRMRecoveryServicesProtectedVm_separateResourceGroups(rInt int, location string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -343,5 +343,5 @@ resource "azurerm_recovery_services_protected_vm" "test" {
   source_vm_id        = "${azurerm_virtual_machine.test.id}"
 }
 
-`, testAbcAzureRMRecoveryServicesProtectedVm_additionalVault(rInt, location))
+`, testAccAzureRMRecoveryServicesProtectedVm_additionalVault(rInt, location))
 }

--- a/website/docs/r/recovery_services_protected_vm.markdown
+++ b/website/docs/r/recovery_services_protected_vm.markdown
@@ -48,8 +48,6 @@ resource "azurerm_recovery_services_protected_vm" "example" {
 
 The following arguments are supported:
 
-* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
-
 * `resource_group_name` - (Required) The name of the resource group in which to create the Recovery Services Protected VM. Changing this forces a new resource to be created.
 
 * `recovery_vault_name` - (Required) Specifies the name of the Recovery Services Vault to use. Changing this forces a new resource to be created.


### PR DESCRIPTION
Fixes #2215