### PR TITLE
Update acctest Exist(name string) -> Exist(resourceName string)

### DIFF
--- a/azurerm/data_source_subscription_test.go
+++ b/azurerm/data_source_subscription_test.go
@@ -51,19 +51,19 @@ func TestAccDataSourceAzureRMSubscription_specific(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSubscriptionId(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubscriptionId(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		attributeName := "subscription_id"
 		subscriptionId := rs.Primary.Attributes[attributeName]
 		client := testAccProvider.Meta().(*ArmClient)
 		if subscriptionId != client.subscriptionId {
-			return fmt.Errorf("%s: Attribute '%s' expected \"%s\", got \"%s\"", name, attributeName, client.subscriptionId, subscriptionId)
+			return fmt.Errorf("%s: Attribute '%s' expected \"%s\", got \"%s\"", resourceName, attributeName, client.subscriptionId, subscriptionId)
 		}
 
 		return nil

--- a/azurerm/logic_apps_test.go
+++ b/azurerm/logic_apps_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func testCheckAzureRMLogicAppActionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogicAppActionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		logicAppId := rs.Primary.Attributes["logic_app_id"]
@@ -57,11 +57,11 @@ func testCheckAzureRMLogicAppActionExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMLogicAppTriggerExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogicAppTriggerExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		logicAppId := rs.Primary.Attributes["logic_app_id"]

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -152,12 +152,12 @@ func testCheckAzureRMApiManagementDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMApiManagementExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMApiManagementExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		apiMangementName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_app_service_custom_hostname_binding_test.go
+++ b/azurerm/resource_arm_app_service_custom_hostname_binding_test.go
@@ -158,12 +158,12 @@ func testCheckAzureRMAppServiceCustomHostnameBindingDestroy(s *terraform.State) 
 	return nil
 }
 
-func testCheckAzureRMAppServiceCustomHostnameBindingExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAppServiceCustomHostnameBindingExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_app_service_plan_test.go
+++ b/azurerm/resource_arm_app_service_plan_test.go
@@ -300,12 +300,12 @@ func testCheckAzureRMAppServicePlanDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMAppServicePlanExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAppServicePlanExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		appServicePlanName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1160,12 +1160,12 @@ func testCheckAzureRMAppServiceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMAppServiceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAppServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		appServiceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -293,11 +293,11 @@ func TestAccAzureRMApplicationGateway_webApplicationFirewall(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMApplicationGatewayExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMApplicationGatewayExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		gatewayName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_application_insights_api_key_test.go
+++ b/azurerm/resource_arm_application_insights_api_key_test.go
@@ -212,12 +212,12 @@ func testCheckAzureRMApplicationInsightsAPIKeyDestroy(s *terraform.State) error 
 	return nil
 }
 
-func testCheckAzureRMApplicationInsightsAPIKeyExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMApplicationInsightsAPIKeyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		id, err := parseAzureResourceID(rs.Primary.Attributes["id"])
@@ -237,7 +237,7 @@ func testCheckAzureRMApplicationInsightsAPIKeyExists(name string) resource.TestC
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Application Insights API Key '%q' (resource group: '%q') does not exist", name, resGroup)
+			return fmt.Errorf("Bad: Application Insights API Key '%q' (resource group: '%q') does not exist", keyID, resGroup)
 		}
 
 		return nil

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -259,7 +259,7 @@ func testCheckAzureRMApplicationInsightsExists(resourceName string) resource.Tes
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for App Insights: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for App Insights: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).appInsightsClient

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -248,18 +248,18 @@ func testCheckAzureRMApplicationInsightsDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMApplicationInsightsExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMApplicationInsightsExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for App Insights: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for App Insights: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).appInsightsClient

--- a/azurerm/resource_arm_application_security_group_test.go
+++ b/azurerm/resource_arm_application_security_group_test.go
@@ -139,12 +139,12 @@ func testCheckAzureRMApplicationSecurityGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMApplicationSecurityGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMApplicationSecurityGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_automation_account_test.go
+++ b/azurerm/resource_arm_automation_account_test.go
@@ -121,13 +121,13 @@ func testCheckAzureRMAutomationAccountDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMAutomationAccountExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutomationAccountExists(resourceName string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_automation_credential_test.go
+++ b/azurerm/resource_arm_automation_credential_test.go
@@ -126,13 +126,13 @@ func testCheckAzureRMAutomationCredentialDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMAutomationCredentialExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutomationCredentialExists(resourceName string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_automation_dsc_configuration_test.go
+++ b/azurerm/resource_arm_automation_dsc_configuration_test.go
@@ -102,13 +102,13 @@ func testCheckAzureRMAutomationDscConfigurationDestroy(s *terraform.State) error
 	return nil
 }
 
-func testCheckAzureRMAutomationDscConfigurationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutomationDscConfigurationExists(resourceName string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
@@ -100,13 +100,13 @@ func testCheckAzureRMAutomationDscNodeConfigurationDestroy(s *terraform.State) e
 	return nil
 }
 
-func testCheckAzureRMAutomationDscNodeConfigurationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutomationDscNodeConfigurationExists(resourceName string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_automation_module_test.go
+++ b/azurerm/resource_arm_automation_module_test.go
@@ -99,13 +99,13 @@ func testCheckAzureRMAutomationModuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMAutomationModuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutomationModuleExists(resourceName string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_automation_runbook_test.go
+++ b/azurerm/resource_arm_automation_runbook_test.go
@@ -151,13 +151,13 @@ func testCheckAzureRMAutomationRunbookDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMAutomationRunbookExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutomationRunbookExists(resourceName string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_automation_schedule_test.go
+++ b/azurerm/resource_arm_automation_schedule_test.go
@@ -274,15 +274,15 @@ func testCheckAzureRMAutomationScheduleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMAutomationScheduleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutomationScheduleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*ArmClient).automationScheduleClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_autoscale_setting_test.go
+++ b/azurerm/resource_arm_autoscale_setting_test.go
@@ -250,11 +250,11 @@ func TestAccAzureRMAutoScaleSetting_fixedDate(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMAutoScaleSettingExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAutoScaleSettingExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		autoscaleSettingName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_availability_set_test.go
+++ b/azurerm/resource_arm_availability_set_test.go
@@ -184,12 +184,12 @@ func TestAccAzureRMAvailabilitySet_managed(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMAvailabilitySetExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMAvailabilitySetExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		availSetName := rs.Primary.Attributes["name"]
@@ -203,7 +203,7 @@ func testCheckAzureRMAvailabilitySetExists(name string) resource.TestCheckFunc {
 		resp, err := client.Get(ctx, resourceGroup, availSetName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Availability Set %q (resource group: %q) does not exist", name, resourceGroup)
+				return fmt.Errorf("Bad: Availability Set %q (resource group: %q) does not exist", availSetName, resourceGroup)
 			}
 
 			return fmt.Errorf("Bad: Get on availSetClient: %+v", err)
@@ -213,12 +213,12 @@ func testCheckAzureRMAvailabilitySetExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMAvailabilitySetDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMAvailabilitySetDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		availSetName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_azuread_application_test.go
+++ b/azurerm/resource_arm_azuread_application_test.go
@@ -131,11 +131,11 @@ func TestAccAzureRMActiveDirectoryApplication_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMActiveDirectoryApplicationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMActiveDirectoryApplicationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).applicationsClient

--- a/azurerm/resource_arm_azuread_service_principal_password_test.go
+++ b/azurerm/resource_arm_azuread_service_principal_password_test.go
@@ -113,11 +113,11 @@ func TestAccAzureRMActiveDirectoryServicePrincipalPassword_customKeyId(t *testin
 	})
 }
 
-func testCheckAzureRMActiveDirectoryServicePrincipalPasswordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMActiveDirectoryServicePrincipalPasswordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).servicePrincipalsClient

--- a/azurerm/resource_arm_azuread_service_principal_test.go
+++ b/azurerm/resource_arm_azuread_service_principal_test.go
@@ -65,11 +65,11 @@ func TestAccAzureRMActiveDirectoryServicePrincipal_requiresImport(t *testing.T) 
 	})
 }
 
-func testCheckAzureRMActiveDirectoryServicePrincipalExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMActiveDirectoryServicePrincipalExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).servicePrincipalsClient

--- a/azurerm/resource_arm_batch_account_test.go
+++ b/azurerm/resource_arm_batch_account_test.go
@@ -98,12 +98,12 @@ func TestAccAzureRMBatchAccount_complete(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMBatchAccountExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMBatchAccountExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		batchAccount := rs.Primary.Attributes["name"]
@@ -119,7 +119,7 @@ func testCheckAzureRMBatchAccountExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Batch account %q (resource group: %q) does not exist", name, resourceGroup)
+			return fmt.Errorf("Bad: Batch account %q (resource group: %q) does not exist", batchAccount, resourceGroup)
 		}
 
 		return nil

--- a/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/resource_arm_cdn_endpoint_test.go
@@ -275,7 +275,7 @@ func testCheckAzureRMCdnEndpointExists(resourceName string) resource.TestCheckFu
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient
@@ -306,7 +306,7 @@ func testCheckAzureRMCdnEndpointDisappears(resourceName string) resource.TestChe
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient

--- a/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/resource_arm_cdn_endpoint_test.go
@@ -263,19 +263,19 @@ func TestAccAzureRMCdnEndpoint_isHttpAndHttpsAllowedUpdate(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMCdnEndpointExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMCdnEndpointExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient
@@ -294,19 +294,19 @@ func testCheckAzureRMCdnEndpointExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMCdnEndpointDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMCdnEndpointDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for cdn endpoint: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient

--- a/azurerm/resource_arm_cdn_profile_test.go
+++ b/azurerm/resource_arm_cdn_profile_test.go
@@ -262,18 +262,18 @@ func TestAccAzureRMCdnProfile_standardMicrosoft(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMCdnProfileExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMCdnProfileExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for cdn profile: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for cdn profile: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnProfilesClient

--- a/azurerm/resource_arm_cdn_profile_test.go
+++ b/azurerm/resource_arm_cdn_profile_test.go
@@ -273,7 +273,7 @@ func testCheckAzureRMCdnProfileExists(resourceName string) resource.TestCheckFun
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for cdn profile: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for cdn profile: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnProfilesClient

--- a/azurerm/resource_arm_cognitive_account_test.go
+++ b/azurerm/resource_arm_cognitive_account_test.go
@@ -152,12 +152,12 @@ func testCheckAzureRMAppCognitiveAccountDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMCognitiveAccountExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMCognitiveAccountExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -638,7 +638,7 @@ func testCheckAzureRMContainerGroupExists(resourceName string) resource.TestChec
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerGroupsClient

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -627,18 +627,18 @@ resource "azurerm_container_group" "test" {
 `, ri, location, ri, ri, ri, ri)
 }
 
-func testCheckAzureRMContainerGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMContainerGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerGroupsClient

--- a/azurerm/resource_arm_container_registry_test.go
+++ b/azurerm/resource_arm_container_registry_test.go
@@ -387,18 +387,18 @@ func testCheckAzureRMContainerRegistryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMContainerRegistryExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMContainerRegistryExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerRegistryClient
@@ -417,18 +417,18 @@ func testCheckAzureRMContainerRegistryExists(name string) resource.TestCheckFunc
 	}
 }
 
-func testCheckAzureRMContainerRegistryGeoreplications(registryName string, sku string, expectedLocations []string) resource.TestCheckFunc {
+func testCheckAzureRMContainerRegistryGeoreplications(resourceName string, sku string, expectedLocations []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[registryName]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", registryName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerRegistryReplicationsClient

--- a/azurerm/resource_arm_container_registry_test.go
+++ b/azurerm/resource_arm_container_registry_test.go
@@ -398,7 +398,7 @@ func testCheckAzureRMContainerRegistryExists(resourceName string) resource.TestC
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerRegistryClient
@@ -428,7 +428,7 @@ func testCheckAzureRMContainerRegistryGeoreplications(resourceName string, sku s
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerRegistryReplicationsClient

--- a/azurerm/resource_arm_container_service_test.go
+++ b/azurerm/resource_arm_container_service_test.go
@@ -407,7 +407,7 @@ func testCheckAzureRMContainerServiceExists(resourceName string) resource.TestCh
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Service Instance: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Container Service Instance: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerServicesClient

--- a/azurerm/resource_arm_container_service_test.go
+++ b/azurerm/resource_arm_container_service_test.go
@@ -396,18 +396,18 @@ resource "azurerm_container_service" "test" {
 `, rInt, location, rInt, rInt, rInt, rInt)
 }
 
-func testCheckAzureRMContainerServiceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMContainerServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Container Service Instance: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Container Service Instance: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).containerServicesClient

