### PR TITLE
Requiring Import (PR 1 of ...)

### DIFF
--- a/azurerm/feature_flags.go
+++ b/azurerm/feature_flags.go
@@ -1,0 +1,4 @@
+package azurerm
+
+// This file contains feature flags for functionality which will prove more challenging to implement en-mass
+var requireResourcesToBeImported = false

--- a/azurerm/feature_flags.go
+++ b/azurerm/feature_flags.go
@@ -1,4 +1,9 @@
 package azurerm
 
+import (
+	"os"
+	"strings"
+)
+
 // This file contains feature flags for functionality which will prove more challenging to implement en-mass
-var requireResourcesToBeImported = false
+var requireResourcesToBeImported = strings.EqualFold(os.Getenv("ARM_PROVIDER_STRICT"), "true")

--- a/azurerm/helpers/tf/errors.go
+++ b/azurerm/helpers/tf/errors.go
@@ -1,0 +1,8 @@
+package tf
+
+import "fmt"
+
+func ImportAsExistsError(resourceName, id string) error {
+	msg := "A resource with the ID %q already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information."
+	return fmt.Errorf(msg, id, resourceName)
+}

--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -97,4 +98,9 @@ func testGetAzureConfig(t *testing.T) *authentication.Config {
 	}
 
 	return config
+}
+
+func testRequiresImportError(resourceName string) *regexp.Regexp {
+	message := "to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information."
+	return regexp.MustCompile(fmt.Sprintf(message, resourceName))
 }

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -299,7 +299,7 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	if requireResourcesToBeImported {
+	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -297,6 +298,20 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported {
+		existing, err := client.Get(ctx, resourceGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing API Management Service %q (Resource Group %q): %s", name, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management", *existing.ID)
+		}
+	}
+
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -35,6 +35,35 @@ func TestAccAzureRMApiManagement_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApiManagement_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_api_management.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagement_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMApiManagement_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_api_management"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMApiManagement_customProps(t *testing.T) {
 	resourceName := "azurerm_api_management.test"
 	ri := acctest.RandInt()
