### PR TITLE
r/notification_hub_namespace: polling to handle eventual consistency

### DIFF
--- a/azurerm/resource_arm_notification_hub.go
+++ b/azurerm/resource_arm_notification_hub.go
@@ -1,10 +1,14 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"strconv"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -156,10 +160,25 @@ func resourceArmNotificationHubCreateUpdate(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error creating Notification Hub %q (Namespace %q / Resource Group %q): %+v", name, namespaceName, resourceGroup, err)
 	}
 
+	// Notification Hubs are eventually consistent
+	log.Printf("[DEBUG] Waiting for Notification Hub %q to become available", name)
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{"404"},
+		Target:                    []string{"200"},
+		Refresh:                   notificationHubStateRefreshFunc(ctx, client, resourceGroup, namespaceName, name),
+		Timeout:                   10 * time.Minute,
+		MinTimeout:                15 * time.Second,
+		ContinuousTargetOccurence: 10,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error waiting for Notification Hub %q to become available: %s", name, err)
+	}
+
 	read, err := client.Get(ctx, resourceGroup, namespaceName, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Notification Hub %q (Namespace %q / Resource Group %q): %+v", name, namespaceName, resourceGroup, err)
 	}
+
 	if read.ID == nil {
 		return fmt.Errorf("Cannot read Notification Hub %q (Namespace %q / Resource Group %q) ID", name, namespaceName, resourceGroup)
 	}
@@ -167,6 +186,21 @@ func resourceArmNotificationHubCreateUpdate(d *schema.ResourceData, meta interfa
 	d.SetId(*read.ID)
 
 	return resourceArmNotificationHubRead(d, meta)
+}
+
+func notificationHubStateRefreshFunc(ctx context.Context, client notificationhubs.Client, resourceGroup, namespaceName, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, resourceGroup, namespaceName, name)
+		if err != nil {
+			if utils.ResponseWasNotFound(res.Response) {
+				return nil, "404", nil
+			}
+
+			return nil, "", fmt.Errorf("Error retrieving Notification Hub %q (Namespace %q / Resource Group %q): %+v", name, namespaceName, resourceGroup, err)
+		}
+
+		return res, strconv.Itoa(res.StatusCode), nil
+	}
 }
 
 func resourceArmNotificationHubRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Seems to fix the issue raised in #1822:

```
$ acctests azurerm TestAccAzureRMNotificationHub_
=== RUN   TestAccAzureRMNotificationHub_basic
=== PAUSE TestAccAzureRMNotificationHub_basic
=== CONT  TestAccAzureRMNotificationHub_basic
--- PASS: TestAccAzureRMNotificationHub_basic (341.71s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	343.183s

12:53 $ acctests azurerm TestAccAzureRMNotificationHub_
=== RUN   TestAccAzureRMNotificationHub_basic
=== PAUSE TestAccAzureRMNotificationHub_basic
=== CONT  TestAccAzureRMNotificationHub_basic
--- PASS: TestAccAzureRMNotificationHub_basic (343.42s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	343.987s

12:59 $ acctests azurerm TestAccAzureRMNotificationHub_
=== RUN   TestAccAzureRMNotificationHub_basic
=== PAUSE TestAccAzureRMNotificationHub_basic
=== CONT  TestAccAzureRMNotificationHub_basic
--- PASS: TestAccAzureRMNotificationHub_basic (345.83s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	346.334s
```

Fixes #1822