### PR TITLE
Unify Resource Name Validation

### DIFF
--- a/azurerm/helpers/azure/generic.go
+++ b/azurerm/helpers/azure/generic.go
@@ -5,10 +5,10 @@ import (
 	"regexp"
 )
 
-const hyphenUnderscoreParenthesesPeriod string = "-_\\(\\)\\."
-const hyphenUnderscorePeriod string = "-_\\."
+const hyphenUnderscoreParenthesesPeriod string = `-_\(\)\.`
+const hyphenUnderscorePeriod string = `-_\.`
 const hyphenUnderscore string = "-_"
-const hyphenPeriod string = "-\\."
+const hyphenPeriod string = `-\.`
 const hyphen string = "-"
 const none string = ""
 const alphanumericLower string = "a-z0-9"
@@ -48,13 +48,13 @@ func ValidateNameGeneric(i interface{}, attributeName string, pattern string, sp
 		errors = append(errors, fmt.Errorf("%s %q first, second, and last characters must be a %s", errorPrefix, attributeName, getOrTxt(pattern)))
 	}
 
-	regEx = fmt.Sprintf("^[%s%s]*$", pattern, specialChars)
+	regEx = fmt.Sprintf(`^[%s%s]*$`, pattern, specialChars)
 	r = regexp.MustCompile(regEx)
 	if !r.MatchString(value) {
 		errors = append(errors, fmt.Errorf("%s %q can only contain %s", errorPrefix, attributeName, getAndTxt(pattern, specialChars)))
 	}
 
-	r = regexp.MustCompile("(--|__|\\.\\.|\\(\\(|\\)\\))")
+	r = regexp.MustCompile(`(--|__|\.\.|\(\(|\)\))`)
 	if r.MatchString(value) {
 		errors = append(errors, fmt.Errorf("%s %q must not contain any consecutive hyphens, underscores, parentheses, or periods", errorPrefix, attributeName))
 	}

--- a/azurerm/helpers/azure/generic.go
+++ b/azurerm/helpers/azure/generic.go
@@ -15,7 +15,14 @@ const alphanumericLower string = "a-z0-9"
 const alphanumericUpper string = "A-Z0-9"
 const alphanumericBoth string = "a-zA-Z0-9"
 
