### PR TITLE
authentication: switching to use Azure CLI Token Authentication

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -323,9 +323,9 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			MsiEndpoint:    d.Get("msi_endpoint").(string),
 
 			// Feature Toggles
-			SupportsClientSecretAuth:          true,
-			SupportsManagedServiceIdentity:    d.Get("use_msi").(bool),
-			SupportsAzureCliCloudShellParsing: true,
+			SupportsClientSecretAuth:       true,
+			SupportsManagedServiceIdentity: d.Get("use_msi").(bool),
+			SupportsAzureCliParsing:        true,
 		}
 
 		config, err := builder.Build()

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -325,7 +325,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			// Feature Toggles
 			SupportsClientSecretAuth:       true,
 			SupportsManagedServiceIdentity: d.Get("use_msi").(bool),
-			SupportsAzureCliParsing:        true,
+			SupportsAzureCliToken:          true,
 		}
 
 		config, err := builder.Build()

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_parsing.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_parsing.go
@@ -48,25 +48,16 @@ func (a azureCliParsingAuth) build(b Builder) (authMethod, error) {
 }
 
 func (a azureCliParsingAuth) isApplicable(b Builder) bool {
-	return b.SupportsAzureCliCloudShellParsing
+	return b.SupportsAzureCliParsing
 }
 
 func (a azureCliParsingAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
-	if a.profile.usingCloudShell {
-		// load the refreshed tokens from the CloudShell Azure CLI credentials
-		err := a.profile.populateClientIdAndAccessToken()
-		if err != nil {
-			return nil, fmt.Errorf("Error loading the refreshed CloudShell tokens: %+v", err)
-		}
-	}
-
 	spt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, a.profile.clientId, endpoint, *a.profile.accessToken)
 	if err != nil {
 		return nil, err
 	}
 
 	err = spt.Refresh()
