### PR TITLE
Add nil check before type conversion and deference.

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -317,23 +317,18 @@ func resourceArmSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 
 func expandSubnetServiceEndpoints(d *schema.ResourceData) []network.ServiceEndpointPropertiesFormat {
 	serviceEndpoints := d.Get("service_endpoints").([]interface{})
-	enpoints := make([]network.ServiceEndpointPropertiesFormat, 0)
+	endpoints := make([]network.ServiceEndpointPropertiesFormat, 0)
 
 	for _, svcEndpointRaw := range serviceEndpoints {
-		if svcEndpointRaw == nil {
-			continue
+		if svc, ok := svcEndpointRaw.(string); ok {
+			endpoint := network.ServiceEndpointPropertiesFormat{
+				Service: &svc,
+			}
+			endpoints = append(endpoints, endpoint)
 		}
-
-		svc := svcEndpointRaw.(string)
-
-		endpoint := network.ServiceEndpointPropertiesFormat{
-			Service: &svc,
-		}
-
-		enpoints = append(enpoints, endpoint)
 	}
 
-	return enpoints
+	return endpoints
 }
 
 func flattenSubnetServiceEndpoints(serviceEndpoints *[]network.ServiceEndpointPropertiesFormat) []string {
@@ -344,11 +339,9 @@ func flattenSubnetServiceEndpoints(serviceEndpoints *[]network.ServiceEndpointPr
 	}
 
 	for _, endpoint := range *serviceEndpoints {
-		if endpoint.Service == nil {
-			continue
+		if endpoint.Service != nil {
+			endpoints = append(endpoints, *endpoint.Service)
 		}
-
-		endpoints = append(endpoints, *endpoint.Service)
 	}
 
 	return endpoints

--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -319,11 +319,15 @@ func expandSubnetServiceEndpoints(d *schema.ResourceData) []network.ServiceEndpo
 	serviceEndpoints := d.Get("service_endpoints").([]interface{})
 	enpoints := make([]network.ServiceEndpointPropertiesFormat, 0)
 
-	for _, serviceEndpointsRaw := range serviceEndpoints {
-		data := serviceEndpointsRaw.(string)
+	for _, svcEndpointRaw := range serviceEndpoints {
+		if svcEndpointRaw == nil {
+			continue
+		}
+
+		svc := svcEndpointRaw.(string)
 
 		endpoint := network.ServiceEndpointPropertiesFormat{
-			Service: &data,
+			Service: &svc,
 		}
 
 		enpoints = append(enpoints, endpoint)
@@ -335,10 +339,16 @@ func expandSubnetServiceEndpoints(d *schema.ResourceData) []network.ServiceEndpo
 func flattenSubnetServiceEndpoints(serviceEndpoints *[]network.ServiceEndpointPropertiesFormat) []string {
 	endpoints := make([]string, 0)
 
-	if serviceEndpoints != nil {
-		for _, endpoint := range *serviceEndpoints {
-			endpoints = append(endpoints, *endpoint.Service)
+	if serviceEndpoints == nil {
+		return endpoints
+	}
+
+	for _, endpoint := range *serviceEndpoints {
+		if endpoint.Service == nil {
+			continue
 		}
+
+		endpoints = append(endpoints, *endpoint.Service)
 	}
 
 	return endpoints


### PR DESCRIPTION
This PR fixes the crash issue in #2682 with `nil` check before type conversion and deference.

(fixes #2682)