### PR TITLE
updated "id" description

### DIFF
--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Log Analytics Workspace ID.
+* `id` - The Azure Resource ID of the Log Analytics Workspace.
 
 * `primary_shared_key` - The Primary shared key for the Log Analytics Workspace.
 


### PR DESCRIPTION
in Azure every resource has a unique "resource Id". The `id` attribute in this datasource incorecctly mentions Id as being the Log Analytics Workspace Id.  Here `Id` outputs the unique "Azure Resource Id" of the Log Analytics Workspace.