--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -559,12 +559,12 @@ func testCheckAzureRMCosmosDBAccountDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMCosmosDBAccountExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMCosmosDBAccountExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_data_lake_analytics_account_test.go
+++ b/azurerm/resource_arm_data_lake_analytics_account_test.go
@@ -133,7 +133,7 @@ func testCheckAzureRMDataLakeAnalyticsAccountExists(resourceName string) resourc
 		accountName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", accountName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeAnalyticsAccountClient

--- a/azurerm/resource_arm_data_lake_analytics_account_test.go
+++ b/azurerm/resource_arm_data_lake_analytics_account_test.go
@@ -122,18 +122,18 @@ func TestAccAzureRMDataLakeAnalyticsAccount_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDataLakeAnalyticsAccountExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDataLakeAnalyticsAccountExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		accountName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeAnalyticsAccountClient

--- a/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
+++ b/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
@@ -141,7 +141,7 @@ func testCheckAzureRMDataLakeAnalyticsFirewallRuleExists(resourceName string) re
 		accountName := rs.Primary.Attributes["account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", firewallRuleName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeAnalyticsFirewallRulesClient

--- a/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
+++ b/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
@@ -129,19 +129,19 @@ func TestAccAzureRMDataLakeAnalyticsFirewallRule_azureServices(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDataLakeAnalyticsFirewallRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDataLakeAnalyticsFirewallRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		firewallRuleName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeAnalyticsFirewallRulesClient

--- a/azurerm/resource_arm_data_lake_store_file_test.go
+++ b/azurerm/resource_arm_data_lake_store_file_test.go
@@ -69,12 +69,12 @@ func TestAccAzureRMDataLakeStoreFile_requiresimport(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDataLakeStoreFileExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDataLakeStoreFileExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		remoteFilePath := rs.Primary.Attributes["remote_file_path"]

--- a/azurerm/resource_arm_data_lake_store_firewall_rule_test.go
+++ b/azurerm/resource_arm_data_lake_store_firewall_rule_test.go
@@ -129,19 +129,19 @@ func TestAccAzureRMDataLakeStoreFirewallRule_azureServices(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDataLakeStoreFirewallRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDataLakeStoreFirewallRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		firewallRuleName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeStoreFirewallRulesClient

--- a/azurerm/resource_arm_data_lake_store_firewall_rule_test.go
+++ b/azurerm/resource_arm_data_lake_store_firewall_rule_test.go
@@ -141,7 +141,7 @@ func testCheckAzureRMDataLakeStoreFirewallRuleExists(resourceName string) resour
 		accountName := rs.Primary.Attributes["account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store firewall rule: %s", firewallRuleName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeStoreFirewallRulesClient

--- a/azurerm/resource_arm_data_lake_store_test.go
+++ b/azurerm/resource_arm_data_lake_store_test.go
@@ -206,7 +206,7 @@ func testCheckAzureRMDataLakeStoreExists(resourceName string) resource.TestCheck
 		accountName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", accountName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeStoreAccountClient

--- a/azurerm/resource_arm_data_lake_store_test.go
+++ b/azurerm/resource_arm_data_lake_store_test.go
@@ -195,18 +195,18 @@ func TestAccAzureRMDataLakeStore_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDataLakeStoreExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDataLakeStoreExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		accountName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for data lake store: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).dataLakeStoreAccountClient

--- a/azurerm/resource_arm_databricks_workspace_test.go
+++ b/azurerm/resource_arm_databricks_workspace_test.go
@@ -161,11 +161,11 @@ func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDatabricksWorkspaceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDatabricksWorkspaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Bad: Not found: %s", name)
+			return fmt.Errorf("Bad: Not found: %s", resourceName)
 		}
 
 		workspaceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dev_test_lab_test.go
+++ b/azurerm/resource_arm_dev_test_lab_test.go
@@ -94,12 +94,12 @@ func TestAccAzureRMDevTestLab_complete(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDevTestLabExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDevTestLabExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		labName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dev_test_linux_virtual_machine_test.go
+++ b/azurerm/resource_arm_dev_test_linux_virtual_machine_test.go
@@ -173,12 +173,12 @@ func TestAccAzureRMDevTestLinuxVirtualMachine_updateStorage(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDevTestLinuxVirtualMachineExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDevTestLinuxVirtualMachineExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		virtualMachineName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dev_test_policy_test.go
+++ b/azurerm/resource_arm_dev_test_policy_test.go
@@ -93,12 +93,12 @@ func TestAccAzureRMDevTestPolicy_complete(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDevTestPolicyExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDevTestPolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		policyName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dev_test_virtual_network_test.go
+++ b/azurerm/resource_arm_dev_test_virtual_network_test.go
@@ -123,12 +123,12 @@ func TestAccAzureRMDevTestVirtualNetwork_subnet(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDevTestVirtualNetworkExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDevTestVirtualNetworkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		virtualNetworkName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dev_test_windows_virtual_machine_test.go
+++ b/azurerm/resource_arm_dev_test_windows_virtual_machine_test.go
@@ -140,12 +140,12 @@ func TestAccAzureRMDevTestWindowsVirtualMachine_updateStorage(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDevTestWindowsVirtualMachineExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDevTestWindowsVirtualMachineExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		virtualMachineName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_devspace_controller_test.go
+++ b/azurerm/resource_arm_devspace_controller_test.go
@@ -67,12 +67,12 @@ func TestAccAzureRMDevSpaceController_requiresImport(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDevSpaceControllerExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDevSpaceControllerExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		ctrlName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_a_record_test.go
+++ b/azurerm/resource_arm_dns_a_record_test.go
@@ -130,12 +130,12 @@ func TestAccAzureRMDnsARecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsARecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsARecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		aName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_aaaa_record_test.go
+++ b/azurerm/resource_arm_dns_aaaa_record_test.go
@@ -130,12 +130,12 @@ func TestAccAzureRMDnsAAAARecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsAaaaRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsAaaaRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		aaaaName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_caa_record_test.go
+++ b/azurerm/resource_arm_dns_caa_record_test.go
@@ -130,12 +130,12 @@ func TestAccAzureRMDnsCaaRecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsCaaRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsCaaRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		caaName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_cname_record_test.go
+++ b/azurerm/resource_arm_dns_cname_record_test.go
@@ -154,12 +154,12 @@ func TestAccAzureRMDnsCNameRecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsCNameRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsCNameRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		cnameName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_mx_record_test.go
+++ b/azurerm/resource_arm_dns_mx_record_test.go
@@ -130,12 +130,12 @@ func TestAccAzureRMDnsMxRecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsMxRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsMxRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		mxName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_ns_record_test.go
+++ b/azurerm/resource_arm_dns_ns_record_test.go
@@ -244,12 +244,12 @@ func TestAccAzureRMDnsNsRecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsNsRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsNsRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		nsName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_ptr_record_test.go
+++ b/azurerm/resource_arm_dns_ptr_record_test.go
@@ -131,12 +131,12 @@ func TestAccAzureRMDnsPtrRecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsPtrRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsPtrRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		ptrName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_srv_record_test.go
+++ b/azurerm/resource_arm_dns_srv_record_test.go
@@ -130,12 +130,12 @@ func TestAccAzureRMDnsSrvRecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsSrvRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsSrvRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		srvName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_txt_record_test.go
+++ b/azurerm/resource_arm_dns_txt_record_test.go
@@ -128,12 +128,12 @@ func TestAccAzureRMDnsTxtRecord_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsTxtRecordExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsTxtRecordExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		txtName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_dns_zone_test.go
+++ b/azurerm/resource_arm_dns_zone_test.go
@@ -124,12 +124,12 @@ func TestAccAzureRMDnsZone_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMDnsZoneExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMDnsZoneExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		zoneName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_eventgrid_topic_test.go
+++ b/azurerm/resource_arm_eventgrid_topic_test.go
@@ -124,18 +124,18 @@ func testCheckAzureRMEventGridTopicDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMEventGridTopicExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMEventGridTopicExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for EventGrid Topic: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for EventGrid Topic: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).eventGridTopicsClient

--- a/azurerm/resource_arm_eventgrid_topic_test.go
+++ b/azurerm/resource_arm_eventgrid_topic_test.go
@@ -135,7 +135,7 @@ func testCheckAzureRMEventGridTopicExists(resourceName string) resource.TestChec
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for EventGrid Topic: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for EventGrid Topic: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).eventGridTopicsClient

--- a/azurerm/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/resource_arm_eventhub_authorization_rule_test.go
@@ -126,12 +126,12 @@ func testCheckAzureRMEventHubAuthorizationRuleDestroy(s *terraform.State) error 
 	return nil
 }
 
-func testCheckAzureRMEventHubAuthorizationRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMEventHubAuthorizationRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -139,7 +139,7 @@ func testCheckAzureRMEventHubAuthorizationRuleExists(name string) resource.TestC
 		eventHubName := rs.Primary.Attributes["eventhub_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubClient

--- a/azurerm/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/resource_arm_eventhub_authorization_rule_test.go
@@ -139,7 +139,7 @@ func testCheckAzureRMEventHubAuthorizationRuleExists(resourceName string) resour
 		eventHubName := rs.Primary.Attributes["eventhub_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubClient

--- a/azurerm/resource_arm_eventhub_consumer_group_test.go
+++ b/azurerm/resource_arm_eventhub_consumer_group_test.go
@@ -126,7 +126,7 @@ func testCheckAzureRMEventHubConsumerGroupExists(resourceName string) resource.T
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub Consumer Group: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub Consumer Group: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubConsumerGroupClient

--- a/azurerm/resource_arm_eventhub_consumer_group_test.go
+++ b/azurerm/resource_arm_eventhub_consumer_group_test.go
@@ -115,18 +115,18 @@ func testCheckAzureRMEventHubConsumerGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMEventHubConsumerGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMEventHubConsumerGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub Consumer Group: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub Consumer Group: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubConsumerGroupClient

--- a/azurerm/resource_arm_eventhub_namespace_authorization_rule_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_authorization_rule_test.go
@@ -124,19 +124,19 @@ func testCheckAzureRMEventHubNamespaceAuthorizationRuleDestroy(s *terraform.Stat
 	return nil
 }
 
-func testCheckAzureRMEventHubNamespaceAuthorizationRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMEventHubNamespaceAuthorizationRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		namespaceName := rs.Primary.Attributes["namespace_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubNamespacesClient

--- a/azurerm/resource_arm_eventhub_namespace_authorization_rule_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_authorization_rule_test.go
@@ -136,7 +136,7 @@ func testCheckAzureRMEventHubNamespaceAuthorizationRuleExists(resourceName strin
 		namespaceName := rs.Primary.Attributes["namespace_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubNamespacesClient

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -315,12 +315,12 @@ func testCheckAzureRMEventHubNamespaceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMEventHubNamespaceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMEventHubNamespaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		namespaceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -355,19 +355,19 @@ func testCheckAzureRMEventHubDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMEventHubExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMEventHubExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		namespaceName := rs.Primary.Attributes["namespace_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubClient

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -367,7 +367,7 @@ func testCheckAzureRMEventHubExists(resourceName string) resource.TestCheckFunc 
 		namespaceName := rs.Primary.Attributes["namespace_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Event Hub: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).eventHubClient

--- a/azurerm/resource_arm_express_route_circuit_authorization_test.go
+++ b/azurerm/resource_arm_express_route_circuit_authorization_test.go
@@ -59,11 +59,11 @@ func testAccAzureRMExpressRouteCircuitAuthorization_multiple(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMExpressRouteCircuitAuthorizationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMExpressRouteCircuitAuthorizationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		authorizationName := rs.Primary.Attributes["name"]
@@ -79,7 +79,7 @@ func testCheckAzureRMExpressRouteCircuitAuthorizationExists(name string) resourc
 		resp, err := client.Get(ctx, resourceGroup, expressRouteCircuitName, authorizationName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Express Route Circuit Authorization %q (Circuit %q / Resource Group: %q) does not exist", name, expressRouteCircuitName, resourceGroup)
+				return fmt.Errorf("Bad: Express Route Circuit Authorization %q (Circuit %q / Resource Group: %q) does not exist", authorizationName, expressRouteCircuitName, resourceGroup)
 			}
 
 			return fmt.Errorf("Bad: Get on expressRouteAuthsClient: %+v", err)

--- a/azurerm/resource_arm_express_route_circuit_peering_test.go
+++ b/azurerm/resource_arm_express_route_circuit_peering_test.go
@@ -66,11 +66,11 @@ func testAccAzureRMExpressRouteCircuitPeering_microsoftPeering(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMExpressRouteCircuitPeeringExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMExpressRouteCircuitPeeringExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		peeringType := rs.Primary.Attributes["peering_type"]

--- a/azurerm/resource_arm_express_route_circuit_test.go
+++ b/azurerm/resource_arm_express_route_circuit_test.go
@@ -238,11 +238,11 @@ func testAccAzureRMExpressRouteCircuit_allowClassicOperationsUpdate(t *testing.T
 	})
 }
 
-func testCheckAzureRMExpressRouteCircuitExists(name string, erc *network.ExpressRouteCircuit) resource.TestCheckFunc {
+func testCheckAzureRMExpressRouteCircuitExists(resourceName string, erc *network.ExpressRouteCircuit) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		expressRouteCircuitName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_firewall_test.go
+++ b/azurerm/resource_arm_firewall_test.go
@@ -168,12 +168,12 @@ func TestAccAzureRMFirewall_disappears(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMFirewallExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMFirewallExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -197,12 +197,12 @@ func testCheckAzureRMFirewallExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMFirewallDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMFirewallDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -545,12 +545,12 @@ func testCheckAzureRMFunctionAppDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMFunctionAppExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMFunctionAppExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		functionAppName := rs.Primary.Attributes["name"]
@@ -574,12 +574,12 @@ func testCheckAzureRMFunctionAppExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMFunctionAppHasContentShare(name string) resource.TestCheckFunc {
+func testCheckAzureRMFunctionAppHasContentShare(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		functionAppName := rs.Primary.Attributes["name"]
@@ -606,12 +606,12 @@ func testCheckAzureRMFunctionAppHasContentShare(name string) resource.TestCheckF
 	}
 }
 
-func testCheckAzureRMFunctionAppHasNoContentShare(name string) resource.TestCheckFunc {
+func testCheckAzureRMFunctionAppHasNoContentShare(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		functionAppName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -223,14 +223,14 @@ func deprovisionVM(userName string, password string, hostName string, port strin
 	return nil
 }
 
-func testCheckAzureRMImageExists(name string, shouldExist bool) resource.TestCheckFunc {
+func testCheckAzureRMImageExists(resourceName string, shouldExist bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		log.Printf("[INFO] testing MANAGED IMAGE EXISTS - BEGIN.")
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		dName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_iothub_consumer_group_test.go
+++ b/azurerm/resource_arm_iothub_consumer_group_test.go
@@ -87,13 +87,13 @@ func testCheckAzureRMIotHubConsumerGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMIotHubConsumerGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMIotHubConsumerGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_iothub_test.go
+++ b/azurerm/resource_arm_iothub_test.go
@@ -107,13 +107,13 @@ func testCheckAzureRMIotHubDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMIotHubExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMIotHubExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 		iothubName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/resource_arm_key_vault_access_policy_test.go
@@ -115,12 +115,12 @@ func TestAccAzureRMKeyVaultAccessPolicy_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMKeyVaultAccessPolicyExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultAccessPolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		vaultName := rs.Primary.Attributes["vault_name"]

--- a/azurerm/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/resource_arm_key_vault_certificate_test.go
@@ -211,12 +211,12 @@ func testCheckAzureRMKeyVaultCertificateDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMKeyVaultCertificateExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultCertificateExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
@@ -237,12 +237,12 @@ func testCheckAzureRMKeyVaultCertificateExists(name string) resource.TestCheckFu
 	}
 }
 
-func testCheckAzureRMKeyVaultCertificateDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultCertificateDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]

--- a/azurerm/resource_arm_key_vault_key_test.go
+++ b/azurerm/resource_arm_key_vault_key_test.go
@@ -217,12 +217,12 @@ func testCheckAzureRMKeyVaultKeyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMKeyVaultKeyExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultKeyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
@@ -243,12 +243,12 @@ func testCheckAzureRMKeyVaultKeyExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMKeyVaultKeyDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultKeyDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_key_vault_secret_test.go
+++ b/azurerm/resource_arm_key_vault_secret_test.go
@@ -162,12 +162,12 @@ func testCheckAzureRMKeyVaultSecretDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMKeyVaultSecretExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultSecretExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
@@ -188,12 +188,12 @@ func testCheckAzureRMKeyVaultSecretExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMKeyVaultSecretDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultSecretDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]

--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -265,12 +265,12 @@ func testCheckAzureRMKeyVaultDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMKeyVaultExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		vaultName := rs.Primary.Attributes["name"]
@@ -295,12 +295,12 @@ func testCheckAzureRMKeyVaultExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMKeyVaultDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMKeyVaultDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		vaultName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -453,12 +453,12 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t *testing.
 	})
 }
 
-func testCheckAzureRMKubernetesClusterExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMKubernetesClusterExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -461,22 +461,22 @@ func testCheckAzureRMKubernetesClusterExists(resourceName string) resource.TestC
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceName := rs.Primary.Attributes["name"]
+		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Managed Kubernetes Cluster: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Managed Kubernetes Cluster: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).kubernetesClustersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		aks, err := client.Get(ctx, resourceGroup, resourceName)
+		aks, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on kubernetesClustersClient: %+v", err)
 		}
 
 		if aks.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Managed Kubernetes Cluster %q (Resource Group: %q) does not exist", resourceName, resourceGroup)
+			return fmt.Errorf("Bad: Managed Kubernetes Cluster %q (Resource Group: %q) does not exist", name, resourceGroup)
 		}
 
 		return nil

--- a/azurerm/resource_arm_loadbalancer_test.go
+++ b/azurerm/resource_arm_loadbalancer_test.go
@@ -189,11 +189,11 @@ func TestAccAzureRMLoadBalancer_emptyPrivateIP(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMLoadBalancerExists(name string, lb *network.LoadBalancer) resource.TestCheckFunc {
+func testCheckAzureRMLoadBalancerExists(resourceName string, lb *network.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		loadBalancerName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_local_network_gateway_test.go
+++ b/azurerm/resource_arm_local_network_gateway_test.go
@@ -216,12 +216,12 @@ func TestAccAzureRMLocalNetworkGateway_bgpSettingsComplete(t *testing.T) {
 // testCheckAzureRMLocalNetworkGatewayExists returns the resource.TestCheckFunc
 // which checks whether or not the expected local network gateway exists both
 // in the schema, and on Azure.
-func testCheckAzureRMLocalNetworkGatewayExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLocalNetworkGatewayExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// first check within the schema for the local network gateway:
-		res, ok := s.RootModule().Resources[name]
+		res, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Local network gateway '%s' not found.", name)
+			return fmt.Errorf("Local network gateway '%s' not found.", resourceName)
 		}
 
 		// then, extract the name and the resource group:
@@ -249,12 +249,12 @@ func testCheckAzureRMLocalNetworkGatewayExists(name string) resource.TestCheckFu
 	}
 }
 
-func testCheckAzureRMLocalNetworkGatewayDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMLocalNetworkGatewayDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// first check within the schema for the local network gateway:
-		res, ok := s.RootModule().Resources[name]
+		res, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Local network gateway '%s' not found.", name)
+			return fmt.Errorf("Local network gateway '%s' not found.", resourceName)
 		}
 
 		// then, extract the name and the resource group:

--- a/azurerm/resource_arm_log_analytics_solution_test.go
+++ b/azurerm/resource_arm_log_analytics_solution_test.go
@@ -84,12 +84,12 @@ func testCheckAzureRMLogAnalyticsSolutionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMLogAnalyticsSolutionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogAnalyticsSolutionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
+++ b/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
@@ -85,12 +85,12 @@ func testCheckAzureRMLogAnalyticsWorkspaceLinkedServiceDestroy(s *terraform.Stat
 	return nil
 }
 
-func testCheckAzureRMLogAnalyticsWorkspaceLinkedServiceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogAnalyticsWorkspaceLinkedServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_log_analytics_workspace_test.go
+++ b/azurerm/resource_arm_log_analytics_workspace_test.go
@@ -127,12 +127,12 @@ func testCheckAzureRMLogAnalyticsWorkspaceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMLogAnalyticsWorkspaceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogAnalyticsWorkspaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_logic_app_workflow_test.go
+++ b/azurerm/resource_arm_logic_app_workflow_test.go
@@ -76,11 +76,11 @@ func TestAccAzureRMLogicAppWorkflow_tags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMLogicAppWorkflowExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogicAppWorkflowExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		workflowName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_managed_disk_test.go
+++ b/azurerm/resource_arm_managed_disk_test.go
@@ -243,11 +243,11 @@ func TestAccAzureRMManagedDisk_importEmpty_withZone(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMManagedDiskExists(name string, d *compute.Disk, shouldExist bool) resource.TestCheckFunc {
+func testCheckAzureRMManagedDiskExists(resourceName string, d *compute.Disk, shouldExist bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		dName := rs.Primary.Attributes["name"]
@@ -303,11 +303,11 @@ func testCheckAzureRMManagedDiskDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testDeleteAzureRMVirtualMachine(name string) resource.TestCheckFunc {
+func testDeleteAzureRMVirtualMachine(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		vmName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_management_group_test.go
+++ b/azurerm/resource_arm_management_group_test.go
@@ -183,26 +183,26 @@ func TestAccAzureRMManagementGroup_withSubscriptions(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMManagementGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMManagementGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
-		name := rs.Primary.Attributes["group_id"]
+		groupName := rs.Primary.Attributes["group_id"]
 
 		client := testAccProvider.Meta().(*ArmClient).managementGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		recurse := false
-		resp, err := client.Get(ctx, name, "", &recurse, "", "no-cache")
+		resp, err := client.Get(ctx, groupName, "", &recurse, "", "no-cache")
 		if err != nil {
 			return fmt.Errorf("Bad: Get on managementGroupsClient: %s", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Management Group does not exist: %s", name)
+			return fmt.Errorf("Management Group does not exist: %s", groupName)
 		}
 
 		return nil

--- a/azurerm/resource_arm_mariadb_server_test.go
+++ b/azurerm/resource_arm_mariadb_server_test.go
@@ -245,7 +245,7 @@ func testCheckAzureRMMariaDbServerExists(resourceName string) resource.TestCheck
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MariaDB Server: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for MariaDB Server: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mariadbServersClient

--- a/azurerm/resource_arm_mariadb_server_test.go
+++ b/azurerm/resource_arm_mariadb_server_test.go
@@ -245,7 +245,7 @@ func testCheckAzureRMMariaDbServerExists(resourceName string) resource.TestCheck
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MariaDB Server: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for MariaDB Server: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mariadbServersClient

--- a/azurerm/resource_arm_metric_alertrule_test.go
+++ b/azurerm/resource_arm_metric_alertrule_test.go
@@ -137,7 +137,7 @@ func testCheckAzureRMMetricAlertRuleExists(resourceName string) resource.TestChe
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Alert Rule: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Alert Rule: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).monitorAlertRulesClient

--- a/azurerm/resource_arm_metric_alertrule_test.go
+++ b/azurerm/resource_arm_metric_alertrule_test.go
@@ -126,18 +126,18 @@ func TestAccAzureRMMetricAlertRule_sqlDatabaseStorage(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMMetricAlertRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMetricAlertRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Alert Rule: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Alert Rule: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).monitorAlertRulesClient

--- a/azurerm/resource_arm_monitor_action_group_test.go
+++ b/azurerm/resource_arm_monitor_action_group_test.go
@@ -482,22 +482,22 @@ func testCheckAzureRMMonitorActionGroupExists(resourceName string) resource.Test
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceName := rs.Primary.Attributes["name"]
+		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Action Group Instance: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Action Group Instance: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).monitorActionGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resp, err := conn.Get(ctx, resourceGroup, resourceName)
+		resp, err := conn.Get(ctx, resourceGroup, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on monitorActionGroupsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Action Group Instance %q (resource group: %q) does not exist", resourceName, resourceGroup)
+			return fmt.Errorf("Bad: Action Group Instance %q (resource group: %q) does not exist", name, resourceGroup)
 		}
 
 		return nil

--- a/azurerm/resource_arm_monitor_action_group_test.go
+++ b/azurerm/resource_arm_monitor_action_group_test.go
@@ -474,12 +474,12 @@ func testCheckAzureRMMonitorActionGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMMonitorActionGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMonitorActionGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_monitor_activity_log_alert_test.go
+++ b/azurerm/resource_arm_monitor_activity_log_alert_test.go
@@ -341,22 +341,22 @@ func testCheckAzureRMMonitorActivityLogAlertExists(resourceName string) resource
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceName := rs.Primary.Attributes["name"]
+		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Activity Log Alert Instance: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Activity Log Alert Instance: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).monitorActivityLogAlertsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resp, err := conn.Get(ctx, resourceGroup, resourceName)
+		resp, err := conn.Get(ctx, resourceGroup, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on monitorActivityLogAlertsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Activity Log Alert Instance %q (resource group: %q) does not exist", resourceName, resourceGroup)
+			return fmt.Errorf("Bad: Activity Log Alert Instance %q (resource group: %q) does not exist", name, resourceGroup)
 		}
 
 		return nil

--- a/azurerm/resource_arm_monitor_activity_log_alert_test.go
+++ b/azurerm/resource_arm_monitor_activity_log_alert_test.go
@@ -333,12 +333,12 @@ func testCheckAzureRMMonitorActivityLogAlertDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMMonitorActivityLogAlertExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMonitorActivityLogAlertExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_monitor_log_profile_test.go
+++ b/azurerm/resource_arm_monitor_log_profile_test.go
@@ -189,12 +189,12 @@ func testCheckAzureRMLogProfileDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMLogProfileExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogProfileExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).monitorLogProfilesClient
@@ -214,12 +214,12 @@ func testCheckAzureRMLogProfileExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMLogProfileDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMLogProfileDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_monitor_metric_alert_test.go
+++ b/azurerm/resource_arm_monitor_metric_alert_test.go
@@ -333,21 +333,21 @@ func testCheckAzureRMMonitorMetricAlertExists(resourceName string) resource.Test
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceName := rs.Primary.Attributes["name"]
+		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Metric Alert Instance: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Metric Alert Instance: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).monitorMetricAlertsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resp, err := conn.Get(ctx, resourceGroup, resourceName)
+		resp, err := conn.Get(ctx, resourceGroup, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on monitorMetricAlertsClient: %+v", err)
 		}
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Metric Alert Instance %q (resource group: %q) does not exist", resourceName, resourceGroup)
+			return fmt.Errorf("Bad: Metric Alert Instance %q (resource group: %q) does not exist", name, resourceGroup)
 		}
 
 		return nil

--- a/azurerm/resource_arm_monitor_metric_alert_test.go
+++ b/azurerm/resource_arm_monitor_metric_alert_test.go
@@ -325,12 +325,12 @@ func testCheckAzureRMMonitorMetricAlertDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMMonitorMetricAlertExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMonitorMetricAlertExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_mssql_elasticpool_test.go
+++ b/azurerm/resource_arm_mssql_elasticpool_test.go
@@ -180,11 +180,11 @@ func TestAccAzureRMMsSqlElasticPool_resize_vCore(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMMsSqlElasticPoolExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMsSqlElasticPoolExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -200,7 +200,7 @@ func testCheckAzureRMMsSqlElasticPoolExists(name string) resource.TestCheckFunc 
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: MsSql Elastic Pool %q on server: %q (resource group: %q) does not exist", name, serverName, resourceGroup)
+			return fmt.Errorf("Bad: MsSql Elastic Pool %q on server: %q (resource group: %q) does not exist", poolName, serverName, resourceGroup)
 		}
 
 		return nil
@@ -233,12 +233,12 @@ func testCheckAzureRMMsSqlElasticPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMMsSqlElasticPoolDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMMsSqlElasticPoolDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_mysql_configuration_test.go
+++ b/azurerm/resource_arm_mysql_configuration_test.go
@@ -124,7 +124,7 @@ func testCheckAzureRMMySQLConfigurationValue(resourceName string, value string) 
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Configuration: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Configuration: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlConfigurationsClient

--- a/azurerm/resource_arm_mysql_configuration_test.go
+++ b/azurerm/resource_arm_mysql_configuration_test.go
@@ -124,7 +124,7 @@ func testCheckAzureRMMySQLConfigurationValue(resourceName string, value string) 
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Configuration: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Configuration: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlConfigurationsClient

--- a/azurerm/resource_arm_mysql_database_test.go
+++ b/azurerm/resource_arm_mysql_database_test.go
@@ -87,19 +87,19 @@ func TestAccAzureRMMySQLDatabase_charsetMixedcase(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMMySQLDatabaseExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMySQLDatabaseExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Database: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Database: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlDatabasesClient

--- a/azurerm/resource_arm_mysql_database_test.go
+++ b/azurerm/resource_arm_mysql_database_test.go
@@ -99,7 +99,7 @@ func testCheckAzureRMMySQLDatabaseExists(resourceName string) resource.TestCheck
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Database: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Database: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlDatabasesClient

--- a/azurerm/resource_arm_mysql_firewall_rule_test.go
+++ b/azurerm/resource_arm_mysql_firewall_rule_test.go
@@ -47,7 +47,7 @@ func testCheckAzureRMMySQLFirewallRuleExists(resourceName string) resource.TestC
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Firewall Rule: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Firewall Rule: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlFirewallRulesClient

--- a/azurerm/resource_arm_mysql_firewall_rule_test.go
+++ b/azurerm/resource_arm_mysql_firewall_rule_test.go
@@ -35,19 +35,19 @@ func TestAccAzureRMMySQLFirewallRule_basic(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMMySQLFirewallRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMySQLFirewallRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Firewall Rule: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Firewall Rule: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlFirewallRulesClient

--- a/azurerm/resource_arm_mysql_server_test.go
+++ b/azurerm/resource_arm_mysql_server_test.go
@@ -218,7 +218,7 @@ func testCheckAzureRMMySQLServerExists(resourceName string) resource.TestCheckFu
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Server: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Server: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlServersClient

--- a/azurerm/resource_arm_mysql_server_test.go
+++ b/azurerm/resource_arm_mysql_server_test.go
@@ -207,18 +207,18 @@ func TestAccAzureRMMySQLServer_updateSKU(t *testing.T) {
 
 //
 
-func testCheckAzureRMMySQLServerExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMySQLServerExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for MySQL Server: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for MySQL Server: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).mysqlServersClient

--- a/azurerm/resource_arm_mysql_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_mysql_virtual_network_rule_test.go
@@ -111,11 +111,11 @@ func TestAccAzureRMMySqlVirtualNetworkRule_multipleSubnets(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMMySqlVirtualNetworkRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMMySqlVirtualNetworkRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -166,12 +166,12 @@ func testCheckAzureRMMySqlVirtualNetworkRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMMySqlVirtualNetworkRuleDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMMySqlVirtualNetworkRuleDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_network_interface_application_gateway_association_test.go
+++ b/azurerm/resource_arm_network_interface_application_gateway_association_test.go
@@ -53,12 +53,12 @@ func TestAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociati
 	})
 }
 
-func testCheckAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
@@ -103,12 +103,12 @@ func testCheckAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssocia
 	}
 }
 
-func testCheckAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])

--- a/azurerm/resource_arm_network_interface_backend_address_pool_association_test.go
+++ b/azurerm/resource_arm_network_interface_backend_address_pool_association_test.go
@@ -53,12 +53,12 @@ func TestAccAzureRMNetworkInterfaceBackendAddressPoolAssociation_deleted(t *test
 	})
 }
 
-func testCheckAzureRMNetworkInterfaceBackendAddressPoolAssociationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceBackendAddressPoolAssociationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
@@ -103,12 +103,12 @@ func testCheckAzureRMNetworkInterfaceBackendAddressPoolAssociationExists(name st
 	}
 }
 
-func testCheckAzureRMNetworkInterfaceBackendAddressPoolAssociationDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceBackendAddressPoolAssociationDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])

--- a/azurerm/resource_arm_network_interface_nat_rule_association_test.go
+++ b/azurerm/resource_arm_network_interface_nat_rule_association_test.go
@@ -53,12 +53,12 @@ func TestAccAzureRMNetworkInterfaceNATRuleAssociation_deleted(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNetworkInterfaceNATRuleAssociationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceNATRuleAssociationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
@@ -103,12 +103,12 @@ func testCheckAzureRMNetworkInterfaceNATRuleAssociationExists(name string) resou
 	}
 }
 