@@ -83,7 +112,7 @@ func TestAccAzureRMApiManagement_complete(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"certificate", // not returned from API, sensitive
+					"certificate",                                            // not returned from API, sensitive
 					"hostname_configuration.0.portal.0.certificate",          // not returned from API, sensitive
 					"hostname_configuration.0.portal.0.certificate_password", // not returned from API, sensitive
 					"hostname_configuration.0.proxy.0.certificate",           // not returned from API, sensitive
@@ -172,6 +201,26 @@ resource "azurerm_api_management" "test" {
   }
 }
 `, rInt, location, rInt)
+}
+
+func testAccAzureRMApiManagement_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMApiManagement_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management" "import" {
+  name                = "${azurerm_api_management.test.name}"
+  location            = "${azurerm_api_management.test.location}"
+  resource_group_name = "${azurerm_api_management.test.resource_group_name}"
+  publisher_name      = "${azurerm_api_management.test.publisher_name}"
+  publisher_email     = "${azurerm_api_management.test.publisher_email}"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+`, template)
 }
 
 func testAccAzureRMApiManagement_customProps(rInt int, location string) string {

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -112,7 +112,7 @@ func TestAccAzureRMApiManagement_complete(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"certificate",                                            // not returned from API, sensitive
+					"certificate", // not returned from API, sensitive
 					"hostname_configuration.0.portal.0.certificate",          // not returned from API, sensitive
 					"hostname_configuration.0.portal.0.certificate_password", // not returned from API, sensitive
 					"hostname_configuration.0.proxy.0.certificate",           // not returned from API, sensitive

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -191,7 +191,7 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 
-	if requireResourcesToBeImported {
+	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_app_service_custom_hostname_binding.go
+++ b/azurerm/resource_arm_app_service_custom_hostname_binding.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -50,6 +51,19 @@ func resourceArmAppServiceCustomHostnameBindingCreate(d *schema.ResourceData, me
 
 	azureRMLockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
 	defer azureRMUnlockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
+
+	if requireResourcesToBeImported {
+		existing, err := client.GetHostNameBinding(ctx, resourceGroup, appServiceName, hostname)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Custom Hostname Binding %q (App Service %q / Resource Group %q): %s", hostname, appServiceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_app_service_custom_hostname_binding", *existing.ID)
+		}
+	}
 
 	properties := web.HostNameBinding{
 		HostNameBindingProperties: &web.HostNameBindingProperties{

--- a/azurerm/resource_arm_app_service_custom_hostname_binding.go
+++ b/azurerm/resource_arm_app_service_custom_hostname_binding.go
@@ -52,7 +52,7 @@ func resourceArmAppServiceCustomHostnameBindingCreate(d *schema.ResourceData, me
 	azureRMLockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
 	defer azureRMUnlockByName(appServiceName, appServiceCustomHostnameBindingResourceName)
 
-	if requireResourcesToBeImported {
+	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.GetHostNameBinding(ctx, resourceGroup, appServiceName, hostname)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_app_service_custom_hostname_binding_test.go
+++ b/azurerm/resource_arm_app_service_custom_hostname_binding_test.go
@@ -13,29 +13,6 @@ import (
 )
 
 func TestAccAzureRMAppServiceCustomHostnameBinding(t *testing.T) {
-	// NOTE: this is a combined test rather than separate split out tests due to
-	// the app service name being shared (so the tests don't conflict with each other)
-	testCases := map[string]map[string]func(t *testing.T){
-		"basic": {
-			"basic":    testAccAzureRMAppServiceCustomHostnameBinding_basic,
-			"multiple": testAccAzureRMAppServiceCustomHostnameBinding_multiple,
-		},
-	}
-
-	for group, m := range testCases {
-		m := m
-		t.Run(group, func(t *testing.T) {
-			for name, tc := range m {
-				tc := tc
-				t.Run(name, func(t *testing.T) {
-					tc(t)
-				})
-			}
-		})
-	}
-}
-
-func testAccAzureRMAppServiceCustomHostnameBinding_basic(t *testing.T) {
 	appServiceEnvVariable := "ARM_TEST_APP_SERVICE"
 	appServiceEnv := os.Getenv(appServiceEnvVariable)
 	if appServiceEnv == "" {
@@ -48,6 +25,30 @@ func testAccAzureRMAppServiceCustomHostnameBinding_basic(t *testing.T) {
 		t.Skipf("Skipping as %q is not specified", domainEnvVariable)
 	}
 
+	// NOTE: this is a combined test rather than separate split out tests due to
+	// the app service name being shared (so the tests don't conflict with each other)
+	testCases := map[string]map[string]func(t *testing.T, appServiceEnv, domainEnv string){
+		"basic": {
+			"basic":          testAccAzureRMAppServiceCustomHostnameBinding_basic,
+			"multiple":       testAccAzureRMAppServiceCustomHostnameBinding_multiple,
+			"requiresImport": testAccAzureRMAppServiceCustomHostnameBinding_requiresImport,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t, appServiceEnv, domainEnv)
+				})
+			}
+		})
+	}
+}
+
+func testAccAzureRMAppServiceCustomHostnameBinding_basic(t *testing.T, appServiceEnv, domainEnv string) {
 	resourceName := "azurerm_app_service_custom_hostname_binding.test"
 	ri := acctest.RandInt()
 	location := testLocation()
@@ -73,23 +74,40 @@ func testAccAzureRMAppServiceCustomHostnameBinding_basic(t *testing.T) {
 	})
 }
 
-func testAccAzureRMAppServiceCustomHostnameBinding_multiple(t *testing.T) {
-	appServiceEnvVariable := "ARM_TEST_APP_SERVICE"
-	appServiceEnv := os.Getenv(appServiceEnvVariable)
-	if appServiceEnv == "" {
-		t.Skipf("Skipping as %q is not specified", appServiceEnvVariable)
+func testAccAzureRMAppServiceCustomHostnameBinding_requiresImport(t *testing.T, appServiceEnv, domainEnv string) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
 	}
 
-	domainEnvVariable := "ARM_TEST_DOMAIN"
-	domainEnv := os.Getenv(domainEnvVariable)
-	if domainEnv == "" {
-		t.Skipf("Skipping as %q is not specified", domainEnvVariable)
-	}
+	resourceName := "azurerm_app_service_custom_hostname_binding.test"
+	ri := acctest.RandInt()
+	location := testLocation()
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceCustomHostnameBindingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceCustomHostnameBinding_basicConfig(ri, location, appServiceEnv, domainEnv),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceCustomHostnameBindingExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMAppServiceCustomHostnameBinding_requiresImportConfig(ri, location, appServiceEnv, domainEnv),
+				ExpectError: testRequiresImportError("azurerm_app_service_custom_hostname_binding"),
+			},
+		},
+	})
+}
+
+func testAccAzureRMAppServiceCustomHostnameBinding_multiple(t *testing.T, appServiceEnv, domainEnv string) {
 	altDomainEnvVariable := "ARM_ALT_TEST_DOMAIN"
 	altDomainEnv := os.Getenv(altDomainEnvVariable)
-	if domainEnv == "" {
-		t.Skipf("Skipping as %q is not specified", domainEnvVariable)
+	if altDomainEnv == "" {
+		t.Skipf("Skipping as %q is not specified", altDomainEnvVariable)
 	}
 
 	resourceName := "azurerm_app_service_custom_hostname_binding.test"
@@ -198,6 +216,19 @@ resource "azurerm_app_service_custom_hostname_binding" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 `, rInt, location, rInt, appServiceName, domain)
+}
+
+func testAccAzureRMAppServiceCustomHostnameBinding_requiresImportConfig(rInt int, location string, appServiceName string, domain string) string {
+	template := testAccAzureRMAppServiceCustomHostnameBinding_basicConfig(rInt, location, appServiceName, domain)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_custom_hostname_binding" "import" {
+  hostname            = "${azurerm_app_service_custom_hostname_binding.test.name}"
+  app_service_name    = "${azurerm_app_service_custom_hostname_binding.test.app_service_name}"
+  resource_group_name = "${azurerm_app_service_custom_hostname_binding.test.resource_group_name}"
+}
+`, template)
 }
 
 func testAccAzureRMAppServiceCustomHostnameBinding_multipleConfig(rInt int, location, appServiceName, domain, altDomain string) string {

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -153,7 +153,7 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 	resGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
 
-	if requireResourcesToBeImported {
+	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -156,7 +156,7 @@ func resourceArmAppServiceSlotCreate(d *schema.ResourceData, meta interface{}) e
 	resGroup := d.Get("resource_group_name").(string)
 	appServiceName := d.Get("app_service_name").(string)
 
-	if requireResourcesToBeImported {
+	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.GetSlot(ctx, resGroup, appServiceName, slot)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -37,6 +37,35 @@ func TestAccAzureRMAppServiceSlot_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServiceSlot_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_app_service_slot.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSlotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceSlot_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSlotExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMAppServiceSlot_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_app_service_slot"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppServiceSlot_32Bit(t *testing.T) {
 	resourceName := "azurerm_app_service_slot.test"
 	ri := acctest.RandInt()
@@ -906,6 +935,21 @@ resource "azurerm_app_service_slot" "test" {
   app_service_name    = "${azurerm_app_service.test.name}"
 }
 `, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMAppServiceSlot_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMAppServiceSlot_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_slot" "import" {
+  name                = "${azurerm_app_service_slot.test.name}"
+  location            = "${azurerm_app_service_slot.test.location}"
+  resource_group_name = "${azurerm_app_service_slot.test.resource_group_name}"
+  app_service_plan_id = "${azurerm_app_service_slot.test.app_service_plan_id}"
+  app_service_name    = "${azurerm_app_service_slot.test.app_service_name}"
+}
+`, template)
 }
 
 func testAccAzureRMAppServiceSlot_32Bit(rInt int, location string) string {

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -730,7 +730,7 @@ func resourceArmApplicationGatewayCreateUpdate(d *schema.ResourceData, meta inte
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 
-	if requireResourcesToBeImported {
+	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -727,8 +728,22 @@ func resourceArmApplicationGatewayCreateUpdate(d *schema.ResourceData, meta inte
 	log.Printf("[INFO] preparing arguments for Application Gateway creation.")
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported {
+		existing, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Application Gateway %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_application_gateway", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 
 	// Gateway ID is needed to link sub-resources together in expand functions

--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 
 	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -75,6 +76,20 @@ func resourceArmApplicationInsightsCreateUpdate(d *schema.ResourceData, meta int
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Application Insights %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_application_insights", *existing.ID)
+		}
+	}
+
 	applicationType := d.Get("application_type").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -36,6 +36,36 @@ func TestAccAzureRMApplicationInsights_basicWeb(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApplicationInsights_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_application_insights.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApplicationInsights_basic(ri, location, "web"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "application_type", "web"),
+				),
+			},
+			{
+				Config:      testAccAzureRMApplicationInsights_requiresImport(ri, location, "web"),
+				ExpectError: testRequiresImportError("azurerm_application_insights"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMApplicationInsights_basicJava(t *testing.T) {
 	resourceName := "azurerm_application_insights.test"
 	ri := acctest.RandInt()
@@ -262,4 +292,18 @@ resource "azurerm_application_insights" "test" {
   application_type    = "%s"
 }
 `, rInt, location, rInt, applicationType)
+}
+
+func testAccAzureRMApplicationInsights_requiresImport(rInt int, location string, applicationType string) string {
+	template := testAccAzureRMApplicationInsights_basic(rInt, location, applicationType)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_application_insights" "import" {
+  name                = "${azurerm_application_insights.test.name}"
+  location            = "${azurerm_application_insights.test.location}"
+  resource_group_name = "${azurerm_application_insights.test.resource_group_name}"
+  application_type    = "${azurerm_application_insights.test.application_type}"
+}
+`, template)
 }

--- a/azurerm/resource_arm_application_security_group.go
+++ b/azurerm/resource_arm_application_security_group.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-04-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -42,6 +43,20 @@ func resourceArmApplicationSecurityGroupCreateUpdate(d *schema.ResourceData, met
 
 	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Application Security Group %q (Resource Group %q): %s", name, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_application_security_group", *existing.ID)
+		}
+	}
+
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 

--- a/azurerm/resource_arm_application_security_group_test.go
+++ b/azurerm/resource_arm_application_security_group_test.go
@@ -31,6 +31,35 @@ func TestAccAzureRMApplicationSecurityGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApplicationSecurityGroup_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	ri := acctest.RandInt()
+	location := testLocation()
+	resourceName := "azurerm_application_security_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApplicationSecurityGroup_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationSecurityGroupExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMApplicationSecurityGroup_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_app_service_custom_hostname_binding"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMApplicationSecurityGroup_complete(t *testing.T) {
 	ri := acctest.RandInt()
 	resourceName := "azurerm_application_security_group.test"
@@ -153,6 +182,19 @@ resource "azurerm_application_security_group" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 `, rInt, location, rInt)
+}
+
+func testAccAzureRMApplicationSecurityGroup_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMApplicationSecurityGroup_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_application_security_group" "import" {
+  name                = "${azurerm_application_security_group.test.name}"
+  location            = "${azurerm_application_security_group.test.location}"
+  resource_group_name = "${azurerm_application_security_group.test.resource_group_name}"
+}
+`, template)
 }
 
 func testAccAzureRMApplicationSecurityGroup_complete(rInt int, location string) string {

--- a/azurerm/resource_arm_automation_account_test.go
+++ b/azurerm/resource_arm_automation_account_test.go
@@ -38,6 +38,35 @@ func TestAccAzureRMAutomationAccount_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAutomationAccount_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_automation_account.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAutomationAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAutomationAccount_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAutomationAccountExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMAutomationAccount_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_automation_account"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAutomationAccount_complete(t *testing.T) {
 	resourceName := "azurerm_automation_account.test"
 	ri := acctest.RandInt()
@@ -141,6 +170,23 @@ resource "azurerm_automation_account" "test" {
   }
 }
 `, rInt, location, rInt)
+}
+
+func testAccAzureRMAutomationAccount_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMAutomationAccount_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_automation_account" "import" {
+  name                = "${azurerm_automation_account.test.name}"
+  location            = "${azurerm_automation_account.test.location}"
+  resource_group_name = "${azurerm_automation_account.test.resource_group_name}"
+
+  sku {
+    name = "Basic"
+  }
+}
+`, template)
 }
 
 func testAccAzureRMAutomationAccount_complete(rInt int, location string) string {

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -63,6 +64,20 @@ func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta in
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	accName := d.Get("account_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, accName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Automation Credential %q (Account %q / Resource Group %q): %s", name, accName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_automation_credential", *existing.ID)
+		}
+	}
+
 	user := d.Get("username").(string)
 	password := d.Get("password").(string)
 	description := d.Get("description").(string)

