### PR TITLE
Support for Management Groups in azurerm_policy_set_definition

### DIFF
--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -62,6 +62,10 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the policy set definition.
 
+* `management_group_id` - (Optional) The ID of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
+
+~> **Note:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `.group_id` and not `.id`.
+
 * `metadata` - (Optional) The metadata for the policy set definition. This is a json object representing additional metadata that should be stored with the policy definition.
 
 * `parameters` - (Optional) Parameters for the policy set definition. This field is a json object that allows you to parameterize your policy definition.
@@ -78,4 +82,8 @@ Policy Set Definitions can be imported using the Resource ID, e.g.
 
 ```shell
 terraform import azurerm_policy_set_definition.test  /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/testPolicySet
+```
+or
+```shell
+terraform import azurerm_policy_set_definition.test /providers/Microsoft.Management/managementgroups/my-mgmt-group-id/providers/Microsoft.Authorization/policySetDefinitions/testPolicySet
 ```


### PR DESCRIPTION
This PR adds support for a Management Groups in Azure Policy Set Definitions (resource `azurerm_policy_set_definition`).

Addresses issue #2617.

Test Results:
```sh
> $ make testacc TESTARGS='-run=TestAccAzureRMPolicySetDefinition'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAzureRMPolicySetDefinition -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
?   	github.com/terraform-providers/terraform-provider-azurerm	[no test files]
=== RUN   TestAccAzureRMPolicySetDefinition_builtIn
=== PAUSE TestAccAzureRMPolicySetDefinition_builtIn
=== RUN   TestAccAzureRMPolicySetDefinition_custom
=== PAUSE TestAccAzureRMPolicySetDefinition_custom
=== RUN   TestAccAzureRMPolicySetDefinition_ManagementGroup
=== PAUSE TestAccAzureRMPolicySetDefinition_ManagementGroup
=== CONT  TestAccAzureRMPolicySetDefinition_builtIn
=== CONT  TestAccAzureRMPolicySetDefinition_ManagementGroup
=== CONT  TestAccAzureRMPolicySetDefinition_custom
--- PASS: TestAccAzureRMPolicySetDefinition_builtIn (110.35s)
--- PASS: TestAccAzureRMPolicySetDefinition_ManagementGroup (149.36s)
--- PASS: TestAccAzureRMPolicySetDefinition_custom (202.85s)
```

(fixed #2617)