### PR TITLE
Fix issue of not able to remove data disks in VMSS once it is set

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -758,14 +758,13 @@ func resourceArmVirtualMachineScaleSetCreateUpdate(d *schema.ResourceData, meta 
 	}
 
 	storageProfile := compute.VirtualMachineScaleSetStorageProfile{}
-
 	osDisk, err := expandAzureRMVirtualMachineScaleSetsStorageProfileOsDisk(d)
 	if err != nil {
 		return err
 	}
 	storageProfile.OsDisk = osDisk
 
-	if osDisk.ManagedDisk != nil && osDisk.ManagedDisk.StorageAccountType != "" {
+	if osDisk != nil && osDisk.ManagedDisk != nil && osDisk.ManagedDisk.StorageAccountType != "" {
 		storageProfile.DataDisks = expandAzureRMVirtualMachineScaleSetsStorageProfileDataDisk(dataDisksRaw)
 	} else if len(dataDisksRaw) > 0 {
 		return fmt.Errorf("[ERROR] `storage_profile_data_disk` should not be used with unmanaged `storage_profile_os_disk`")

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -757,15 +757,19 @@ func resourceArmVirtualMachineScaleSetCreateUpdate(d *schema.ResourceData, meta 
 		return err
 	}
 
-	storageProfile := compute.VirtualMachineScaleSetStorageProfile{
-		DataDisks: expandAzureRMVirtualMachineScaleSetsStorageProfileDataDisk(dataDisksRaw),
-	}
+	storageProfile := compute.VirtualMachineScaleSetStorageProfile{}
 
 	osDisk, err := expandAzureRMVirtualMachineScaleSetsStorageProfileOsDisk(d)
 	if err != nil {
 		return err
 	}
 	storageProfile.OsDisk = osDisk
+
+	if osDisk.ManagedDisk != nil && osDisk.ManagedDisk.StorageAccountType != "" {
+		storageProfile.DataDisks = expandAzureRMVirtualMachineScaleSetsStorageProfileDataDisk(dataDisksRaw)
+	} else if len(dataDisksRaw) > 0 {
+		return fmt.Errorf("[ERROR] `storage_profile_data_disk` should not be used with unmanaged `storage_profile_os_disk`")
+	}
 
 	if _, ok := d.GetOk("storage_profile_image_reference"); ok {
 		imageRef, err2 := expandAzureRmVirtualMachineScaleSetStorageProfileImageReference(d)

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -980,7 +980,7 @@ func TestAccAzureRMVirtualMachineScaleSet_updateDataDisks(t *testing.T) {
 				Config: noDataDisksConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualMachineScaleSetExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "storage_profile_data_disk.#", "0"),
+					resource.TestCheckNoResourceAttr(resourceName, "storage_profile_data_disk.#"),
 				),
 			},
 			{


### PR DESCRIPTION
This PR fixes #1669 by refactoring `expandAzureRMVirtualMachineScaleSetsStorageProfileDataDisk`.

The root cause of the issue is because `storageProfile` does not include any `DataDisks` sections when no `storage_profile_data_disk` is presented in HCL, which makes ARM API think nothing about data disks has been changed.

There is one additional check before setting `DataDisks`, which is when `storage_profile_data_disk` is an unmanaged disk, ARM API will report error if you pass in `DataDisks` section (even when it is an empty array). Therefore I checked this condition and report the error to the user.