### PR TITLE
fix schema panic: azurerm_snapshot

### DIFF
--- a/azurerm/data_source_snapshot.go
+++ b/azurerm/data_source_snapshot.go
@@ -24,7 +24,7 @@ func dataSourceArmSnapshot() *schema.Resource {
 				Computed: true,
 			},
 			"disk_size_gb": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 			"time_created": {

--- a/azurerm/data_source_snapshot_test.go
+++ b/azurerm/data_source_snapshot_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceAzureRMSnapshot_importBasic(t *testing.T) {
+func TestAccDataSourceAzureRMSnapshot_basic(t *testing.T) {
 	dataSourceName := "data.azurerm_snapshot.snapshot"
 	ri := acctest.RandInt()
 
@@ -27,7 +27,7 @@ func TestAccDataSourceAzureRMSnapshot_importBasic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAzureRMSnapshot_importEncryption(t *testing.T) {
+func TestAccDataSourceAzureRMSnapshot_encryption(t *testing.T) {
 	dataSourceName := "data.azurerm_snapshot.snapshot"
 	ri := acctest.RandInt()
 	rs := acctest.RandString(4)


### PR DESCRIPTION
fixes schema panic:
```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccDataSourceAzureRMSnapshot_importBasic
=== PAUSE TestAccDataSourceAzureRMSnapshot_importBasic
=== CONT  TestAccDataSourceAzureRMSnapshot_importBasic

------- Stderr: -------
panic: disk_size_gb: '' expected type 'string', got unconvertible type 'int'

goroutine 319 [running]:
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc420542690, 0x240cbe3, 0xc, 0x20b0260, 0xc42072a528, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-azurerm/azurerm.dataSourceArmSnapshotRead(0xc420542690, 0x23cc8e0, 0xc420ee8000, 0xc420542690, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_snapshot.go:123 +0x972
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).ReadDataApply(0xc4202c8fc0, 0xc4204b1c80, 0x23cc8e0, 0xc420ee8000, 0xc420293570, 0xc420291101, 0xc4204b4a40)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:290 +0x88
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).ReadDataApply(0xc4201901c0, 0xc4205e3950, 0xc4204b1c80, 0x0, 0x30, 0xc420ccc000)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:426 +0x9a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalReadDataApply).Eval(0xc4204b1000, 0x2741bc0, 0xc4209f1450, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_read_data.go:122 +0xfe
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2708420, 0xc4204b1000, 0x2741bc0, 0xc4209f1450, 0x0, 0x0, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc4204b1060, 0x2741bc0, 0xc4209f1450, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x7a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2708520, 0xc4204b1060, 0x2741bc0, 0xc4209f1450, 0x212a320, 0x38afac2, 0x20b0e60, 0xc420742dd0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.Eval(0x2708520, 0xc4204b1060, 0x2741bc0, 0xc4209f1450, 0xc4204b1060, 0x2708520, 0xc4204b1060, 0xc4208e9be0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x2372760, 0xc4204a9628, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xc26
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc42048dea0, 0x2372760, 0xc4204a9628, 0xc420727a80)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x3a0
created by github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x1248
```