-func testCheckAzureRMNetworkInterfaceNATRuleAssociationDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceNATRuleAssociationDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -424,12 +424,12 @@ func TestAccAzureRMNetworkInterface_importPublicIP(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNetworkInterfaceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -454,12 +454,12 @@ func testCheckAzureRMNetworkInterfaceExists(name string) resource.TestCheckFunc 
 	}
 }
 
-func testCheckAzureRMNetworkInterfaceDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkInterfaceDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_network_security_group_test.go
+++ b/azurerm/resource_arm_network_security_group_test.go
@@ -216,12 +216,12 @@ func TestAccAzureRMNetworkSecurityGroup_applicationSecurityGroup(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNetworkSecurityGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkSecurityGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		sgName := rs.Primary.Attributes["name"]
@@ -235,7 +235,7 @@ func testCheckAzureRMNetworkSecurityGroupExists(name string) resource.TestCheckF
 		resp, err := client.Get(ctx, resourceGroup, sgName, "")
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Network Security Group %q (resource group: %q) does not exist", name, resourceGroup)
+				return fmt.Errorf("Bad: Network Security Group %q (resource group: %q) does not exist", sgName, resourceGroup)
 			}
 
 			return fmt.Errorf("Bad: Get on secGroupClient: %+v", err)
@@ -245,12 +245,12 @@ func testCheckAzureRMNetworkSecurityGroupExists(name string) resource.TestCheckF
 	}
 }
 
