### PR TITLE
data.azurerm_network_interface: add missing property ip_configuration.private_ip_address_version

### DIFF
--- a/azurerm/data_source_network_interface.go
+++ b/azurerm/data_source_network_interface.go
@@ -59,6 +59,12 @@ func dataSourceArmNetworkInterface() *schema.Resource {
 							Computed: true,
 						},
 
+						"private_ip_address_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						//TODO: should this be renamed to private_ip_address_allocation_method or private_ip_allocation_method ?
 						"private_ip_address_allocation": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -81,7 +81,6 @@ func resourceArmNetworkInterface() *schema.Resource {
 							Optional: true,
 						},
 
-						//TODO: should this be renamed to private_ip_address_allocation_method or private_ip_allocation_method ?
 						"private_ip_address_version": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -93,6 +92,7 @@ func resourceArmNetworkInterface() *schema.Resource {
 							}, false),
 						},
 
+						//TODO: should this be renamed to private_ip_address_allocation_method or private_ip_allocation_method ?
 						"private_ip_address_allocation": {
 							Type:     schema.TypeString,
 							Required: true,


### PR DESCRIPTION
before
```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccDataSourceArmVirtualNetworkInterface_basic
=== PAUSE TestAccDataSourceArmVirtualNetworkInterface_basic
=== CONT  TestAccDataSourceArmVirtualNetworkInterface_basic

------- Stderr: -------
panic: Invalid address to set: []string{"ip_configuration", "0", "private_ip_address_version"}
```
after
```
[17:38:55] kt@snowbook:~/hashi/..3../terraform-providers/terraform-provider-azurerm▸eventhub/fix_acctests$ testazure TestAccDataSourceArmVirtualNetworkInterface_basic
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccDataSourceArmVirtualNetworkInterface_basic -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceArmVirtualNetworkInterface_basic
=== PAUSE TestAccDataSourceArmVirtualNetworkInterface_basic
=== CONT  TestAccDataSourceArmVirtualNetworkInterface_basic
--- PASS: TestAccDataSourceArmVirtualNetworkInterface_basic (125.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	127.032s
```