### PR TITLE
Expose `provision_vm_agent` in `os_profile_linux_config` for VM and VMSS

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -1761,7 +1761,12 @@ func resourceArmVirtualMachineStorageOsProfileLinuxConfigHash(v interface{}) int
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%t-%t", m["disable_password_authentication"].(bool), m["provision_vm_agent"].(bool)))
+		if v, ok := m["disable_password_authentication"]; ok {
+			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+		}
+		if v, ok := m["provision_vm_agent"]; ok {
+			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+		}
 	}
 
 	return hashcode.String(buf.String())

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -342,9 +342,12 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"disable_password_authentication": {
 							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"provision_vm_agent": {
+							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
-							ForceNew: true,
 						},
 						"ssh_keys": {
 							Type:     schema.TypeList,
@@ -1082,6 +1085,10 @@ func flattenAzureRmVirtualMachineScaleSetOsProfileLinuxConfig(config *compute.Li
 		result["disable_password_authentication"] = *v
 	}
 
+	if v := config.ProvisionVMAgent; v != nil {
+		result["provision_vm_agent"] = *v
+	}
+
 	if ssh := config.SSH; ssh != nil {
 		if keys := ssh.PublicKeys; keys != nil {
 			ssh_keys := make([]map[string]interface{}, 0, len(*keys))
@@ -1517,7 +1524,7 @@ func resourceArmVirtualMachineScaleSetOsProfileLinuxConfigHash(v interface{}) in
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%t-", m["disable_password_authentication"].(bool)))
+		buf.WriteString(fmt.Sprintf("%t-%t", m["disable_password_authentication"].(bool), m["provision_vm_agent"].(bool)))
 	}
 
 	return hashcode.String(buf.String())
@@ -1976,6 +1983,7 @@ func expandAzureRmVirtualMachineScaleSetOsProfileLinuxConfig(d *schema.ResourceD
 
 	linuxConfig := osProfilesLinuxConfig[0].(map[string]interface{})
 	disablePasswordAuth := linuxConfig["disable_password_authentication"].(bool)
+	provisionVMAgent := linuxConfig["provision_vm_agent"].(bool)
 
 	linuxKeys := linuxConfig["ssh_keys"].([]interface{})
 	sshPublicKeys := make([]compute.SSHPublicKey, 0, len(linuxKeys))
@@ -1997,6 +2005,7 @@ func expandAzureRmVirtualMachineScaleSetOsProfileLinuxConfig(d *schema.ResourceD
 
 	config := &compute.LinuxConfiguration{
 		DisablePasswordAuthentication: &disablePasswordAuth,
+		ProvisionVMAgent:              &provisionVMAgent,
 		SSH: &compute.SSHConfiguration{
 			PublicKeys: &sshPublicKeys,
 		},

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -1524,7 +1524,12 @@ func resourceArmVirtualMachineScaleSetOsProfileLinuxConfigHash(v interface{}) in
 	var buf bytes.Buffer
 
 	if m, ok := v.(map[string]interface{}); ok {
-		buf.WriteString(fmt.Sprintf("%t-%t", m["disable_password_authentication"].(bool), m["provision_vm_agent"].(bool)))
+		if v, ok := m["disable_password_authentication"]; ok {
+			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+		}
+		if v, ok := m["provision_vm_agent"]; ok {
+			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+		}
 	}
 
 	return hashcode.String(buf.String())

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -2659,7 +2659,8 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 
   os_profile_linux_config {
-    disable_password_authentication = true
+    disable_password_authentication = false
+    provision_vm_agent              = true
 
     ssh_keys {
       path     = "/home/ubuntu/.ssh/authorized_keys"
@@ -3715,7 +3716,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 
   os_profile_linux_config {
-    disable_password_authentication = true
+    disable_password_authentication = false
 
     ssh_keys {
       path     = "/home/myadmin/.ssh/authorized_keys"
@@ -3828,7 +3829,8 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 
   os_profile_linux_config {
-    disable_password_authentication = true
+    disable_password_authentication = false
+    provision_vm_agent              = true
 
     ssh_keys {
       path     = "/home/myadmin/.ssh/authorized_keys"
@@ -4409,6 +4411,7 @@ resource "azurerm_virtual_machine" "testsource" {
 
   os_profile_linux_config {
     disable_password_authentication = false
+    provision_vm_agent              = true
   }
 
   tags {

--- a/azurerm/resource_arm_virtual_machine_test.go
+++ b/azurerm/resource_arm_virtual_machine_test.go
@@ -534,6 +534,7 @@ resource "azurerm_virtual_machine" "test" {
 
   os_profile_linux_config {
     disable_password_authentication = false
+    provision_vm_agent              = true
   }
 
   identity {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -208,6 +208,8 @@ A `os_profile_linux_config` block supports the following:
 
 * `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled. If set to `false`, an `admin_password` must be specified.
 
+* `provision_vm_agent` - (Optional) Specifies whether VM agent should be provisioned.
+
 * `ssh_keys` - (Optional) One or more `ssh_keys` blocks. This field is required if `disable_password_authentication` is set to `true`.
 
 ---

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -85,6 +85,7 @@ resource "azurerm_virtual_machine" "main" {
   }
   os_profile_linux_config {
     disable_password_authentication = false
+    provision_vm_agent              = true
   }
   tags {
     environment = "staging"
@@ -208,7 +209,7 @@ A `os_profile_linux_config` block supports the following:
 
 * `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled. If set to `false`, an `admin_password` must be specified.
 
-* `provision_vm_agent` - (Optional) Specifies whether VM agent should be provisioned.
+* `provision_vm_agent` - (Optional) Should the Azure Virtual Machine Guest Agent be installed on this Virtual Machine? Defaults to `false`.
 
 * `ssh_keys` - (Optional) One or more `ssh_keys` blocks. This field is required if `disable_password_authentication` is set to `true`.
 

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -138,6 +138,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
 
   os_profile_linux_config {
     disable_password_authentication = false
+    provision_vm_agent              = true
 
     ssh_keys {
       path     = "/home/myadmin/.ssh/authorized_keys"
@@ -225,6 +226,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
 
   os_profile_linux_config {
     disable_password_authentication = false
+    provision_vm_agent              = true
 
     ssh_keys {
       path     = "/home/myadmin/.ssh/authorized_keys"
@@ -414,7 +416,7 @@ output "principal_id" {
 `os_profile_linux_config` supports the following:
 
 * `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled. If set to `false`, an `admin_password` must be specified.
-* `provision_vm_agent` - (Optional) Specifies whether VM agent should be provisioned.
+* `provision_vm_agent` - (Optional) Indicates whether virtual machine agent should be provisioned on the virtual machines in the scale set.
 * `ssh_keys` - (Optional) Specifies a collection of `path` and `key_data` to be placed on the virtual machine.
 
 ~> _**Note:** Please note that the only allowed `path` is `/home/<username>/.ssh/authorized_keys` due to a limitation of Azure_

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -137,7 +137,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 
   os_profile_linux_config {
-    disable_password_authentication = true
+    disable_password_authentication = false
 
     ssh_keys {
       path     = "/home/myadmin/.ssh/authorized_keys"
@@ -224,7 +224,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 
   os_profile_linux_config {
-    disable_password_authentication = true
+    disable_password_authentication = false
 
     ssh_keys {
       path     = "/home/myadmin/.ssh/authorized_keys"
@@ -413,7 +413,8 @@ output "principal_id" {
 
 `os_profile_linux_config` supports the following:
 
-* `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled. Changing this forces a new resource to be created.
+* `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled. If set to `false`, an `admin_password` must be specified.
+* `provision_vm_agent` - (Optional) Specifies whether VM agent should be provisioned.
 * `ssh_keys` - (Optional) Specifies a collection of `path` and `key_data` to be placed on the virtual machine.
 
 ~> _**Note:** Please note that the only allowed `path` is `/home/<username>/.ssh/authorized_keys` due to a limitation of Azure_


### PR DESCRIPTION
This PR includes below changes:
1. Resolve #2264, to expose the `provision_vm_agent` in `os_profile_linux_config` for VM and VMSS.
2. Make schema attribute change for `disable_password_authentication` in VMSS to be consistent with definition in doc and VM.