### PR TITLE
Implement private_ip_address_version for network interfaces.

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -227,7 +227,6 @@ func resourceArmNetworkInterface() *schema.Resource {
 				Computed: true,
 			},
 
-
 			"private_ip_addresses": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -89,7 +89,7 @@ func resourceArmNetworkInterface() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								string(network.IPv4),
 								string(network.IPv6),
-							}, true),
+							}, false),
 						},
 
 						"private_ip_address_allocation": {
@@ -515,7 +515,7 @@ func flattenNetworkInterfaceIPConfigurations(ipConfigs *[]network.InterfaceIPCon
 
 		niIPConfig["name"] = *ipConfig.Name
 
-		if props.Subnet != nil {
+		if props.Subnet != nil && props.Subnet.ID != nil {
 			niIPConfig["subnet_id"] = *props.Subnet.ID
 		}
 
@@ -526,7 +526,7 @@ func flattenNetworkInterfaceIPConfigurations(ipConfigs *[]network.InterfaceIPCon
 		}
 
 		if props.PrivateIPAddressVersion != "" {
-			niIPConfig["private_ip_address_version"] = props.PrivateIPAddressVersion
+			niIPConfig["private_ip_address_version"] = string(props.PrivateIPAddressVersion)
 		}
 
 		if props.PublicIPAddress != nil {
@@ -594,7 +594,7 @@ func expandAzureRmNetworkInterfaceIpConfigurations(d *schema.ResourceData) ([]ne
 		}
 
 		if private_ip_address_version == network.IPv4 && subnet_id == "" {
-			return nil, nil, nil, fmt.Errorf("Required field `ip_configuration`, `subnet_id` must be specified when using IPv4.")
+			return nil, nil, nil, fmt.Errorf("A Subnet ID must be specified for an IPv4 Network Interface.")
 		}
 
 		if subnet_id != "" {

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -368,18 +368,18 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	if props.IPConfigurations != nil && len(*props.IPConfigurations) > 0 {
 		configs := *props.IPConfigurations
 
-		if configs[0].InterfaceIPConfigurationPropertiesFormat != nil {
-			privateIPAddress := configs[0].InterfaceIPConfigurationPropertiesFormat.PrivateIPAddress
-			d.Set("private_ip_address", *privateIPAddress)
-			privateIPAddressVersion := configs[0].InterfaceIPConfigurationPropertiesFormat.PrivateIPAddressVersion
-			d.Set("private_ip_address_version", string(privateIPAddressVersion))
+		if ipProps := configs[0].InterfaceIPConfigurationPropertiesFormat; ipProps != nil {
+			if privateIPAddress := ipProps.PrivateIPAddress; privateIPAddress != nil {
+				d.Set("private_ip_address", *privateIPAddress)
+			}
+			d.Set("private_ip_address_version", string(ipProps.PrivateIPAddressVersion))
 		}
 
 		addresses := make([]interface{}, 0)
 		for _, config := range configs {
-			if config.InterfaceIPConfigurationPropertiesFormat != nil {
-				if config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAddressVersion == network.IPv4 {
-					addresses = append(addresses, *config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAddress)
+			if ipProps := config.InterfaceIPConfigurationPropertiesFormat; ipProps != nil {
+				if ipProps.PrivateIPAddressVersion == network.IPv4 && ipProps.PrivateIPAddress != nil {
+					addresses = append(addresses, *ipProps.PrivateIPAddress)
 				}
 			}
 		}

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -226,6 +226,11 @@ func resourceArmNetworkInterface() *schema.Resource {
 				Computed: true,
 			},
 
+			"private_ip_address_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"private_ip_addresses": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -375,16 +380,17 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 			d.Set("private_ip_address_version", string(ipProps.PrivateIPAddressVersion))
 		}
 
-		addresses := make([]interface{}, 0)
+		addressesIPv4 := make([]interface{}, 0)
+
 		for _, config := range configs {
-			if ipProps := config.InterfaceIPConfigurationPropertiesFormat; ipProps != nil {
-				if ipProps.PrivateIPAddressVersion == network.IPv4 && ipProps.PrivateIPAddress != nil {
-					addresses = append(addresses, *ipProps.PrivateIPAddress)
+			if ipProps := config.InterfaceIPConfigurationPropertiesFormat; ipProps != nil && ipProps.PrivateIPAddress != nil {
+				if ipProps.PrivateIPAddressVersion == network.IPv4 {
+					addressesIPv4 = append(addressesIPv4, *ipProps.PrivateIPAddress)
 				}
 			}
 		}
 
-		if err := d.Set("private_ip_addresses", addresses); err != nil {
+		if err := d.Set("private_ip_addresses", addressesIPv4); err != nil {
 			return err
 		}
 	}

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -380,6 +380,7 @@ func TestAccAzureRMNetworkInterface_IPAddressesFeature2543(t *testing.T) {
 					testCheckAzureRMNetworkInterfaceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "ip_configuration.0.private_ip_address_version", "IPv4"),
 					resource.TestCheckResourceAttr(resourceName, "ip_configuration.1.private_ip_address_version", "IPv6"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_ip_address"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -75,6 +75,26 @@ func testSweepNetworkInterfaces(region string) error {
 	return nil
 }
 
+func TestAccAzureRMNetworkInterface_disappears(t *testing.T) {
+	resourceName := "azurerm_network_interface.test"
+	rInt := acctest.RandInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterface_basic(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists(resourceName),
+					testCheckAzureRMNetworkInterfaceDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterface_basic(t *testing.T) {
 	resourceName := "azurerm_network_interface.test"
 	rInt := acctest.RandInt()
@@ -93,26 +113,6 @@ func TestAccAzureRMNetworkInterface_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccAzureRMNetworkInterface_disappears(t *testing.T) {
-	resourceName := "azurerm_network_interface.test"
-	rInt := acctest.RandInt()
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMNetworkInterface_basic(rInt, testLocation()),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMNetworkInterfaceExists(resourceName),
-					testCheckAzureRMNetworkInterfaceDisappears(resourceName),
-				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -80,11 +80,13 @@ The `ip_configuration` block supports:
 
 * `name` - (Required) User-defined name of the IP.
 
-* `subnet_id` - (Required) Reference to a subnet in which this NIC has been created.
+* `subnet_id` - (Optional) Reference to a subnet in which this NIC has been created. Required when `private_ip_address_version` is IPv4.
 
 * `private_ip_address` - (Optional) Static IP Address.
 
 * `private_ip_address_allocation` - (Required) Defines how a private IP address is assigned. Options are Static or Dynamic.
+
+* `private_ip_address_version` - (Optional) The IP Version to use, IPv6 or IPv4. Defaults to IPv4.
 
 * `public_ip_address_id` - (Optional) Reference to a Public IP Address to associate with this NIC
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -86,7 +86,7 @@ The `ip_configuration` block supports:
 
 * `private_ip_address_allocation` - (Required) Defines how a private IP address is assigned. Options are Static or Dynamic.
 
-* `private_ip_address_version` - (Optional) The IP Version to use, IPv6 or IPv4. Defaults to IPv4.
+* `private_ip_address_version` - (Optional) The IP Version to use. Possible values are `IPv4` or `IPv6`. Defaults to `IPv4`.
 
 * `public_ip_address_id` - (Optional) Reference to a Public IP Address to associate with this NIC
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -112,8 +112,8 @@ The following attributes are exported:
 
 * `id` - The Virtual Network Interface ID.
 * `mac_address` - The media access control (MAC) address of the network interface.
-* `private_ip_address` - The private IP address of the network interface.
-* `private_ip_address_version` - The private IP address version.
+* `private_ip_address` - The first private IP address of the network interface.
+* `private_ip_addresses` - The private IP addresses of the network interface.
 * `virtual_machine_id` - Reference to a VM with which this NIC has been associated.
 * `applied_dns_servers` - If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are part of the Availability Set
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -112,7 +112,8 @@ The following attributes are exported:
 
 * `id` - The Virtual Network Interface ID.
 * `mac_address` - The media access control (MAC) address of the network interface.
-* `private_ip_address` - The private ip address of the network interface.
+* `private_ip_address` - The private IP address of the network interface.
+* `private_ip_address_version` - The private IP address version.
 * `virtual_machine_id` - Reference to a VM with which this NIC has been associated.
 * `applied_dns_servers` - If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are part of the Availability Set
 


### PR DESCRIPTION
Implements #2543 and allows IPv6 `ip_configuration`s to be created in `azurerm_network_interface`.

* Added `private_ip_address_version` (IPv4/IPv6).
* `subnet_id` becomes optional for IPv6 and required for IPv4.