### PR TITLE
Fix testAccDataSourceEventHubNamespace_complete tf

### DIFF
--- a/azurerm/data_source_eventhub_namespace_test.go
+++ b/azurerm/data_source_eventhub_namespace_test.go
@@ -84,9 +84,8 @@ resource "azurerm_eventhub_namespace" "test" {
   resource_group_name      = "${azurerm_resource_group.test.name}"
   sku                      = "Standard"
   capacity                 = "2"
-	auto_inflate_enabled     = true
-	auto_inflate_enabled     = true
-	kafka_enabled .          = true
+  auto_inflate_enabled     = true
+  kafka_enabled            = true
   maximum_throughput_units = 20
 }
 


### PR DESCRIPTION
before 

```
------- Stdout: -------
=== RUN   TestAccDataSourceAzureRMEventHubNamespace_complete
=== PAUSE TestAccDataSourceAzureRMEventHubNamespace_complete
=== CONT  TestAccDataSourceAzureRMEventHubNamespace_complete
--- FAIL: TestAccDataSourceAzureRMEventHubNamespace_complete (0.00s)
	testing.go:538: Step 0 error: Error loading configuration: Error parsing /opt/teamcity-agent/temp/buildTmp/tf-test553763838/main.tf: At 15:16: expected: IDENT | STRING | ASSIGN | LBRACE got: PERIOD
FAIL
```

after

```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccDataSourceAzureRMEventHubNamespace_complete -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAzureRMEventHubNamespace_complete
=== PAUSE TestAccDataSourceAzureRMEventHubNamespace_complete
=== CONT  TestAccDataSourceAzureRMEventHubNamespace_complete
--- PASS: TestAccDataSourceAzureRMEventHubNamespace_complete (180.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	181.972s
```