### PR TITLE
azurerm_public_ip: fixed inverted validtion condition regression

### DIFF
--- a/azurerm/resource_arm_databricks_workspace_test.go
+++ b/azurerm/resource_arm_databricks_workspace_test.go
@@ -225,7 +225,7 @@ resource "azurerm_databricks_workspace" "test" {
   name                = "acctestdbw-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_monitor_log_profile_test.go
+++ b/azurerm/resource_arm_monitor_log_profile_test.go
@@ -282,7 +282,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestsbns-%s"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_namespace_authorization_rule" "test" {

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -955,11 +955,11 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name                         = "test-%d"
-  location                     = "${azurerm_resource_group.test.location}"
-  resource_group_name          = "${azurerm_resource_group.test.name}"
-  public_ip_address_allocation = "static"
-  domain_name_label            = "${azurerm_resource_group.test.name}"
+  name                = "test-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  allocation_method   = "Static"
+  domain_name_label   = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_network_interface" "test" {

--- a/azurerm/resource_arm_public_ip.go
+++ b/azurerm/resource_arm_public_ip.go
@@ -162,7 +162,7 @@ func resourceArmPublicIpCreateUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if strings.EqualFold(sku, "standard") {
-		if strings.EqualFold(ipAllocationMethod, "static") {
+		if !strings.EqualFold(ipAllocationMethod, "static") {
 			return fmt.Errorf("Static IP allocation must be used when creating Standard SKU public IP addresses.")
 		}
 	}

--- a/azurerm/resource_arm_public_ip_test.go
+++ b/azurerm/resource_arm_public_ip_test.go
@@ -624,7 +624,7 @@ resource "azurerm_public_ip" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   allocation_method   = "Static"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 `, rInt, location, rInt)
 }
@@ -642,7 +642,7 @@ resource "azurerm_public_ip" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   allocation_method   = "Static"
   ip_version          = "%s"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 `, rInt, location, rInt, ipVersion)
 }

--- a/azurerm/resource_arm_scheduler_job_test.go
+++ b/azurerm/resource_arm_scheduler_job_test.go
@@ -545,7 +545,7 @@ resource "azurerm_scheduler_job_collection" "test" {
   name                = "acctest-%[1]d-job_collection"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 `, rInt, location)
 }

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -130,7 +130,7 @@ resource "azurerm_search_service" "test" {
   name                = "acctestsearchservice%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     environment = "staging"
@@ -150,7 +150,7 @@ resource "azurerm_search_service" "test" {
   name                = "acctestsearchservice%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
   replica_count       = 2
 
   tags {

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -397,7 +397,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
@@ -444,7 +444,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
@@ -468,7 +468,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
@@ -492,7 +492,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
@@ -563,7 +563,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
@@ -586,7 +586,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
@@ -609,7 +609,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {
@@ -635,7 +635,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_queue" "test" {

--- a/azurerm/resource_arm_servicebus_subscription_rule_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_rule_test.go
@@ -367,7 +367,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -235,7 +235,7 @@ resource "azurerm_servicebus_namespace" "test" {
     name                = "acctestservicebusnamespace-%d"
     location            = "${azurerm_resource_group.test.location}"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    sku                 = "standard"
+    sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -326,7 +326,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
@@ -348,7 +348,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
@@ -371,7 +371,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
@@ -419,7 +419,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
@@ -468,7 +468,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {
@@ -491,7 +491,7 @@ resource "azurerm_servicebus_namespace" "test" {
   name                = "acctestservicebusnamespace-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_topic" "test" {

--- a/examples/scheduler-jobs/main.tf
+++ b/examples/scheduler-jobs/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_scheduler_job_collection" "example" {
   name                = "tfex-scheduler-job-collection"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
   state               = "enabled"
 
   quota {

--- a/examples/servicebus/main.tf
+++ b/examples/servicebus/main.tf
@@ -12,7 +12,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex-servicebus${random_integer.ri.result}"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 
 resource "azurerm_servicebus_namespace_authorization_rule" "example" {

--- a/website/docs/r/firewall_application_rule_collection.html.markdown
+++ b/website/docs/r/firewall_application_rule_collection.html.markdown
@@ -34,11 +34,11 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name                         = "testpip"
-  location                     = "${azurerm_resource_group.test.location}"
-  resource_group_name          = "${azurerm_resource_group.test.name}"
-  public_ip_address_allocation = "Static"
-  sku                          = "Standard"
+  name                = "testpip"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  allocation_method   = "Static"
+  sku                 = "Standard"
 }
 
 resource "azurerm_firewall" "test" {

--- a/website/docs/r/recovery_services_vault.markdown
+++ b/website/docs/r/recovery_services_vault.markdown
@@ -22,7 +22,7 @@ resource "azurerm_recovery_services_vault" "vault" {
   name                = "example_recovery_vault"
   location            = "${azurerm_resource_group.rg.location}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 }
 ```
 

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_search_service" "test" {
   name                = "acceptanceTestSearchService1"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     environment = "staging"

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"

--- a/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"

--- a/website/docs/r/servicebus_queue_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_queue_authorization_rule.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"

--- a/website/docs/r/servicebus_subscription_rule.html.markdown
+++ b/website/docs/r/servicebus_subscription_rule.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"
@@ -68,7 +68,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -24,7 +24,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_sevicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"

--- a/website/docs/r/servicebus_topic_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_topic_authorization_rule.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_servicebus_namespace" "example" {
   name                = "tfex_servicebus_namespace"
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
-  sku                 = "standard"
+  sku                 = "Standard"
 
   tags {
     source = "terraform"


### PR DESCRIPTION
This should fix failing firewall tests:
```
------- Stdout: -------
=== RUN   TestAccAzureRMFirewallApplicationRuleCollection_multipleRules
=== PAUSE TestAccAzureRMFirewallApplicationRuleCollection_multipleRules
=== CONT  TestAccAzureRMFirewallApplicationRuleCollection_multipleRules
--- FAIL: TestAccAzureRMFirewallApplicationRuleCollection_multipleRules (78.29s)
	testing.go:538: Step 0 error: Error applying: 1 error(s) occurred:
		
		* azurerm_public_ip.test: 1 error(s) occurred:
		
		* azurerm_public_ip.test: Static IP allocation must be used when creating Standard SKU public IP addresses.
FAIL
```