### PR TITLE
fix policy definition imports rendering

### DIFF
--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -95,9 +95,11 @@ The following attributes are exported:
 Policy Definitions can be imported using the `policy name`, e.g.
 
 ```shell
-terraform import azurerm_policy_definition.testPolicy  /subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
+terraform import azurerm_policy_definition.testPolicy /subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
 ```
+
 or
+
 ```shell
 terraform import azurerm_policy_definition.testPolicy /providers/Microsoft.Management/managementgroups/<MANGAGEMENT_GROUP_ID>/providers/Microsoft.Authorization/policyDefinitions/<POLICY_NAME>
 ```


### PR DESCRIPTION
with the v1.21.0 release, I noticed that the imports for [azurerm_policy_definition](https://www.terraform.io/docs/providers/azurerm/r/policy_definition.html#import) didn't render correctly. This patch corrects that.