--- a/azurerm/resource_arm_automation_credential_test.go
+++ b/azurerm/resource_arm_automation_credential_test.go
@@ -36,6 +36,35 @@ func TestAccAzureRMAutomationCredential_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAutomationCredential_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_automation_credential.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAutomationCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAutomationCredential_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAutomationCredentialExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMAutomationCredential_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_automation_credential"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAutomationCredential_complete(t *testing.T) {
 	resourceName := "azurerm_automation_credential.test"
 	ri := acctest.RandInt()
@@ -156,6 +185,21 @@ resource "azurerm_automation_credential" "test" {
   password            = "test_pwd"
 }
 `, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAutomationCredential_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMAutomationCredential_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_automation_credential" "import" {
+  name                = "${azurerm_automation_credential.test.name}"
+  resource_group_name = "${azurerm_automation_credential.test.resource_group_name}"
+  account_name        = "${azurerm_automation_credential.test.account_name}"
+  username            = "${azurerm_automation_credential.test.username}"
+  password            = "${azurerm_automation_credential.test.password}"
+}
+`, template)
 }
 
 func testAccAzureRMAutomationCredential_complete(rInt int, location string) string {

--- a/azurerm/resource_arm_automation_dsc_configuration.go
+++ b/azurerm/resource_arm_automation_dsc_configuration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -80,6 +81,20 @@ func resourceArmAutomationDscConfigurationCreateUpdate(d *schema.ResourceData, m
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	accName := d.Get("automation_account_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, accName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Automation DSC Configuration %q (Account %q / Resource Group %q): %s", name, accName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_automation_dsc_configuration", *existing.ID)
+		}
+	}
+
 	contentEmbedded := d.Get("content_embedded").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	logVerbose := d.Get("log_verbose").(bool)

--- a/azurerm/resource_arm_automation_dsc_configuration_test.go
+++ b/azurerm/resource_arm_automation_dsc_configuration_test.go
@@ -39,6 +39,35 @@ func TestAccAzureRMAutomationDscConfiguration_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAutomationDscConfiguration_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_automation_dsc_configuration.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAutomationDscConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAutomationDscConfiguration_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAutomationDscConfigurationExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMAutomationDscConfiguration_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_automation_dsc_configuration"),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMAutomationDscConfigurationDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).automationDscConfigurationClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -133,4 +162,20 @@ resource "azurerm_automation_dsc_configuration" "test" {
   description             = "test"
 }
 `, rInt, location, rInt)
+}
+
+func testAccAzureRMAutomationDscConfiguration_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMAutomationDscConfiguration_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_automation_dsc_configuration" "import" {
+  name                    = "${azurerm_automation_dsc_configuration.test.name}"
+  resource_group_name     = "${azurerm_automation_dsc_configuration.test.resource_group_name}"
+  automation_account_name = "${azurerm_automation_dsc_configuration.test.automation_account_name}"
+  location                = "${azurerm_automation_dsc_configuration.test.location}"
+  content_embedded        = "${azurerm_automation_dsc_configuration.test.content_embedded}"
+  description             = "${azurerm_automation_dsc_configuration.test.description}"
+}
+`, template)
 }

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -62,6 +63,20 @@ func resourceArmAutomationDscNodeConfigurationCreateUpdate(d *schema.ResourceDat
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	accName := d.Get("automation_account_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, accName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Automation DSC Node Configuration %q (Account %q / Resource Group %q): %s", name, accName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_automation_dsc_nodeconfiguration", *existing.ID)
+		}
+	}
+
 	content := d.Get("content_embedded").(string)
 
 	// configuration name is always the first part of the dsc node configuration

