### PR TITLE
azurerm_search_service: disallow uppercase in sku and fix acctest

### DIFF
--- a/azurerm/resource_arm_search_service.go
+++ b/azurerm/resource_arm_search_service.go
@@ -40,8 +40,7 @@ func resourceArmSearchService() *schema.Resource {
 					string(search.Standard),
 					string(search.Standard2),
 					string(search.Standard3),
-				}, true),
-				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+				}, false),
 			},
 
 			"replica_count": {

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -130,7 +130,7 @@ resource "azurerm_search_service" "test" {
   name                = "acctestsearchservice%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "Standard"
+  sku                 = "standard"
 
   tags {
     environment = "staging"
@@ -150,7 +150,7 @@ resource "azurerm_search_service" "test" {
   name                = "acctestsearchservice%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  sku                 = "Standard"
+  sku                 = "standard"
   replica_count       = 2
 
   tags {


### PR DESCRIPTION
Fixing regression with acctest sku casing. It also appears uppercase SKU's cause a failure.
before:
```
------- Stdout: -------
=== RUN   TestAccAzureRMSearchService_basic
=== PAUSE TestAccAzureRMSearchService_basic
=== CONT  TestAccAzureRMSearchService_basic
--- FAIL: TestAccAzureRMSearchService_basic (59.34s)
	testing.go:538: Step 0 error: Error applying: 1 error(s) occurred:
		
		* azurerm_search_service.test: 1 error(s) occurred:
		
		* azurerm_search_service.test: search.ServicesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidSkuName" Message="Invalid SKU Name: Standard"
FAIL
```
after
```
==> Fixing source code with gofmt...
gofmt -s -w ./azurerm
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./azurerm -v -test.run=TestAccAzureRMSearchService -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMSearchService_basic
=== PAUSE TestAccAzureRMSearchService_basic
=== RUN   TestAccAzureRMSearchService_complete
=== PAUSE TestAccAzureRMSearchService_complete
=== CONT  TestAccAzureRMSearchService_basic
=== CONT  TestAccAzureRMSearchService_complete
--- PASS: TestAccAzureRMSearchService_basic (95.00s)
--- PASS: TestAccAzureRMSearchService_complete (117.11s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	119.038s
```