### PR TITLE
Support app_command_line in App Service site_config

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -26,6 +26,11 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 					Default:  false,
 				},
 
+				"app_command_line": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+
 				"default_documents": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -221,6 +226,10 @@ func ExpandAppServiceSiteConfig(input interface{}) web.SiteConfig {
 		siteConfig.AlwaysOn = utils.Bool(v.(bool))
 	}
 
+	if v, ok := config["app_command_line"]; ok {
+		siteConfig.AppCommandLine = utils.String(v.(string))
+	}
+
 	if v, ok := config["default_documents"]; ok {
 		input := v.([]interface{})
 
@@ -345,6 +354,10 @@ func FlattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 
 	if input.AlwaysOn != nil {
 		result["always_on"] = *input.AlwaysOn
+	}
+
+	if input.AppCommandLine != nil {
+		result["app_command_line"] = *input.AppCommandLine
 	}
 
 	documents := make([]string, 0)

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -204,6 +204,32 @@ func TestAccAzureRMAppService_alwaysOn(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_appCommandLine(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_appCommandLine(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.app_command_line", "/sbin/myserver -b 0.0.0.0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_httpsOnly(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := acctest.RandInt()
@@ -1250,6 +1276,37 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     always_on = true
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_appCommandLine(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    app_command_line = "/sbin/myserver -b 0.0.0.0"
   }
 }
 `, rInt, location, rInt, rInt)

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -67,6 +67,8 @@ output "app_service_id" {
 
 * `always_on` - Is the app be loaded at all times?
 
+* `app_command_line` - App command line to launch.
+
 * `default_documents` - The ordering of default documents to load, if an address isn't specified.
 
 * `dotnet_framework_version` - The version of the .net framework's CLR used in this App Service.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -154,6 +154,7 @@ The following arguments are supported:
 `site_config` supports the following:
 
 * `always_on` - (Optional) Should the app be loaded at all times? Defaults to `false`.
+* `app_command_line` - (Optional) App command line to launch, e.g. `/sbin/myserver -b 0.0.0.0`.
 * `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
 * `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`) and `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`). [For more information on which .net CLR version to use based on the .net framework you're targeting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
 * `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`.

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -183,6 +183,7 @@ The following arguments are supported:
 `site_config` supports the following:
 
 * `always_on` - (Optional) Should the app be loaded at all times? Defaults to `false`.
+* `app_command_line` - (Optional) App command line to launch, e.g. `/sbin/myserver -b 0.0.0.0`.
 * `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
 * `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service Slot. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`) and `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`). [For more information on which .net CLR version to use based on the .net framework you're targeting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
 * `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`.


### PR DESCRIPTION
I took a look at fixing #2349 myself and this is my first draft! Happy to change things if I've misunderstood anything :)

--

App Service supports setting a command line to use with Linux applications (e.g. to override the default in the container image). Expose this configuration as `app_command_line` in `site_config` for `azurerm_app_service`.

N.B. This is also referred to as "startup file" by some sources, including the `az` Azure CLI and the Azure Portal.

References:

- https://docs.microsoft.com/en-us/rest/api/appservice/webapps/createorupdate#siteconfig
- https://docs.microsoft.com/en-us/cli/azure/webapp?view=azure-cli-latest#az-webapp-create

--

Closes #2349.