### PR TITLE
App Service Plan: removing a field which isn't expose

### DIFF
--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -110,8 +110,6 @@ The following arguments are supported:
 
 ~> **NOTE:** Attaching to an App Service Environment requires the App Service Plan use a `Premium` SKU (when using an ASEv1) and the `Isolated` SKU (for an ASEv2).
 
-* `maximum_number_of_workers` - (Optional) Maximum number of instances that can be assigned to this App Service plan.
-
 * `reserved` - (Optional) Is this App Service Plan `Reserved`. Defaults to `false`.
 
 * `per_site_scaling` - (Optional) Can Apps assigned to this App Service Plan be scaled independently? If set to `false` apps assigned to this plan will scale to all instances of the plan.  Defaults to `false`.


### PR DESCRIPTION
The `maximum_number_of_workers` field is Computed only, not user-setable - so displaying it as an optional field is misleading. This PR fixes that.