### PR TITLE
Fixes for handling the `dns_prefix` property of an AKS cluster

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -1127,7 +1127,7 @@ func validateKubernetesClusterAgentPoolName() schema.SchemaValidateFunc {
 
 func validateKubernetesClusterDnsPrefix() schema.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9\\-]{0,43}[a-zA-Z0-9]$"),
+		regexp.MustCompile("^[a-zA-Z][-a-zA-Z0-9]{0,43}[a-zA-Z0-9]$"),
 		"The DNS name must contain between 3 and 45 characters. The name can contain only letters, numbers, and hyphens. The name must start with a letter and must end with a letter or a number.",
 	)
 }

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -75,6 +75,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 			"dns_prefix": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"kubernetes_version": {

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -73,9 +73,9 @@ func resourceArmKubernetesCluster() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"dns_prefix": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validateKubernetesClusterDnsPrefix(),
 			},
 

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -76,6 +76,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validateKubernetesClusterDnsPrefix(),
 			},
 
 			"kubernetes_version": {
@@ -1121,6 +1122,13 @@ func validateKubernetesClusterAgentPoolName() schema.SchemaValidateFunc {
 	return validation.StringMatch(
 		regexp.MustCompile("^[a-z]{1}[a-z0-9]{0,11}$"),
 		"Agent Pool names must start with a lowercase letter, have max length of 12, and only have characters a-z0-9.",
+	)
+}
+
+func validateKubernetesClusterDnsPrefix() schema.SchemaValidateFunc {
+	return validation.StringMatch(
+		regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9\\-]{0,43}[a-zA-Z0-9]$"),
+		"The DNS name must contain between 3 and 45 characters. The name can contain only letters, numbers, and hyphens. The name must start with a letter and must end with a letter or a number.",
 	)
 }
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `dns_prefix` - (Required) DNS prefix specified when creating the managed cluster. Changing this forces a new resource to be created.
 
+-> **NOTE:** The `dns_prefix` must contain between 3 and 45 characters, and can contain only letters, numbers, and hyphens. It must start with a letter and must end with a letter or a number.
+
 * `service_principal` - (Required) A `service_principal` block as documented below.
 
 ---

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `agent_pool_profile` - (Required) One or more `agent_pool_profile` blocks as documented below.
 
-* `dns_prefix` - (Required) DNS prefix specified when creating the managed cluster.
+* `dns_prefix` - (Required) DNS prefix specified when creating the managed cluster. Changing this forces a new resource to be created.
 
 * `service_principal` - (Required) A `service_principal` block as documented below.
 


### PR DESCRIPTION
I got help from Microsoft Support today because one of my clusters were badly broken. Eventually, we figured out that it was because of a bad `dns_prefix`.

When I tried to use Terraform to change the prefix it didn't complain, until the underlying ARM call failed because the `dns_prefix` can only be set when the cluster is created, and then never changed.

This PR fixes both these issues: it forces recreation of the cluster if the `dns_prefix` changes, and it adds the missing validation for DNS prefixes. See the respective commit messages for more details on each change.