-// Generic method to validate Azure Resource names which enforces the Azure standards for naming conventions...
+// Generic method to validate Azure Resource names which enforce the Azure standards for naming conventions...
+// 1. First two characters must be a number or a letter
+// 2. Last characters must be a number or a letter
+// 3. No consecutive hyphens, underscores, parentheses, or periods
+// 4. Min and Max length for values vary depending on the resource
+// 5. Value can not start or end with any special character
+// NOTE: There is an absolute minimum length for all values of 3, it can not be lower than 3 because of the
+//       first two chars and last char must be a number or letter rule, it can however be larger than 3 if desired.
 func ValidateNameGeneric(i interface{}, attributeName string, pattern string, specialChars string, errorPrefix string, minLength int, maxLength int) (_ []string, errors []error) {
 	value, ok := i.(string)
 	if !ok {
@@ -41,7 +48,6 @@ func ValidateNameGeneric(i interface{}, attributeName string, pattern string, sp
 		errors = append(errors, fmt.Errorf("%s %q can only contain %s%s", errorPrefix, attributeName, getAndTxt(pattern), getAndTxt(specialChars)))
 	}
 
-	//No consecutive dashes.
 	r = regexp.MustCompile("(--|__|\\.\\.|\\(\\(|\\)\\))")
 	if r.MatchString(value) {
 		errors = append(errors, fmt.Errorf("%s %q must not contain any consecutive hyphens, underscores, parentheses, or periods", errorPrefix, attributeName))

--- a/azurerm/helpers/azure/generic.go
+++ b/azurerm/helpers/azure/generic.go
@@ -1,0 +1,91 @@
+package azure
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const hyphenUnderscoreParenthesesPeriod string = "-_\\(\\)\\."
+const hyphenUnderscorePeriod string = "-_\\."
+const hyphenUnderscore string = "-_"
+const hyphenPeriod string = "-\\."
+const hyphen string = "-"
+const none string = ""
+const alphanumericLower string = "a-z0-9"
+const alphanumericUpper string = "A-Z0-9"
+const alphanumericBoth string = "a-zA-Z0-9"
+
+// Generic method to validate Azure Resource names which enforces the Azure standards for naming conventions...
+func ValidateNameGeneric(i interface{}, attributeName string, pattern string, specialChars string, errorPrefix string, minLength int, maxLength int) (_ []string, errors []error) {
+	value, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", attributeName))
+		return nil, errors
+	}
+
+	if minLength < 3 {
+		minLength = 3
+	}
+
+	if maxLength < minLength {
+		maxLength = minLength + 1
+	}
+
+	regEx := fmt.Sprintf("^[%s]{2}[%s%s]{%d,%d}[%s]{1}$", pattern, pattern, specialChars, (minLength - 3), (maxLength - minLength), pattern)
+	r := regexp.MustCompile(regEx)
+	if !r.MatchString(value) {
+		if len(value) < minLength || len(value) > maxLength {
+			errors = append(errors, fmt.Errorf("%s %q must be %d - %d characters in length", errorPrefix, attributeName, minLength, maxLength))
+		}
+		errors = append(errors, fmt.Errorf("%s %q first, second, and last characters must be a %s", errorPrefix, attributeName, getOrTxt(pattern)))
+		errors = append(errors, fmt.Errorf("%s %q can only contain %s%s", errorPrefix, attributeName, getAndTxt(pattern), getAndTxt(specialChars)))
+	}
+
+	//No consecutive dashes.
+	r = regexp.MustCompile("(--|__|\\.\\.|\\(\\(|\\)\\))")
+	if r.MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s %q must not contain any consecutive hyphens, underscores, parentheses, or periods", errorPrefix, attributeName))
+	}
+
+	return nil, errors
+}
+
+func getAndTxt(expression string) (msg string) {
+
+	switch expression {
+	case hyphenUnderscoreParenthesesPeriod:
+		msg = ", hyphens, underscores, parentheses, and periods"
+	case hyphen:
+		msg = " and hyphens"
+	case hyphenPeriod:
+		msg = ", hyphens and periods"
+	case hyphenUnderscorePeriod:
+		msg = ", hyphens, underscores, and periods"
+	case alphanumericBoth:
+		msg = "letters, numbers"
+	case alphanumericLower:
+		msg = "lowercase letters, numbers"
+	case alphanumericUpper:
+		msg = "uppercase letters, numbers"
+	default:
+		msg = ""
+	}
+
+	return msg
+}
+
+func getOrTxt(expression string) (msg string) {
+
+	switch expression {
+	case alphanumericBoth:
+		msg = "letter or number"
+	case alphanumericLower:
+		msg = "lowercase letter or number"
+	case alphanumericUpper:
+		msg = "uppercase letter or number"
+	default:
+		msg = ""
+	}
+
+	return msg
+}

--- a/azurerm/helpers/azure/validate.go
+++ b/azurerm/helpers/azure/validate.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"fmt"
-	"regexp"
 )
 
 func ValidateResourceID(i interface{}, k string) (ws []string, errors []error) {
@@ -34,27 +33,86 @@ func ValidateResourceIDOrEmpty(i interface{}, k string) (_ []string, errors []er
 	return ValidateResourceID(i, k)
 }
 
-//true for a resource ID or an empty string
-func ValidateMsSqlServiceName(i interface{}, k string) (_ []string, errors []error) {
-	v, ok := i.(string)
-	if !ok {
-		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
-		return nil, errors
-	}
+func ValidateMsSqlElasticPoolName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericLower, hyphen, "azurerm_mssql_elasticpool", 3, 50)
+}
 
