### PR TITLE
doc change from oms to Azure Monitor for containers

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -870,7 +870,7 @@
             </li>
 
             <li<%= sidebar_current("docs-azurerm-oms") %>>
-              <a href="#">OMS Resources</a>
+              <a href="#">Azure Monitor for containers Resources</a>
               <ul class="nav nav-visible">
                 <li<%= sidebar_current("docs-azurerm-oms-log-analytics-solution") %>>
                   <a href="/docs/providers/azurerm/r/log_analytics_solution.html">azurerm_log_analytics_solution</a>


### PR DESCRIPTION
brand name change from oms to Azure Monitor for containers in the doc