-func testCheckAzureRMNetworkSecurityGroupDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkSecurityGroupDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		sgName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_network_security_rule_test.go
+++ b/azurerm/resource_arm_network_security_rule_test.go
@@ -127,12 +127,12 @@ func TestAccAzureRMNetworkSecurityRule_applicationSecurityGroups(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNetworkSecurityRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkSecurityRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		sgName := rs.Primary.Attributes["network_security_group_name"]
@@ -157,12 +157,12 @@ func testCheckAzureRMNetworkSecurityRuleExists(name string) resource.TestCheckFu
 	}
 }
 
-func testCheckAzureRMNetworkSecurityRuleDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkSecurityRuleDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		sgName := rs.Primary.Attributes["network_security_group_name"]

--- a/azurerm/resource_arm_network_watcher_test.go
+++ b/azurerm/resource_arm_network_watcher_test.go
@@ -134,12 +134,12 @@ func testAccAzureRMNetworkWatcher_disappears(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNetworkWatcherExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkWatcherExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -163,12 +163,12 @@ func testCheckAzureRMNetworkWatcherExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMNetworkWatcherDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMNetworkWatcherDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_notification_hub_authorization_rule_test.go
+++ b/azurerm/resource_arm_notification_hub_authorization_rule_test.go
@@ -140,11 +140,11 @@ func TestAccAzureRMNotificationHubAuthorizationRule_updated(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNotificationHubAuthorizationRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNotificationHubAuthorizationRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).notificationHubsClient
@@ -161,7 +161,7 @@ func testCheckAzureRMNotificationHubAuthorizationRuleExists(name string) resourc
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Notification Hub Authorization Rule does not exist: %s", name)
+			return fmt.Errorf("Notification Hub Authorization Rule does not exist: %s", ruleName)
 		}
 
 		return nil

