### PR TITLE
Fix: add Node.JS for application_type in application_insight resource

### DIFF
--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `Java`, `iOS`, `MobileCenter`, `Other`, `Phone`, `Store` and `Web`.
+* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `Java`, `iOS`, `MobileCenter`, `Other`, `Phone`, `Store`, `Web` and `Node.JS`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
This PR updated the documentation for `application_type` of `application_insight` resource.