### PR TITLE
Update GNUMakefile's fmt step to match the search logic in gofmtcheck.sh

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,7 +30,8 @@ debugacc: fmtcheck
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."
-	gofmt -s -w ./$(PKG_NAME)
+	# This logic should match the search logic in scripts/gofmtcheck.sh
+	gofmt -s -w `find . -name '*.go' | grep -v vendor`
 
 # Currently required by tf-deploy compile
 fmtcheck:

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,6 +2,8 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
+
+# This filter should match the search filter in ../GNUMakefile
 gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
 if [ -n "${gofmt_files}" ]; then
     echo 'gofmt needs running on the following files:'


### PR DESCRIPTION
This is a fix for #2689 

This is the new output showing that `make fmt` fixes all of the files and allows `make build` to run. This excludes the files under vendor, matching the behavior of gofmtcheck.sh.

```
$ make build
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./azurerm/azurerm_sweeper_test.go
..... (files removed from brevity)
./azurerm/utils/utils.go
./azurerm/validators.go
./azurerm/validators_test.go
./main.go
./version/version.go  
You can use the command: `make fmt` to reformat code.  
make: *** [fmtcheck] Error 1


$ make fmt
==> Fixing source code with gofmt...
# This logic should match the search logic in scripts/gofmtcheck.sh
gofmt -s -w `find . -name '*.go' \| grep -v vendor`


$ make build
==> Checking that code complies with gofmt requirements...
go install
```