### PR TITLE
notification hubs: added tags support

### DIFF
--- a/azurerm/data_source_notification_hub.go
+++ b/azurerm/data_source_notification_hub.go
@@ -72,9 +72,7 @@ func dataSourceNotificationHub() *schema.Resource {
 				},
 			},
 
-			// NOTE: skipping tags as there's a bug in the API where the Keys for Tags are returned in lower-case
-			// Azure Rest API Specs issue: https://github.com/Azure/azure-sdk-for-go/issues/2239
-			//"tags": tagsForDataSourceSchema(),
+			"tags": tagsForDataSourceSchema(),
 		},
 	}
 }
@@ -122,6 +120,7 @@ func dataSourceNotificationHubRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	flattenAndSetTags(d, resp.Tags)
 	return nil
 }
 

--- a/azurerm/data_source_notification_hub_namespace.go
+++ b/azurerm/data_source_notification_hub_namespace.go
@@ -45,14 +45,12 @@ func dataSourceNotificationHubNamespace() *schema.Resource {
 				Computed: true,
 			},
 
-			// NOTE: skipping tags as there's a bug in the API where the Keys for Tags are returned in lower-case
-			// Azure Rest API Specs issue: https://github.com/Azure/azure-sdk-for-go/issues/2239
-			//"tags": tagsForDataSourceSchema(),
-
 			"servicebus_endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsForDataSourceSchema(),
 		},
 	}
 }
@@ -92,6 +90,7 @@ func resourceArmDataSourceNotificationHubNamespaceRead(d *schema.ResourceData, m
 		d.Set("servicebus_endpoint", props.ServiceBusEndpoint)
 	}
 
+	flattenAndSetTags(d, resp.Tags)
 	return nil
 }
 

