### PR TITLE
fix azurerm_public_ip: TestAccAzureRMPublicIpStatic_canLabelBe63 acc test

### DIFF
--- a/azurerm/resource_arm_public_ip_test.go
+++ b/azurerm/resource_arm_public_ip_test.go
@@ -397,7 +397,7 @@ func TestAccAzureRMPublicIpStatic_canLabelBe63(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIpExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
-					resource.TestCheckResourceAttr(resourceName, "public_ip_address_allocation", "static"),
+					resource.TestCheckResourceAttr(resourceName, "public_ip_address_allocation", "Static"),
 				),
 			},
 			{


### PR DESCRIPTION
before:
```
------- Stdout: -------
=== RUN   TestAccAzureRMPublicIpStatic_canLabelBe63
=== PAUSE TestAccAzureRMPublicIpStatic_canLabelBe63
=== CONT  TestAccAzureRMPublicIpStatic_canLabelBe63
--- FAIL: TestAccAzureRMPublicIpStatic_canLabelBe63 (77.23s)
	testing.go:538: Step 0 error: Check failed: Check 3/3 error: azurerm_public_ip.test: Attribute 'public_ip_address_allocation' expected "static", got "Static"
FAIL
```
after
```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccAzureRMPublicIpStatic_canLabelBe63 -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMPublicIpStatic_canLabelBe63
=== PAUSE TestAccAzureRMPublicIpStatic_canLabelBe63
=== CONT  TestAccAzureRMPublicIpStatic_canLabelBe63
--- PASS: TestAccAzureRMPublicIpStatic_canLabelBe63 (100.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	101.721s
```