### PR TITLE
Added missing public_ip_addresses property to api_management

### DIFF
--- a/azurerm/data_source_api_management.go
+++ b/azurerm/data_source_api_management.go
@@ -25,6 +25,14 @@ func dataSourceApiManagementService() *schema.Resource {
 
 			"location": locationForDataSourceSchema(),
 
+			"public_ip_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"publisher_name": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/azurerm/data_source_api_management_test.go
+++ b/azurerm/data_source_api_management_test.go
@@ -26,7 +26,7 @@ func TestAccDataSourceAzureRMApiManagement_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "sku.0.capacity", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "sku.0.name", "Developer"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "public_ip_addresses"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "public_ip_addresses.#"),
 				),
 			},
 		},

--- a/azurerm/data_source_api_management_test.go
+++ b/azurerm/data_source_api_management_test.go
@@ -26,6 +26,7 @@ func TestAccDataSourceAzureRMApiManagement_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "sku.0.capacity", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "sku.0.name", "Developer"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "public_ip_addresses"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -44,6 +44,14 @@ func resourceArmApiManagementService() *schema.Resource {
 
 			"location": locationSchema(),
 
+			"public_ip_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
 			"publisher_name": {
 				Type:         schema.TypeString,
 				Required:     true,

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -75,7 +75,7 @@ func TestAccAzureRMApiManagement_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.Acceptance", "Test"),
-					resource.TestCheckResourceAttrSet(resourceName, "public_ip_addresses"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip_addresses.#"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -75,6 +75,7 @@ func TestAccAzureRMApiManagement_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "tags.Acceptance", "Test"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip_addresses"),
 				),
 			},
 			{
@@ -82,7 +83,7 @@ func TestAccAzureRMApiManagement_complete(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"certificate",                                            // not returned from API, sensitive
+					"certificate", // not returned from API, sensitive
 					"hostname_configuration.0.portal.0.certificate",          // not returned from API, sensitive
 					"hostname_configuration.0.portal.0.certificate_password", // not returned from API, sensitive
 					"hostname_configuration.0.proxy.0.certificate",           // not returned from API, sensitive

--- a/website/docs/d/api_management.html.markdown
+++ b/website/docs/d/api_management.html.markdown
@@ -49,6 +49,8 @@ output "api_management_id" {
 
 * `portal_url` - The URL of the Publisher Portal.
 
+* `public_ip_adresses` - The Public IP adresses of the API Management Service.
+
 * `publisher_name` - The name of the Publisher/Company of the API Management Service.
 
 * `publisher_email` - The email of Publisher/Company of the API Management Service.

--- a/website/docs/d/api_management.html.markdown
+++ b/website/docs/d/api_management.html.markdown
@@ -49,7 +49,7 @@ output "api_management_id" {
 
 * `portal_url` - The URL of the Publisher Portal.
 
-* `public_ip_adresses` - The Public IP adresses of the API Management Service.
+* `public_ip_addresses` - The Public IP addresses of the API Management Service.
 
 * `publisher_name` - The name of the Publisher/Company of the API Management Service.
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -192,7 +192,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `portal_url` - The URL for the Publisher Portal associated with this API Management service.
 
-* `public_ip_adresses` - The Public IP adresses of the API Management Service.
+* `public_ip_addresses` - The Public IP addresses of the API Management Service.
 
 * `scm_url` - The URL for the SCM (Source Code Management) Endpoint associated with this API Management service.
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -192,6 +192,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `portal_url` - The URL for the Publisher Portal associated with this API Management service.
 
+* `public_ip_adresses` - The Public IP adresses of the API Management Service.
+
 * `scm_url` - The URL for the SCM (Source Code Management) Endpoint associated with this API Management service.
 
 * `identity` - An `identity` block as defined below.


### PR DESCRIPTION
Adds the missing property fields of *public_ip_addresses* to the terraform api_management resource and data source.

Example code that demonstrates the fixed problem:

```hcl
provider "azurerm" {}

resource "azurerm_resource_group" "test" {
  name     = "amtestRG-vidarw"
  location = "westeurope"
}

resource "azurerm_api_management" "test" {
  name            = "acctestAM-vidarw"
  publisher_name  = "pub1"
  publisher_email = "pub1@email.com"

  sku {
    name     = "Developer"
    capacity = 1
  }

  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"
}

data "azurerm_api_management" "test" {
  name                = "${azurerm_api_management.test.name}"
  resource_group_name = "${azurerm_api_management.test.resource_group_name}"
}

resource "local_file" "foo" {
  content = "${data.azurerm_api_management.test.public_ip_addresses.0}"
  filename = "${path.module}/output.txt"
}
```