### PR TITLE
data.azurerm_network_interface: added missing property ip_configuration.0.application_security_group_ids

### DIFF
--- a/azurerm/data_source_network_interface.go
+++ b/azurerm/data_source_network_interface.go
@@ -90,6 +90,13 @@ func dataSourceArmNetworkInterface() *schema.Resource {
 							Set:      schema.HashString,
 						},
 
+						"application_security_group_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+
 						"primary": {
 							Type:     schema.TypeBool,
 							Computed: true,


### PR DESCRIPTION

fixes:
```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccDataSourceArmVirtualNetworkInterface_basic
=== PAUSE TestAccDataSourceArmVirtualNetworkInterface_basic
=== CONT  TestAccDataSourceArmVirtualNetworkInterface_basic

------- Stderr: -------
panic: Invalid address to set: []string{"ip_configuration", "0", "application_security_group_ids"}

goroutine 1304 [running]:
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc42028da40, 0x2413149, 0x10, 0x20841e0, 0xc420ce9740, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go:191 +0x237
github.com/terraform-providers/terraform-provider-azurerm/azurerm.dataSourceArmNetworkInterfaceRead(0xc42028da40, 0x23cc8e0, 0xc420d54000, 0xc42028da40, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_network_interface.go:204 +0xc3e
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).ReadDataApply(0xc4202c8380, 0xc420726f80, 0x23cc8e0, 0xc420d54000, 0xc420293708, 0xc4208bcc01, 0xc420776cc0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:290 +0x88
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).ReadDataApply(0xc4206081c0, 0xc42101aaf0, 0xc420726f80, 0x0, 0x30, 0xc420c5c000)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:426 +0x9a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalReadDataApply).Eval(0xc420cf86c0, 0x2741bc0, 0xc4203fe4e0, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_read_data.go:122 +0xfe
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2708420, 0xc420cf86c0, 0x2741bc0, 0xc4203fe4e0, 0x0, 0x0, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc420cf86e0, 0x2741bc0, 0xc4203fe4e0, 0x2, 0x2, 0x2402b44, 0x4)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0x7a
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.EvalRaw(0x2708520, 0xc420cf86e0, 0x2741bc0, 0xc4203fe4e0, 0x212a320, 0x38afac5, 0x20b0e60, 0xc42039dc70)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:53 +0x156
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.Eval(0x2708520, 0xc420cf86e0, 0x2741bc0, 0xc4203fe4e0, 0xc420cf86e0, 0x2708520, 0xc420cf86e0, 0xc420821be0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x2352d40, 0xc4206261a0, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/terraform/graph.go:126 +0xc26
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc420458e70, 0x2352d40, 0xc4206261a0, 0xc4212ed900)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:387 +0x3a0
created by github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag.(*Walker).Update
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/dag/walk.go:310 +0x1248
```