### PR TITLE
Fix the doc of app service

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -221,7 +221,7 @@ The following attributes are exported:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
--> You can access the Principal ID via `${azurerm_app_service.test.identity.0.principal_id}` and the Tenant ID via `${azurerm_app_service.test.identity.0.principal_id}`
+-> You can access the Principal ID via `${azurerm_app_service.test.identity.0.principal_id}` and the Tenant ID via `${azurerm_app_service.test.identity.0.tenant_id}`
 
 ---
 


### PR DESCRIPTION
This PR includes the quick fix to update the misuse of `partner_id` in tenant ID scenario. It was open in issue #2674 .

(fixes #2674)