### PR TITLE
update travis CI check order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ install:
 - make tools
 
 script:
-- make lint
 - make test
 - make vendor-status
+- make lint
 - make website-test
 
 branches:


### PR DESCRIPTION
moved linting down as it take much longer, this should allow some builds to error out faster