--- a/azurerm/resource_arm_automation_module.go
+++ b/azurerm/resource_arm_automation_module.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -82,6 +83,20 @@ func resourceArmAutomationModuleCreateUpdate(d *schema.ResourceData, meta interf
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	accName := d.Get("automation_account_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, accName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Automation Module %q (Account %q / Resource Group %q): %s", name, accName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_automation_module", *existing.ID)
+		}
+	}
+
 	contentLink := expandModuleLink(d)
 
 	parameters := automation.ModuleCreateOrUpdateParameters{

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -125,11 +126,25 @@ func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta inter
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Runbook creation.")
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
+	accName := d.Get("account_name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, accName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Automation Runbook %q (Account %q / Resource Group %q): %s", name, accName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_automation_runbook", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 
-	accName := d.Get("account_name").(string)
 	runbookType := automation.RunbookTypeEnum(d.Get("runbook_type").(string))
 	logProgress := d.Get("log_progress").(bool)
 	logVerbose := d.Get("log_verbose").(bool)

--- a/azurerm/resource_arm_automation_runbook_test.go
+++ b/azurerm/resource_arm_automation_runbook_test.go
@@ -36,6 +36,35 @@ func TestAccAzureRMAutomationRunbook_PSWorkflow(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAutomationRunbook_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_automation_runbook.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAutomationRunbookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAutomationRunbook_PSWorkflow(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAutomationRunbookExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMAutomationRunbook_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_automation_runbook"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAutomationRunbook_PSWorkflowWithHash(t *testing.T) {
 	resourceName := "azurerm_automation_runbook.test"
 	ri := acctest.RandInt()
@@ -189,6 +218,29 @@ resource "azurerm_automation_runbook" "test" {
   }
 }
 `, rInt, location, rInt)
+}
+
+func testAccAzureRMAutomationRunbook_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMAutomationRunbook_PSWorkflow(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_automation_runbook" "import" {
+  name                = "${azurerm_automation_runbook.test.name}"
+  location            = "${azurerm_automation_runbook.test.location}"
+  resource_group_name = "${azurerm_automation_runbook.test.resource_group_name}"
+
+  account_name = "${azurerm_automation_runbook.test.account_name}"
+  log_verbose  = "true"
+  log_progress = "true"
+  description  = "This is a test runbook for terraform acceptance test"
+  runbook_type = "PowerShellWorkflow"
+
+  publish_content_link {
+    uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
+  }
+}
+`, template)
 }
 
 func testAccAzureRMAutomationRunbook_PSWorkflowWithHash(rInt int, location string) string {


### PR DESCRIPTION
Whilst the Requiring Import change can be feature-toggled; unfortunately the Timeouts change can't - as such we're going to roll out Requiring Import and Timeouts separately.

This is feature-toggled off by default, but can be enabled by an Environment Variable for testing (which we'll enable in 2.0)

Supersedes #1746 