### PR TITLE
Deprecating the `azurerm_container_service` resource

### DIFF
--- a/azurerm/resource_arm_container_service.go
+++ b/azurerm/resource_arm_container_service.go
@@ -22,6 +22,15 @@ func resourceArmContainerService() *schema.Resource {
 		Update: resourceArmContainerServiceCreate,
 		Delete: resourceArmContainerServiceDelete,
 
+		DeprecationMessage: `Azure Container Service (ACS) has been deprecated in favour of Azure (Managed) Kubernetes Service (AKS).
+
+Azure will remove support for ACS Clusters on January 31, 2020. In preparation for this, the AzureRM Provider will remove support for the 'azurerm_container_service' resource in the next major version of the AzureRM Provider, which is targeted for Early 2019.
+
+If you're using ACS with Kubernetes, we'd recommend migrating to AKS / the 'azurerm_kubernetes_cluster' resource.
+
+More information can be found here: https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/
+`,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/website/docs/r/container_service.html.markdown
+++ b/website/docs/r/container_service.html.markdown
@@ -13,7 +13,7 @@ Manages an Azure Container Service Instance
 ~> **NOTE:** All arguments including the client secret will be stored in the raw state as plain-text.
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
-~> **NOTE:** You may wish to consider using [Azure Kubernetes Service (AKS)](kubernetes_cluster.html) for new deployments.
+~> **DEPRECATED:** [Azure Container Service (ACS) has been deprecated by Azure in favour of Azure (Managed) Kubernetes Service (AKS)](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/). Support for ACS will be removed in the next major version of the AzureRM Provider (2.0) - and we **strongly recommend** you consider using [Azure Kubernetes Service (AKS)](kubernetes_cluster.html) for new deployments.
 
 ## Example Usage (DCOS)
 


### PR DESCRIPTION
ACS [is scheduled to be retired in early 2020](https://azure.microsoft.com/en-us/updates/azure-container-service-will-retire-on-january-31-2020/) and the recommendation is to move to AKS. In preparation for this, this PR deprecates the `azurerm_container_service` resource such that we can remove it in 2.0