--- a/azurerm/resource_arm_notification_hub_namespace_test.go
+++ b/azurerm/resource_arm_notification_hub_namespace_test.go
@@ -36,11 +36,11 @@ func TestAccAzureRMNotificationHubNamespace_free(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNotificationHubNamespaceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNotificationHubNamespaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).notificationNamespacesClient
@@ -55,7 +55,7 @@ func testCheckAzureRMNotificationHubNamespaceExists(name string) resource.TestCh
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Notification Hub Namespace does not exist: %s", name)
+			return fmt.Errorf("Notification Hub Namespace does not exist: %s", namespaceName)
 		}
 
 		return nil

--- a/azurerm/resource_arm_notification_hub_test.go
+++ b/azurerm/resource_arm_notification_hub_test.go
@@ -38,11 +38,11 @@ func TestAccAzureRMNotificationHub_basic(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMNotificationHubExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMNotificationHubExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).notificationHubsClient
@@ -58,7 +58,7 @@ func testCheckAzureRMNotificationHubExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Notification Hub does not exist: %s", name)
+			return fmt.Errorf("Notification Hub does not exist: %s", hubName)
 		}
 
 		return nil

--- a/azurerm/resource_arm_packet_capture_test.go
+++ b/azurerm/resource_arm_packet_capture_test.go
@@ -116,11 +116,11 @@ func testAccAzureRMPacketCapture_withFilters(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMPacketCaptureExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPacketCaptureExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -136,7 +136,7 @@ func testCheckAzureRMPacketCaptureExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Packet Capture does not exist: %s", name)
+			return fmt.Errorf("Packet Capture does not exist: %s", packetCaptureName)
 		}
 
 		return nil

--- a/azurerm/resource_arm_policy_assignment_test.go
+++ b/azurerm/resource_arm_policy_assignment_test.go
@@ -62,11 +62,11 @@ func TestAccAzureRMPolicyAssignment_complete(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMPolicyAssignmentExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPolicyAssignmentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).policyAssignmentsClient
@@ -79,7 +79,7 @@ func testCheckAzureRMPolicyAssignmentExists(name string) resource.TestCheckFunc 
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Policy Assignment does not exist: %s", name)
+			return fmt.Errorf("Policy Assignment does not exist: %s", id)
 		}
 
 		return nil

--- a/azurerm/resource_arm_policy_definition_test.go
+++ b/azurerm/resource_arm_policy_definition_test.go
@@ -87,11 +87,11 @@ func testCheckAzureRMPolicyDefinitionExistsInMgmtGroup(policyName string, manage
 	}
 }
 
-func testCheckAzureRMPolicyDefinitionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPolicyDefinitionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		policyName := rs.Primary.Attributes["name"]
@@ -105,7 +105,7 @@ func testCheckAzureRMPolicyDefinitionExists(name string) resource.TestCheckFunc 
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("policy does not exist: %s", name)
+			return fmt.Errorf("policy does not exist: %s", policyName)
 		}
 
 		return nil

