### PR TITLE
Support for Azure Active Directory for Azure Service fabric

### DIFF
--- a/azurerm/resource_arm_service_fabric_cluster.go
+++ b/azurerm/resource_arm_service_fabric_cluster.go
@@ -70,7 +70,7 @@ func resourceArmServiceFabricCluster() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			
+
 			"add_on_features": {
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/azurerm/resource_arm_service_fabric_cluster.go
+++ b/azurerm/resource_arm_service_fabric_cluster.go
@@ -81,6 +81,7 @@ func resourceArmServiceFabricCluster() *schema.Resource {
 			"azure_active_directory": {
 				Type:     schema.TypeList,
 				Optional: true,
+			  ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/azurerm/resource_arm_service_fabric_cluster.go
+++ b/azurerm/resource_arm_service_fabric_cluster.go
@@ -81,7 +81,7 @@ func resourceArmServiceFabricCluster() *schema.Resource {
 			"azure_active_directory": {
 				Type:     schema.TypeList,
 				Optional: true,
-			  ForceNew: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -254,7 +254,7 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectory(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.tenant_id"),
-					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.cluster_application_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.cluster_application_id"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.client_application_id", "00000000-0000-0000-0000-000000000000"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -773,9 +773,9 @@ resource "azurerm_service_fabric_cluster" "test" {
   vm_image            = "Windows"
   management_endpoint = "https://example:80"
 	
-  client_certificate_thumbprint {
-    thumbprint = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
-    is_admin   = true
+  certificate {
+    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    x509_store_name = "My"
   }
 
   azure_active_directory {

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -255,7 +255,7 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectory(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.tenant_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.cluster_application_id"),
-					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.client_application_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.client_application_id"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
 					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "https://example:80"),

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -253,9 +253,9 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectory(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
 					resource.TestCheckResourceAttr(resourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.tenant_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.cluster_application_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.client_application_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.0.tenant_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.0.cluster_application_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.0.client_application_id"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
 					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "https://example:80"),
@@ -770,7 +770,7 @@ resource "azurerm_azuread_application" "test" {
   name                       = "${azurerm_resource_group.test.name}-AAD"
   homepage                   = "https://example:80/Explorer/index.html"
   identifier_uris            = ["https://acctestAAD-app"]
-  reply_urls                 = ["https://example"]
+  reply_urls                 = ["https://acctestAAD-app"]
   available_to_other_tenants = false
   oauth2_allow_implicit_flow = true
 }

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -253,7 +253,7 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectory(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
 					resource.TestCheckResourceAttr(resourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.tenant_id", "00000000-0000-0000-0000-00000000000"),
+					resource.TestCheckResourceAttrSet(resourceName, "azure_active_directory.tenant_id"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.cluster_application_id", "00000000-0000-0000-0000-000000000000"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.client_application_id", "00000000-0000-0000-0000-000000000000"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -249,6 +249,9 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectory(t *testing.T) {
 				Config: testAccAzureRMServiceFabricCluster_azureActiveDirectory(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.tenant_id", "00000000-0000-0000-0000-00000000000"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.cluster_application_id", "00000000-0000-0000-0000-000000000000"),
@@ -770,6 +773,11 @@ resource "azurerm_service_fabric_cluster" "test" {
   vm_image            = "Windows"
   management_endpoint = "https://example:80"
 	
+	client_certificate_thumbprint {
+    thumbprint = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    is_admin   = true
+  }
+
   azure_active_directory {
     tenant_id              = "00000000-0000-0000-0000-000000000000"
     cluster_application_id = "00000000-0000-0000-0000-000000000000"

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -754,7 +754,7 @@ resource "azurerm_service_fabric_cluster" "test" {
 `, rInt, location, rInt)
 }
 
-func testAccAzureRMServiceFabricCluster_readerAdminClientCertificateThumbprint(rInt int, location string) string {
+func testAccAzureRMServiceFabricCluster_azureActiveDirectory(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -764,6 +764,8 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_service_fabric_cluster" "test" {
   name                = "acctest-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -779,7 +781,7 @@ resource "azurerm_service_fabric_cluster" "test" {
   }
 
   azure_active_directory {
-    tenant_id              = "00000000-0000-0000-0000-000000000000"
+    tenant_id              = "${azurerm_client_config.current.tenant_id}"
     cluster_application_id = "00000000-0000-0000-0000-000000000000"
     client_application_id  = "00000000-0000-0000-0000-000000000000"
   }

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -767,7 +767,7 @@ resource "azurerm_resource_group" "test" {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_azuread_application" "test" {
-  name                       = "acctestAAD-%d"
+  name                       = "${azurerm_resource_group.test.name}-AAD"
   homepage                   = "https://example:80/Explorer/index.html"
   identifier_uris            = ["https://acctestAAD-app"]
   reply_urls                 = ["https://example"]

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -246,7 +246,7 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectory(t *testing.T) {
 		CheckDestroy: testCheckAzureRMServiceFabricClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMServiceFabricCluster_clientCertificateThumbprint(ri, location),
+				Config: testAccAzureRMServiceFabricCluster_azureActiveDirectory(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "1"),

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -766,6 +766,15 @@ resource "azurerm_resource_group" "test" {
 
 data "azurerm_client_config" "current" {}
 
+resource "azurerm_azuread_application" "test" {
+  name                       = "acctestAAD-%d"
+  homepage                   = "https://example:80/Explorer/index.html"
+  identifier_uris            = ["https://acctestAAD-app"]
+  reply_urls                 = ["https://example"]
+  available_to_other_tenants = false
+  oauth2_allow_implicit_flow = true
+}
+
 resource "azurerm_service_fabric_cluster" "test" {
   name                = "acctest-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -782,7 +791,7 @@ resource "azurerm_service_fabric_cluster" "test" {
 
   azure_active_directory {
     tenant_id              = "${data.azurerm_client_config.current.tenant_id}"
-    cluster_application_id = "00000000-0000-0000-0000-000000000000"
+    cluster_application_id = "${azurerm_azuread_application.test.application_id}"
     client_application_id  = "00000000-0000-0000-0000-000000000000"
   }
 

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -771,9 +771,9 @@ resource "azurerm_service_fabric_cluster" "test" {
   management_endpoint = "https://example:80"
 	
   azure_active_directory {
-	  tenant_id              = "00000000-0000-0000-0000-000000000000"
-	  cluster_application_id = "00000000-0000-0000-0000-000000000000"
-	  client_application_id  = "00000000-0000-0000-0000-000000000000"
+    tenant_id              = "00000000-0000-0000-0000-000000000000"
+    cluster_application_id = "00000000-0000-0000-0000-000000000000"
+    client_application_id  = "00000000-0000-0000-0000-000000000000"
   }
 
   fabric_settings {

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -770,11 +770,11 @@ resource "azurerm_service_fabric_cluster" "test" {
   vm_image            = "Windows"
   management_endpoint = "https://example:80"
 	
-	azure_active_directory {
-		tenant_id              = "00000000-0000-0000-0000-000000000000"
-		cluster_application_id = "00000000-0000-0000-0000-000000000000"
-		client_application_id  = "00000000-0000-0000-0000-000000000000"
-	}
+  azure_active_directory {
+	  tenant_id              = "00000000-0000-0000-0000-000000000000"
+	  cluster_application_id = "00000000-0000-0000-0000-000000000000"
+	  client_application_id  = "00000000-0000-0000-0000-000000000000"
+  }
 
   fabric_settings {
     name = "Security"

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -773,7 +773,7 @@ resource "azurerm_service_fabric_cluster" "test" {
   vm_image            = "Windows"
   management_endpoint = "https://example:80"
 	
-	client_certificate_thumbprint {
+  client_certificate_thumbprint {
     thumbprint = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
     is_admin   = true
   }

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -781,7 +781,7 @@ resource "azurerm_service_fabric_cluster" "test" {
   }
 
   azure_active_directory {
-    tenant_id              = "${azurerm_client_config.current.tenant_id}"
+    tenant_id              = "${data.azurerm_client_config.current.tenant_id}"
     cluster_application_id = "00000000-0000-0000-0000-000000000000"
     client_application_id  = "00000000-0000-0000-0000-000000000000"
   }

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -87,7 +87,7 @@ A `azure_active_directory` block supports the following:
 
 * `cluster_application_id` - (Required) The GUID of the cluster application.
 
-* `client_application_id` - (Required) The GUID of the client application.
+* `cluster_application_id` - (Required) The Azure Active Directory Client ID which should be used for the Client Application. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
 
 * `add_on_features` - (Optional) A List of one or more features which should be enabled, such as `DnsService`.
 
+* `azure_active_directory` - (Optional) `azure_active_directory` block as defined below. Changing this forces a new resource to be created.
+
 * `certificate` - (Optional) A `certificate` block as defined below.
 
 * `client_certificate_thumbprint` - (Optional) One or two `client_certificate_thumbprint` blocks as defined below.
@@ -76,6 +78,16 @@ The following arguments are supported:
 * `fabric_settings` - (Optional) One or more `fabric_settings` blocks as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `azure_active_directory` block supports the following:
+
+* `tenant_id` - (Required) The TenantID of the Azure Active Directory resource.
+
+* `cluster_application` - (Required) The GUID of the cluster application.
+
+* `client_application` - (Required) The GUID of the client application.
 
 ---
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -85,7 +85,7 @@ A `azure_active_directory` block supports the following:
 
 * `tenant_id` - (Required) The Azure Active Directory Tenant ID. Changing this forces a new resource to be created.
 
-* `cluster_application_id` - (Required) The GUID of the cluster application.
+* `cluster_application_id` - (Required) The Azure Active Directory Client ID which should be used for the Cluster Application. Changing this forces a new resource to be created.
 
 * `cluster_application_id` - (Required) The Azure Active Directory Client ID which should be used for the Client Application. Changing this forces a new resource to be created.
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 A `azure_active_directory` block supports the following:
 
-* `tenant_id` - (Required) The TenantID of the Azure Active Directory resource.
+* `tenant_id` - (Required) The Azure Active Directory Tenant ID. Changing this forces a new resource to be created.
 
 * `cluster_application_id` - (Required) The GUID of the cluster application.
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `add_on_features` - (Optional) A List of one or more features which should be enabled, such as `DnsService`.
 
-* `azure_active_directory` - (Optional) `azure_active_directory` block as defined below. Changing this forces a new resource to be created.
+* `azure_active_directory` - (Optional) An `azure_active_directory` block as defined below. Changing this forces a new resource to be created.
 
 * `certificate` - (Optional) A `certificate` block as defined below.
 


### PR DESCRIPTION
This PR adds support for Azure Active Directory (azure_active_directory) for Azure Service fabric (azurerm_service_fabric_cluster)

Addresses issue #2539 

```hcl
Terraform will perform the following actions:

-/+ azurerm_service_fabric_cluster.test (new resource required)
      id:                                                        "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/Microsoft.ServiceFabric/clusters/test" => <computed> (forces new resource)
      add_on_features.#:                                         "2" => "2"
      add_on_features.1911128025:                                "DnsService" => "DnsService"
      add_on_features.2685698132:                                "RepairManager" => "RepairManager"
      azure_active_directory.#:                                  "0" => "1"
      azure_active_directory.0.client_application_id:            "" => "00000000-0000-0000-0000-000000000000" (forces new resource)
      azure_active_directory.0.cluster_application_id:           "" => "00000000-0000-0000-0000-000000000000" (forces new resource)
      azure_active_directory.0.tenant_id:                        "" => "00000000-0000-0000-0000-000000000000" (forces new resource)
      certificate.#:                                             "1" => "1"
      certificate.0.thumbprint:                                  "0000000000000000000000000000000000000000" => "0000000000000000000000000000000000000000"
      certificate.0.x509_store_name:                             "My" => "My"
      client_certificate_thumbprint.#:                           "1" => "1"
      client_certificate_thumbprint.0.is_admin:                  "true" => "true"
      client_certificate_thumbprint.0.thumbprint:                "0000000000000000000000000000000000000000" => "0000000000000000000000000000000000000000"
      cluster_code_version:                                      "6.4.617.9590" => <computed>
      cluster_endpoint:                                          "https://northeurope.servicefabric.azure.com/runtime/clusters/00000000-0000-0000-0000-000000000000" => <computed>
      diagnostics_config.#:                                      "1" => "1"
      diagnostics_config.0.blob_endpoint:                        "https://test.blob.core.windows.net/" => "https://test.blob.core.windows.net/"
      diagnostics_config.0.protected_account_key_name:           "StorageAccountKey1" => "StorageAccountKey1"
      diagnostics_config.0.queue_endpoint:                       "https://test.queue.core.windows.net/" => "https://test.queue.core.windows.net/"
      diagnostics_config.0.storage_account_name:                 "test" => "test"
      diagnostics_config.0.table_endpoint:                       "https://test.table.core.windows.net/" => "https://test.table.core.windows.net/"
      fabric_settings.#:                                         "2" => "2"
      fabric_settings.0.name:                                    "Security" => "Security"
      fabric_settings.0.parameters.%:                            "1" => "1"
      fabric_settings.0.parameters.ClusterProtectionLevel:       "EncryptAndSign" => "EncryptAndSign"
      fabric_settings.1.name:                                    "ClusterManager" => "ClusterManager"
      fabric_settings.1.parameters.%:                            "1" => "1"
      fabric_settings.1.parameters.EnableDefaultServicesUpgrade: "true" => "true"
      location:                                                  "northeurope" => "northeurope"
      management_endpoint:                                       "https://10.0.0.20:19080" => "https://10.0.0.20:19080"
      name:                                                      "test" => "test"
      node_type.#:                                               "1" => "1"
      node_type.0.application_ports.#:                           "1" => <computed>
      node_type.0.client_endpoint_port:                          "19000" => "19000"
      node_type.0.durability_level:                              "Bronze" => "Bronze"
      node_type.0.ephemeral_ports.#:                             "1" => <computed>
      node_type.0.http_endpoint_port:                            "19080" => "19080"
      node_type.0.instance_count:                                "3" => "3"
      node_type.0.is_primary:                                    "true" => "true"
      node_type.0.name:                                          "jdssvm1" => "jdssvm1"
      reliability_level:                                         "Bronze" => "Bronze"
      resource_group_name:                                       "test-rg" => "test-rg"
      tags.%:                                                    "0" => <computed>
      upgrade_mode:                                              "Automatic" => "Automatic"
      vm_image:                                                  "Windows" => "Windows"

  ~ azurerm_virtual_machine_scale_set.scale-set
      extension.1288337054.auto_upgrade_minor_version:           "false" => "false"
      extension.1288337054.name:                                 "ServiceFabricNodeVmExt" => ""
      extension.1288337054.protected_settings:                   "" => ""
      extension.1288337054.publisher:                            "Microsoft.Azure.ServiceFabric" => ""
      extension.1288337054.settings:                             "{\"NicPrefixOverride\":\"10.0.0\",\"certificate\":{\"thumbprint\":\"0000000000000000000000000000000000000000\",\"x509StoreName\":\"My\"},\"clusterEndpoint\":\"https://northeurope.servicefabric.azure.com/runtime/clusters/00000000-0000-0000-0000-000000000000\",\"dataPath\":\"D:\\\\\\\\SvcFab\",\"durabilityLevel\":\"Bronze\",\"nodeTypeRef\":\"jdssvm1\"}" => ""
      extension.1288337054.type:                                 "ServiceFabricNode" => ""
      extension.1288337054.type_handler_version:                 "1.0" => ""
      extension.~2201358812.auto_upgrade_minor_version:          "" => ""
      extension.~2201358812.name:                                "" => "ServiceFabricNodeVmExt"
      extension.~2201358812.protected_settings:                  <sensitive> => <sensitive> (attribute changed)
      extension.~2201358812.publisher:                           "" => "Microsoft.Azure.ServiceFabric"
      extension.~2201358812.settings:                            "" => "      {\n        \"clusterEndpoint\": \"${azurerm_service_fabric_cluster.test.cluster_endpoint}\",\n      \"nodeTypeRef\": \"jdssvm1\",\n        \"dataPath\": \"D:\\\\\\\\SvcFab\",\n        \"durabilityLevel\": \"Bronze\",\n        \"NicPrefixOverride\": \"10.0.0\",\n\"certificate\": {\n          \"thumbprint\": \"0000000000000000000000000000000000000000\",\n          \"x509StoreName\": \"My\"\n        }\n      }\n"
      extension.~2201358812.type:                                "" => "ServiceFabricNode"
      extension.~2201358812.type_handler_version:                "" => "1.0"


Plan: 1 to add, 1 to change, 1 to destroy.
```

(fixes #2539 )