--- a/azurerm/resource_arm_notification_hub.go
+++ b/azurerm/resource_arm_notification_hub.go
@@ -129,29 +129,19 @@ func resourceArmNotificationHubCreateUpdate(d *schema.ResourceData, meta interfa
 	namespaceName := d.Get("namespace_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
-
 	apnsRaw := d.Get("apns_credential").([]interface{})
-	apnsCredential, err := expandNotificationHubsAPNSCredentials(apnsRaw)
-	if err != nil {
-		return err
-	}
-
 	gcmRaw := d.Get("gcm_credential").([]interface{})
-	gcmCredentials, err := expandNotificationHubsGCMCredentials(gcmRaw)
-	if err != nil {
-		return err
-	}
 
 	parameters := notificationhubs.CreateOrUpdateParameters{
 		Location: utils.String(location),
 		Properties: &notificationhubs.Properties{
-			ApnsCredential: apnsCredential,
-			GcmCredential:  gcmCredentials,
+			ApnsCredential: expandNotificationHubsAPNSCredentials(apnsRaw),
+			GcmCredential:  expandNotificationHubsGCMCredentials(gcmRaw),
 		},
 		Tags: expandTags(d.Get("tags").(map[string]interface{})),
 	}
 
-	if _, err = client.CreateOrUpdate(ctx, resourceGroup, namespaceName, name, parameters); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, namespaceName, name, parameters); err != nil {
 		return fmt.Errorf("Error creating Notification Hub %q (Namespace %q / Resource Group %q): %+v", name, namespaceName, resourceGroup, err)
 	}
 
@@ -241,9 +231,9 @@ func resourceArmNotificationHubDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func expandNotificationHubsAPNSCredentials(inputs []interface{}) (*notificationhubs.ApnsCredential, error) {
+func expandNotificationHubsAPNSCredentials(inputs []interface{}) *notificationhubs.ApnsCredential {
 	if len(inputs) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	input := inputs[0].(map[string]interface{})
@@ -268,7 +258,7 @@ func expandNotificationHubsAPNSCredentials(inputs []interface{}) (*notificationh
 			Token:    utils.String(token),
 		},
 	}
-	return &credentials, nil
+	return &credentials
 }
 
 func flattenNotificationHubsAPNSCredentials(input *notificationhubs.ApnsCredential) []interface{} {
@@ -306,9 +296,9 @@ func flattenNotificationHubsAPNSCredentials(input *notificationhubs.ApnsCredenti
 	return []interface{}{output}
 }
 
-func expandNotificationHubsGCMCredentials(inputs []interface{}) (*notificationhubs.GcmCredential, error) {
+func expandNotificationHubsGCMCredentials(inputs []interface{}) *notificationhubs.GcmCredential {
 	if len(inputs) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	input := inputs[0].(map[string]interface{})
@@ -318,7 +308,7 @@ func expandNotificationHubsGCMCredentials(inputs []interface{}) (*notificationhu
 			GoogleAPIKey: utils.String(apiKey),
 		},
 	}
-	return &credentials, nil
+	return &credentials
 }
 
 func flattenNotificationHubsGCMCredentials(input *notificationhubs.GcmCredential) []interface{} {

--- a/azurerm/resource_arm_notification_hub.go
+++ b/azurerm/resource_arm_notification_hub.go
@@ -116,9 +116,7 @@ func resourceArmNotificationHub() *schema.Resource {
 				},
 			},
 
-			// NOTE: skipping tags as there's a bug in the API where the Keys for Tags are returned in lower-case
-			// Azure Rest API Specs issue: https://github.com/Azure/azure-sdk-for-go/issues/2239
-			//"tags": tagsSchema(),
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -150,6 +148,7 @@ func resourceArmNotificationHubCreateUpdate(d *schema.ResourceData, meta interfa
 			ApnsCredential: apnsCredential,
 			GcmCredential:  gcmCredentials,
 		},
+		Tags: expandTags(d.Get("tags").(map[string]interface{})),
 	}
 
 	if _, err = client.CreateOrUpdate(ctx, resourceGroup, namespaceName, name, parameters); err != nil {
@@ -216,6 +215,7 @@ func resourceArmNotificationHubRead(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	flattenAndSetTags(d, resp.Tags)
 	return nil
 }
 

--- a/azurerm/resource_arm_notification_hub_namespace.go
+++ b/azurerm/resource_arm_notification_hub_namespace.go
@@ -73,14 +73,12 @@ func resourceArmNotificationHubNamespace() *schema.Resource {
 				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
-			// NOTE: skipping tags as there's a bug in the API where the Keys for Tags are returned in lower-case
-			// Azure Rest API Specs issue: https://github.com/Azure/azure-sdk-for-go/issues/2239
-			//"tags": tagsSchema(),
-
 			"servicebus_endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -106,7 +104,9 @@ func resourceArmNotificationHubNamespaceCreateUpdate(d *schema.ResourceData, met
 			NamespaceType: notificationhubs.NamespaceType(namespaceType),
 			Enabled:       utils.Bool(enabled),
 		},
+		Tags: expandTags(d.Get("tags").(map[string]interface{})),
 	}
+
 	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters); err != nil {
 		return fmt.Errorf("Error creating/updating Notification Hub Namesapce %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
@@ -163,6 +163,7 @@ func resourceArmNotificationHubNamespaceRead(d *schema.ResourceData, meta interf
 		d.Set("servicebus_endpoint", props.ServiceBusEndpoint)
 	}
 
+	flattenAndSetTags(d, resp.Tags)
 	return nil
 }
 

--- a/azurerm/resource_arm_notification_hub_namespace_test.go
+++ b/azurerm/resource_arm_notification_hub_namespace_test.go
@@ -14,7 +14,6 @@ func TestAccAzureRMNotificationHubNamespace_free(t *testing.T) {
 	resourceName := "azurerm_notification_hub_namespace.test"
 
 	ri := acctest.RandInt()
-	location := testLocation()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,9 +21,50 @@ func TestAccAzureRMNotificationHubNamespace_free(t *testing.T) {
 		CheckDestroy: testCheckAzureRMNotificationHubNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMNotificationHubNamespace_free(ri, location),
+				Config: testAccAzureRMNotificationHubNamespace_free(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNotificationHubNamespaceExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNotificationHubNamespace_withTags(t *testing.T) {
+	resourceName := "azurerm_notification_hub_namespace.test"
+
+	ri := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNotificationHubNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNotificationHubNamespace_withTags(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNotificationHubNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.company", "hashicorp"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAzureRMNotificationHubNamespace_withTagsUpdated(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNotificationHubNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
 				),
 			},
 			{
@@ -102,6 +142,55 @@ resource "azurerm_notification_hub_namespace" "test" {
 
   sku {
     name = "Free"
+  }
+}
+`, ri, location, ri)
+}
+
+func testAccAzureRMNotificationHubNamespace_withTags(ri int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_notification_hub_namespace" "test" {
+  name                = "acctestnhn-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  namespace_type      = "NotificationHub"
+
+  sku {
+    name = "Free"
+  }
+
+  tags {
+    environment = "test"
+    company     = "hashicorp"
+  }
+}
+`, ri, location, ri)
+}
+
+func testAccAzureRMNotificationHubNamespace_withTagsUpdated(ri int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_notification_hub_namespace" "test" {
+  name                = "acctestnhn-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  namespace_type      = "NotificationHub"
+
+  sku {
+    name = "Free"
+  }
+
+  tags {
+    environment = "production"
   }
 }
 `, ri, location, ri)

--- a/website/docs/d/notification_hub.html.markdown
+++ b/website/docs/d/notification_hub.html.markdown
@@ -42,6 +42,8 @@ output "id" {
 
 * `gcm_credential` - A `gcm_credential` block as defined below.
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
 
 A `apns_credential` block exports:

--- a/website/docs/d/notification_hub_namespace.html.markdown
+++ b/website/docs/d/notification_hub_namespace.html.markdown
@@ -41,6 +41,8 @@ output "servicebus_endpoint" {
 
 * `enabled` - Is this Notification Hub Namespace enabled?
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
 
 A `sku` block exports the following:

--- a/website/docs/r/notification_hub.html.markdown
+++ b/website/docs/r/notification_hub.html.markdown
@@ -35,6 +35,10 @@ resource "azurerm_notification_hub" "test" {
   namespace_name      = "${azurerm_notification_hub_namespace.test.name}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
+  
+  tags {
+    environment = "Production"
+  }
 }
 ```
 
@@ -57,6 +61,8 @@ The following arguments are supported:
 * `gcm_credential` - (Optional) A `gcm_credential` block as defined below.
 
 ~> **NOTE:** Removing the `gcm_credential` block will currently force a recreation of this resource [due to this bug in the Azure SDK for Go](https://github.com/Azure/azure-sdk-for-go/issues/2246) - we'll remove this limitation when the SDK bug is fixed.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 

--- a/website/docs/r/notification_hub_namespace.html.markdown
+++ b/website/docs/r/notification_hub_namespace.html.markdown
@@ -28,6 +28,10 @@ resource "azurerm_notification_hub_namespace" "test" {
   sku {
     name = "Free"
   }
+  
+  tags {
+    environment = "Production"
+  }
 }
 ```
 
@@ -46,6 +50,8 @@ The following arguments are supported:
 * `sku` - (Required) A `sku` block as defined below.
 
 * `enabled` - (Optional) Is this Notification Hub Namespace enabled? Defaults to `true`.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 


### PR DESCRIPTION
It appears https://github.com/Azure/azure-sdk-for-go/issues/2239 has been fixed:

```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccAzureRMNotificationHubNamespace_withTags -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMNotificationHubNamespace_withTags
=== PAUSE TestAccAzureRMNotificationHubNamespace_withTags
=== CONT  TestAccAzureRMNotificationHubNamespace_withTags
--- PASS: TestAccAzureRMNotificationHubNamespace_withTags (117.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	119.620s

==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccAzureRMNotificationHub_withTags -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMNotificationHub_withTags
=== PAUSE TestAccAzureRMNotificationHub_withTags
=== CONT  TestAccAzureRMNotificationHub_withTags
--- PASS: TestAccAzureRMNotificationHub_withTags (144.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	145.407s

```