### PR TITLE
New DataSource: `azurerm_monitor_action_group`

### DIFF
--- a/azurerm/data_source_monitor_action_group.go
+++ b/azurerm/data_source_monitor_action_group.go
@@ -1,0 +1,125 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmMonitorActionGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmMonitorActionGroupRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"short_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"email_receiver": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"email_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"sms_receiver": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"country_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"phone_number": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"webhook_receiver": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_uri": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceArmMonitorActionGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).monitorActionGroupsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Action Group %q (Resource Group %q) was not found", name, resourceGroup)
+		}
+		return fmt.Errorf("Error making Read request on Action Group %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+	d.SetId(*resp.ID)
+
+	if group := resp.ActionGroup; group != nil {
+		d.Set("short_name", group.GroupShortName)
+		d.Set("enabled", group.Enabled)
+
+		if err = d.Set("email_receiver", flattenMonitorActionGroupEmailReceiver(group.EmailReceivers)); err != nil {
+			return fmt.Errorf("Error setting `email_receiver`: %+v", err)
+		}
+
+		if err = d.Set("sms_receiver", flattenMonitorActionGroupSmsReceiver(group.SmsReceivers)); err != nil {
+			return fmt.Errorf("Error setting `sms_receiver`: %+v", err)
+		}
+
+		if err = d.Set("webhook_receiver", flattenMonitorActionGroupWebHookReceiver(group.WebhookReceivers)); err != nil {
+			return fmt.Errorf("Error setting `webhook_receiver`: %+v", err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/data_source_monitor_action_group_test.go
+++ b/azurerm/data_source_monitor_action_group_test.go
@@ -1,0 +1,181 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceArmMonitorActionGroup_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_monitor_action_group.test"
+	ri := acctest.RandInt()
+	config := testAccDataSourceArmMonitorActionGroup_basic(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "short_name", "acctestag"),
+					resource.TestCheckResourceAttr(dataSourceName, "email_receiver.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "sms_receiver.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "webhook_receiver.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceArmMonitorActionGroup_disabledBasic(t *testing.T) {
+	dataSourceName := "data.azurerm_monitor_action_group.test"
+	ri := acctest.RandInt()
+	config := testAccDataSourceArmMonitorActionGroup_disabledBasic(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "short_name", "acctestag"),
+					resource.TestCheckResourceAttr(dataSourceName, "email_receiver.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "sms_receiver.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "webhook_receiver.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceArmMonitorActionGroup_complete(t *testing.T) {
+	dataSourceName := "data.azurerm_monitor_action_group.test"
+	ri := acctest.RandInt()
+	config := testAccDataSourceArmMonitorActionGroup_complete(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "email_receiver.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "email_receiver.0.email_address", "admin@contoso.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "email_receiver.1.email_address", "devops@contoso.com"),
+					resource.TestCheckResourceAttr(dataSourceName, "sms_receiver.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "sms_receiver.0.country_code", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "sms_receiver.0.phone_number", "1231231234"),
+					resource.TestCheckResourceAttr(dataSourceName, "sms_receiver.1.country_code", "86"),
+					resource.TestCheckResourceAttr(dataSourceName, "sms_receiver.1.phone_number", "13888888888"),
+					resource.TestCheckResourceAttr(dataSourceName, "webhook_receiver.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "webhook_receiver.0.service_uri", "http://example.com/alert"),
+					resource.TestCheckResourceAttr(dataSourceName, "webhook_receiver.1.service_uri", "https://backup.example.com/warning"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceArmMonitorActionGroup_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_action_group" "test" {
+  name                = "acctestActionGroup-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  short_name          = "acctestag"
+}
+
+data "azurerm_monitor_action_group" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "${azurerm_monitor_action_group.test.name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceArmMonitorActionGroup_disabledBasic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_action_group" "test" {
+  name                = "acctestActionGroup-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  short_name          = "acctestag"
+  enabled             = false
+}
+
+data "azurerm_monitor_action_group" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "${azurerm_monitor_action_group.test.name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceArmMonitorActionGroup_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_action_group" "test" {
+  name                = "acctestActionGroup-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  short_name          = "acctestag"
+
+  email_receiver {
+    name          = "sendtoadmin"
+    email_address = "admin@contoso.com"
+  }
+
+  email_receiver {
+    name          = "sendtodevops"
+    email_address = "devops@contoso.com"
+  }
+
+  sms_receiver {
+    name         = "oncallmsg"
+    country_code = "1"
+    phone_number = "1231231234"
+  }
+
+  sms_receiver {
+    name         = "remotesupport"
+    country_code = "86"
+    phone_number = "13888888888"
+  }
+
+  webhook_receiver {
+    name        = "callmyapiaswell"
+    service_uri = "http://example.com/alert"
+  }
+
+  webhook_receiver {
+    name        = "callmybackupapi"
+    service_uri = "https://backup.example.com/warning"
+  }
+}
+
+data "azurerm_monitor_action_group" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "${azurerm_monitor_action_group.test.name}"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -97,6 +97,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_logic_app_workflow":                    dataSourceArmLogicAppWorkflow(),
 			"azurerm_managed_disk":                          dataSourceArmManagedDisk(),
 			"azurerm_management_group":                      dataSourceArmManagementGroup(),
+			"azurerm_monitor_action_group":                  dataSourceArmMonitorActionGroup(),
 			"azurerm_monitor_diagnostic_categories":         dataSourceArmMonitorDiagnosticCategories(),
 			"azurerm_monitor_log_profile":                   dataSourceArmMonitorLogProfile(),
 			"azurerm_network_interface":                     dataSourceArmNetworkInterface(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -136,6 +136,10 @@
                     <a href="/docs/providers/azurerm/d/management_group.html">azurerm_management_group</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-monitor-action-group") %>>
+                    <a href="/docs/providers/azurerm/d/monitor_action_group.html">azurerm_monitor_action_group</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-monitor-diagnostic-categories") %>>
                     <a href="/docs/providers/azurerm/d/monitor_diagnostic_categories.html">azurerm_monitor_diagnostic_categories</a>
                 </li>

--- a/website/docs/d/monitor_action_group.html.markdown
+++ b/website/docs/d/monitor_action_group.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_monitor_action_group"
+sidebar_current: "docs-azurerm-datasource-monitor-action-group"
+description: |-
+  Get information about the specified Action Group.
+---
+
+# Data Source: azurerm_monitor_action_group
+
+Use this data source to access the properties of an Action Group.
+
+## Example Usage
+
+```hcl
+data "azurerm_monitor_action_group" "example" {
+  resource_group_name = "terraform-example-rg"
+  name                = "tfex-actiongroup"
+}
+
+output "action_group_id" {
+  value = "${data.azurerm_monitor_action_group.example.id}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the name of the Action Group.
+* `resource_group_name` - (Required) Specifies the name of the resource group the Action Group is located in.
+
+## Attributes Reference
+
+* `id` - The ID of the Action Group.
+* `short_name` - The short name of the action group.
+* `enabled` - Whether this action group is enabled.
+* `email_receiver` - One or more `email_receiver` blocks as defined below.
+* `sms_receiver` - One or more `sms_receiver ` blocks as defined below.
+* `webhook_receiver` - One or more `webhook_receiver ` blocks as defined below.
+
+---
+
+`email_receiver` supports the following:
+
+* `name` - The name of the email receiver.
+* `email_address` - The email address of this receiver.
+
+---
+
+`sms_receiver` supports the following:
+
+* `name` - The name of the SMS receiver.
+* `country_code` - The country code of the SMS receiver.
+* `phone_number` - The phone number of the SMS receiver.
+
+---
+
+`webhook_receiver` supports the following:
+
+* `name` - The name of the webhook receiver. 
+* `service_uri` - The URI where webhooks should be sent.


### PR DESCRIPTION
In this PR, I introduced `azurerm_monitor_action_group` data source, which contains identical attributes as the corresponding resource.

This PR also fulfills our community request #2323.

(fixes #2323)