### PR TITLE
Updated documentation for agent_pool_profile on container service

### DIFF
--- a/website/docs/r/container_service.html.markdown
+++ b/website/docs/r/container_service.html.markdown
@@ -168,7 +168,7 @@ The following arguments are supported:
 
 * `linux_profile` - (Required) A Linux Profile block as documented below.
 
-* `agent_pool_profile` - (Required) One or more Agent Pool Profile's block as documented below.
+* `agent_pool_profile` - (Required) A Agent Pool Profile's block as documented below.
 
 * `service_principal` - (only Required when you're using `Kubernetes` as an Orchestration Platform) A Service Principal block as documented below.
 


### PR DESCRIPTION
Documentation for the agent_pool_profile on the Container service states...

```
agent_pool_profile - (Required) One or more agent_pool_profile blocks as documented below.
```

However, only one profile is actually allowed

```
 98       "agent_pool_profile": {
 99         Type:     schema.TypeSet,
100         Required: true,
101         MaxItems: 1,
102         Elem: &schema.Resource{
103           Schema: map[string]*schema.Schema{
104             "name": {
105               Type:     schema.TypeString,
106               Required: true,
107               ForceNew: true,
108             },
```