### PR TITLE
example: ensuring that winrm is correctly configured

### DIFF
--- a/examples/virtual-machines/provisioners/windows/2-certificates.tf
+++ b/examples/virtual-machines/provisioners/windows/2-certificates.tf
@@ -62,6 +62,9 @@ resource "azurerm_key_vault_certificate" "main" {
     }
 
     x509_certificate_properties {
+      # Server Authentication = 1.3.6.1.5.5.7.3.1
+      # Client Authentication = 1.3.6.1.5.5.7.3.2
+      extended_key_usage = [ "1.3.6.1.5.5.7.3.1" ]
       key_usage = [
         "cRLSign",
         "dataEncipherment",

--- a/examples/virtual-machines/provisioners/windows/files/winrm.ps1
+++ b/examples/virtual-machines/provisioners/windows/files/winrm.ps1
@@ -1,3 +1,9 @@
+$profiles = Get-NetConnectionProfile
+Foreach ($i in $profiles) {
+    Write-Host ("Updating Interface ID {0} to be Private.." -f $profiles.InterfaceIndex)
+    Set-NetConnectionProfile -InterfaceIndex $profiles.InterfaceIndex -NetworkCategory Private
+}
+
 Write-Host "Obtaining the Thumbprint of the Certificate from KeyVault"
 $Thumbprint = (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object {$_.Subject -match "$ComputerName"}).Thumbprint
 
@@ -6,6 +12,10 @@ winrm create winrm/config/Listener?Address=*+Transport=HTTPS "@{Hostname=`"$Comp
 
 Write-Host "Enabling Basic Authentication.."
 winrm set winrm/config/service/Auth "@{Basic=`"true`"}"
+
+Write-Host "Re-starting the WinRM Service"
+net stop winrm
+net start winrm
 
 Write-Host "Open Firewall Ports"
 netsh advfirewall firewall add rule name="Windows Remote Management (HTTPS-In)" dir=in action=allow protocol=TCP localport=5986

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -194,6 +194,10 @@ resource "azurerm_key_vault_certificate" "test" {
     }
 
     x509_certificate_properties {
+      # Server Authentication = 1.3.6.1.5.5.7.3.1
+      # Client Authentication = 1.3.6.1.5.5.7.3.2
+      extended_key_usage = [ "1.3.6.1.5.5.7.3.1" ]
+
       key_usage = [
         "cRLSign",
         "dataEncipherment",
@@ -275,7 +279,7 @@ The following arguments are supported:
 
 `x509_certificate_properties` supports the following:
 
-* `extended_key_usage` - (Optional) A list of Extended/Enhanced Key Usages. If this argument is not specified, it defaults to `["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"]` (Server Authentication and Client Authentication respectively). Changing this forces a new resource to be created.
+* `extended_key_usage` - (Optional) A list of Extended/Enhanced Key Usages. Changing this forces a new resource to be created.
 * `key_usage` - (Required) A list of uses associated with this Key. Possible values include `cRLSign`, `dataEncipherment`, `decipherOnly`, `digitalSignature`, `encipherOnly`, `keyAgreement`, `keyCertSign`, `keyEncipherment` and `nonRepudiation` and are case-sensitive. Changing this forces a new resource to be created.
 * `subject` - (Required) The Certificate's Subject. Changing this forces a new resource to be created.
 * `subject_alternative_names` - (Optional) A `subject_alternative_names` block as defined below.


### PR DESCRIPTION
The default within Azure's been changed such that generated certificates are no longer defaulted to Server/Client Authorization - which is why this fails.