### PR TITLE
fix schema panic: dns resources

### DIFF
--- a/azurerm/data_source_dns_zone.go
+++ b/azurerm/data_source_dns_zone.go
@@ -27,12 +27,12 @@ func dataSourceArmDnsZone() *schema.Resource {
 			},
 
 			"number_of_record_sets": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
 			"max_number_of_record_sets": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 

--- a/azurerm/resource_arm_dns_ptr_record.go
+++ b/azurerm/resource_arm_dns_ptr_record.go
@@ -137,7 +137,6 @@ func resourceArmDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
-	d.Set("etag", resp.Etag)
 
 	if err := d.Set("records", flattenAzureRmDnsPtrRecords(resp.PtrRecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_zone.go
+++ b/azurerm/resource_arm_dns_zone.go
@@ -31,12 +31,12 @@ func resourceArmDnsZone() *schema.Resource {
 			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"number_of_record_sets": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
 			"max_number_of_record_sets": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 


### PR DESCRIPTION
fixes a few of dns schema panics:
```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccAzureRMDnsPtrRecord_withTags
=== PAUSE TestAccAzureRMDnsPtrRecord_withTags
=== CONT  TestAccAzureRMDnsPtrRecord_withTags

------- Stderr: -------
panic: number_of_record_sets: '' expected type 'string', got unconvertible type 'int64'

goroutine 232 [running]:
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc420431260, 0x241c766, 0x15, 0x20b0320, 0xc420790768, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmDnsZoneRead(0xc420431260, 0x23cc8e0, 0xc42082c000, 0xc420824bc0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_dns_zone.go:158 +0x557
github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmDnsZoneCreateUpdate(0xc420431260, 0x23cc8e0, 0xc42082c000, 0xc420431260, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_dns_zone.go:132 +0x869
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc4203e8070, 0xc4202a2230, 0xc4206de9c0, 0x23cc8e0, 0xc42082c000, 0xc420624001, 0x35, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:225 +0x35a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc420187180, 0xc420465db0, 0xc4202a2230, 0xc4206de9c0, 0x1, 0xbb75cd00, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:283 +0xa4
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalApply).Eval(0xc420899f00, 0x2741bc0, 0xc4208d84e0, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_apply.go:57 +0x22c
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2707fe0, 0xc420899f00, 0x2741bc0, 0xc4208d84e0, 0x0, 0x0, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc42029df80, 0x2741bc0, 0xc4208d84e0, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x7a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2708520, 0xc42029df80, 0x2741bc0, 0xc4208d84e0, 0x212a320, 0x38afac2, 0x20b0e60, 0xc42058ec50)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.Eval(0x2708520, 0xc42029df80, 0x2741bc0, 0xc4208d84e0, 0xc42029df80, 0x2708520, 0xc42029df80, 0xc42006ebe0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x2372760, 0xc4200b1b00, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xc26
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc4203b6540, 0x2372760, 0xc4200b1b00, 0xc420819940)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x3a0
created by github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x1248
```