### PR TITLE
Add more info for `metric_name` setting in `autoscale_setting` documentation

### DIFF
--- a/website/docs/r/autoscale_setting.html.markdown
+++ b/website/docs/r/autoscale_setting.html.markdown
@@ -317,7 +317,9 @@ A `rule` block supports the following:
 
 A `metric_trigger` block supports the following:
 
-* `metric_name` - (Required) The name of the metric that defines what the rule monitors, such as `Percentage CPU`.
+* `metric_name` - (Required) The name of the metric that defines what the rule monitors, such as `Percentage CPU` for `Virtual Machine Scale Sets`.
+
+-> **NOTE:** The allowed value of `metric_name` highly depends on the targeting resource type, please visit [Supported metrics with Azure Monitor](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/metrics-supported) for more details.
 
 * `metric_resource_id` - (Required) The ID of the Resource which the Rule monitors.
 


### PR DESCRIPTION
This PR fixes #2726 to address the documentation concern about `metric_name` for different types of resources.