-	//First, second, and last characters must be a letter or number with a total length between 3 to 50 lowercase characters.
-	r := regexp.MustCompile("^[a-z0-9]{2}[-a-z0-9]{0,47}[a-z0-9]{1}$")
-	if !r.MatchString(v) {
-		errors = append(errors, fmt.Errorf("%q must be 3 - 50 characters in length", k))
-		errors = append(errors, fmt.Errorf("%q first, second, and last characters must be a lowercase letter or number", k))
-		errors = append(errors, fmt.Errorf("%q can only contain lowercase letters, numbers and hyphens", k))
-	}
+func ValidateSqlServerName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericLower, hyphen, "azurerm_sql_server", 3, 50)
+}
 
-	//No consecutive dashes.
-	r = regexp.MustCompile("(--)")
-	if r.MatchString(v) {
-		errors = append(errors, fmt.Errorf("%q must not contain any consecutive hyphens", k))
-	}
+func ValidateMySqlServerName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericLower, hyphen, "azurerm_mysql_server", 3, 50)
+}
 
-	return nil, errors
+func ValidatePostgreSqlServerName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericLower, hyphen, "azurerm_postgresql_server", 3, 50)
+}
+
+func ValidateAvailabilitySet(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenUnderscore, "", 3, 80)
+}
+
+func ValidateVirtualMachineWindows(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphen, "", 3, 15)
+}
+
+func ValidateVirtualMachineLinux(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphen, "", 3, 64)
+}
+
+func ValidateFunctionAppName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphen, "", 3, 60)
+}
+
+func ValidateStorageAccountName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericLower, none, "", 3, 24)
+}
+
+func ValidateContainerName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphen, "", 3, 63)
+}
+
+func ValidateQueueName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericLower, none, "", 3, 63)
+}
+
+func ValidateTableName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, none, "", 3, 63)
+}
+
+func ValidateDataLakeStoreName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericLower, none, "", 3, 24)
+}
+
+func ValidateVirtualNetworkName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenUnderscorePeriod, "", 3, 64)
+}
+
+func ValidateSubnetName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenUnderscorePeriod, "", 3, 80)
+}
+
+func ValidateSecurityGroupName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenUnderscorePeriod, "", 3, 80)
+}
+
+func ValidateSecurityGroupRuleName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenUnderscorePeriod, "", 3, 80)
+}
+
+func ValidateLoadBalancerName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenUnderscorePeriod, "", 3, 80)
+}
+
+func ValidateLoadBalancerRulesName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenUnderscorePeriod, "", 3, 80)
+}
+
+func ValidateTrafficManagerName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, hyphenPeriod, "", 3, 80)
+}
+
+func ValidateContainerRegistryName(i interface{}, k string) (_ []string, errors []error) {
+	return ValidateNameGeneric(i, k, alphanumericBoth, none, "", 5, 50)
 }

--- a/azurerm/helpers/azure/validate_test.go
+++ b/azurerm/helpers/azure/validate_test.go
@@ -91,63 +91,67 @@ func TestAzureResourceIDOrEmpty(t *testing.T) {
 	}
 }
 
