### PR TITLE
azurerm_cosmosdb_account: fix failing acceptance tests

### DIFF
--- a/azurerm/data_source_cosmos_db_account_test.go
+++ b/azurerm/data_source_cosmos_db_account_test.go
@@ -88,9 +88,9 @@ func TestAccDataSourceAzureRMCosmosDBAccount_complete(t *testing.T) {
 				Config: testAccDataSourceAzureRMCosmosDBAccount_complete(ri, testLocation(), testAltLocation()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAccAzureRMCosmosDBAccount_basic(dataSourceName, testLocation(), string(documentdb.BoundedStaleness), 2),
-					resource.TestCheckResourceAttr(dataSourceName, "ip_range_filter", "104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45,52.187.184.26,10.20.0.0/16"),
+					resource.TestCheckResourceAttr(dataSourceName, "ip_range_filter", "104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45/32,52.187.184.26,10.20.0.0/16"),
 					resource.TestCheckResourceAttr(dataSourceName, "enable_automatic_failover", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "enable_multiple_write_locations", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "enable_multiple_write_locations", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "geo_location.0.location", testLocation()),
 					resource.TestCheckResourceAttr(dataSourceName, "geo_location.1.location", testAltLocation()),
 					resource.TestCheckResourceAttr(dataSourceName, "geo_location.0.failover_priority", "0"),


### PR DESCRIPTION
before:

```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccDataSourceAzureRMCosmosDBAccount_complete -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAzureRMCosmosDBAccount_complete
=== PAUSE TestAccDataSourceAzureRMCosmosDBAccount_complete
=== CONT  TestAccDataSourceAzureRMCosmosDBAccount_complete
^[[A--- FAIL: TestAccDataSourceAzureRMCosmosDBAccount_complete (2991.26s)
    testing.go:538: Step 0 error: Check failed: 1 error(s) occurred:

        * Check 4/8 error: data.azurerm_cosmosdb_account.test: Attribute 'enable_multiple_write_locations' expected "true", got "false"
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	2991.692s
make: *** [testacc] Error 1
```

after

```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccDataSourceAzureRMCosmosDBAccount_complete -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAzureRMCosmosDBAccount_complete
=== PAUSE TestAccDataSourceAzureRMCosmosDBAccount_complete
=== CONT  TestAccDataSourceAzureRMCosmosDBAccount_complete
--- PASS: TestAccDataSourceAzureRMCosmosDBAccount_complete (2710.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	2711.897s
```