### PR TITLE
Support AKS Virtual Nodes

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -750,7 +750,7 @@ func expandKubernetesClusterAddonProfiles(d *schema.ResourceData) map[string]*co
 		enabled := value["enabled"].(bool)
 
 		if subnetName, ok := value["subnet_name"]; ok {
-			config["SubnetName"] = utils.String(subnetName.(string))
+			config["subnetName"] = utils.String(subnetName.(string))
 		}
 
 		addonProfiles["aciConnectorLinux"] = &containerservice.ManagedClusterAddonProfile{
@@ -813,7 +813,7 @@ func flattenKubernetesClusterAddonProfiles(profile map[string]*containerservice.
 		}
 
 		subnetName := ""
-		if v := aciConnector.Config["SubnetName"]; v != nil {
+		if v := aciConnector.Config["subnetName"]; v != nil {
 			subnetName = *v
 		}
 

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -797,9 +797,9 @@ resource "azurerm_subnet" "test-aci" {
   name                 = "acctestsubnet-aci%d"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
-	address_prefix       = "172.0.3.0/24"
+  address_prefix       = "172.0.3.0/24"
 
-	delegation {
+  delegation {
     name = "aciDelegation"
     service_delegation {
       name    = "Microsoft.ContainerInstance/containerGroups"

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -797,7 +797,15 @@ resource "azurerm_subnet" "test-aci" {
   name                 = "acctestsubnet-aci%d"
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
-  address_prefix       = "172.0.3.0/24"
+	address_prefix       = "172.0.3.0/24"
+
+	delegation {
+    name = "aciDelegation"
+    service_delegation {
+      name    = "Microsoft.ContainerInstance/containerGroups"
+      actions = [ "Microsoft.Network/virtualNetworks/subnets/action" ]
+    }
+  }
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
@@ -815,9 +823,9 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 
   agent_pool_profile {
-    name    = "default"
-    count   = "1"
-    vm_size = "Standard_DS2_v2"
+    name           = "default"
+    count          = "1"
+    vm_size        = "Standard_DS2_v2"
     vnet_subnet_id = "${azurerm_subnet.test.id}"
   }
 
@@ -828,8 +836,8 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   addon_profile {
     aci_connector_linux {
-      enabled                    = true
-      subnet_name                = "${azurerm_subnet.test-aci.name}"
+      enabled     = true
+      subnet_name = "${azurerm_subnet.test-aci.name}"
     }
   }
 

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -309,6 +309,32 @@ func TestAccAzureRMKubernetesCluster_internalNetwork(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T) {
+	resourceName := "azurerm_kubernetes_cluster.test"
+	ri := acctest.RandInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux(ri, clientId, clientSecret, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.http_application_routing.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.aci_connector_linux.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.aci_connector_linux.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.aci_connector_linux.0.subnet_name", fmt.Sprintf("acctestsubnet-aci%d", ri)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMKubernetesCluster_addonProfileOMS(t *testing.T) {
 	resourceName := "azurerm_kubernetes_cluster.test"
 	ri := acctest.RandInt()
@@ -740,6 +766,78 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
+}
+
+func testAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux(rInt int, clientId string, clientSecret string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  tags {
+    environment = "Testing"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "172.0.2.0/24"
+}
+
+resource "azurerm_subnet" "test-aci" {
+  name                 = "acctestsubnet-aci%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "172.0.3.0/24"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  agent_pool_profile {
+    name    = "default"
+    count   = "1"
+    vm_size = "Standard_DS2_v2"
+    vnet_subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  service_principal {
+    client_id     = "%s"
+    client_secret = "%s"
+  }
+
+  addon_profile {
+    aci_connector_linux {
+      enabled                    = true
+      subnet_name                = "${azurerm_subnet.test-aci.name}"
+    }
+  }
+
+  network_profile {
+    network_plugin = "azure"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
 }
 
 func testAccAzureRMKubernetesCluster_addonProfileOMS(rInt int, clientId string, clientSecret string, location string) string {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -95,6 +95,7 @@ A `addon_profile` block supports the following:
 
 * `http_application_routing` - (Optional) A `http_application_routing` block.
 * `oms_agent` - (Optional) A `oms_agent` block. For more details, please visit [How to onboard Azure Monitor for containers](https://docs.microsoft.com/en-us/azure/monitoring/monitoring-container-insights-onboard).
+* `aci_connector_linux` - (Optional) A `aci_connector_linux` block. For more details, please visit [Create and configure an AKS cluster to use virtual nodes](https://docs.microsoft.com/en-us/azure/aks/virtual-nodes-portal).
 
 ---
 
@@ -164,6 +165,14 @@ A `oms_agent` block supports the following:
 * `enabled` - (Required) Is the OMS Agent Enabled?
 
 * `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace which the OMS Agent should send data to.
+
+---
+
+A `aci_connector_linux` block supports the following:
+
+* `enabled` - (Required) Is the virtual node addon enabled?
+
+* `subnet_name` - (Required) The subnet name for the virtual nodes to run.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -93,9 +93,9 @@ The following arguments are supported:
 
 A `addon_profile` block supports the following:
 
+* `aci_connector_linux` - (Optional) A `aci_connector_linux` block. For more details, please visit [Create and configure an AKS cluster to use virtual nodes](https://docs.microsoft.com/en-us/azure/aks/virtual-nodes-portal).
 * `http_application_routing` - (Optional) A `http_application_routing` block.
 * `oms_agent` - (Optional) A `oms_agent` block. For more details, please visit [How to onboard Azure Monitor for containers](https://docs.microsoft.com/en-us/azure/monitoring/monitoring-container-insights-onboard).
-* `aci_connector_linux` - (Optional) A `aci_connector_linux` block. For more details, please visit [Create and configure an AKS cluster to use virtual nodes](https://docs.microsoft.com/en-us/azure/aks/virtual-nodes-portal).
 
 ---
 


### PR DESCRIPTION
Support for the AKS virtual nodes feature currently in preview (https://docs.microsoft.com/en-us/azure/aks/virtual-nodes-cli ).

The corresponding issue is https://github.com/terraform-providers/terraform-provider-azurerm/issues/2508 

I updated the docs and created an integration test.

I could use some help getting the test running. At the moment it fails with:

```
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
?       github.com/terraform-providers/terraform-provider-azurerm       [no test files]
=== RUN   TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux
=== PAUSE TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux
=== CONT  TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux
--- FAIL: TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux (800.89s)
    testing.go:538: Step 0 error: After applying this step and refreshing, the plan was not empty:
        
        DIFF:
        
        UPDATE: azurerm_subnet.test-aci
          delegation.#:                                "1" => "0"
          delegation.0.name:                           "aciDelegation" => ""
          delegation.0.service_delegation.#:           "1" => "0"
          delegation.0.service_delegation.0.actions.#: "1" => "0"
          delegation.0.service_delegation.0.actions.0: "Microsoft.Network/virtualNetworks/subnets/action" => ""
          delegation.0.service_delegation.0.name:      "Microsoft.ContainerInstance/containerGroups" => ""
        
        STATE:
        ...
```
Any ideas why? It seems the Virtual Node plugins modifies the subnet config.