### PR TITLE
Support for Managed Identity on azurerm_policy_assignment

### DIFF
--- a/azurerm/resource_arm_policy_assignment.go
+++ b/azurerm/resource_arm_policy_assignment.go
@@ -71,8 +71,8 @@ func resourceArmPolicyAssignment() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"None",
-					"SystemAssigned",
+					string(policy.None),
+					string(policy.SystemAssigned),
 				}, false),
 			},
 

--- a/azurerm/resource_arm_policy_assignment_test.go
+++ b/azurerm/resource_arm_policy_assignment_test.go
@@ -36,6 +36,32 @@ func TestAccAzureRMPolicyAssignment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPolicyAssignment_deployIfNotExists_policy(t *testing.T) {
+	resourceName := "azurerm_policy_assignment.test"
+
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPolicyAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMPolicyAssignment_deployIfNotExists_policy(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPolicyAssignmentExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMPolicyAssignment_complete(t *testing.T) {
 	resourceName := "azurerm_policy_assignment.test"
 
@@ -144,6 +170,80 @@ resource "azurerm_policy_assignment" "test" {
   policy_definition_id = "${azurerm_policy_definition.test.id}"
 }
 `, ri, ri, location, ri, location, ri)
+}
+
+func testAzureRMPolicyAssignment_deployIfNotExists_policy(ri int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_policy_definition" "test" {
+  name         = "acctestpol-%d"
+  policy_type  = "Custom"
+  mode         = "All"
+  display_name = "acctestpol-%d"
+
+  policy_rule = <<POLICY_RULE
+{
+	"if": {
+		"field": "type",
+		"equals": "Microsoft.Sql/servers/databases"
+	},
+	"then": {
+		"effect": "DeployIfNotExists",
+		"details": {
+			"type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+			"name": "current",
+			"roleDefinitionIds": [
+				"/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+			],
+			"existenceCondition": {
+				"field": "Microsoft.Sql/transparentDataEncryption.status",
+				"equals": "Enabled"
+			},
+			"deployment": {
+				"properties": {
+					"mode": "incremental",
+					"template": {
+						"$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+						"contentVersion": "1.0.0.0",
+						"parameters": {
+							"fullDbName": {
+								"type": "string"
+							}
+						},
+						"resources": [{
+							"name": "[concat(parameters('fullDbName'), '/current')]",
+							"type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
+							"apiVersion": "2014-04-01",
+							"properties": {
+								"status": "Enabled"
+							}
+						}]
+					},
+					"parameters": {
+						"fullDbName": {
+							"value": "[field('fullName')]"
+						}
+					}
+				}
+			}
+		}
+	}
+}
+POLICY_RULE
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_policy_assignment" "test" {
+  name                 = "acctestpa-%d"
+  scope                = "${azurerm_resource_group.test.id}"
+  policy_definition_id = "${azurerm_policy_definition.test.id}"
+  identity_type        = "SystemAssigned"
+  location             = "%s" 
+}
+`, ri, ri, ri, location, ri, location)
 }
 
 func testAzureRMPolicyAssignment_complete(ri int, location string) string {

--- a/website/docs/r/policy_assignment.html.markdown
+++ b/website/docs/r/policy_assignment.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_policy_assignment
 
-Configures the specified Policy Definition at the specified Scope.
+Configures the specified Policy Definition at the specified Scope. Also, Policy Set Definitions are supported.
 
 ## Example Usage
 
@@ -79,6 +79,10 @@ The following arguments are supported:
 
 * `policy_definition_id` - (Required) The ID of the Policy Definition to be applied at the specified Scope.
 
+* `identity_type` - (Optional) The managed identity type associated with the policy assignment. Either `None` or `SystemAssigned`. Change forces a new resource. Will be mandatory if you assign a policy with `deployIfNotExists` effect.
+
+* `location` - (Optional) The location of the policy assignment. Only required when utilizing managed identity. Change forces a new resource.
+
 * `description` - (Optional) A description to use for this Policy Assignment. Changing this forces a new resource to be created.
 
 * `display_name` - (Optional) A friendly display name to use for this Policy Assignment. Changing this forces a new resource to be created.
@@ -92,6 +96,10 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Policy Assignment id.
+
+* `identity_principal_id` - The principal ID of the resource identity. Only relevant if using `SystemAssigned` as `identity_type`.
+
+* `identity_tenant_id` - The tenant ID of the resource identity. Only relevant if using `SystemAssigned` as `identity_type`.
 
 ## Import
 


### PR DESCRIPTION
This PR adds support for Managed Identity on azurerm_policy_assignment.

Addresses issue #2194 

Test Results:
```
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAzureRMPolicyAssignment -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
?   	github.com/terraform-providers/terraform-provider-azurerm	[no test files]
=== RUN   TestAccAzureRMPolicyAssignment_basic
=== PAUSE TestAccAzureRMPolicyAssignment_basic
=== RUN   TestAccAzureRMPolicyAssignment_deployIfNotExists_policy
=== PAUSE TestAccAzureRMPolicyAssignment_deployIfNotExists_policy
=== RUN   TestAccAzureRMPolicyAssignment_complete
=== PAUSE TestAccAzureRMPolicyAssignment_complete
=== CONT  TestAccAzureRMPolicyAssignment_basic
=== CONT  TestAccAzureRMPolicyAssignment_complete
=== CONT  TestAccAzureRMPolicyAssignment_deployIfNotExists_policy
--- PASS: TestAccAzureRMPolicyAssignment_complete (247.55s)
--- PASS: TestAccAzureRMPolicyAssignment_basic (247.76s)
--- PASS: TestAccAzureRMPolicyAssignment_deployIfNotExists_policy (251.44s)
```

(fixes #2194)