### PR TITLE
Add application insights data source

### DIFF
--- a/azurerm/data_source_application_insights.go
+++ b/azurerm/data_source_application_insights.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -17,7 +17,7 @@ func dataSourceArmApplicationInsights() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.NoZeroValues,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 
 			"instrumentation_key": {

--- a/azurerm/data_source_application_insights.go
+++ b/azurerm/data_source_application_insights.go
@@ -24,6 +24,26 @@ func dataSourceArmApplicationInsights() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"application_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"app_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -46,6 +66,10 @@ func dataSourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface
 
 	d.SetId(*resp.ID)
 	d.Set("instrumentation_key", *resp.InstrumentationKey)
+	d.Set("location", *resp.Location)
+	d.Set("app_id", *resp.AppID)
+	d.Set("application_type", resp.ApplicationType)
+	d.Set("tags", resp.Tags)
 
 	return nil
 }

--- a/azurerm/data_source_application_insights.go
+++ b/azurerm/data_source_application_insights.go
@@ -69,7 +69,7 @@ func dataSourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface
 	d.Set("location", resp.Location)
 	d.Set("app_id", resp.AppID)
 	d.Set("application_type", resp.ApplicationType)
-	d.Set("tags", resp.Tags)
+	flattenAndSetTags(d, resp.Tags)
 
 	return nil
 }

--- a/azurerm/data_source_application_insights.go
+++ b/azurerm/data_source_application_insights.go
@@ -65,9 +65,9 @@ func dataSourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface
 	}
 
 	d.SetId(*resp.ID)
-	d.Set("instrumentation_key", *resp.InstrumentationKey)
-	d.Set("location", *resp.Location)
-	d.Set("app_id", *resp.AppID)
+	d.Set("instrumentation_key", resp.InstrumentationKey)
+	d.Set("location", resp.Location)
+	d.Set("app_id", resp.AppID)
 	d.Set("application_type", resp.ApplicationType)
 	d.Set("tags", resp.Tags)
 

--- a/azurerm/data_source_application_insights.go
+++ b/azurerm/data_source_application_insights.go
@@ -1,0 +1,51 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmApplicationInsights() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmApplicationInsightsRead,
+		Schema: map[string]*schema.Schema{
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"instrumentation_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).appInsightsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resGroup := d.Get("resource_group_name").(string)
+	name := d.Get("name").(string)
+
+	resp, err := client.Get(ctx, resGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Application Insights bucket %q (Resource Group %q) was not found", name, resGroup)
+		}
+
+		return fmt.Errorf("Error making Read request on Application Insights bucket %q (Resource Group %q): %+v", name, resGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+	d.Set("instrumentation_key", *resp.InstrumentationKey)
+
+	return nil
+}

--- a/azurerm/data_source_application_insights_test.go
+++ b/azurerm/data_source_application_insights_test.go
@@ -1,0 +1,39 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceApplicationInsights_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_application_insights.test"
+	ri := acctest.RandInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceApplicationInsights_complete(ri, location),
+				Check:  resource.TestCheckResourceAttrSet(dataSourceName, "instrumentation_key"),
+			},
+		},
+	})
+}
+
+func testAccResourceApplicationInsights_complete(rInt int, location string) string {
+	resource := testAccAzureRMApplicationInsights_basic(rInt, location, "other")
+
+	return fmt.Sprintf(`
+	%s
+
+data "azurerm_application_insights" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "${azurerm_application_insights.test.name}"
+}
+`, resource)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -143,6 +143,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_virtual_machine":                       dataSourceArmVirtualMachine(),
 			"azurerm_virtual_network":                       dataSourceArmVirtualNetwork(),
 			"azurerm_virtual_network_gateway":               dataSourceArmVirtualNetworkGateway(),
+			"azurerm_application_insights":                  dataSourceArmApplicationInsights(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -60,6 +60,10 @@
                     <a href="/docs/providers/azurerm/d/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-application-insights") %>>
+                    <a href="/docs/providers/azurerm/d/application_insights.html">azurerm_application_insights</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-azuread-application") %>>
                   <a href="/docs/providers/azurerm/d/azuread_application.html">azurerm_azuread_application</a>
                 </li>

--- a/website/docs/d/application_insights.html.markdown
+++ b/website/docs/d/application_insights.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_application_insights"
+sidebar_current: "docs-azurerm-datasource-application-insights"
+description: |-
+  Gets information about an existing Application Insights component.
+---
+
+# Data Source: azurerm_application_insights
+
+Use this data source to access information about an existing Application Insights component.
+
+## Example Usage
+
+```hcl
+data "azurerm_application_insights" "test" {
+  name                = "production"
+  resource_group_name = "networking"
+}
+
+output "application_insights_instrumentation_key" {
+  value = "${data.azurerm_application_insights.test.instrumentation_key}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the name of the Application Insights component.
+* `resource_group_name` - (Required) Specifies the name of the resource group the Application Insights component is located in.
+
+## Attributes Reference
+
+* `id` - The ID of the Virtual Machine.
+* `instrumentation_key` - The instrumentation key of the Application Insights component.

--- a/website/docs/d/application_insights.html.markdown
+++ b/website/docs/d/application_insights.html.markdown
@@ -31,4 +31,8 @@ output "application_insights_instrumentation_key" {
 ## Attributes Reference
 
 * `id` - The ID of the Virtual Machine.
+* `app_id` - The App ID associated with this Application Insights component.
+* `application_type` - The type of the component.
 * `instrumentation_key` - The instrumentation key of the Application Insights component.
+* `location` - The Azure location where the component exists.
+* `tags` - Tags applied to the component.


### PR DESCRIPTION
As proposed in #2623 this PR adds a new `azurerm_application_insights` data source that allows to get the instrumentation key of an existing Application Insights component.

## Usage

```hcl
data "azurerm_application_insights" "myappinsights" {
    name = "my_app_insights_bucket"
    resource_group_name = "${var.resource_group_name}"
}

// Here we use it to inject the AppInsights' instrumentation key in another resource
resource "azurerm_app_service" "myappsvc" {
    # …all other properties…

    app_settings {
        "APPINSIGHTS_INSTRUMENTATIONKEY" = "${data.azurerm_application_insights.myappinsights.instrumentation_key}"
    }
}
```