### PR TITLE
Add `possible_outbound_ip_addresses` to app service

### DIFF
--- a/azurerm/data_source_app_service.go
+++ b/azurerm/data_source_app_service.go
@@ -101,6 +101,11 @@ func dataSourceArmAppService() *schema.Resource {
 				Computed: true,
 			},
 
+			"possible_outbound_ip_addresses": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"source_control": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/azurerm/data_source_app_service.go
+++ b/azurerm/data_source_app_service.go
@@ -183,6 +183,7 @@ func dataSourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("https_only", props.HTTPSOnly)
 		d.Set("default_site_hostname", props.DefaultHostName)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
+		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 	}
 
 	if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {

--- a/azurerm/data_source_app_service_test.go
+++ b/azurerm/data_source_app_service_test.go
@@ -21,6 +21,8 @@ func TestAccDataSourceAzureRMAppService_basic(t *testing.T) {
 				Config: testAccDataSourceAppService_basic(rInt, location),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(dataSourceName, "app_service_plan_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "outbound_ip_addresses"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "possible_outbound_ip_addresses"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 				),
 			},

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -160,6 +160,10 @@ func resourceArmAppService() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"possible_outbound_ip_addresses": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"source_control": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -436,6 +440,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("https_only", props.HTTPSOnly)
 		d.Set("default_site_hostname", props.DefaultHostName)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
+		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)
 	}
 
 	if err := d.Set("app_settings", flattenAppServiceAppSettings(appSettingsResp.Properties)); err != nil {

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -65,6 +65,8 @@ func TestAccAzureRMAppService_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "outbound_ip_addresses"),
+					resource.TestCheckResourceAttrSet(resourceName, "possible_outbound_ip_addresses"),
 				),
 			},
 			{

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -51,6 +51,10 @@ output "app_service_id" {
 
 * `tags` - A mapping of tags to assign to the resource.
 
+* `outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12`
+
+* `possible_outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12,52.143.43.17` - not all of which are necessarily in use. Superset of `outbound_ip_addresses`.
+
 ---
 
 `connection_string` supports the following:

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -205,6 +205,8 @@ The following attributes are exported:
 
 * `outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12`
 
+* `possible_outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12,52.143.43.17` - not all of which are necessarily in use. Superset of `outbound_ip_addresses`.
+
 * `source_control` - A `source_control` block as defined below, which contains the Source Control information when `scm_type` is set to `LocalGit`.
 
 * `site_credential` - A `site_credential` block as defined below, which contains the site-level credentials used to publish to this App Service.


### PR DESCRIPTION
This is useful for e.g. setting up firewall rules for Azure SQL - since an App Service can be rescheduled, it's possible that the `outbound_ip_addresses` field output at deploy-time does not catch all IP addresses you need to open up to be future-safe.

Note: I couldn't get the code to build and run tests on my Windows machine (neither from PowerShell, inspecting the makefile to see what was required, nor from WSL), so I've basically just looked at #700 to see what I need to do to support this. (I think this could have been made easier with a `.gitattributes` and an `.editorconfig` at the project root, that - at the very least - specify line endings to be what we expect.) Please feel free to request changes if I missed something 😄 