-
 	if err != nil {
 		return nil, fmt.Errorf("Error refreshing Service Principal Token: %+v", err)
 	}

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_token.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_token.go
@@ -1,0 +1,146 @@
+package authentication
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure/cli"
+	"github.com/hashicorp/go-multierror"
+)
+
+type azureCliTokenAuth struct {
+	profile *azureCLIProfile
+}
+
+func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
+	auth := azureCliTokenAuth{
+		profile: &azureCLIProfile{
+			clientId:       b.ClientID,
+			environment:    b.Environment,
+			subscriptionId: b.SubscriptionID,
+			tenantId:       b.TenantID,
+		},
+	}
+	profilePath, err := cli.ProfilePath()
+	if err != nil {
+		return nil, fmt.Errorf("Error loading the Profile Path from the Azure CLI: %+v", err)
+	}
+
+	profile, err := cli.LoadProfile(profilePath)
+	if err != nil {
+		return nil, fmt.Errorf("Azure CLI Authorization Profile was not found. Please ensure the Azure CLI is installed and then log-in with `az login`.")
+	}
+
+	auth.profile.profile = profile
+
+	err = auth.profile.populateFields()
+	if err != nil {
+		return nil, err
+	}
+
+	err = auth.profile.populateClientId()
+	if err != nil {
+		return nil, fmt.Errorf("Error populating Client ID from the Azure CLI: %+v", err)
+	}
+
+	return auth, nil
+}
+
+func (a azureCliTokenAuth) isApplicable(b Builder) bool {
+	return b.SupportsAzureCliToken
+}
+
+func (a azureCliTokenAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+	// the Azure CLI appears to cache these, so to maintain compatibility with the interface this method is intentionally not on the pointer
+	token, err := obtainAuthorizationToken(endpoint, a.profile.subscriptionId)
+	if err != nil {
+		return nil, fmt.Errorf("Error obtaining Authorization Token from the Azure CLI: %s", err)
+	}
+
+	adalToken, err := token.ToADALToken()
+	if err != nil {
+		return nil, fmt.Errorf("Error converting Authorization Token to an ADAL Token: %s", err)
+	}
+
+	spt, err := adal.NewServicePrincipalTokenFromManualToken(*oauthConfig, a.profile.clientId, endpoint, adalToken)
+	if err != nil {
+		return nil, err
+	}
+
+	auth := autorest.NewBearerAuthorizer(spt)
+	return auth, nil
+}
+
+func (a azureCliTokenAuth) name() string {
+	return "Obtaining a token from the Azure CLI"
+}
+
+func (a azureCliTokenAuth) populateConfig(c *Config) error {
+	c.ClientID = a.profile.clientId
+	c.Environment = a.profile.environment
+	c.SubscriptionID = a.profile.subscriptionId
+	c.TenantID = a.profile.tenantId
+	return nil
+}
+
+func (a azureCliTokenAuth) validate() error {
+	var err *multierror.Error
+
+	errorMessageFmt := "A %s was not found in your Azure CLI Credentials.\n\nPlease login to the Azure CLI again via `az login`"
+
+	if a.profile == nil {
+		return fmt.Errorf("Azure CLI Profile is nil - this is an internal error and should be reported.")
+	}
+
+	if a.profile.clientId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Client ID"))
+	}
+
+	if a.profile.subscriptionId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Subscription ID"))
+	}
+
+	if a.profile.tenantId == "" {
+		err = multierror.Append(err, fmt.Errorf(errorMessageFmt, "Tenant ID"))
+	}
+
+	return err.ErrorOrNil()
+}
+
+func obtainAuthorizationToken(endpoint string, subscriptionId string) (*cli.Token, error) {
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	cmd := exec.Command("az", "account", "get-access-token", "--resource", endpoint, "--subscription", subscriptionId, "-o=json")
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("Error launching Azure CLI: %+v", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("Error waiting for the Azure CLI: %+v", err)
+	}
+
+	stdOutStr := stdout.String()
+	stdErrStr := stderr.String()
+
+	if stdErrStr != "" {
+		return nil, fmt.Errorf("Error retrieving access token from Azure CLI: %s", strings.TrimSpace(stdErrStr))
+	}
+
+	var token *cli.Token
+	err := json.Unmarshal([]byte(stdOutStr), &token)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling Access Token from the Azure CLI: %s", err)
+	}
+
+	return token, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/azure_cli_profile.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/azure_cli_profile.go
@@ -13,7 +13,6 @@ type azureCLIProfile struct {
 	subscriptionId  string
 	tenantId        string
 	accessToken     *adal.Token
-	usingCloudShell bool
 }
 
 func (a *azureCLIProfile) populateFields() error {
@@ -31,12 +30,6 @@ func (a *azureCLIProfile) populateFields() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	// now we know the Subscription ID & Tenant ID we can find the associated Client ID/Access Token
-	err := a.populateClientIdAndAccessToken()
-	if err != nil {
-		return err
 	}
 
 	// always pull the environment from the Azure CLI, since the Access Token's associated with it

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
@@ -18,8 +18,11 @@ type Builder struct {
 	// only applicable for Azure Stack at this time.
 	CustomResourceManagerEndpoint string
 
-	// Azure CLI Parsing / CloudShell Auth
-	SupportsAzureCliCloudShellParsing bool
+	// Azure CLI Parsing
+	SupportsAzureCliParsing bool
+
+	// Azure CLI Tokens Auth
+	SupportsAzureCliToken bool
 
 	// Managed Service Identity Auth
 	SupportsManagedServiceIdentity bool
@@ -52,6 +55,7 @@ func (b Builder) Build() (*Config, error) {
 		servicePrincipalClientCertificateAuth{},
 		servicePrincipalClientSecretAuth{},
 		managedServiceIdentityAuth{},
+		azureCliTokenAuth{},
 		azureCliParsingAuth{},
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -844,36 +844,36 @@
 			"revisionTime": "2018-07-15T04:49:06Z"
 		},
 		{
-			"checksumSHA1": "YOs3XOIFl4xo5etkrYYdZgH7Kr0=",
+			"checksumSHA1": "6wvg4jOPIzX4P41T0BQidyhCZuo=",
 			"path": "github.com/hashicorp/go-azure-helpers/authentication",
-			"revision": "c51a3103be3beb7b0ae7256eabfca145382acfc1",
-			"revisionTime": "2018-11-22T15:17:43Z",
-			"version": "0.1.2",
-			"versionExact": "0.1.2"
+			"revision": "ec113df69f49ef0d7ce828c6433022c61fa474eb",
+			"revisionTime": "2018-11-26T13:55:26Z",
+			"version": "0.2.0",
+			"versionExact": "0.2.0"
 		},
 		{
 			"checksumSHA1": "QwsnT5sLpT2jJ/1qJQRvqU8xl14=",
 			"path": "github.com/hashicorp/go-azure-helpers/resourceproviders",
-			"revision": "c51a3103be3beb7b0ae7256eabfca145382acfc1",
-			"revisionTime": "2018-11-22T15:17:43Z",
-			"version": "0.1.2",
-			"versionExact": "0.1.2"
+			"revision": "ec113df69f49ef0d7ce828c6433022c61fa474eb",
+			"revisionTime": "2018-11-26T13:55:26Z",
+			"version": "0.2.0",
+			"versionExact": "0.2.0"
 		},
 		{
 			"checksumSHA1": "ip//Px6kdSuCH6OKEJUSMIgI3ng=",
 			"path": "github.com/hashicorp/go-azure-helpers/response",
-			"revision": "c51a3103be3beb7b0ae7256eabfca145382acfc1",
-			"revisionTime": "2018-11-22T15:17:43Z",
-			"version": "0.1.2",
-			"versionExact": "0.1.2"
+			"revision": "ec113df69f49ef0d7ce828c6433022c61fa474eb",
+			"revisionTime": "2018-11-26T13:55:26Z",
+			"version": "0.2.0",
+			"versionExact": "0.2.0"
 		},
 		{
 			"checksumSHA1": "Ji4mcyJSLYqsL5LWgYWVairiOpQ=",
 			"path": "github.com/hashicorp/go-azure-helpers/storage",
-			"revision": "c51a3103be3beb7b0ae7256eabfca145382acfc1",
-			"revisionTime": "2018-11-22T15:17:43Z",
-			"version": "0.1.2",
-			"versionExact": "0.1.2"
+			"revision": "ec113df69f49ef0d7ce828c6433022c61fa474eb",
+			"revisionTime": "2018-11-26T13:55:26Z",
+			"version": "0.2.0",
+			"versionExact": "0.2.0"
 		},
 		{
 			"checksumSHA1": "b8F628srIitj5p7Y130xc9k0QWs=",

--- a/website/docs/authenticating_via_azure_cli.html.markdown
+++ b/website/docs/authenticating_via_azure_cli.html.markdown
@@ -19,13 +19,13 @@ We recommend [using a Service Principal when running in a shared environment](au
   
   When the timezones `az` and `terraform` run in differ (for example when `az` is run inside docker, which defaults to UTC, and the system timezone where `terraform` runs is not UTC), `terraform` interprets the token differently from what `az` intended and may incorrectly determine the token to be stale and invalid.
   
-  When `terraform`  and `az` are run on hosts / containers with different timezones, the variable $TZ should be set on the host.  
+  When `terraform`  and `az` are run on hosts / containers with different timezones, the variable $TZ should be set on the host.
 
 When authenticating via the Azure CLI, Terraform will automatically connect to the Default Subscription - this can be changed by using the Azure CLI - and is documented below.
 
 ## Configuring the Azure CLI
 
-~> **Note:** There are multiple versions of the Azure CLI - the latest version is known as [the Azure CLI 2.0 (Python)](https://github.com/Azure/azure-cli) and [the older Azure CLI (Node.JS)](https://github.com/Azure/azure-xplat-cli). While Terraform currently supports both - we highly recommend users upgrade to the Azure CLI 2.0 (Python) if possible.
+~> **Note:** There are multiple versions of the Azure CLI - the latest version is known as [the Azure CLI 2.0 (Python)](https://github.com/Azure/azure-cli), which can be used for authentication. Terraform does not support the older [Azure CLI (Node.JS)](https://github.com/Azure/azure-xplat-cli) or [Azure PowerShell](https://github.com/Azure/azure-powershell).
 
 This guide assumes that you have [the Azure CLI 2.0 (Python)](https://github.com/Azure/azure-cli) installed.
 

--- a/website/docs/authenticating_via_azure_cli.html.markdown
+++ b/website/docs/authenticating_via_azure_cli.html.markdown
@@ -9,17 +9,11 @@ description: |-
 
 # Azure Provider: Authenticating using the Azure CLI
 
-Terraform supports authenticating to Azure through a Service Principal or the Azure CLI.
+Terraform supports authenticating to Azure using the Azure CLI, a Service Principal or via Managed Service Identity.
 
-We recommend [using a Service Principal when running in a shared environment](authenticating_via_service_principal.html) (such as within a CI server/automation) - and authenticating via the Azure CLI when you're running Terraform locally.
+We recommend [using a Service Principal when running in a shared environment](authenticating_via_service_principal.html) (such as within a CI server/automation) and authenticating via the Azure CLI when running Terraform locally.
 
-~> **NOTE:** Authenticating via the Azure CLI is only supported when using a User Account. If you're using a Service Principal (e.g. via `az login --service-principal`) you should instead [authenticate via the Service Principal directly](authenticating_via_service_principal.html).
-
-~> **NOTE:** Take note that when `az login` fetches the access tokens, these are interpreted (and stored) according to the timezone settings the azure-cli runs in.
-  
-  When the timezones `az` and `terraform` run in differ (for example when `az` is run inside docker, which defaults to UTC, and the system timezone where `terraform` runs is not UTC), `terraform` interprets the token differently from what `az` intended and may incorrectly determine the token to be stale and invalid.
-  
-  When `terraform`  and `az` are run on hosts / containers with different timezones, the variable $TZ should be set on the host.
+~> **NOTE:** Authenticating via the Azure CLI is only supported when using a User Account. If you're using a Service Principal (for example via `az login --service-principal`) you should instead [authenticate via the Service Principal directly](authenticating_via_service_principal.html).
 
 When authenticating via the Azure CLI, Terraform will automatically connect to the Default Subscription - this can be changed by using the Azure CLI - and is documented below.
 
@@ -29,7 +23,7 @@ When authenticating via the Azure CLI, Terraform will automatically connect to t
 
 This guide assumes that you have [the Azure CLI 2.0 (Python)](https://github.com/Azure/azure-cli) installed.
 
-~> **Note:** If you're using the **China**, **German** or **Government** Azure Clouds - you'll need to first configure the Azure CLI to work with that Cloud.  You can do this by running:
+~> **Note:** If you're using the **China**, **German** or **US Government** Azure Clouds, you'll need to first configure the Azure CLI to work with that Cloud. You can do this by running:
 
 ```shell
 $ az cloud set --name AzureChinaCloud|AzureGermanCloud|AzureUSGovernment
@@ -43,7 +37,7 @@ Firstly, login to the Azure CLI using:
 $ az login
 ```
 
-~> **NOTE:** Authenticating via the Azure CLI is only supported when using a User Account. If you're using a Service Principal (e.g. via `az login --service-principal`) you should instead [authenticate via the Service Principal directly](authenticating_via_service_principal.html).
+~> **NOTE:** Authenticating via the Azure CLI is only supported when using a User Account. If you're using a Service Principal (for example via `az login --service-principal`) you should instead [authenticate via the Service Principal directly](authenticating_via_service_principal.html).
 
 This will prompt you to open a web browser, as shown below:
 
@@ -51,13 +45,13 @@ This will prompt you to open a web browser, as shown below:
 To sign in, use a web browser to open the page https://aka.ms/devicelogin and enter the code XXXXXXXX to authenticate.
 ```
 
-Once logged in - it's possible to list the Subscriptions associated with the account via:
+Once logged in, it's possible to list the Subscriptions associated with the account via:
 
 ```shell
 $ az account list
 ```
 
-The output (similar to below) will display one or more Subscriptions - with the `id` field being the Subscription ID.
+The output (similar to below) will display one or more Subscriptions:
 
 ```json
 [
@@ -76,10 +70,12 @@ The output (similar to below) will display one or more Subscriptions - with the 
 ]
 ```
 
-~> **Note:** When authenticating via the Azure CLI, Terraform will automatically connect to the Default Subscription. As such if you have multiple subscriptions on the account, you may need to set the Default Subscription, via:
+In the snippet above, `id` refers to the Subscription ID and `isDefault` refers to whether this Subscription is configured as the default.
+
+~> **Note:** When authenticating via the Azure CLI, Terraform will automatically connect to the Default Subscription. Therefore, if you have multiple subscriptions on the account, you may need to set the Default Subscription, via:
 
 ```shell
 $ az account set --subscription="SUBSCRIPTION_ID"
 ```
 
-Also, if you have been authenticating with a service principal and you switch to Azure CLI, you must null out the ARM_* environment variables. Failure to do so causes errors to be thrown.
+If you're previously authenticated using a Service Principal (configured via Environment Variables) - you must remove the `ARM_*` prefixed Environment Variables in order to be able to authenticate using the Azure CLI.


### PR DESCRIPTION
This PR updates the Azure CLI authentication such that rather than parsing the Access Tokens out of the Azure CLI credentials files

This also wants a review of the docs to ensure they mention using Azure CLI v2 rather than v1

This fixes #502