### PR TITLE
Added Virtual Network Integration to the API Management service

### DIFF
--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -460,8 +460,8 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 
 		d.Set("virtual_network_type", props.VirtualNetworkType)
 
-		if err := d.Set("virtual_network_coniguration", flattenApiManagementVirtualNetworkConfiguration(props.VirtualNetworkConfiguration)); err != nil {
-			return fmt.Errorf("Error setting `virtual_network_coniguration`: %+v", err)
+		if err := d.Set("virtual_network_configuration", flattenApiManagementVirtualNetworkConfiguration(props.VirtualNetworkConfiguration)); err != nil {
+			return fmt.Errorf("Error setting `virtual_network_configuration`: %+v", err)
 		}
 
 		if err := d.Set("additional_location", flattenApiManagementAdditionalLocations(props.AdditionalLocations)); err != nil {

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -263,6 +263,7 @@ func resourceArmApiManagementService() *schema.Resource {
 			"virtual_network_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  string(apimanagement.VirtualNetworkTypeNone),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(apimanagement.VirtualNetworkTypeInternal),
 					string(apimanagement.VirtualNetworkTypeExternal),
@@ -350,19 +351,14 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 	certificates := expandAzureRmApiManagementCertificates(d)
 	hostnameConfigurations := expandAzureRmApiManagementHostnameConfigurations(d)
 
-	virtualNetworkType := apimanagement.VirtualNetworkType(d.Get("virtual_network_type").(string))
-	virtualNetworkConfiguration := expandAzureRmApiManagementVirtualNetworkConfiguration(d)
-
 	properties := apimanagement.ServiceResource{
 		Location: utils.String(location),
 		ServiceProperties: &apimanagement.ServiceProperties{
-			PublisherName:               utils.String(publisherName),
-			PublisherEmail:              utils.String(publisherEmail),
-			CustomProperties:            customProperties,
-			Certificates:                certificates,
-			HostnameConfigurations:      hostnameConfigurations,
-			VirtualNetworkType:          virtualNetworkType,
-			VirtualNetworkConfiguration: virtualNetworkConfiguration,
+			PublisherName:          utils.String(publisherName),
+			PublisherEmail:         utils.String(publisherEmail),
+			CustomProperties:       customProperties,
+			Certificates:           certificates,
+			HostnameConfigurations: hostnameConfigurations,
 		},
 		Tags: expandTags(tags),
 		Sku:  sku,
@@ -370,6 +366,14 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 
 	if _, ok := d.GetOk("identity"); ok {
 		properties.Identity = expandAzureRmApiManagementIdentity(d)
+	}
+
+	if _, ok := d.GetOk("virtual_network_type"); ok {
+		properties.ServiceProperties.VirtualNetworkType = apimanagement.VirtualNetworkType(d.Get("virtual_network_type").(string))
+	}
+
+	if _, ok := d.GetOk("virtual_network_configuration"); ok {
+		properties.ServiceProperties.VirtualNetworkConfiguration = expandAzureRmApiManagementVirtualNetworkConfiguration(d)
 	}
 
 	if _, ok := d.GetOk("additional_location"); ok {

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -62,6 +62,10 @@ The following arguments are supported:
 
 * `security` - (Optional) A `security` block as defined below.
 
+* `virtual_network_type` - (Optional) Specifies the Virtual Network Integration for the API Management Service. Possible values include: `None`, `External`, and `Internal`.
+
+* `virtual_network_configuration` - (Optional) A `virtual_network_configuration` block as defined below.
+
 * `tags` - (Optional) A mapping of tags assigned to the resource.
 
 ---
@@ -117,6 +121,12 @@ A `security` block supports the following:
 * `disable_triple_des_chipers` - (Optional) Should the `TLS_RSA_WITH_3DES_EDE_CBC_SHA` cipher be disabled for alL TLS versions (1.0, 1.1 and 1.2)? Defaults to `false`.
 
 -> **info:** This maps to the `Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168` field
+
+---
+
+A `virtual_network_configuration` block supports the following:
+
+* `subnet_id` - (Required) Specifies the resource id of the subnet to integrate the API management service with.
 
 ---
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -74,6 +74,8 @@ A `additional_location` block supports the following:
 
 * `location` - (Required) The name of the Azure Region in which the API Management Service should be expanded to.
 
+* `virtual_network_configuration` - (Optional) A `virtual_network_configuration` block as defined below. Required when `virtual_network_type` is  `External` or `Internal`
+
 ---
 
 A `certificate` block supports the following:
@@ -204,6 +206,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `public_ip_addresses` - The Public IP addresses of the API Management Service.
 
+* `private_ip_addresses` - The Private IP addresses of the API Management Service if integrated in the Virtual Network.
+
 * `scm_url` - The URL for the SCM (Source Code Management) Endpoint associated with this API Management service.
 
 * `identity` - An `identity` block as defined below.
@@ -225,6 +229,8 @@ An `additional_location` block exports the following:
 * `gateway_regional_url` - The URL of the Regional Gateway for the API Management Service in the specified region.
 
 * `public_ip_addresses` - Public Static Load Balanced IP addresses of the API Management service in the additional location. Available only for Basic, Standard and Premium SKU.
+
+* `private_ip_addresses` - Private Static Load Balanced IP addresses of the API Management service in the virtual network of the additional locations. Available only for Basic, Standard and Premium SKU.
 
 ## Import
 


### PR DESCRIPTION
- Added the virtual_network_type property which allows None, Internal or External

- Added virtual_network_configuration object with property subnet_id which references the subnet to integrate with.

See https://docs.microsoft.com/en-us/azure/api-management/api-management-using-with-vnet for details regarding API Management with Vnet integration