### PR TITLE
Support exclusions (notScopes) in azurerm_policy_assignment

### DIFF
--- a/azurerm/resource_arm_policy_assignment.go
+++ b/azurerm/resource_arm_policy_assignment.go
@@ -97,7 +97,6 @@ func resourceArmPolicyAssignment() *schema.Resource {
 			"not_scopes": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: false,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},

--- a/azurerm/resource_arm_policy_assignment.go
+++ b/azurerm/resource_arm_policy_assignment.go
@@ -93,6 +93,13 @@ func resourceArmPolicyAssignment() *schema.Resource {
 				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
+
+			"not_scopes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: false,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -137,6 +144,11 @@ func resourceArmPolicyAssignmentCreateOrUpdate(d *schema.ResourceData, meta inte
 		assignment.AssignmentProperties.Parameters = &expandedParams
 	}
 
+	if _, ok := d.GetOk("not_scopes"); ok {
+		notScopes := expandAzureRmPolicyNotScopes(d)
+		assignment.AssignmentProperties.NotScopes = notScopes
+	}
+
 	if _, err := client.Create(ctx, scope, name, assignment); err != nil {
 		return err
 	}
@@ -151,6 +163,7 @@ func resourceArmPolicyAssignmentCreateOrUpdate(d *schema.ResourceData, meta inte
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
+
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Policy Assignment %q to become available: %s", name, err)
 	}
@@ -207,6 +220,8 @@ func resourceArmPolicyAssignmentRead(d *schema.ResourceData, meta interface{}) e
 
 			d.Set("parameters", json)
 		}
+
+		d.Set("not_scopes", props.NotScopes)
 	}
 
 	return nil
@@ -271,4 +286,15 @@ func flattenAzureRmPolicyIdentity(identity *policy.Identity) []interface{} {
 	}
 
 	return []interface{}{result}
+}
+
+func expandAzureRmPolicyNotScopes(d *schema.ResourceData) *[]string {
+	notScopes := d.Get("not_scopes").([]interface{})
+	notScopesRes := make([]string, 0)
+
+	for _, notScope := range notScopes {
+		notScopesRes = append(notScopesRes, notScope.(string))
+	}
+
+	return &notScopesRes
 }

--- a/azurerm/resource_arm_policy_assignment_test.go
+++ b/azurerm/resource_arm_policy_assignment_test.go
@@ -88,6 +88,32 @@ func TestAccAzureRMPolicyAssignment_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPolicyAssignment_not_scopes(t *testing.T) {
+	resourceName := "azurerm_policy_assignment.test"
+
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPolicyAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMPolicyAssignment_not_scopes(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPolicyAssignmentExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMPolicyAssignmentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -294,6 +320,68 @@ resource "azurerm_policy_assignment" "test" {
   scope                = "${azurerm_resource_group.test.id}"
   policy_definition_id = "${azurerm_policy_definition.test.id}"
   description          = "Policy Assignment created via an Acceptance Test"
+  display_name         = "Acceptance Test Run %d"
+
+  parameters = <<PARAMETERS
+{
+  "allowedLocations": {
+    "value": [ "%s" ]
+  }
+}
+PARAMETERS
+}
+`, ri, ri, ri, location, ri, ri, location)
+}
+
+func testAzureRMPolicyAssignment_not_scopes(ri int, location string) string {
+	return fmt.Sprintf(`
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_policy_definition" "test" {
+  name         = "acctestpol-%d"
+  policy_type  = "Custom"
+  mode         = "All"
+  display_name = "acctestpol-%d"
+
+  policy_rule = <<POLICY_RULE
+	{
+    "if": {
+      "not": {
+        "field": "location",
+        "in": "[parameters('allowedLocations')]"
+      }
+    },
+    "then": {
+      "effect": "audit"
+    }
+  }
+POLICY_RULE
+
+  parameters = <<PARAMETERS
+	{
+    "allowedLocations": {
+      "type": "Array",
+      "metadata": {
+        "description": "The list of allowed locations for resources.",
+        "displayName": "Allowed locations",
+        "strongType": "location"
+      }
+    }
+  }
+PARAMETERS
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_policy_assignment" "test" {
+  name                 = "acctestpa-%d"
+  scope                = "${data.azurerm_subscription.current.id}"
+  policy_definition_id = "${azurerm_policy_definition.test.id}"
+  description          = "Policy Assignment created via an Acceptance Test"
+  not_scopes           = ["${azurerm_resource_group.test.id}"]
   display_name         = "Acceptance Test Run %d"
 
   parameters = <<PARAMETERS

--- a/website/docs/r/policy_assignment.html.markdown
+++ b/website/docs/r/policy_assignment.html.markdown
@@ -91,6 +91,8 @@ The following arguments are supported:
 
 ~> **NOTE:** This value is required when the specified Policy Definition contains the `parameters` field.
 
+* `not_scopes` - (Optional) A list of the Policy Assignment's excluded scopes. The list must contain Resource IDs (such as Subscriptions e.g. `/subscriptions/00000000-0000-0000-000000000000` or Resource Groups e.g.`/subscriptions/00000000-0000-0000-000000000000/resourceGroups/myResourceGroup`). 
+
 ---
 
 An `identity` block supports the following:


### PR DESCRIPTION
This PR adds support for exlcusions (notScopes) in Azure Policy Assignments (resource `azurerm_policy_set_definition`).

Addresses issue #1138 

Test Results:
```
> $ make testacc TESTARGS='-run=TestAccAzureRMPolicyAssignment'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAzureRMPolicyAssignment -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
?   	github.com/terraform-providers/terraform-provider-azurerm	[no test files]
=== RUN   TestAccAzureRMPolicyAssignment_basic
=== PAUSE TestAccAzureRMPolicyAssignment_basic
=== RUN   TestAccAzureRMPolicyAssignment_deployIfNotExists_policy
=== PAUSE TestAccAzureRMPolicyAssignment_deployIfNotExists_policy
=== RUN   TestAccAzureRMPolicyAssignment_complete
=== PAUSE TestAccAzureRMPolicyAssignment_complete
=== RUN   TestAccAzureRMPolicyAssignment_not_scopes
=== PAUSE TestAccAzureRMPolicyAssignment_not_scopes
=== CONT  TestAccAzureRMPolicyAssignment_basic
=== CONT  TestAccAzureRMPolicyAssignment_not_scopes
=== CONT  TestAccAzureRMPolicyAssignment_complete
=== CONT  TestAccAzureRMPolicyAssignment_deployIfNotExists_policy
--- PASS: TestAccAzureRMPolicyAssignment_basic (247.49s)
--- PASS: TestAccAzureRMPolicyAssignment_complete (247.53s)
--- PASS: TestAccAzureRMPolicyAssignment_not_scopes (249.56s)
--- PASS: TestAccAzureRMPolicyAssignment_deployIfNotExists_policy (250.12s)
```

(fixed #1138)