--- a/azurerm/resource_arm_policy_set_definition_test.go
+++ b/azurerm/resource_arm_policy_set_definition_test.go
@@ -167,11 +167,11 @@ POLICY_DEFINITIONS
 `, ri, ri, ri, ri)
 }
 
-func testCheckAzureRMPolicySetDefinitionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPolicySetDefinitionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("not found: %s", name)
+			return fmt.Errorf("not found: %s", resourceName)
 		}
 
 		policySetName := rs.Primary.Attributes["name"]
@@ -185,7 +185,7 @@ func testCheckAzureRMPolicySetDefinitionExists(name string) resource.TestCheckFu
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("policy set definition does not exist: %s", name)
+			return fmt.Errorf("policy set definition does not exist: %s", policySetName)
 		}
 
 		return nil

--- a/azurerm/resource_arm_postgresql_configuration_test.go
+++ b/azurerm/resource_arm_postgresql_configuration_test.go
@@ -124,7 +124,7 @@ func testCheckAzureRMPostgreSQLConfigurationValue(resourceName string, value str
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Configuration: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Configuration: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlConfigurationsClient

--- a/azurerm/resource_arm_postgresql_configuration_test.go
+++ b/azurerm/resource_arm_postgresql_configuration_test.go
@@ -124,7 +124,7 @@ func testCheckAzureRMPostgreSQLConfigurationValue(resourceName string, value str
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Configuration: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Configuration: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlConfigurationsClient

--- a/azurerm/resource_arm_postgresql_database_test.go
+++ b/azurerm/resource_arm_postgresql_database_test.go
@@ -76,19 +76,19 @@ func TestAccAzureRMPostgreSQLDatabase_charsetMixedcase(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMPostgreSQLDatabaseExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPostgreSQLDatabaseExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Database: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Database: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlDatabasesClient

--- a/azurerm/resource_arm_postgresql_database_test.go
+++ b/azurerm/resource_arm_postgresql_database_test.go
@@ -88,7 +88,7 @@ func testCheckAzureRMPostgreSQLDatabaseExists(resourceName string) resource.Test
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Database: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Database: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlDatabasesClient

--- a/azurerm/resource_arm_postgresql_firewall_rule_test.go
+++ b/azurerm/resource_arm_postgresql_firewall_rule_test.go
@@ -49,7 +49,7 @@ func testCheckAzureRMPostgreSQLFirewallRuleExists(resourceName string) resource.
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Firewall Rule: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Firewall Rule: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlFirewallRulesClient

--- a/azurerm/resource_arm_postgresql_firewall_rule_test.go
+++ b/azurerm/resource_arm_postgresql_firewall_rule_test.go
@@ -37,19 +37,19 @@ func TestAccAzureRMPostgreSQLFirewallRule_basic(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMPostgreSQLFirewallRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPostgreSQLFirewallRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		serverName := rs.Primary.Attributes["server_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Firewall Rule: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Firewall Rule: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlFirewallRulesClient

--- a/azurerm/resource_arm_postgresql_server_test.go
+++ b/azurerm/resource_arm_postgresql_server_test.go
@@ -295,18 +295,18 @@ func TestAccAzureRMPostgreSQLServer_updateSKU(t *testing.T) {
 
 //
 
-func testCheckAzureRMPostgreSQLServerExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPostgreSQLServerExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Server: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Server: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlServersClient

--- a/azurerm/resource_arm_postgresql_server_test.go
+++ b/azurerm/resource_arm_postgresql_server_test.go
@@ -306,7 +306,7 @@ func testCheckAzureRMPostgreSQLServerExists(resourceName string) resource.TestCh
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Server: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for PostgreSQL Server: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).postgresqlServersClient

--- a/azurerm/resource_arm_postgresql_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_postgresql_virtual_network_rule_test.go
@@ -139,11 +139,11 @@ func TestAccAzureRMPostgreSQLVirtualNetworkRule_IgnoreEndpointValid(t *testing.T
 	})
 }
 
-func testCheckAzureRMPostgreSQLVirtualNetworkRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPostgreSQLVirtualNetworkRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -194,12 +194,12 @@ func testCheckAzureRMPostgreSQLVirtualNetworkRuleDestroy(s *terraform.State) err
 	return nil
 }
 
-func testCheckAzureRMPostgreSQLVirtualNetworkRuleDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMPostgreSQLVirtualNetworkRuleDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_public_ip_test.go
+++ b/azurerm/resource_arm_public_ip_test.go
@@ -409,12 +409,12 @@ func TestAccAzureRMPublicIpStatic_canLabelBe63(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMPublicIpExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMPublicIpExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		publicIPName := rs.Primary.Attributes["name"]
@@ -432,19 +432,19 @@ func testCheckAzureRMPublicIpExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Public IP %q (resource group: %q) does not exist", name, resourceGroup)
+			return fmt.Errorf("Bad: Public IP %q (resource group: %q) does not exist", publicIPName, resourceGroup)
 		}
 
 		return nil
 	}
 }
 
-func testCheckAzureRMPublicIpDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMPublicIpDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		publicIpName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_recovery_services_protection_policy_vm_test.go
+++ b/azurerm/resource_arm_recovery_services_protection_policy_vm_test.go
@@ -266,13 +266,12 @@ func testCheckAzureRMRecoveryServicesProtectionPolicyVmExists(resourceName strin
 			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Recovery Services Vault Policy: %q", resourceName)
-		}
-
 		vaultName := rs.Primary.Attributes["recovery_vault_name"]
 		policyName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for Recovery Services Vault %q Policy: %q", vaultName, policyName)
+		}
 
 		resp, err := client.Get(ctx, vaultName, resourceGroup, policyName)
 		if err != nil {

--- a/azurerm/resource_arm_recovery_services_vault_test.go
+++ b/azurerm/resource_arm_recovery_services_vault_test.go
@@ -70,12 +70,12 @@ func testCheckAzureRMRecoveryServicesVaultDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMRecoveryServicesVaultExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMRecoveryServicesVaultExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -451,12 +451,12 @@ func TestAccAzureRMRedisCache_InternalSubnetStaticIP(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMRedisCacheExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMRedisCacheExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		redisName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_redis_firewall_rule_test.go
+++ b/azurerm/resource_arm_redis_firewall_rule_test.go
@@ -103,12 +103,12 @@ func TestAccAzureRMRedisFirewallRule_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMRedisFirewallRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMRedisFirewallRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_resource_group_test.go
+++ b/azurerm/resource_arm_resource_group_test.go
@@ -145,12 +145,12 @@ func TestAccAzureRMResourceGroup_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMResourceGroupExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMResourceGroupExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["name"]
@@ -165,19 +165,19 @@ func testCheckAzureRMResourceGroupExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Virtual Network %q (resource group: %q) does not exist", name, resourceGroup)
+			return fmt.Errorf("Bad: resource group: %q does not exist", resourceGroup)
 		}
 
 		return nil
 	}
 }
 
-func testCheckAzureRMResourceGroupDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMResourceGroupDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_role_assignment_test.go
+++ b/azurerm/resource_arm_role_assignment_test.go
@@ -165,11 +165,11 @@ func testAccAzureRMRoleAssignment_custom(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMRoleAssignmentExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMRoleAssignmentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		scope := rs.Primary.Attributes["scope"]
@@ -181,7 +181,7 @@ func testCheckAzureRMRoleAssignmentExists(name string) resource.TestCheckFunc {
 
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Role Assignment %q (Scope: %q) does not exist", name, scope)
+				return fmt.Errorf("Bad: Role Assignment %q (Scope: %q) does not exist", roleAssignmentName, scope)
 			}
 			return fmt.Errorf("Bad: Get on roleDefinitionsClient: %+v", err)
 		}

--- a/azurerm/resource_arm_role_definition_test.go
+++ b/azurerm/resource_arm_role_definition_test.go
@@ -123,11 +123,11 @@ func TestAccAzureRMRoleDefinition_emptyName(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMRoleDefinitionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMRoleDefinitionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		scope := rs.Primary.Attributes["scope"]
@@ -139,7 +139,7 @@ func testCheckAzureRMRoleDefinitionExists(name string) resource.TestCheckFunc {
 
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Role Definition %q (Scope: %q) does not exist", name, scope)
+				return fmt.Errorf("Bad: Role Definition %q (Scope: %q) does not exist", roleDefinitionId, scope)
 			}
 			return fmt.Errorf("Bad: Get on roleDefinitionsClient: %+v", err)
 		}

--- a/azurerm/resource_arm_route_table_test.go
+++ b/azurerm/resource_arm_route_table_test.go
@@ -271,12 +271,12 @@ func TestAccAzureRMRouteTable_withTagsSubnet(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMRouteTableExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMRouteTableExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -301,11 +301,11 @@ func testCheckAzureRMRouteTableExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMRouteTableDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMRouteTableDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_route_test.go
+++ b/azurerm/resource_arm_route_test.go
@@ -121,12 +121,12 @@ func TestAccAzureRMRoute_multipleRoutes(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMRouteExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMRouteExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -151,19 +151,19 @@ func testCheckAzureRMRouteExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMRouteDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMRouteDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		rtName := rs.Primary.Attributes["route_table_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for route: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for route: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).routesClient

--- a/azurerm/resource_arm_route_test.go
+++ b/azurerm/resource_arm_route_test.go
@@ -163,7 +163,7 @@ func testCheckAzureRMRouteDisappears(resourceName string) resource.TestCheckFunc
 		rtName := rs.Primary.Attributes["route_table_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for route: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for route: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).routesClient

--- a/azurerm/resource_arm_scheduler_job_collection_test.go
+++ b/azurerm/resource_arm_scheduler_job_collection_test.go
@@ -90,12 +90,12 @@ func testCheckAzureRMSchedulerJobCollectionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSchedulerJobCollectionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSchedulerJobCollectionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_scheduler_job_test.go
+++ b/azurerm/resource_arm_scheduler_job_test.go
@@ -502,12 +502,12 @@ func testCheckAzureRMSchedulerJobDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSchedulerJobExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSchedulerJobExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %q", name)
+			return fmt.Errorf("Not found: %q", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -65,12 +65,12 @@ func TestAccAzureRMSearchService_complete(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSearchServiceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSearchServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_security_center_contact_test.go
+++ b/azurerm/resource_arm_security_center_contact_test.go
@@ -73,14 +73,14 @@ func TestAccAzureRMSecurityCenterContact_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSecurityCenterContactExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSecurityCenterContactExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*ArmClient).securityCenterContactsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		contactName := rs.Primary.Attributes["securityContacts"]

--- a/azurerm/resource_arm_security_center_subscription_pricing_test.go
+++ b/azurerm/resource_arm_security_center_subscription_pricing_test.go
@@ -44,14 +44,14 @@ func testAccAzureRMSecurityCenterSubscriptionPricing_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSecurityCenterSubscriptionPricingExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSecurityCenterSubscriptionPricingExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*ArmClient).securityCenterPricingClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		pricingName := rs.Primary.Attributes["pricings"]

--- a/azurerm/resource_arm_security_center_workspace_test.go
+++ b/azurerm/resource_arm_security_center_workspace_test.go
@@ -79,14 +79,14 @@ func testAccAzureRMSecurityCenterWorkspace_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSecurityCenterWorkspaceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSecurityCenterWorkspaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*ArmClient).securityCenterWorkspaceClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		contactName := rs.Primary.Attributes["workspaceSettings"]

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -508,12 +508,12 @@ func testCheckAzureRMServiceFabricClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMServiceFabricClusterExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceFabricClusterExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		clusterName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
@@ -137,7 +137,7 @@ func testCheckAzureRMServiceBusNamespaceAuthorizationRuleExists(resourceName str
 		namespaceName := rs.Primary.Attributes["namespace_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Namespace: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Namespace: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).serviceBusNamespacesClient

--- a/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
@@ -125,19 +125,19 @@ func testCheckAzureRMServiceBusNamespaceAuthorizationRuleDestroy(s *terraform.St
 	return nil
 }
 
-func testCheckAzureRMServiceBusNamespaceAuthorizationRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceBusNamespaceAuthorizationRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		namespaceName := rs.Primary.Attributes["namespace_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Namespace: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Namespace: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).serviceBusNamespacesClient

--- a/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_test.go
@@ -197,12 +197,12 @@ func testCheckAzureRMServiceBusNamespaceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMServiceBusNamespaceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceBusNamespaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		namespaceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
@@ -126,11 +126,11 @@ func testCheckAzureRMServiceBusQueueAuthorizationRuleDestroy(s *terraform.State)
 	return nil
 }
 
-func testCheckAzureRMServiceBusQueueAuthorizationRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceBusQueueAuthorizationRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -139,7 +139,7 @@ func testCheckAzureRMServiceBusQueueAuthorizationRuleExists(name string) resourc
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Queue Authorization Rule: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Queue Authorization Rule: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).serviceBusQueuesClient

--- a/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
@@ -139,7 +139,7 @@ func testCheckAzureRMServiceBusQueueAuthorizationRuleExists(resourceName string)
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Queue Authorization Rule: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Queue Authorization Rule: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).serviceBusQueuesClient

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -355,12 +355,12 @@ func testCheckAzureRMServiceBusQueueDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMServiceBusQueueExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceBusQueueExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		queueName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -193,12 +193,12 @@ func testCheckAzureRMServiceBusSubscriptionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMServiceBusSubscriptionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceBusSubscriptionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		subscriptionName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
@@ -125,12 +125,12 @@ func testCheckAzureRMServiceBusTopicAuthorizationRuleDestroy(s *terraform.State)
 	return nil
 }
 
-func testCheckAzureRMServiceBusTopicAuthorizationRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceBusTopicAuthorizationRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -138,7 +138,7 @@ func testCheckAzureRMServiceBusTopicAuthorizationRuleExists(name string) resourc
 		topicName := rs.Primary.Attributes["topic_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Topic: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Topic: %s", resourceName)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).serviceBusTopicsClient

--- a/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
@@ -138,7 +138,7 @@ func testCheckAzureRMServiceBusTopicAuthorizationRuleExists(resourceName string)
 		topicName := rs.Primary.Attributes["topic_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Topic: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Topic: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).serviceBusTopicsClient

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -284,12 +284,12 @@ func testCheckAzureRMServiceBusTopicDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMServiceBusTopicExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMServiceBusTopicExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		topicName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_shared_image_gallery_test.go
+++ b/azurerm/resource_arm_shared_image_gallery_test.go
@@ -94,12 +94,12 @@ func testCheckAzureRMSharedImageGalleryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSharedImageGalleryExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSharedImageGalleryExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		galleryName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_shared_image_test.go
+++ b/azurerm/resource_arm_shared_image_test.go
@@ -96,12 +96,12 @@ func testCheckAzureRMSharedImageDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSharedImageExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSharedImageExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		imageName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -92,12 +92,12 @@ func testCheckAzureRMSharedImageVersionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSharedImageVersionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSharedImageVersionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		imageVersion := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -329,21 +329,21 @@ func testCheckAzureRMSignalRServiceExists(resourceName string) resource.TestChec
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceName := rs.Primary.Attributes["name"]
+		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for SignalR service: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for SignalR service: %s", name)
 		}
 
 		conn := testAccProvider.Meta().(*ArmClient).signalRClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resp, err := conn.Get(ctx, resourceGroup, resourceName)
+		resp, err := conn.Get(ctx, resourceGroup, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on signalRClient: %+v", err)
 		}
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: SignalR service %q (resource group: %q) does not exist", resourceName, resourceGroup)
+			return fmt.Errorf("Bad: SignalR service %q (resource group: %q) does not exist", name, resourceGroup)
 		}
 
 		return nil

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -321,12 +321,12 @@ func testCheckAzureRMSignalRServiceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSignalRServiceExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSignalRServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_snapshot_test.go
+++ b/azurerm/resource_arm_snapshot_test.go
@@ -225,12 +225,12 @@ func testCheckAzureRMSnapshotDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSnapshotExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSnapshotExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_sql_administrator_test.go
+++ b/azurerm/resource_arm_sql_administrator_test.go
@@ -66,11 +66,11 @@ func TestAccAzureRMSqlAdministrator_disappears(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSqlAdministratorExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlAdministratorExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -84,11 +84,11 @@ func testCheckAzureRMSqlAdministratorExists(name string) resource.TestCheckFunc 
 	}
 }
 
-func testCheckAzureRMSqlAdministratorDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlAdministratorDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_sql_database_test.go
+++ b/azurerm/resource_arm_sql_database_test.go
@@ -272,12 +272,12 @@ func TestAccAzureRMSqlDatabase_threatDetectionPolicy(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSqlDatabaseExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlDatabaseExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -328,12 +328,12 @@ func testCheckAzureRMSqlDatabaseDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSqlDatabaseDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlDatabaseDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_sql_elasticpool_test.go
+++ b/azurerm/resource_arm_sql_elasticpool_test.go
@@ -89,11 +89,11 @@ func TestAccAzureRMSqlElasticPool_resizeDtu(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSqlElasticPoolExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlElasticPoolExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -109,7 +109,7 @@ func testCheckAzureRMSqlElasticPoolExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: SQL Elastic Pool %q on server: %q (resource group: %q) does not exist", name, serverName, resourceGroup)
+			return fmt.Errorf("Bad: SQL Elastic Pool %q on server: %q (resource group: %q) does not exist", poolName, serverName, resourceGroup)
 		}
 
 		return nil
@@ -143,12 +143,12 @@ func testCheckAzureRMSqlElasticPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSqlElasticPoolDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlElasticPoolDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_sql_firewall_rule_test.go
+++ b/azurerm/resource_arm_sql_firewall_rule_test.go
@@ -68,11 +68,11 @@ func TestAccAzureRMSqlFirewallRule_disappears(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSqlFirewallRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlFirewallRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -123,12 +123,12 @@ func testCheckAzureRMSqlFirewallRuleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSqlFirewallRuleDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlFirewallRuleDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -144,12 +144,12 @@ func TestAccAzureRMSqlServer_withTags(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSqlServerExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlServerExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		sqlServerName := rs.Primary.Attributes["name"]
@@ -201,12 +201,12 @@ func testCheckAzureRMSqlServerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCheckAzureRMSqlServerDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlServerDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_sql_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_sql_virtual_network_rule_test.go
@@ -320,11 +320,11 @@ func TestResourceAzureRMSqlVirtualNetworkRule_validNameValidation(t *testing.T) 
 /*
 	Test Check function to assert if a rule exists or not.
 */
-func testCheckAzureRMSqlVirtualNetworkRuleExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlVirtualNetworkRuleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -381,12 +381,12 @@ func testCheckAzureRMSqlVirtualNetworkRuleDestroy(s *terraform.State) error {
 /*
 	Test Check function to assert if that a rule gets deleted.
 */
-func testCheckAzureRMSqlVirtualNetworkRuleDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSqlVirtualNetworkRuleDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -530,12 +530,12 @@ func TestAccAzureRMStorageAccount_networkRulesDeleted(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMStorageAccountExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMStorageAccountExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		storageAccount := rs.Primary.Attributes["name"]
@@ -551,19 +551,19 @@ func testCheckAzureRMStorageAccountExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: StorageAccount %q (resource group: %q) does not exist", name, resourceGroup)
+			return fmt.Errorf("Bad: StorageAccount %q (resource group: %q) does not exist", storageAccount, resourceGroup)
 		}
 
 		return nil
 	}
 }
 
-func testCheckAzureRMStorageAccountDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMStorageAccountDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		storageAccount := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -247,12 +247,12 @@ func TestAccAzureRMStorageBlobBlock_blockContentType(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMStorageBlobExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMStorageBlobExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -260,7 +260,7 @@ func testCheckAzureRMStorageBlobExists(name string) resource.TestCheckFunc {
 		storageContainerName := rs.Primary.Attributes["storage_container_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -288,12 +288,12 @@ func testCheckAzureRMStorageBlobExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMStorageBlobDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMStorageBlobDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -301,7 +301,7 @@ func testCheckAzureRMStorageBlobDisappears(name string) resource.TestCheckFunc {
 		storageContainerName := rs.Primary.Attributes["storage_container_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -322,12 +322,12 @@ func testCheckAzureRMStorageBlobDisappears(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMStorageBlobMatchesFile(name string, kind storage.BlobType, filePath string) resource.TestCheckFunc {
+func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind storage.BlobType, filePath string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -335,7 +335,7 @@ func testCheckAzureRMStorageBlobMatchesFile(name string, kind storage.BlobType, 
 		storageContainerName := rs.Primary.Attributes["storage_container_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -260,7 +260,7 @@ func testCheckAzureRMStorageBlobExists(resourceName string) resource.TestCheckFu
 		storageContainerName := rs.Primary.Attributes["storage_container_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -301,7 +301,7 @@ func testCheckAzureRMStorageBlobDisappears(resourceName string) resource.TestChe
 		storageContainerName := rs.Primary.Attributes["storage_container_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -335,7 +335,7 @@ func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind storage.Bl
 		storageContainerName := rs.Primary.Attributes["storage_container_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for storage blob: %s", name)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -144,7 +144,7 @@ func testCheckAzureRMStorageContainerExists(resourceName string, c *storage.Cont
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage container: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for storage container: %s", name)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -132,19 +132,19 @@ func TestAccAzureRMStorageContainer_root(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMStorageContainerExists(name string, c *storage.Container) resource.TestCheckFunc {
+func testCheckAzureRMStorageContainerExists(resourceName string, c *storage.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage container: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for storage container: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -185,11 +185,11 @@ func testCheckAzureRMStorageContainerExists(name string, c *storage.Container) r
 	}
 }
 
-func testAccARMStorageContainerDisappears(name string, c *storage.Container) resource.TestCheckFunc {
+func testAccARMStorageContainerDisappears(resourceName string, c *storage.Container) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -88,7 +88,7 @@ func testCheckAzureRMStorageQueueExists(resourceName string) resource.TestCheckF
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage queue: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for storage queue: %s", name)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -76,19 +76,19 @@ func TestAccAzureRMStorageQueue_basic(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMStorageQueueExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMStorageQueueExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage queue: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for storage queue: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -96,19 +96,19 @@ func TestAccAzureRMStorageShare_updateQuota(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMStorageShareExists(name string, sS *storage.Share) resource.TestCheckFunc {
+func testCheckAzureRMStorageShareExists(resourceName string, sS *storage.Share) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroupName, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for share: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for share: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -149,11 +149,11 @@ func testCheckAzureRMStorageShareExists(name string, sS *storage.Share) resource
 	}
 }
 
-func testAccARMStorageShareDisappears(name string, sS *storage.Share) resource.TestCheckFunc {
+func testAccARMStorageShareDisappears(resourceName string, sS *storage.Share) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -178,11 +178,11 @@ func testAccARMStorageShareDisappears(name string, sS *storage.Share) resource.T
 		options := &storage.FileRequestOptions{}
 		err = reference.Create(options)
 		if err != nil {
-			return fmt.Errorf("Error creating Storage Share %q reference (storage account: %q) : %+v", name, storageAccountName, err)
+			return fmt.Errorf("Error creating Storage Share %q reference (storage account: %q) : %+v", sS.Name, storageAccountName, err)
 		}
 
 		if _, err = reference.DeleteIfExists(options); err != nil {
-			return fmt.Errorf("Error deleting storage file %q: %s", name, err)
+			return fmt.Errorf("Error deleting storage Share %q: %s", sS.Name, err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -108,7 +108,7 @@ func testCheckAzureRMStorageShareExists(resourceName string, sS *storage.Share) 
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroupName, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for share: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for share: %s", name)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -76,7 +76,7 @@ func testCheckAzureRMStorageTableExists(resourceName string, t *storage.Table) r
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", name)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -64,19 +64,19 @@ func TestAccAzureRMStorageTable_disappears(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMStorageTableExists(name string, t *storage.Table) resource.TestCheckFunc {
+func testCheckAzureRMStorageTableExists(resourceName string, t *storage.Table) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		storageAccountName := rs.Primary.Attributes["storage_account_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)
@@ -114,11 +114,11 @@ func testCheckAzureRMStorageTableExists(name string, t *storage.Table) resource.
 	}
 }
 
-func testAccARMStorageTableDisappears(name string, t *storage.Table) resource.TestCheckFunc {
+func testAccARMStorageTableDisappears(resourceName string, t *storage.Table) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		armClient := testAccProvider.Meta().(*ArmClient)

--- a/azurerm/resource_arm_subnet_network_security_group_association_test.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association_test.go
@@ -60,12 +60,12 @@ func TestAccAzureRMSubnetNetworkSecurityGroupAssociation_deleted(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSubnetNetworkSecurityGroupAssociationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetNetworkSecurityGroupAssociationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		subnetId := rs.Primary.Attributes["subnet_id"]
@@ -102,12 +102,12 @@ func testCheckAzureRMSubnetNetworkSecurityGroupAssociationExists(name string) re
 	}
 }
 
-func testCheckAzureRMSubnetNetworkSecurityGroupAssociationDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetNetworkSecurityGroupAssociationDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		subnetId := rs.Primary.Attributes["subnet_id"]
@@ -143,12 +143,12 @@ func testCheckAzureRMSubnetNetworkSecurityGroupAssociationDisappears(name string
 	}
 }
 
-func testCheckAzureRMSubnetHasNoNetworkSecurityGroup(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetHasNoNetworkSecurityGroup(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		subnetId := rs.Primary.Attributes["subnet_id"]

--- a/azurerm/resource_arm_subnet_route_table_association_test.go
+++ b/azurerm/resource_arm_subnet_route_table_association_test.go
@@ -60,12 +60,12 @@ func TestAccAzureRMSubnetRouteTableAssociation_deleted(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSubnetRouteTableAssociationExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetRouteTableAssociationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		subnetId := rs.Primary.Attributes["subnet_id"]
@@ -102,12 +102,12 @@ func testCheckAzureRMSubnetRouteTableAssociationExists(name string) resource.Tes
 	}
 }
 
-func testCheckAzureRMSubnetRouteTableAssociationDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetRouteTableAssociationDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		subnetId := rs.Primary.Attributes["subnet_id"]
@@ -143,12 +143,12 @@ func testCheckAzureRMSubnetRouteTableAssociationDisappears(name string) resource
 	}
 }
 
-func testCheckAzureRMSubnetHasNoRouteTable(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetHasNoRouteTable(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		subnetId := rs.Primary.Attributes["subnet_id"]

--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -196,12 +196,12 @@ func TestAccAzureRMSubnet_disappears(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		log.Printf("[INFO] Checking Subnet addition.")
@@ -210,7 +210,7 @@ func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).subnetClient
@@ -229,21 +229,21 @@ func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
 	}
 }
 
-func testCheckAzureRMSubnetRouteTableExists(subnetName string, routeTableId string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetRouteTableExists(resourceName string, routeTableId string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[subnetName]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", subnetName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		log.Printf("[INFO] Checking Subnet update.")
 
-		name := rs.Primary.Attributes["name"]
+		subnetName := rs.Primary.Attributes["name"]
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", resourceName)
 		}
 
 		networksClient := testAccProvider.Meta().(*ArmClient).vnetClient
@@ -259,7 +259,7 @@ func testCheckAzureRMSubnetRouteTableExists(subnetName string, routeTableId stri
 			return fmt.Errorf("Bad: Vnet %q (resource group: %q) does not have subnets after update", vnetName, resourceGroup)
 		}
 
-		resp, err := subnetsClient.Get(ctx, resourceGroup, vnetName, name, "")
+		resp, err := subnetsClient.Get(ctx, resourceGroup, vnetName, subnetName, "")
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not exist", subnetName, resourceGroup)
@@ -280,19 +280,19 @@ func testCheckAzureRMSubnetRouteTableExists(subnetName string, routeTableId stri
 	}
 }
 
-func testCheckAzureRMSubnetDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMSubnetDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).subnetClient

--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -210,7 +210,7 @@ func testCheckAzureRMSubnetExists(resourceName string) resource.TestCheckFunc {
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).subnetClient
@@ -243,7 +243,7 @@ func testCheckAzureRMSubnetRouteTableExists(resourceName string, routeTableId st
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", subnetName)
 		}
 
 		networksClient := testAccProvider.Meta().(*ArmClient).vnetClient
@@ -292,7 +292,7 @@ func testCheckAzureRMSubnetDisappears(resourceName string) resource.TestCheckFun
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).subnetClient

--- a/azurerm/resource_arm_template_deployment_test.go
+++ b/azurerm/resource_arm_template_deployment_test.go
@@ -161,7 +161,7 @@ func testCheckAzureRMTemplateDeploymentExists(resourceName string) resource.Test
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).deploymentsClient
@@ -191,7 +191,7 @@ func testCheckAzureRMTemplateDeploymentDisappears(resourceName string) resource.
 		deploymentName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", deploymentName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).deploymentsClient

--- a/azurerm/resource_arm_template_deployment_test.go
+++ b/azurerm/resource_arm_template_deployment_test.go
@@ -150,18 +150,18 @@ func TestAccAzureRMTemplateDeployment_withError(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMTemplateDeploymentExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMTemplateDeploymentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).deploymentsClient
@@ -180,18 +180,18 @@ func testCheckAzureRMTemplateDeploymentExists(name string) resource.TestCheckFun
 	}
 }
 
-func testCheckAzureRMTemplateDeploymentDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMTemplateDeploymentDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		deploymentName := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for template deployment: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).deploymentsClient

--- a/azurerm/resource_arm_traffic_manager_endpoint_test.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint_test.go
@@ -256,12 +256,12 @@ func TestAccAzureRMTrafficManagerEndpoint_withGeoMappings(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMTrafficManagerEndpointExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMTrafficManagerEndpointExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -269,7 +269,7 @@ func testCheckAzureRMTrafficManagerEndpointExists(name string) resource.TestChec
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", resourceName)
 		}
 
 		// Ensure resource group/virtual network combination exists in API
@@ -288,12 +288,12 @@ func testCheckAzureRMTrafficManagerEndpointExists(name string) resource.TestChec
 	}
 }
 
-func testCheckAzureRMTrafficManagerEndpointDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMTrafficManagerEndpointDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
@@ -301,7 +301,7 @@ func testCheckAzureRMTrafficManagerEndpointDisappears(name string) resource.Test
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", resourceName)
 		}
 
 		// Ensure resource group/virtual network combination exists in API

--- a/azurerm/resource_arm_traffic_manager_endpoint_test.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint_test.go
@@ -269,7 +269,7 @@ func testCheckAzureRMTrafficManagerEndpointExists(resourceName string) resource.
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", name)
 		}
 
 		// Ensure resource group/virtual network combination exists in API
@@ -301,7 +301,7 @@ func testCheckAzureRMTrafficManagerEndpointDisappears(resourceName string) resou
 		profileName := rs.Primary.Attributes["profile_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", name)
 		}
 
 		// Ensure resource group/virtual network combination exists in API

--- a/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -283,18 +283,18 @@ func TestAccAzureRMTrafficManagerProfile_priorityToWeighted(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMTrafficManagerProfileExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMTrafficManagerProfileExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", resourceName)
 		}
 
 		// Ensure resource group/virtual network combination exists in API

--- a/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -294,7 +294,7 @@ func testCheckAzureRMTrafficManagerProfileExists(resourceName string) resource.T
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for Traffic Manager Profile: %s", name)
 		}
 
 		// Ensure resource group/virtual network combination exists in API

--- a/azurerm/resource_arm_user_assigned_identity_test.go
+++ b/azurerm/resource_arm_user_assigned_identity_test.go
@@ -51,7 +51,7 @@ func testCheckAzureRMUserAssignedIdentityExists(resourceName string) resource.Te
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual machine: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for virtual machine: %s", name)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).userAssignedIdentitiesClient

--- a/azurerm/resource_arm_user_assigned_identity_test.go
+++ b/azurerm/resource_arm_user_assigned_identity_test.go
@@ -51,7 +51,7 @@ func testCheckAzureRMUserAssignedIdentityExists(resourceName string) resource.Te
 		name := rs.Primary.Attributes["name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual machine: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for virtual machine: %s", resourceName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).userAssignedIdentitiesClient

--- a/azurerm/resource_arm_virtual_machine_extension_test.go
+++ b/azurerm/resource_arm_virtual_machine_extension_test.go
@@ -90,12 +90,12 @@ func TestAccAzureRMVirtualMachineExtension_linuxDiagnostics(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMVirtualMachineExtensionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualMachineExtensionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_virtual_machine_test.go
+++ b/azurerm/resource_arm_virtual_machine_test.go
@@ -105,12 +105,12 @@ func TestAccAzureRMVirtualMachine_multipleAssignedIdentity(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMVirtualMachineExists(name string, vm *compute.VirtualMachine) resource.TestCheckFunc {
+func testCheckAzureRMVirtualMachineExists(resourceName string, vm *compute.VirtualMachine) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		vmName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
@@ -3040,12 +3040,12 @@ func testCheckAzureRMVirtualMachineVHDExistence(name string, shouldExist bool) r
 	}
 }
 
-func testCheckAzureRMVirtualMachineDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualMachineDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		vmName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_virtual_network_gateway_connection_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection_test.go
@@ -120,11 +120,11 @@ func TestAccAzureRMVirtualNetworkGatewayConnection_updatingSharedKey(t *testing.
 	})
 }
 
-func testCheckAzureRMVirtualNetworkGatewayConnectionExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualNetworkGatewayConnectionExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		connectionName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_virtual_network_gateway_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_test.go
@@ -250,11 +250,11 @@ func TestAccAzureRMVirtualNetworkGateway_expressRoute(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMVirtualNetworkGatewayExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualNetworkGatewayExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		gatewayName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_virtual_network_peering_test.go
+++ b/azurerm/resource_arm_virtual_network_peering_test.go
@@ -107,19 +107,19 @@ func TestAccAzureRMVirtualNetworkPeering_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMVirtualNetworkPeeringExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualNetworkPeeringExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", resourceName)
 		}
 
 		// Ensure resource group/virtual network peering combination exists in API
@@ -139,19 +139,19 @@ func testCheckAzureRMVirtualNetworkPeeringExists(name string) resource.TestCheck
 	}
 }
 
-func testCheckAzureRMVirtualNetworkPeeringDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualNetworkPeeringDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		name := rs.Primary.Attributes["name"]
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", name)
+			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", resourceName)
 		}
 
 		// Ensure resource group/virtual network peering combination exists in API

--- a/azurerm/resource_arm_virtual_network_peering_test.go
+++ b/azurerm/resource_arm_virtual_network_peering_test.go
@@ -119,7 +119,7 @@ func testCheckAzureRMVirtualNetworkPeeringExists(resourceName string) resource.T
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", name)
 		}
 
 		// Ensure resource group/virtual network peering combination exists in API
@@ -151,7 +151,7 @@ func testCheckAzureRMVirtualNetworkPeeringDisappears(resourceName string) resour
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", resourceName)
+			return fmt.Errorf("Bad: no resource group found in state for virtual network peering: %s", name)
 		}
 
 		// Ensure resource group/virtual network peering combination exists in API

--- a/azurerm/resource_arm_virtual_network_test.go
+++ b/azurerm/resource_arm_virtual_network_test.go
@@ -183,12 +183,12 @@ func TestAccAzureRMVirtualNetwork_bug373(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMVirtualNetworkExists(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualNetworkExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		virtualNetworkName := rs.Primary.Attributes["name"]
@@ -207,19 +207,19 @@ func testCheckAzureRMVirtualNetworkExists(name string) resource.TestCheckFunc {
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Virtual Network %q (resource group: %q) does not exist", name, resourceGroup)
+			return fmt.Errorf("Bad: Virtual Network %q (resource group: %q) does not exist", virtualNetworkName, resourceGroup)
 		}
 
 		return nil
 	}
 }
 
-func testCheckAzureRMVirtualNetworkDisappears(name string) resource.TestCheckFunc {
+func testCheckAzureRMVirtualNetworkDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", name)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
 		virtualNetworkName := rs.Primary.Attributes["name"]


### PR DESCRIPTION
Updates acceptance test `Exist(name string)` functions to `Exist(resourceName string)` for clarity. Many times name would be redefined below & mistakenly used in debug output.

Also fixes a bunch of debug messages where the tf resource name was outputted instead of the azure name.