-func TestAzureValidateMsSqlServiceName(t *testing.T) {
+func TestAzureValidateMsSqlElasticPoolName(t *testing.T) {
 	cases := []struct {
-		ServiceName string
-		Errors      int
+		ElasticPoolName string
+		Errors          int
 	}{
 		{
-			ServiceName: "as",
-			Errors:      3,
+			ElasticPoolName: "as",
+			Errors:          2,
 		},
 		{
-			ServiceName: "Asd",
-			Errors:      2,
+			ElasticPoolName: "Asd",
+			Errors:          2,
 		},
 		{
-			ServiceName: "asd",
-			Errors:      0,
+			ElasticPoolName: "asd",
+			Errors:          0,
 		},
 		{
-			ServiceName: "-asd",
-			Errors:      2,
+			ElasticPoolName: "-asd",
+			Errors:          1,
 		},
 		{
-			ServiceName: "asd-",
-			Errors:      2,
+			ElasticPoolName: "asd-",
+			Errors:          1,
 		},
 		{
-			ServiceName: "asd-1",
-			Errors:      0,
+			ElasticPoolName: "asd-1",
+			Errors:          0,
 		},
 		{
-			ServiceName: "asd--1",
-			Errors:      1,
+			ElasticPoolName: "asd--1",
+			Errors:          1,
 		},
 		{
-			ServiceName: "asd--1-",
-			Errors:      3,
+			ElasticPoolName: "asd--1-",
+			Errors:          2,
 		},
 		{
-			ServiceName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz",
-			Errors:      0,
+			ElasticPoolName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz",
+			Errors:          0,
 		},
 		{
-			ServiceName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz1",
-			Errors:      3,
+			ElasticPoolName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz1",
+			Errors:          1,
 		},
 		{
-			ServiceName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz1--",
-			Errors:      4,
+			ElasticPoolName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz1--",
+			Errors:          3,
+		},
+		{
+			ElasticPoolName: "Aasdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz1--",
+			Errors:          4,
 		},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.ServiceName, func(t *testing.T) {
-			_, errors := ValidateMsSqlServiceName(tc.ServiceName, "name")
+		t.Run(tc.ElasticPoolName, func(t *testing.T) {
+			_, errors := ValidateMsSqlElasticPoolName(tc.ElasticPoolName, "name")
 
 			if len(errors) < tc.Errors {
-				t.Fatalf("Expected TestAzureValidateMsSqlServiceName to have %d not %d errors for %q", tc.Errors, len(errors), tc.ServiceName)
+				t.Fatalf("Expected TestAzureValidateMsSqlElasticPoolName to have %d not %d errors for %q", tc.Errors, len(errors), tc.ElasticPoolName)
 			}
 		})
 	}

--- a/azurerm/helpers/azure/validate_test.go
+++ b/azurerm/helpers/azure/validate_test.go
@@ -102,7 +102,7 @@ func TestAzureValidateMsSqlServiceName(t *testing.T) {
 		},
 		{
 			ServiceName: "Asd",
-			Errors:      3,
+			Errors:      2,
 		},
 		{
 			ServiceName: "asd",
@@ -110,11 +110,11 @@ func TestAzureValidateMsSqlServiceName(t *testing.T) {
 		},
 		{
 			ServiceName: "-asd",
-			Errors:      3,
+			Errors:      2,
 		},
 		{
 			ServiceName: "asd-",
-			Errors:      3,
+			Errors:      2,
 		},
 		{
 			ServiceName: "asd-1",
@@ -126,7 +126,7 @@ func TestAzureValidateMsSqlServiceName(t *testing.T) {
 		},
 		{
 			ServiceName: "asd--1-",
-			Errors:      4,
+			Errors:      3,
 		},
 		{
 			ServiceName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz",
@@ -135,6 +135,10 @@ func TestAzureValidateMsSqlServiceName(t *testing.T) {
 		{
 			ServiceName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz1",
 			Errors:      3,
+		},
+		{
+			ServiceName: "asdfghjklzasdfghjklzasdfghjklzasdfghjklzasdfghjklz1--",
+			Errors:      4,
 		},
 	}
 

--- a/azurerm/resource_arm_mssql_elasticpool.go
+++ b/azurerm/resource_arm_mssql_elasticpool.go
@@ -253,7 +253,7 @@ func resourceArmMsSqlElasticPoolCreate(d *schema.ResourceData, meta interface{})
 	tags := d.Get("tags").(map[string]interface{})
 
 	elasticPool := sql.ElasticPool{
-		Sku: sku,
+		Sku:                   sku,
 		ElasticPoolProperties: properties,
 		Location:              &location,
 		Tags:                  expandTags(tags),

--- a/azurerm/resource_arm_mssql_elasticpool.go
+++ b/azurerm/resource_arm_mssql_elasticpool.go
@@ -30,7 +30,7 @@ func resourceArmMsSqlElasticPool() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: azure.ValidateMsSqlServiceName,
+				ValidateFunc: azure.ValidateMsSqlElasticPoolName,
 			},
 
 			"location": locationSchema(),
@@ -41,7 +41,7 @@ func resourceArmMsSqlElasticPool() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: azure.ValidateMsSqlServiceName,
+				ValidateFunc: azure.ValidateSqlServerName,
 			},
 
 			"sku": {
@@ -253,7 +253,7 @@ func resourceArmMsSqlElasticPoolCreate(d *schema.ResourceData, meta interface{})
 	tags := d.Get("tags").(map[string]interface{})
 
 	elasticPool := sql.ElasticPool{
-		Sku:                   sku,
+		Sku: sku,
 		ElasticPoolProperties: properties,
 		Location:              &location,
 		Tags:                  expandTags(tags),

--- a/azurerm/resource_arm_mysql_server.go
+++ b/azurerm/resource_arm_mysql_server.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -24,9 +26,10 @@ func resourceArmMySqlServer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 
 			"location": locationSchema(),
@@ -62,7 +65,7 @@ func resourceArmMySqlServer() *schema.Resource {
 								"MO_Gen5_8",
 								"MO_Gen5_16",
 							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							DiffSuppressFunc: suppress.CaseDifference,
 						},
 
 						"capacity": {
@@ -86,7 +89,7 @@ func resourceArmMySqlServer() *schema.Resource {
 								string(mysql.GeneralPurpose),
 								string(mysql.MemoryOptimized),
 							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							DiffSuppressFunc: suppress.CaseDifference,
 						},
 
 						"family": {
@@ -96,7 +99,7 @@ func resourceArmMySqlServer() *schema.Resource {
 								"Gen4",
 								"Gen5",
 							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							DiffSuppressFunc: suppress.CaseDifference,
 						},
 					},
 				},
@@ -121,7 +124,7 @@ func resourceArmMySqlServer() *schema.Resource {
 					string(mysql.FiveFullStopSix),
 					string(mysql.FiveFullStopSeven),
 				}, true),
-				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+				DiffSuppressFunc: suppress.CaseDifference,
 				ForceNew:         true,
 			},
 
@@ -148,7 +151,7 @@ func resourceArmMySqlServer() *schema.Resource {
 								"Enabled",
 								"Disabled",
 							}, true),
-							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							DiffSuppressFunc: suppress.CaseDifference,
 						},
 					},
 				},
@@ -161,7 +164,7 @@ func resourceArmMySqlServer() *schema.Resource {
 					string(mysql.SslEnforcementEnumDisabled),
 					string(mysql.SslEnforcementEnumEnabled),
 				}, true),
-				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"fqdn": {

--- a/azurerm/resource_arm_postgresql_server.go
+++ b/azurerm/resource_arm_postgresql_server.go
@@ -5,13 +5,13 @@ import (
 	"log"
 	"strings"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
-
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -27,9 +27,10 @@ func resourceArmPostgreSQLServer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidatePostgreSqlServerName,
 			},
 
 			"location": locationSchema(),

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -3,11 +3,11 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2015-05-01-preview/sql"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -24,13 +24,10 @@ func resourceArmSqlServer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[-a-z0-9]{3,50}$"),
-					"SQL server name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
-				),
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateSqlServerName,
 			},
 
 			"location": locationSchema(),


### PR DESCRIPTION
Introduces method to validate Azure Resource names which enforce the Azure standards for naming resources. Currently there isn't a standard way to do the validation which causes the validation to not be consistent within the provider.

 1. First two characters must be a number or a letter
 2. Last characters must be a number or a letter
 3. No consecutive hyphens, underscores, parentheses, or periods
 4. Min and Max length for values vary depending on the resource
 5. Value can not start or end with any special character
