### PR TITLE
azurerm_app_service: Adding node language support

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -114,6 +114,30 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 					DiffSuppressFunc: suppress.CaseDifference,
 				},
 
+				"node_version": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"0.6",
+						"0.8",
+						"0.10",
+						"0.12",
+						"4.8",
+						"6.5",
+						"6.9",
+						"6.12",
+						"7.10",
+						"8.1",
+						"8.4",
+						"8.5",
+						"8.9",
+						"8.10",
+						"8.11",
+						"10.0",
+						"10.6",
+					}, false),
+				},
+
 				"php_version": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -300,6 +324,10 @@ func ExpandAppServiceSiteConfig(input interface{}) web.SiteConfig {
 		siteConfig.ManagedPipelineMode = web.ManagedPipelineMode(v.(string))
 	}
 
+	if v, ok := config["node_version"]; ok {
+		siteConfig.NodeVersion = utils.String(v.(string))
+	}
+
 	if v, ok := config["php_version"]; ok {
 		siteConfig.PhpVersion = utils.String(v.(string))
 	}
@@ -414,6 +442,10 @@ func FlattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 	result["ip_restriction"] = restrictions
 
 	result["managed_pipeline_mode"] = string(input.ManagedPipelineMode)
+
+	if input.NodeVersion != nil {
+		result["node_version"] = *input.NodeVersion
+	}
 
 	if input.PhpVersion != nil {
 		result["php_version"] = *input.PhpVersion

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1007,6 +1007,32 @@ func TestAccAzureRMAppService_windowsPython(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_windowsNode(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMAppService_windowsNode(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.node_version", "8.4"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_webSockets(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := tf.AccRandTimeInt()
@@ -2159,6 +2185,37 @@ resource "azurerm_app_service" "test" {
 
   site_config {
     python_version = "3.4"
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_windowsNode(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    node_version = "8.4"
   }
 }
 `, rInt, location, rInt, rInt)

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -171,6 +171,7 @@ The following arguments are supported:
 * `linux_fx_version` - (Optional) Linux App Framework and version for the AppService, e.g. `DOCKER|(golang:latest)`.
 * `managed_pipeline_mode` - (Optional) The Managed Pipeline Mode. Possible values are `Integrated` and `Classic`. Defaults to `Integrated`.
 * `min_tls_version` - (Optional) The minimum supported TLS version for the app service. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new app services.
+* `node_version` - (Optional) The version of Node to use in this App Service. Possible values are `0.6`, `0.8`, `0.10`, `0.12`, `4.8`, `6.5`, `6.9`, `6.12`, `7.10`, `8.1`, `8.4`, `8.5`, `8.9`, `8.10`, `8.11`, `10.0` and `10.6`.
 * `php_version` - (Optional) The version of PHP to use in this App Service. Possible values are `5.5`, `5.6`, `7.0`, `7.1` and `7.2`.
 * `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7` and `3.4`.
 * `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.


### PR DESCRIPTION
This PR introduces the ability to support node.js in Azure App Service (requested in #2183)