### PR TITLE
Added Service Fabric Reverse Proxy Certificate and Endpoint in Nodetype

### DIFF
--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -176,7 +176,7 @@ func TestAccAzureRMServiceFabricCluster_reverseProxyCertificate(t *testing.T) {
 		CheckDestroy: testCheckAzureRMServiceFabricClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMServiceFabricCluster_certificates(ri, location),
+				Config: testAccAzureRMServiceFabricCluster_reverseProxyCertificates(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "certificate.#", "1"),

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -28,6 +28,7 @@ func TestAccAzureRMServiceFabricCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "http://example:80"),
 					resource.TestCheckResourceAttr(resourceName, "add_on_features.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "certificate.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "client_certificate_thumbprint.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "diagnostics_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "node_type.#", "1"),
@@ -150,6 +151,41 @@ func TestAccAzureRMServiceFabricCluster_certificate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "certificate.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
 					resource.TestCheckResourceAttr(resourceName, "certificate.0.x509_store_name", "My"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
+					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "https://example:80"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+
+func TestAccAzureRMServiceFabricCluster_reverseProxyCertificate(t *testing.T) {
+	resourceName := "azurerm_service_fabric_cluster.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceFabricClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMServiceFabricCluster_certificates(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceFabricClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.x509_store_name", "My"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
 					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "https://example:80"),
@@ -621,6 +657,52 @@ resource "azurerm_service_fabric_cluster" "test" {
     is_primary           = true
     client_endpoint_port = 2020
     http_endpoint_port   = 80
+  }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMServiceFabricCluster_reverseProxyCertificates(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_service_fabric_cluster" "test" {
+  name                = "acctest-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  reliability_level   = "Bronze"
+  upgrade_mode        = "Automatic"
+  vm_image            = "Windows"
+  management_endpoint = "https://example:80"
+
+  certificate {
+    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    x509_store_name = "My"
+  }
+
+	reverse_proxy_certificate {
+    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    x509_store_name = "My"
+  }
+
+  fabric_settings {
+    name = "Security"
+
+    parameters {
+      "ClusterProtectionLevel" = "EncryptAndSign"
+    }
+  }
+
+  node_type {
+    name                 				= "first"
+    instance_count       				= 3
+    is_primary           				= true
+    client_endpoint_port 			  = 2020
+		http_endpoint_port   			  = 80
+		reverse_proxy_endpoint_port	= 19081
   }
 }
 `, rInt, location, rInt)

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -165,7 +165,6 @@ func TestAccAzureRMServiceFabricCluster_certificate(t *testing.T) {
 	})
 }
 
-
 func TestAccAzureRMServiceFabricCluster_reverseProxyCertificate(t *testing.T) {
 	resourceName := "azurerm_service_fabric_cluster.test"
 	ri := acctest.RandInt()

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 * `certificate` - (Optional) A `certificate` block as defined below.
 
+* `reverse_proxy_certificate` - (Optional) A `reverse_proxy_certificate` block as defined below.
+
 * `client_certificate_thumbprint` - (Optional) One or two `client_certificate_thumbprint` blocks as defined below.
 
 -> **NOTE:** If Client Certificates are enabled then at a Certificate must be configured on the cluster.
@@ -80,6 +82,16 @@ The following arguments are supported:
 ---
 
 A `certificate` block supports the following:
+
+* `thumbprint` - (Required) The Thumbprint of the Certificate.
+
+* `thumbprint_secondary` - (Required) The Secondary Thumbprint of the Certificate.
+
+* `x509_store_name` - (Required) The X509 Store where the Certificate Exists, such as `My`.
+
+---
+
+A `reverse_proxy_certificate` block supports the following:
 
 * `thumbprint` - (Required) The Thumbprint of the Certificate.
 
@@ -136,6 +148,8 @@ A `node_type` block supports the following:
 * `application_ports` - (Optional) A `application_ports` block as defined below.
 
 * `ephemeral_ports` - (Optional) A `ephemeral_ports` block as defined below.
+
+* `reverse_proxy_endpoint_port` - (Optional) The Port used for the Reverse Proxy Endpoint  for this Node Type. Changing this will upgrade the cluster.
 
 ---
 


### PR DESCRIPTION
Added reverse_proxy_certificate and reverse_proxy_endpoint_port to the azurerm_service_fabric_cluster resource.

```ruby
resource "azurerm_service_fabric_cluster" "sf" {
  name                = "test-app-sf"
  resource_group_name = "${azurerm_resource_group.test.name}"
  location            = "${azurerm_resource_group.test.location}"
  reliability_level   = "Bronze"
  upgrade_mode        = "Automatic"
  vm_image            = "Windows"

  management_endpoint = "https://${azurerm_lb.test.private_ip_address}:19080"
  add_on_features     = ["DnsService"]

  certificate {
    thumbprint      = "${azurerm_key_vault_certificate.test.thumbprint}"
    x509_store_name = "My"
  }

  reverse_proxy_certificate {
    thumbprint      = "${azurerm_key_vault_certificate.test.thumbprint}"
    x509_store_name = "My"
  }

  diagnostics_config {
    storage_account_name       = "${azurerm_storage_account.sflogs.name}"
    protected_account_key_name = "StorageAccountKey1"
    blob_endpoint              = "${azurerm_storage_account.sflogs.primary_blob_endpoint}"
    queue_endpoint             = "${azurerm_storage_account.sflogs.primary_queue_endpoint}"
    table_endpoint             = "${azurerm_storage_account.sflogs.primary_table_endpoint}"
  }
  fabric_settings {
    name = "Security"

    parameters = {
      ClusterProtectionLevel = "EncryptAndSign"
    }
  }
  node_type {
    name                 = "backend"
    durability_level     = "Bronze"
    instance_count       = 3
    is_primary           = true
    client_endpoint_port = 19000
    http_endpoint_port   = 19080

    reverse_proxy_endpoint_port = 19081

    ephemeral_ports {
      start_port = 49152
      end_port   = 65534
    }
    application_ports {
      start_port = 20000
      end_port   = 30000
    }
  }
  tags {
    resourceType = "Service Fabric"
    clusterName  = "jms-test-app-sf"
  }
}
```