### PR TITLE
DNS: Parsing `dnsZones` rather than `dnszones` since the ID format changed

### DIFF
--- a/azurerm/resource_arm_dns_a_record.go
+++ b/azurerm/resource_arm_dns_a_record.go
@@ -121,7 +121,7 @@ func resourceArmDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 
 	resGroup := id.ResourceGroup
 	name := id.Path["A"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Get(ctx, resGroup, zoneName, name, dns.A)
 	if err != nil {
@@ -156,7 +156,7 @@ func resourceArmDnsARecordDelete(d *schema.ResourceData, meta interface{}) error
 
 	resGroup := id.ResourceGroup
 	name := id.Path["A"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, name, dns.A, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_aaaa_record.go
+++ b/azurerm/resource_arm_dns_aaaa_record.go
@@ -121,7 +121,7 @@ func resourceArmDnsAaaaRecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	resGroup := id.ResourceGroup
 	name := id.Path["AAAA"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Get(ctx, resGroup, zoneName, name, dns.AAAA)
 	if err != nil {
@@ -156,7 +156,7 @@ func resourceArmDnsAaaaRecordDelete(d *schema.ResourceData, meta interface{}) er
 
 	resGroup := id.ResourceGroup
 	name := id.Path["AAAA"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, name, dns.AAAA, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_caa_record.go
+++ b/azurerm/resource_arm_dns_caa_record.go
@@ -147,7 +147,7 @@ func resourceArmDnsCaaRecordRead(d *schema.ResourceData, meta interface{}) error
 
 	resGroup := id.ResourceGroup
 	name := id.Path["CAA"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.CAA)
 	if err != nil {
@@ -182,7 +182,7 @@ func resourceArmDnsCaaRecordDelete(d *schema.ResourceData, meta interface{}) err
 
 	resGroup := id.ResourceGroup
 	name := id.Path["CAA"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Delete(ctx, resGroup, zoneName, name, dns.CAA, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_cname_record.go
+++ b/azurerm/resource_arm_dns_cname_record.go
@@ -125,7 +125,7 @@ func resourceArmDnsCNameRecordRead(d *schema.ResourceData, meta interface{}) err
 
 	resGroup := id.ResourceGroup
 	name := id.Path["CNAME"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Get(ctx, resGroup, zoneName, name, dns.CNAME)
 	if err != nil {
@@ -163,7 +163,7 @@ func resourceArmDnsCNameRecordDelete(d *schema.ResourceData, meta interface{}) e
 
 	resGroup := id.ResourceGroup
 	name := id.Path["CNAME"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, name, dns.CNAME, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_mx_record.go
+++ b/azurerm/resource_arm_dns_mx_record.go
@@ -136,7 +136,7 @@ func resourceArmDnsMxRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 	resGroup := id.ResourceGroup
 	name := id.Path["MX"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.MX)
 	if err != nil {
@@ -171,7 +171,7 @@ func resourceArmDnsMxRecordDelete(d *schema.ResourceData, meta interface{}) erro
 
 	resGroup := id.ResourceGroup
 	name := id.Path["MX"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Delete(ctx, resGroup, zoneName, name, dns.MX, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_ns_record.go
+++ b/azurerm/resource_arm_dns_ns_record.go
@@ -138,7 +138,7 @@ func resourceArmDnsNsRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 	resGroup := id.ResourceGroup
 	name := id.Path["NS"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Get(ctx, resGroup, zoneName, name, dns.NS)
 	if err != nil {
@@ -179,7 +179,7 @@ func resourceArmDnsNsRecordDelete(d *schema.ResourceData, meta interface{}) erro
 
 	resGroup := id.ResourceGroup
 	name := id.Path["NS"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, name, dns.NS, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_ptr_record.go
+++ b/azurerm/resource_arm_dns_ptr_record.go
@@ -121,7 +121,7 @@ func resourceArmDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error
 
 	resGroup := id.ResourceGroup
 	name := id.Path["PTR"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Get(ctx, resGroup, zoneName, name, dns.PTR)
 	if err != nil {
@@ -158,7 +158,7 @@ func resourceArmDnsPtrRecordDelete(d *schema.ResourceData, meta interface{}) err
 
 	resGroup := id.ResourceGroup
 	name := id.Path["PTR"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, name, dns.PTR, "")
 	if err != nil {

--- a/azurerm/resource_arm_dns_srv_record.go
+++ b/azurerm/resource_arm_dns_srv_record.go
@@ -145,7 +145,7 @@ func resourceArmDnsSrvRecordRead(d *schema.ResourceData, meta interface{}) error
 
 	resGroup := id.ResourceGroup
 	name := id.Path["SRV"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
 	if err != nil {
@@ -180,7 +180,7 @@ func resourceArmDnsSrvRecordDelete(d *schema.ResourceData, meta interface{}) err
 
 	resGroup := id.ResourceGroup
 	name := id.Path["SRV"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Delete(ctx, resGroup, zoneName, name, dns.SRV, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_txt_record.go
+++ b/azurerm/resource_arm_dns_txt_record.go
@@ -127,7 +127,7 @@ func resourceArmDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error
 
 	resGroup := id.ResourceGroup
 	name := id.Path["TXT"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.TXT)
 	if err != nil {
@@ -162,7 +162,7 @@ func resourceArmDnsTxtRecordDelete(d *schema.ResourceData, meta interface{}) err
 
 	resGroup := id.ResourceGroup
 	name := id.Path["TXT"]
-	zoneName := id.Path["dnszones"]
+	zoneName := id.Path["dnsZones"]
 
 	resp, err := client.Delete(ctx, resGroup, zoneName, name, dns.TXT, "")
 	if resp.StatusCode != http.StatusOK {

--- a/azurerm/resource_arm_dns_zone.go
+++ b/azurerm/resource_arm_dns_zone.go
@@ -142,7 +142,7 @@ func resourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	resGroup := id.ResourceGroup
-	name := id.Path["dnszones"]
+	name := id.Path["dnsZones"]
 
 	resp, err := zonesClient.Get(ctx, resGroup, name)
 	if err != nil {
@@ -192,7 +192,7 @@ func resourceArmDnsZoneDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	resGroup := id.ResourceGroup
-	name := id.Path["dnszones"]
+	name := id.Path["dnsZones"]
 
 	etag := ""
 	future, err := client.Delete(ctx, resGroup, name, etag)


### PR DESCRIPTION
Switching to use dnsZones rather than dnszones to match the ID format changed to now be:

> /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/{recordType}/{relativeRecordSetName}

Fixes #2493