### PR TITLE
azurerm_network_security_rule: fixed app id read & import

### DIFF
--- a/azurerm/resource_arm_network_security_rule.go
+++ b/azurerm/resource_arm_network_security_rule.go
@@ -314,6 +314,14 @@ func resourceArmNetworkSecurityRuleRead(d *schema.ResourceData, meta interface{}
 		d.Set("access", string(props.Access))
 		d.Set("priority", int(*props.Priority))
 		d.Set("direction", string(props.Direction))
+
+		if err := d.Set("source_application_security_group_ids", flattenApplicationSecurityGroupIds(props.SourceApplicationSecurityGroups)); err != nil {
+			return fmt.Errorf("Error setting `source_application_security_group_ids`: %+v", err)
+		}
+
+		if err := d.Set("destination_application_security_group_ids", flattenApplicationSecurityGroupIds(props.DestinationApplicationSecurityGroups)); err != nil {
+			return fmt.Errorf("Error setting `source_application_security_group_ids`: %+v", err)
+		}
 	}
 
 	return nil
@@ -344,4 +352,16 @@ func resourceArmNetworkSecurityRuleDelete(d *schema.ResourceData, meta interface
 	}
 
 	return nil
+}
+
+func flattenApplicationSecurityGroupIds(groups *[]network.ApplicationSecurityGroup) []string {
+	ids := make([]string, 0)
+
+	if groups != nil {
+		for _, v := range *groups {
+			ids = append(ids, *v.ID)
+		}
+	}
+
+	return ids
 }


### PR DESCRIPTION
before:
```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups
=== PAUSE TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups
=== CONT  TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups
--- FAIL: TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups (112.99s)
    testing.go:538: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.

        (map[string]string) {
        }


        (map[string]string) (len=4) {
         (string) (len=44) "destination_application_security_group_ids.#": (string) (len=1) "1",
         (string) (len=53) "destination_application_security_group_ids.2652169896": (string) (len=184) "/subscriptions//resourceGroups/acctestRG-2004195443384880969/providers/Microsoft.Network/applicationSecurityGroups/acctest-second2004195443384880969",
         (string) (len=39) "source_application_security_group_ids.#": (string) (len=1) "1",
         (string) (len=48) "source_application_security_group_ids.1551054417": (string) (len=183) "/subscriptions//resourceGroups/acctestRG-2004195443384880969/providers/Microsoft.Network/applicationSecurityGroups/acctest-first2004195443384880969"
        }

FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	114.633s
make: *** [testacc] Error 1
``` 

after

```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups
=== PAUSE TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups
=== CONT  TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups
--- PASS: TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups (102.43s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	104.323s
```