### PR TITLE
data.azurerm_managed_disk: add missing create_option property

### DIFF
--- a/azurerm/data_source_managed_disk.go
+++ b/azurerm/data_source_managed_disk.go
@@ -2,7 +2,6 @@ package azurerm
 
 import (
 	"fmt"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -43,6 +42,11 @@ func dataSourceArmManagedDisk() *schema.Resource {
 
 			"disk_size_gb": {
 				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"create_option": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 

--- a/azurerm/data_source_managed_disk.go
+++ b/azurerm/data_source_managed_disk.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )


### PR DESCRIPTION
fixes

```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccDataSourceAzureRMManagedDisk_basic
=== PAUSE TestAccDataSourceAzureRMManagedDisk_basic
=== CONT  TestAccDataSourceAzureRMManagedDisk_basic

------- Stderr: -------
panic: Invalid address to set: []string{"create_option"}

goroutine 276 [running]:
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc420418af0, 0x240e22e, 0xd, 0x20b0e60, 0xc420012060, 0x4, 0x20b02e0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-azurerm/azurerm.flattenAzureRmManagedDiskCreationData(0xc420418af0, 0xc4205e8150)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_managed_disk.go:297 +0x88
github.com/terraform-providers/terraform-provider-azurerm/azurerm.dataSourceArmManagedDiskRead(0xc420418af0, 0x23cc8e0, 0xc420990000, 0xc420418af0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_managed_disk.go:85 +0x615
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).ReadDataApply(0xc4202a9f10, 0xc420cbe2c0, 0x23cc8e0, 0xc420990000, 0xc420293c00, 0xc420034901, 0xc42058a510)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:290 +0x88
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).ReadDataApply(0xc4204101c0, 0xc42032e4b0, 0xc420cbe2c0, 0x0, 0x30, 0xc420c12000)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:426 +0x9a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalReadDataApply).Eval(0xc420bf9de0, 0x2741bc0, 0xc4209b4f70, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_read_data.go:122 +0xfe
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2708420, 0xc420bf9de0, 0x2741bc0, 0xc4209b4f70, 0x0, 0x0, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc420bf9e20, 0x2741bc0, 0xc4209b4f70, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x7a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2708520, 0xc420bf9e20, 0x2741bc0, 0xc4209b4f70, 0x212a320, 0x38afac2, 0x20b0e60, 0xc4203fc500)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.Eval(0x2708520, 0xc420bf9e20, 0x2741bc0, 0xc4209b4f70, 0xc420bf9e20, 0x2708520, 0xc420bf9e20, 0xc420223be0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x2372760, 0xc4204a81c0, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xc26
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc420394e00, 0x2372760, 0xc4204a81c0, 0xc4206af100)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x3a0
created by github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x1248
```