### PR TITLE
allowing the partner_id to be set to an empty string

### DIFF
--- a/azurerm/helpers/validate/uuid.go
+++ b/azurerm/helpers/validate/uuid.go
@@ -23,3 +23,16 @@ func UUID(i interface{}, k string) (warnings []string, errors []error) {
 
 	return warnings, errors
 }
+func UUIDOrEmpty(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if v == "" {
+		return
+	}
+
+	return UUID(i, k)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -80,7 +80,7 @@ func Provider() terraform.ResourceProvider {
 				Type:         schema.TypeString,
 				Optional:     true,
 				DefaultFunc:  schema.EnvDefaultFunc("ARM_PARTNER_ID", ""),
-				ValidateFunc: validate.UUID,
+				ValidateFunc: validate.UUIDOrEmpty,
 			},
 
 			// Advanced feature flags


### PR DESCRIPTION
Fixing a bug where the Partner ID being set to an empty string would cause a validation error