### PR TITLE
azurerm_express_route_circuit_peering: fix testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering acc test

### DIFF
--- a/azurerm/resource_arm_express_route_circuit_peering.go
+++ b/azurerm/resource_arm_express_route_circuit_peering.go
@@ -18,6 +18,7 @@ func resourceArmExpressRouteCircuitPeering() *schema.Resource {
 		Read:   resourceArmExpressRouteCircuitPeeringRead,
 		Update: resourceArmExpressRouteCircuitPeeringCreateUpdate,
 		Delete: resourceArmExpressRouteCircuitPeeringDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/resource_arm_express_route_circuit_peering_test.go
+++ b/azurerm/resource_arm_express_route_circuit_peering_test.go
@@ -30,9 +30,10 @@ func testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering(t *testing.T) 
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"shared_key"}, //is not returned by the API
 			},
 		},
 	})


### PR DESCRIPTION
before:

```
 --- FAIL: TestAccAzureRMExpressRouteCircuit/PrivatePeering/azurePrivatePeering (149.07s)
        	testing.go:538: Step 1 error: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        		
        		(map[string]string) {
        		}
        		
        		
        		(map[string]string) (len=1) {
        		 (string) (len=10) "shared_key": (string) (len=24) "ABCdefGHIJklm@nOPqrsTU!!"
        		}
        		
```

after

```
--- PASS: TestAccAzureRMExpressRouteCircuit (160.52s)
    --- PASS: TestAccAzureRMExpressRouteCircuit/PrivatePeering (0.00s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/PrivatePeering/azurePrivatePeering (160.52s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	162.158s
```