### PR TITLE
assign policy to a managementgroup

### DIFF
--- a/azurerm/resource_arm_policy_definition.go
+++ b/azurerm/resource_arm_policy_definition.go
@@ -166,7 +166,7 @@ func resourceArmPolicyDefinitionCreateUpdate(d *schema.ResourceData, meta interf
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
-	if _, err := stateConf.WaitForState(); err != nil {
+	if _, err = stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Policy Definition %q to become available: %s", name, err)
 	}
 

--- a/azurerm/resource_arm_policy_definition_test.go
+++ b/azurerm/resource_arm_policy_definition_test.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -21,7 +22,7 @@ func TestAccAzureRMPolicyDefinition_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMPolicyDefinitionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAzureRMPolicyDefinition_basic(ri),
+				Config: testAzureRMPolicyDefinition_basic(ri, false),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPolicyDefinitionExists(resourceName),
 				),
@@ -33,6 +34,64 @@ func TestAccAzureRMPolicyDefinition_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAzureRMPolicyDefinitionAtMgmtGroup_basic(t *testing.T) {
+	resourceName := "azurerm_policy_definition.test"
+	mgmtGroupName := "azurerm_management_group.test"
+
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPolicyDefinitionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMPolicyDefinition_basic(ri, true),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPolicyDefinitionExistsInMgmtGroup(resourceName, mgmtGroupName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMPolicyDefinitionExistsInMgmtGroup(policyName string, managementGroupName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[policyName]
+		if !ok {
+			return fmt.Errorf("not found: %s", policyName)
+		}
+
+		policyName := rs.Primary.Attributes["name"]
+
+		rs, ok = s.RootModule().Resources[managementGroupName]
+		if !ok {
+			return fmt.Errorf("not found: %s", managementGroupName)
+		}
+
+		managementGroupID := rs.Primary.Attributes["group_id"]
+
+		client := testAccProvider.Meta().(*ArmClient).policyDefinitionsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := client.GetAtManagementGroup(ctx, policyName, managementGroupID)
+		if err != nil {
+			return fmt.Errorf("Bad: GetAtManagementGroup on policyDefinitionsClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("policy does not exist: %s", policyName)
+		}
+
+		return nil
+	}
 }
 
 func testCheckAzureRMPolicyDefinitionExists(name string) resource.TestCheckFunc {
@@ -85,14 +144,29 @@ func testCheckAzureRMPolicyDefinitionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAzureRMPolicyDefinition_basic(ri int) string {
-	return fmt.Sprintf(`
+func testAzureRMPolicyDefinition_basic(ri int, managementGroup bool) string {
+	var builder strings.Builder
+
+	if managementGroup {
+		builder.WriteString(fmt.Sprintf(`
+resource "azurerm_management_group" "test" {
+  display_name = "acctestmg-%d"
+}
+`, ri))
+	}
+
+	builder.WriteString(fmt.Sprintf(`
 resource "azurerm_policy_definition" "test" {
   name         = "acctestpol-%d"
   policy_type  = "Custom"
   mode         = "All"
-  display_name = "acctestpol-%d"
+  display_name = "acctestpol-%d"`, ri, ri))
 
+	if managementGroup {
+		builder.WriteString(fmt.Sprintf(`management_group_id = "${azurerm_management_group.test.group_id}"`))
+	}
+
+	builder.WriteString(fmt.Sprintf(`
   policy_rule = <<POLICY_RULE
 	{
     "if": {
@@ -120,5 +194,7 @@ POLICY_RULE
   }
 PARAMETERS
 }
-`, ri, ri)
+`))
+
+	return builder.String()
 }

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the policy definition.
 
-* `management_group_id` - (Optional) the management group id (IE: `${data.azurerm_management_group.test.group_id`) where where to define this policy
+* `management_group_id` - (Optional) The Group ID (IE: `${data.azurerm_management_group.test.group_id`) of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
 
 * `policy_rule` - (Optional) The policy rule for the policy definition. This
     is a json object representing the rule that contains an if and

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # azurerm_policy_definition
 
-Manages a policy rule definition. Policy definitions do not take effect until they are assigned to a scope using a Policy Assignment.
+Manages a policy rule definition on a management group or your provider subscription. 
+
+Policy definitions do not take effect until they are assigned to a scope using a Policy Assignment.
 
 ## Example Usage
 
@@ -67,6 +69,8 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the policy definition.
 
+* `management_group_id` - (Optional) the management group id (IE: `${data.azurerm_management_group.test.group_id`) where where to define this policy
+
 * `policy_rule` - (Optional) The policy rule for the policy definition. This
     is a json object representing the rule that contains an if and
     a then block.
@@ -90,4 +94,8 @@ Policy Definitions can be imported using the `policy name`, e.g.
 
 ```shell
 terraform import azurerm_policy_definition.testPolicy  /subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
+```
+or
+```shell
+terraform import azurerm_policy_definition.testPolicy /providers/Microsoft.Management/managementgroups/<MANGAGEMENT_GROUP_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
 ```

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -69,7 +69,9 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the policy definition.
 
-* `management_group_id` - (Optional) The Group ID (IE: `${data.azurerm_management_group.test.group_id`) of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
+* `management_group_id` - (Optional) The ID of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
+
+~> **Note:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `.group_id` and not `.id`.
 
 * `policy_rule` - (Optional) The policy rule for the policy definition. This
     is a json object representing the rule that contains an if and


### PR DESCRIPTION
This pull request adds the ability to optionally define a policy on a **management group** level. The existing functionality -- define on a subscription or resource group is still intact.

I've done so by adding `management_group_id` to `azurerm_policy_definition`. IE:

```hcl
data "azurerm_management_group" "test" {
  group_id = "00000000-0000-0000-0000-000000000000"
}

resource "azurerm_policy_definition" "policy" {
  name         = "accTestPolicy"
  policy_type  = "Custom"
  mode         = "Indexed"
  display_name = "acceptance test policy definition"
  management_group_id = "${data.azurerm_management_group.test.id}"
...
}
```

btw, `azurerm_policy_assignment` will need no change to support this.


Feedback most welcome -- this is my first PR for the azurerm terraform provider