### PR TITLE
New Datasource: "azurerm_ip_ranges"

### DIFF
--- a/azurerm/data_source_ip_ranges.go
+++ b/azurerm/data_source_ip_ranges.go
@@ -1,0 +1,123 @@
+package azurerm
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"golang.org/x/net/html"
+)
+
+type Result struct {
+	XMLName xml.Name `xml:"AzurePublicIpAddresses"`
+	Regions []Region `xml:"Region"`
+}
+
+type Region struct {
+	Name     string    `xml:"Name,attr"`
+	IpRanges []IpRange `xml:"IpRange"`
+}
+
+type IpRange struct {
+	Subnet string `xml:"Subnet,attr"`
+}
+
+func dataSourceIpRanges() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIpRangesRead,
+
+		Schema: map[string]*schema.Schema{
+			"regions": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"subnets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceIpRangesRead(d *schema.ResourceData, meta interface{}) error {
+	regionsSet := d.Get("regions").(*schema.Set)
+
+	url := "https://www.microsoft.com/en-us/download/confirmation.aspx?id=41653"
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("Error performing GET on url (%s): %s", url, err)
+	}
+
+	xmlUrl, err := getLinkToPublicIpsXML(resp.Body)
+	if err != nil {
+		return fmt.Errorf("Error extracting link to XML document: %s", err)
+	}
+	d.SetId(xmlUrl)
+
+	log.Printf("[DEBUG] Reading IP ranges from %s", xmlUrl)
+
+	resp, err = http.Get(xmlUrl)
+	if err != nil {
+		return fmt.Errorf("Error extracting XML from url (%s): %s", url, err)
+	}
+
+	result := &Result{}
+	err = xml.NewDecoder(resp.Body).Decode(result)
+	if err != nil {
+		return fmt.Errorf("Error decoding XML: %s", err)
+	}
+
+	var subnets []string
+	for _, region := range result.Regions {
+		if regionsSet.Len() == 0 ||
+			regionsSet.Contains(strings.ToLower(region.Name)) {
+			for _, ipRange := range region.IpRanges {
+				subnets = append(subnets, ipRange.Subnet)
+			}
+		}
+	}
+
+	if len(subnets) == 0 {
+		return fmt.Errorf("No IP ranges results from regions: %s",
+			regionsSet.GoString(),
+		)
+	}
+
+	sort.Strings(subnets)
+	if err := d.Set("subnets", subnets); err != nil {
+		return fmt.Errorf("Error setting subnets: %s", err)
+	}
+
+	return nil
+}
+
+func getLinkToPublicIpsXML(body io.Reader) (string, error) {
+	z := html.NewTokenizer(body)
+	for {
+		tt := z.Next()
+		switch tt {
+		case html.ErrorToken:
+			return "", z.Err()
+		case html.StartTagToken, html.EndTagToken:
+			token := z.Token()
+			if "a" == token.Data {
+				for _, attr := range token.Attr {
+					if attr.Key == "href" {
+						if strings.Contains(attr.Val, "PublicIPs") {
+							return attr.Val, nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return "", errors.New("unable to find link")
+}

--- a/azurerm/data_source_ip_ranges_test.go
+++ b/azurerm/data_source_ip_ranges_test.go
@@ -1,0 +1,60 @@
+package azurerm
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccIpRanges_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureIpRangesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAzureIpRangesCheckAttributes("data.azurerm_ip_ranges.test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAzureIpRangesCheckAttributes(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find regions data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("regions data source ID not set.")
+		}
+
+		count, ok := rs.Primary.Attributes["subnets.#"]
+		if !ok {
+			return errors.New("can't find 'subnets' attribute")
+		}
+
+		noOfSubnets, err := strconv.Atoi(count)
+		if err != nil {
+			return errors.New("failed to read number of subnets")
+		}
+		if noOfSubnets < 10 {
+			return fmt.Errorf("expected at least 10 subnets, received %d, this is most likely a bug", noOfSubnets)
+		}
+
+		return nil
+	}
+}
+
+const testAccAzureIpRangesConfig = `
+data "azurerm_ip_ranges" "test" {
+	regions = ["australiaeast", "australiasouth"]
+}
+`

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -105,6 +105,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_dns_zone":                              dataSourceArmDnsZone(),
 			"azurerm_eventhub_namespace":                    dataSourceEventHubNamespace(),
 			"azurerm_image":                                 dataSourceArmImage(),
+			"azurerm_ip_ranges":                             dataSourceIpRanges(),
 			"azurerm_key_vault":                             dataSourceArmKeyVault(),
 			"azurerm_key_vault_key":                         dataSourceArmKeyVaultKey(),
 			"azurerm_key_vault_access_policy":               dataSourceArmKeyVaultAccessPolicy(),

--- a/website/docs/d/ip_ranges.html.markdown
+++ b/website/docs/d/ip_ranges.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "azurerm"
+page_title: "Azure IP Ranges: azurerm_ip_ranges"
+sidebar_current: "docs-azurerm-datasource-ip-ranges"
+description: |-
+  Get information on Azure Datacenter IP Ranges
+---
+
+# Data Source: azurerm_ip_ranges
+
+Use this data source to get the public IP addresses of Azure Datacenters.
+
+## Example Usage
+
+```hcl
+data "azurerm_ip_ranges" "test" {
+  regions = ["australiaeast", "australiasouth"]
+}
+
+resource "azurerm_network_security_rule" "test" {
+  count                       = "${length(data.azurerm_ip_ranges.test.subnets)}"
+  name                        = "aksWorkerSubnetSecurityGroup-${count.index}"
+  priority                    = "${(count.index + 100)}"
+  direction                   = "Outbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "${data.azurerm_ip_ranges.test.subnets[count.index]}"
+  resource_group_name         = "${azurerm_resource_group.test.name}"
+  network_security_group_name = "${azurerm_network_security_group.test.name}"
+}
+```
+
+## Argument Reference
+
+* `regions` - (Optional) Filter IP ranges by Azure region (or include all regions if omitted). Valid items are all Azure regions (eg. `australiaeast`).
+
+## Attributes Reference
+
+* `subnets` - The lexically ordered list of CIDR blocks


### PR DESCRIPTION
This pull request includes a new datasource called "azurerm_ip_ranges".  This allows a user to pull in the Compute IP address ranges (including SQL ranges) used by the Microsoft Azure Datacenters.