### PR TITLE
Including default value for maxmemory-policy

### DIFF
--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -600,11 +600,11 @@ func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) 
 		}
 		outputs["maxmemory_reserved"] = i
 	}
-	
+
 	if v := input["maxmemory-policy"]; v != nil {
 		outputs["maxmemory_policy"] = *v
 	} else {
-		outputs["maxmemory_policy"] = "volatile-lru";
+		outputs["maxmemory_policy"] = "volatile-lru"
 	}
 
 	// delta, reserved, enabled, frequency,, count,

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -600,8 +600,11 @@ func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) 
 		}
 		outputs["maxmemory_reserved"] = i
 	}
+	
 	if v := input["maxmemory-policy"]; v != nil {
 		outputs["maxmemory_policy"] = *v
+	} else {
+		outputs["maxmemory_policy"] = "volatile-lru";
 	}
 
 	// delta, reserved, enabled, frequency,, count,


### PR DESCRIPTION
As noted in docs (https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-configure), volatile-lru is the default value for maxmemory-policy.

Fix for #2516 