### PR TITLE
[service_fabric] Don't pass the reverse proxy port if not set

### DIFF
--- a/azurerm/resource_arm_service_fabric_cluster.go
+++ b/azurerm/resource_arm_service_fabric_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -249,8 +250,9 @@ func resourceArmServiceFabricCluster() *schema.Resource {
 							ForceNew: true,
 						},
 						"reverse_proxy_endpoint_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validate.PortNumber,
 						},
 						"durability_level": {
 							Type:     schema.TypeString,
@@ -890,7 +892,6 @@ func expandServiceFabricClusterNodeTypes(input []interface{}) *[]servicefabric.N
 		instanceCount := node["instance_count"].(int)
 		clientEndpointPort := node["client_endpoint_port"].(int)
 		httpEndpointPort := node["http_endpoint_port"].(int)
-		reverseProxyEndpointPort := node["reverse_proxy_endpoint_port"].(int)
 		isPrimary := node["is_primary"].(bool)
 		durabilityLevel := node["durability_level"].(string)
 
@@ -900,8 +901,10 @@ func expandServiceFabricClusterNodeTypes(input []interface{}) *[]servicefabric.N
 			IsPrimary:                    utils.Bool(isPrimary),
 			ClientConnectionEndpointPort: utils.Int32(int32(clientEndpointPort)),
 			HTTPGatewayEndpointPort:      utils.Int32(int32(httpEndpointPort)),
-			ReverseProxyEndpointPort:     utils.Int32(int32(reverseProxyEndpointPort)),
 			DurabilityLevel:              servicefabric.DurabilityLevel(durabilityLevel),
+		}
+		if v := int32(node["reverse_proxy_endpoint_port"].(int)); v != 0 {
+			result.ReverseProxyEndpointPort = utils.Int32(v)
 		}
 
 		applicationPortsRaw := node["application_ports"].([]interface{})

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -190,6 +190,44 @@ func TestAccAzureRMServiceFabricCluster_reverseProxyCertificate(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
 					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "https://example:80"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.0.reverse_proxy_endpoint_port", "19081"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMServiceFabricCluster_reverseProxyNotSet(t *testing.T) {
+	resourceName := "azurerm_service_fabric_cluster.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	config := testAccAzureRMServiceFabricCluster_basic(ri, location, 3)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceFabricClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceFabricClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "http://example:80"),
+					resource.TestCheckResourceAttr(resourceName, "add_on_features.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "node_type.0.reverse_proxy_endpoint_port"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_thumbprint.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "diagnostics_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.0.instance_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -221,7 +221,44 @@ func TestAccAzureRMServiceFabricCluster_reverseProxyNotSet(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "add_on_features.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "certificate.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "0"),
-					resource.TestCheckNoResourceAttr(resourceName, "node_type.0.reverse_proxy_endpoint_port"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_thumbprint.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "diagnostics_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.0.instance_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.0.reverse_proxy_endpoint_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMServiceFabricCluster_reverseProxyUpdate(t *testing.T) {
+	resourceName := "azurerm_service_fabric_cluster.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	configBasic := testAccAzureRMServiceFabricCluster_basic(ri, location, 3)
+	configProxy := testAccAzureRMServiceFabricCluster_reverseProxyCertificates(ri, location)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceFabricClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceFabricClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "http://example:80"),
+					resource.TestCheckResourceAttr(resourceName, "add_on_features.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "client_certificate_thumbprint.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "diagnostics_config.#", "0"),
@@ -231,9 +268,37 @@ func TestAccAzureRMServiceFabricCluster_reverseProxyNotSet(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: configProxy,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceFabricClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.0.x509_store_name", "My"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.0.x509_store_name", "My"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.name", "Security"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
+					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "https://example:80"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.0.reverse_proxy_endpoint_port", "19081"),
+				),
+			},
+			{
+				Config: configBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceFabricClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "http://example:80"),
+					resource.TestCheckResourceAttr(resourceName, "add_on_features.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "certificate.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_certificate_thumbprint.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "diagnostics_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.0.instance_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "node_type.0.reverse_proxy_endpoint_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
This prevents the reverse proxy port being passed to the API when not specified. Previously if you didn't specify it then a value of `0` was passed, which breaks the cluster provisioning.

I tried adding a test for this using `TestCheckNoResourceAttr` but I always get `Check failed: Check 6/12 error: azurerm_service_fabric_cluster.test: Attribute 'node_type.0.reverse_proxy_endpoint_port' found when not expected` so not sure if I am using it correctly?

```go
func TestAccAzureRMServiceFabricCluster_reverseProxyNotSet(t *testing.T) {
	resourceName := "azurerm_service_fabric_cluster.test"
	ri := tf.AccRandTimeInt()
	location := testLocation()
	config := testAccAzureRMServiceFabricCluster_basic(ri, location, 3)

	resource.ParallelTest(t, resource.TestCase{
		PreCheck:     func() { testAccPreCheck(t) },
		Providers:    testAccProviders,
		CheckDestroy: testCheckAzureRMServiceFabricClusterDestroy,
		Steps: []resource.TestStep{
			{
				Config: config,
				Check: resource.ComposeTestCheckFunc(
					testCheckAzureRMServiceFabricClusterExists(resourceName),
					resource.TestCheckResourceAttr(resourceName, "management_endpoint", "http://example:80"),
					resource.TestCheckResourceAttr(resourceName, "add_on_features.#", "0"),
					resource.TestCheckResourceAttr(resourceName, "certificate.#", "0"),
					resource.TestCheckResourceAttr(resourceName, "reverse_proxy_certificate.#", "0"),
					resource.TestCheckNoResourceAttr(resourceName, "node_type.0.reverse_proxy_endpoint_port"),
					resource.TestCheckResourceAttr(resourceName, "client_certificate_thumbprint.#", "0"),
					resource.TestCheckResourceAttr(resourceName, "azure_active_directory.#", "0"),
					resource.TestCheckResourceAttr(resourceName, "diagnostics_config.#", "0"),
					resource.TestCheckResourceAttr(resourceName, "node_type.#", "1"),
					resource.TestCheckResourceAttr(resourceName, "node_type.0.instance_count", "3"),
					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
				),
			},
			{
				ResourceName:      resourceName,
				ImportState:       true,
				ImportStateVerify: true,
			},
		},
	})
}
```