### PR TITLE
[Batch Pool] Fix issue when setting multiple env var in pool start task

### DIFF
--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -208,10 +208,11 @@ func ExpandBatchPoolStartTask(list []interface{}) (*batch.StartTask, error) {
 		envSettings := make([]batch.EnvironmentSetting, 0)
 
 		for k, v := range envMap {
-			envValue := v.(string)
+			theValue := v.(string)
+			theKey := k
 			envSetting := batch.EnvironmentSetting{
-				Name:  &k,
-				Value: &envValue,
+				Name:  &theKey,
+				Value: &theValue,
 			}
 
 			envSettings = append(envSettings, envSetting)

--- a/azurerm/resource_arm_batch_pool_test.go
+++ b/azurerm/resource_arm_batch_pool_test.go
@@ -206,8 +206,9 @@ func TestAccAzureRMBatchPoolStartTask_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "fixed_scale.0.target_low_priority_nodes", "0"),
 					resource.TestCheckResourceAttr(resourceName, "start_task.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "start_task.0.max_task_retry_count", "1"),
-					resource.TestCheckResourceAttr(resourceName, "start_task.0.environment.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "start_task.0.environment.%", "2"),
 					resource.TestCheckResourceAttr(resourceName, "start_task.0.environment.env", "TEST"),
+					resource.TestCheckResourceAttr(resourceName, "start_task.0.environment.bu", "Research&Dev"),
 					resource.TestCheckResourceAttr(resourceName, "start_task.0.user_identity.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "start_task.0.user_identity.0.auto_user.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "start_task.0.user_identity.0.auto_user.0.scope", "Task"),
@@ -449,7 +450,8 @@ resource "azurerm_batch_pool" "test" {
     wait_for_success     = true
 
     environment {
-      env = "TEST"
+			env = "TEST",
+			bu  = "Research&Dev"
     }
 
     user_identity {


### PR DESCRIPTION
This PR fixes #2673.
Was just a value capture issue inside a for loop.
I've added unit test to reproduce the issue and committed a fix.