### PR TITLE
Add the ability to do basic filtering with azurerm_subscriptions

### DIFF
--- a/azurerm/data_source_subscriptions.go
+++ b/azurerm/data_source_subscriptions.go
@@ -47,7 +47,7 @@ func dataSourceArmSubscriptionsRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error listing subscriptions: %+v", err)
 	}
 
-	//check if the display name matches the 'prefix' comparison
+	//iterate across each subscriptions and append them to slice
 	subscriptions := make([]map[string]interface{}, 0)
 	for results.NotDone() {
 		val := results.Value()

--- a/azurerm/data_source_subscriptions.go
+++ b/azurerm/data_source_subscriptions.go
@@ -54,7 +54,7 @@ func dataSourceArmSubscriptionsRead(d *schema.ResourceData, meta interface{}) er
 
 		//check if the display name prefix matches the given input
 		if displayNamePrefix != "" {
-			if strings.HasPrefix(strings.ToLower(*val.DisplayName), displayNamePrefix) == false {
+			if !strings.HasPrefix(strings.ToLower(*val.DisplayName), displayNamePrefix) {
 				//the display name does not match the given prefix
 				log.Printf("[DEBUG][data_azurerm_subscriptions] %q does not match the prefix check %q", *val.DisplayName, displayNamePrefix)
 				if err = results.Next(); err != nil {
@@ -66,7 +66,7 @@ func dataSourceArmSubscriptionsRead(d *schema.ResourceData, meta interface{}) er
 
 		//check if the display name matches the 'contains' comparison
 		if displayNameContains != "" {
-			if strings.Contains(strings.ToLower(*val.DisplayName), displayNameContains) == false {
+			if !strings.Contains(strings.ToLower(*val.DisplayName), displayNameContains) {
 				//the display name does not match the contains check
 				log.Printf("[DEBUG][data_azurerm_subscriptions] %q does not match the contains check %q", *val.DisplayName, displayNameContains)
 				if err = results.Next(); err != nil {

--- a/website/docs/d/subscriptions.html.markdown
+++ b/website/docs/d/subscriptions.html.markdown
@@ -26,10 +26,8 @@ output "first_available_subscription_display_name" {
 
 ## Argument Reference
 
--> **NOTE** The comparisons are case-insensitive.
-
-* `display_name_prefix` - (Optional) This argument can be used to only return subscriptions that start with this given string.
-* `display_name_contains` - (Optional) This argument can be used to only return subscriptions that contain the given string.
+* `display_name_prefix` - (Optional) A case-insensitive prefix which can be used to filter on the `display_name` field
+* `display_name_contains` - (Optional) A case-insensitive value which must be contained within the `display_name` field, used to filter the results
 
 ## Attributes Reference
 

--- a/website/docs/d/subscriptions.html.markdown
+++ b/website/docs/d/subscriptions.html.markdown
@@ -26,7 +26,10 @@ output "first_available_subscription_display_name" {
 
 ## Argument Reference
 
-There are no arguments available for this data source.
+-> **NOTE** The comparisons are case-insensitive.
+
+* `display_name_prefix` - (Optional) This argument can be used to only return subscriptions that start with this given string.
+* `display_name_contains` - (Optional) This argument can be used to only return subscriptions that contain the given string.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This adds two new optional parameters to the data source azurerm_subscriptions:

* `display_name_prefix`
* `display_name_contains`

Example:
```hcl
data "azurerm_subscriptions" "current" {
  display_name_prefix = "Sub_"
  display_name_contains = "_123"
}

output "available_subscriptions" {
  value = "${data.azurerm_subscriptions.current.subscriptions}"
}
```

This gives:
```
{
        display_name = Sub_FooBar_123,
        location_placement_id = Public_2014-09-01,
        quota_id = AAD_2015-09-01,
        spending_limit = On,
        state = Enabled,
        subscription_id = foo
}
```