### PR TITLE
azurerm_databricks_workspace fix for #2214

### DIFF
--- a/azurerm/resource_arm_databricks_workspace.go
+++ b/azurerm/resource_arm_databricks_workspace.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/databricks/mgmt/2018-04-01/databricks"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -158,6 +159,9 @@ func resourceArmDatabricksWorkspaceRead(d *schema.ResourceData, meta interface{}
 
 	if props := resp.WorkspaceProperties; props != nil {
 		d.Set("managed_resource_group_id", props.ManagedResourceGroupID)
+		//get the managed resource group name from the resource group id property
+		managedResourceGroupID := strings.Split(*props.ManagedResourceGroupID, "/")
+		d.Set("managed_resource_group", managedResourceGroupID[4])
 	}
 
 	flattenAndSetTags(d, resp.Tags)

--- a/azurerm/resource_arm_databricks_workspace.go
+++ b/azurerm/resource_arm_databricks_workspace.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/databricks/mgmt/2018-04-01/databricks"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -40,8 +39,8 @@ func resourceArmDatabricksWorkspace() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"Standard",
-					"Premium",
+					"standard",
+					"premium",
 				}, false),
 			},
 
@@ -50,6 +49,7 @@ func resourceArmDatabricksWorkspace() *schema.Resource {
 			"managed_resource_group": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				ForceNew:     true,
 				Computed:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -72,7 +72,7 @@ func resourceArmDatabricksWorkspaceCreateUpdate(d *schema.ResourceData, meta int
 	name := d.Get("name").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	resourceGroup := d.Get("resource_group_name").(string)
-	skuName := strings.ToLower(d.Get("sku").(string))
+	skuName := d.Get("sku").(string)
 	managedResourceGroupName := d.Get("managed_resource_group").(string)
 	var managedResourceGroupID string
 

--- a/azurerm/resource_arm_databricks_workspace_test.go
+++ b/azurerm/resource_arm_databricks_workspace_test.go
@@ -186,15 +186,15 @@ func testCheckAzureRMDatabricksWorkspaceDestroy(s *terraform.State) error {
 func testAccAzureRMDatabricksWorkspace_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+	name     = "acctestRG-%d"
+	location = "%s"
 }
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestdbw-%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+	name                = "acctestdbw-%d"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+	location            = "${azurerm_resource_group.test.location}"
+	sku                 = "standard"
 }
 `, rInt, location, rInt)
 }
@@ -202,21 +202,21 @@ resource "azurerm_databricks_workspace" "test" {
 func testAccAzureRMDatabricksWorkspace_complete(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+	name     = "acctestRG-%d"
+	location = "%s"
 }
 
 resource "azurerm_databricks_workspace" "test" {
-  name                		= "acctestdbw-%d"
-  resource_group_name 		= "${azurerm_resource_group.test.name}"
-  location            		= "${azurerm_resource_group.test.location}"
+	name                		= "acctestdbw-%d"
+	resource_group_name 		= "${azurerm_resource_group.test.name}"
+	location            		= "${azurerm_resource_group.test.location}"
 	sku                 		= "standard"
 	managed_resource_group 	= "acctestRG-%d-managed"
 
-  tags {
-    environment = "Production"
-    pricing     = "Standard"
-  }
+	tags {
+		environment = "Production"
+		pricing     = "Standard"
+	}
 }
 `, rInt, location, rInt, rInt)
 }
@@ -224,20 +224,20 @@ resource "azurerm_databricks_workspace" "test" {
 func testAccAzureRMDatabricksWorkspace_completeUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+	name     = "acctestRG-%d"
+	location = "%s"
 }
 
 resource "azurerm_databricks_workspace" "test" {
-  name                		= "acctestdbw-%d"
-  resource_group_name		 	= "${azurerm_resource_group.test.name}"
-  location            		= "${azurerm_resource_group.test.location}"
+	name                		= "acctestdbw-%d"
+	resource_group_name		 	= "${azurerm_resource_group.test.name}"
+	location            		= "${azurerm_resource_group.test.location}"
 	sku                 		= "standard"
 	managed_resource_group 	= "acctestRG-%d-managed"
 
-  tags {
-    pricing = "Standard"
-  }
+	tags {
+		pricing = "Standard"
+	}
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_databricks_workspace_test.go
+++ b/azurerm/resource_arm_databricks_workspace_test.go
@@ -107,6 +107,7 @@ func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDatabricksWorkspaceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_resource_group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_resource_group_name"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
 					resource.TestCheckResourceAttr(resourceName, "tags.pricing", "Standard"),
@@ -117,6 +118,7 @@ func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDatabricksWorkspaceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_resource_group_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_resource_group_name"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.pricing", "Standard"),
 				),
