### PR TITLE
Update the doc for NSG and RouteTable associations with subnet

### DIFF
--- a/website/docs/r/subnet_network_security_group_association.html.markdown
+++ b/website/docs/r/subnet_network_security_group_association.html.markdown
@@ -64,7 +64,7 @@ resource "azurerm_subnet_network_security_group_association" "test" {
 
 The following arguments are supported:
 
-* `network_security_group_id` - (Optional) The ID of the Network Security Group which should be associated with the Subnet. Changing this forces a new resource to be created.
+* `network_security_group_id` - (Required) The ID of the Network Security Group which should be associated with the Subnet. Changing this forces a new resource to be created.
 
 * `subnet_id` - (Required) The ID of the Subnet. Changing this forces a new resource to be created.
 

--- a/website/docs/r/subnet_route_table_association.html.markdown
+++ b/website/docs/r/subnet_route_table_association.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_subnet_route_table_association" "test" {
 
 The following arguments are supported:
 
-* `route_table_id` - (Optional) The ID of the Route Table which should be associated with the Subnet. Changing this forces a new resource to be created.
+* `route_table_id` - (Required) The ID of the Route Table which should be associated with the Subnet. Changing this forces a new resource to be created.
 
 * `subnet_id` - (Required) The ID of the Subnet. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
`network_security_group_id` and `route_table_id` are both `required` fields in NSG and RT associations for subnet, update the doc to align with schema definition.