@@ -207,11 +209,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_databricks_workspace" "test" {
-	name                		= "acctestdbw-%d"
-	resource_group_name 		= "${azurerm_resource_group.test.name}"
-	location            		= "${azurerm_resource_group.test.location}"
-	sku                 		= "standard"
-	managed_resource_group 	= "acctestRG-%d-managed"
+	name                					= "acctestdbw-%d"
+	resource_group_name 					= "${azurerm_resource_group.test.name}"
+	location            					= "${azurerm_resource_group.test.location}"
+	sku                 					= "standard"
+	managed_resource_group_name 	= "acctestRG-%d-managed"
 
 	tags {
 		environment = "Production"
@@ -229,11 +231,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_databricks_workspace" "test" {
-	name                		= "acctestdbw-%d"
-	resource_group_name		 	= "${azurerm_resource_group.test.name}"
-	location            		= "${azurerm_resource_group.test.location}"
-	sku                 		= "standard"
-	managed_resource_group 	= "acctestRG-%d-managed"
+	name                					= "acctestdbw-%d"
+	resource_group_name		 				= "${azurerm_resource_group.test.name}"
+	location            					= "${azurerm_resource_group.test.location}"
+	sku                 					= "standard"
+	managed_resource_group_name 	= "acctestRG-%d-managed"
 
 	tags {
 		pricing = "Standard"

--- a/azurerm/resource_arm_databricks_workspace_test.go
+++ b/azurerm/resource_arm_databricks_workspace_test.go
@@ -92,7 +92,7 @@ func TestAccAzureRMDatabricksWorkspace_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMDatabricksWorkspace_withTags(t *testing.T) {
+func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 	resourceName := "azurerm_databricks_workspace.test"
 	ri := acctest.RandInt()
 	location := testLocation()
@@ -103,7 +103,7 @@ func TestAccAzureRMDatabricksWorkspace_withTags(t *testing.T) {
 		CheckDestroy: testCheckAzureRMDatabricksWorkspaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMDatabricksWorkspace_withTags(ri, location),
+				Config: testAccAzureRMDatabricksWorkspace_complete(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDatabricksWorkspaceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_resource_group_id"),
@@ -113,7 +113,7 @@ func TestAccAzureRMDatabricksWorkspace_withTags(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMDatabricksWorkspace_withTagsUpdate(ri, location),
+				Config: testAccAzureRMDatabricksWorkspace_completeUpdate(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDatabricksWorkspaceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_resource_group_id"),
@@ -194,12 +194,12 @@ resource "azurerm_databricks_workspace" "test" {
   name                = "acctestdbw-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "Standard"
+  sku                 = "standard"
 }
 `, rInt, location, rInt)
 }
 
-func testAccAzureRMDatabricksWorkspace_withTags(rInt int, location string) string {
+func testAccAzureRMDatabricksWorkspace_complete(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -207,20 +207,21 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestdbw-%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-  sku                 = "Standard"
+  name                		= "acctestdbw-%d"
+  resource_group_name 		= "${azurerm_resource_group.test.name}"
+  location            		= "${azurerm_resource_group.test.location}"
+	sku                 		= "standard"
+	managed_resource_group 	= "acctestRG-%d-managed"
 
   tags {
     environment = "Production"
     pricing     = "Standard"
   }
 }
-`, rInt, location, rInt)
+`, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMDatabricksWorkspace_withTagsUpdate(rInt int, location string) string {
+func testAccAzureRMDatabricksWorkspace_completeUpdate(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -228,14 +229,15 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_databricks_workspace" "test" {
-  name                = "acctestdbw-%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-  sku                 = "Standard"
+  name                		= "acctestdbw-%d"
+  resource_group_name		 	= "${azurerm_resource_group.test.name}"
+  location            		= "${azurerm_resource_group.test.location}"
+	sku                 		= "standard"
+	managed_resource_group 	= "acctestRG-%d-managed"
 
   tags {
     pricing = "Standard"
   }
 }
-`, rInt, location, rInt)
+`, rInt, location, rInt, rInt)
 }

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `sku` - (Required) The `sku` to use for the Databricks Workspace. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
-* `managed_resource_group` - (Optional) The name of the resource group where Azure should place the managed Databricks resources.
+* `managed_resource_group` - (Optional) The name of the resource group where Azure should place the managed Databricks resources. Changing this forces a new resource to be created.
 
 ~> **NOTE** You have to provide a unused resource group name in `managed_resource_group` as Azure has to create the resource group as 'managed' resource group during the deployment. The deployment will fail if a resource group with the same name in the same subscription already exists.
 

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `sku` - (Required) The `sku` to use for the Databricks Workspace. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
-* `managed_resource_group` - (Optional) The name of the resource group where Azure should place the managed Databricks resources. Changing this forces a new resource to be created.
+* `managed_resource_group_name` - (Optional) The name of the resource group where Azure should place the managed Databricks resources. Changing this forces a new resource to be created.
 
 ~> **NOTE** Azure requires that this Resource Group does not exist in this Subscription (and that the Azure API creates it) - otherwise the deployment will fail.
 

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `managed_resource_group` - (Optional) The name of the resource group where Azure should place the managed Databricks resources. Changing this forces a new resource to be created.
 
-~> **NOTE** You have to provide a unused resource group name in `managed_resource_group` as Azure has to create the resource group as 'managed' resource group during the deployment. The deployment will fail if a resource group with the same name in the same subscription already exists.
+~> **NOTE** Azure requires that this Resource Group does not exist in this Subscription (and that the Azure API creates it) - otherwise the deployment will fail.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -42,6 +42,10 @@ The following arguments are supported:
 
 * `sku` - (Required) The `sku` to use for the Databricks Workspace. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `managed_resource_group` - (Optional) The name of the resource group where Azure should place the managed Databricks resources.
+
+~> **NOTE** You have to provide a unused resource group name in `managed_resource_group` as Azure has to create the resource group as 'managed' resource group during the deployment. The deployment will fail if a resource group with the same name in the same subscription already exists.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
This fixes #2214 and adds an additional (optional) parameter to define the name of the resource group which contains the managed Databricks resources.

```hcl
resource "azurerm_resource_group" "test" {
  name     = "example-resources"
  location = "West US"
}

resource "azurerm_databricks_workspace" "test" {
  name                  = "databricks-test"
  resource_group_name   = "${azurerm_resource_group.test.name}"
  location              = "${azurerm_resource_group.test.location}"
  sku                   = "Standard"
  managed_resource_group = "managed-databricks-resources"

  tags {
    Environment = "Production"
  }
}
```