### PR TITLE
azurerm_app_service: Allow to turn off/on "Incoming client certificates"

### DIFF
--- a/azurerm/data_source_app_service.go
+++ b/azurerm/data_source_app_service.go
@@ -45,6 +45,11 @@ func dataSourceArmAppService() *schema.Resource {
 				Computed: true,
 			},
 
+			"client_cert_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"app_settings": {
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -187,6 +192,7 @@ func dataSourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("enabled", props.Enabled)
 		d.Set("https_only", props.HTTPSOnly)
+		d.Set("client_cert_enabled", props.ClientCertEnabled)
 		d.Set("default_site_hostname", props.DefaultHostName)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -85,7 +85,6 @@ func resourceArmAppService() *schema.Resource {
 			"client_cert_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"enabled": {
@@ -231,7 +230,6 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
-	clientCertEnabled := d.Get("client_cert_enabled").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
 	siteConfig := azure.ExpandAppServiceSiteConfig(d.Get("site_config"))
@@ -240,11 +238,10 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 		Location: &location,
 		Tags:     expandTags(tags),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID:      utils.String(appServicePlanId),
-			Enabled:           utils.Bool(enabled),
-			HTTPSOnly:         utils.Bool(httpsOnly),
-			ClientCertEnabled: utils.Bool(clientCertEnabled),
-			SiteConfig:        &siteConfig,
+			ServerFarmID: utils.String(appServicePlanId),
+			Enabled:      utils.Bool(enabled),
+			HTTPSOnly:    utils.Bool(httpsOnly),
+			SiteConfig:   &siteConfig,
 		},
 	}
 
@@ -256,6 +253,11 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	if v, ok := d.GetOkExists("client_affinity_enabled"); ok {
 		enabled := v.(bool)
 		siteEnvelope.SiteProperties.ClientAffinityEnabled = utils.Bool(enabled)
+	}
+
+	if v, ok := d.GetOkExists("client_cert_enabled"); ok {
+		certEnabled := v.(bool)
+		siteEnvelope.SiteProperties.ClientCertEnabled = utils.Bool(certEnabled)
 	}
 
 	createFuture, err := client.CreateOrUpdate(ctx, resGroup, name, siteEnvelope)
@@ -297,7 +299,6 @@ func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
-	clientCertEnabled := d.Get("client_cert_enabled").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
 	siteConfig := azure.ExpandAppServiceSiteConfig(d.Get("site_config"))
@@ -305,12 +306,16 @@ func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		Location: &location,
 		Tags:     expandTags(tags),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID:      utils.String(appServicePlanId),
-			Enabled:           utils.Bool(enabled),
-			HTTPSOnly:         utils.Bool(httpsOnly),
-			ClientCertEnabled: utils.Bool(clientCertEnabled),
-			SiteConfig:        &siteConfig,
+			ServerFarmID: utils.String(appServicePlanId),
+			Enabled:      utils.Bool(enabled),
+			HTTPSOnly:    utils.Bool(httpsOnly),
+			SiteConfig:   &siteConfig,
 		},
+	}
+
+	if v, ok := d.GetOkExists("client_cert_enabled"); ok {
+		certEnabled := v.(bool)
+		siteEnvelope.SiteProperties.ClientCertEnabled = utils.Bool(certEnabled)
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, siteEnvelope)

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -82,6 +82,12 @@ func resourceArmAppService() *schema.Resource {
 				Default:  false,
 			},
 
+			"client_cert_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -225,6 +231,7 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
+	clientCertEnabled := d.Get("client_cert_enabled").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
 	siteConfig := azure.ExpandAppServiceSiteConfig(d.Get("site_config"))
@@ -233,10 +240,11 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 		Location: &location,
 		Tags:     expandTags(tags),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID: utils.String(appServicePlanId),
-			Enabled:      utils.Bool(enabled),
-			HTTPSOnly:    utils.Bool(httpsOnly),
-			SiteConfig:   &siteConfig,
+			ServerFarmID:      utils.String(appServicePlanId),
+			Enabled:           utils.Bool(enabled),
+			HTTPSOnly:         utils.Bool(httpsOnly),
+			ClientCertEnabled: utils.Bool(clientCertEnabled),
+			SiteConfig:        &siteConfig,
 		},
 	}
 
@@ -289,6 +297,7 @@ func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error
 	appServicePlanId := d.Get("app_service_plan_id").(string)
 	enabled := d.Get("enabled").(bool)
 	httpsOnly := d.Get("https_only").(bool)
+	clientCertEnabled := d.Get("client_cert_enabled").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 
 	siteConfig := azure.ExpandAppServiceSiteConfig(d.Get("site_config"))
@@ -296,10 +305,11 @@ func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		Location: &location,
 		Tags:     expandTags(tags),
 		SiteProperties: &web.SiteProperties{
-			ServerFarmID: utils.String(appServicePlanId),
-			Enabled:      utils.Bool(enabled),
-			HTTPSOnly:    utils.Bool(httpsOnly),
-			SiteConfig:   &siteConfig,
+			ServerFarmID:      utils.String(appServicePlanId),
+			Enabled:           utils.Bool(enabled),
+			HTTPSOnly:         utils.Bool(httpsOnly),
+			ClientCertEnabled: utils.Bool(clientCertEnabled),
+			SiteConfig:        &siteConfig,
 		},
 	}
 
@@ -453,6 +463,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("client_affinity_enabled", props.ClientAffinityEnabled)
 		d.Set("enabled", props.Enabled)
 		d.Set("https_only", props.HTTPSOnly)
+		d.Set("client_cert_enabled", props.ClientCertEnabled)
 		d.Set("default_site_hostname", props.DefaultHostName)
 		d.Set("outbound_ip_addresses", props.OutboundIPAddresses)
 		d.Set("possible_outbound_ip_addresses", props.PossibleOutboundIPAddresses)

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -288,6 +288,32 @@ func TestAccAzureRMAppService_httpsOnly(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_clientCertEnabled(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMAppService_clientCertEnabled(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_cert_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_appSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := tf.AccRandTimeInt()
@@ -1393,6 +1419,34 @@ resource "azurerm_app_service" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   app_service_plan_id = "${azurerm_app_service_plan.test.id}"
   https_only          = true
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_clientCertEnabled(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  client_cert_enabled          = true
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -291,7 +291,8 @@ func TestAccAzureRMAppService_httpsOnly(t *testing.T) {
 func TestAccAzureRMAppService_clientCertEnabled(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := tf.AccRandTimeInt()
-	config := testAccAzureRMAppService_clientCertEnabled(ri, testLocation())
+	configClientCertEnabled := testAccAzureRMAppService_clientCertEnabled(ri, testLocation())
+	configClientCertEnabledNotSet := testAccAzureRMAppService_clientCertEnabledNotSet(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -299,10 +300,17 @@ func TestAccAzureRMAppService_clientCertEnabled(t *testing.T) {
 		CheckDestroy: testCheckAzureRMAppServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: configClientCertEnabled,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "client_cert_enabled", "true"),
+				),
+			},
+			{
+				Config: configClientCertEnabledNotSet,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_cert_enabled", "false"),
 				),
 			},
 			{
@@ -1446,7 +1454,34 @@ resource "azurerm_app_service" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-  client_cert_enabled          = true
+  client_cert_enabled = true
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_clientCertEnabledNotSet(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctestAS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
 }
 `, rInt, location, rInt, rInt)
 }

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -47,6 +47,8 @@ output "app_service_id" {
 
 * `https_only` - Can the App Service only be accessed via HTTPS?
 
+* `client_cert_enabled` - Does the App Service require client certificates for incoming requests?
+
 * `site_config` - A `site_config` block as defined below.
 
 * `tags` - A mapping of tags to assign to the resource.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -127,6 +127,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`.
 
+* `client_cert_enabled` - (Optional) Does the App Service require client certificates for incoming requests? Defaults to `false`.
+
 * `site_config` - (Optional) A `site_config` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
The PR has changes to fix #2004 . 

Changes
* Added configurations and tests for similar to https_only for new property client_cert_enabled (clientCertEnabled) 
* Modified the app service and App service data source resource
* Modified corresponding test and markdown files
* Manually validated that new property works as expected
* executed the acceptance tests. Results below which include successful execution of the new test for clientCertEnabled (--- PASS: TestAccAzureRMAppService_clientCertEnabled (150.55s)):
```
make testacc TESTARGS='-run=TestAccAzureRMAppService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAzureRMAppService -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
?       github.com/terraform-providers/terraform-provider-azurerm       [no test files]




=== RUN   TestAccAzureRMAppServiceActiveSlot_basic
=== PAUSE TestAccAzureRMAppServiceActiveSlot_basic
=== RUN   TestAccAzureRMAppServiceActiveSlot_update
=== PAUSE TestAccAzureRMAppServiceActiveSlot_update
=== RUN   TestAccAzureRMAppServiceCustomHostnameBinding
--- SKIP: TestAccAzureRMAppServiceCustomHostnameBinding (0.00s)
    resource_arm_app_service_custom_hostname_binding_test.go:19: Skipping as "ARM_TEST_APP_SERVICE" is not specified
=== RUN   TestAccAzureRMAppServicePlan_basicWindows
=== PAUSE TestAccAzureRMAppServicePlan_basicWindows
=== RUN   TestAccAzureRMAppServicePlan_basicLinux
=== PAUSE TestAccAzureRMAppServicePlan_basicLinux
=== RUN   TestAccAzureRMAppServicePlan_requiresImport
--- SKIP: TestAccAzureRMAppServicePlan_requiresImport (0.00s)
    resource_arm_app_service_plan_test.go:113: Skipping since resources aren't required to be imported
=== RUN   TestAccAzureRMAppServicePlan_standardWindows
=== PAUSE TestAccAzureRMAppServicePlan_standardWindows
=== RUN   TestAccAzureRMAppServicePlan_premiumWindows
=== PAUSE TestAccAzureRMAppServicePlan_premiumWindows
=== RUN   TestAccAzureRMAppServicePlan_premiumWindowsUpdated
=== PAUSE TestAccAzureRMAppServicePlan_premiumWindowsUpdated
=== RUN   TestAccAzureRMAppServicePlan_completeWindows
=== PAUSE TestAccAzureRMAppServicePlan_completeWindows
=== RUN   TestAccAzureRMAppServicePlan_consumptionPlan
=== PAUSE TestAccAzureRMAppServicePlan_consumptionPlan
=== RUN   TestAccAzureRMAppServiceSlot_basic
=== PAUSE TestAccAzureRMAppServiceSlot_basic
=== RUN   TestAccAzureRMAppServiceSlot_requiresImport
--- SKIP: TestAccAzureRMAppServiceSlot_requiresImport (0.00s)
    resource_arm_app_service_slot_test.go:42: Skipping since resources aren't required to be imported
=== RUN   TestAccAzureRMAppServiceSlot_32Bit
=== PAUSE TestAccAzureRMAppServiceSlot_32Bit
=== RUN   TestAccAzureRMAppServiceSlot_alwaysOn
=== PAUSE TestAccAzureRMAppServiceSlot_alwaysOn
=== RUN   TestAccAzureRMAppServiceSlot_appCommandLine
=== PAUSE TestAccAzureRMAppServiceSlot_appCommandLine
=== RUN   TestAccAzureRMAppServiceSlot_appSettings
=== PAUSE TestAccAzureRMAppServiceSlot_appSettings
=== RUN   TestAccAzureRMAppServiceSlot_clientAffinityEnabled
=== PAUSE TestAccAzureRMAppServiceSlot_clientAffinityEnabled
=== RUN   TestAccAzureRMAppServiceSlot_clientAffinityEnabledUpdate
=== PAUSE TestAccAzureRMAppServiceSlot_clientAffinityEnabledUpdate
=== RUN   TestAccAzureRMAppServiceSlot_connectionStrings
=== PAUSE TestAccAzureRMAppServiceSlot_connectionStrings
=== RUN   TestAccAzureRMAppServiceSlot_defaultDocuments
=== PAUSE TestAccAzureRMAppServiceSlot_defaultDocuments
=== RUN   TestAccAzureRMAppServiceSlot_enabled
=== PAUSE TestAccAzureRMAppServiceSlot_enabled
=== RUN   TestAccAzureRMAppServiceSlot_enabledUpdate
=== PAUSE TestAccAzureRMAppServiceSlot_enabledUpdate
=== RUN   TestAccAzureRMAppServiceSlot_httpsOnly
=== PAUSE TestAccAzureRMAppServiceSlot_httpsOnly
=== RUN   TestAccAzureRMAppServiceSlot_httpsOnlyUpdate
=== PAUSE TestAccAzureRMAppServiceSlot_httpsOnlyUpdate
=== RUN   TestAccAzureRMAppServiceSlot_http2Enabled
=== PAUSE TestAccAzureRMAppServiceSlot_http2Enabled
=== RUN   TestAccAzureRMAppServiceSlot_oneIpRestriction
=== PAUSE TestAccAzureRMAppServiceSlot_oneIpRestriction
=== RUN   TestAccAzureRMAppServiceSlot_manyIpRestrictions
=== PAUSE TestAccAzureRMAppServiceSlot_manyIpRestrictions
=== RUN   TestAccAzureRMAppServiceSlot_localMySql
=== PAUSE TestAccAzureRMAppServiceSlot_localMySql
=== RUN   TestAccAzureRMAppServiceSlot_managedPipelineMode
=== PAUSE TestAccAzureRMAppServiceSlot_managedPipelineMode
=== RUN   TestAccAzureRMAppServiceSlot_tagsUpdate
=== PAUSE TestAccAzureRMAppServiceSlot_tagsUpdate
=== RUN   TestAccAzureRMAppServiceSlot_remoteDebugging
=== PAUSE TestAccAzureRMAppServiceSlot_remoteDebugging
=== RUN   TestAccAzureRMAppServiceSlot_virtualNetwork
=== PAUSE TestAccAzureRMAppServiceSlot_virtualNetwork
=== RUN   TestAccAzureRMAppServiceSlot_windowsDotNet2
=== PAUSE TestAccAzureRMAppServiceSlot_windowsDotNet2
=== RUN   TestAccAzureRMAppServiceSlot_windowsDotNet4
=== PAUSE TestAccAzureRMAppServiceSlot_windowsDotNet4
=== RUN   TestAccAzureRMAppServiceSlot_windowsDotNetUpdate
=== PAUSE TestAccAzureRMAppServiceSlot_windowsDotNetUpdate
=== RUN   TestAccAzureRMAppServiceSlot_windowsJava7Jetty
=== PAUSE TestAccAzureRMAppServiceSlot_windowsJava7Jetty
=== RUN   TestAccAzureRMAppServiceSlot_windowsJava8Jetty
=== PAUSE TestAccAzureRMAppServiceSlot_windowsJava8Jetty
=== RUN   TestAccAzureRMAppServiceSlot_windowsJava7Tomcat
=== PAUSE TestAccAzureRMAppServiceSlot_windowsJava7Tomcat
=== RUN   TestAccAzureRMAppServiceSlot_windowsJava8Tomcat
=== PAUSE TestAccAzureRMAppServiceSlot_windowsJava8Tomcat
=== RUN   TestAccAzureRMAppServiceSlot_windowsPHP7
=== PAUSE TestAccAzureRMAppServiceSlot_windowsPHP7
=== RUN   TestAccAzureRMAppServiceSlot_windowsPython
=== PAUSE TestAccAzureRMAppServiceSlot_windowsPython
=== RUN   TestAccAzureRMAppServiceSlot_webSockets
=== PAUSE TestAccAzureRMAppServiceSlot_webSockets
=== RUN   TestAccAzureRMAppServiceSlot_enableManageServiceIdentity
=== PAUSE TestAccAzureRMAppServiceSlot_enableManageServiceIdentity
=== RUN   TestAccAzureRMAppServiceSlot_minTls
=== PAUSE TestAccAzureRMAppServiceSlot_minTls
=== RUN   TestAccAzureRMAppService_basic
=== PAUSE TestAccAzureRMAppService_basic
=== RUN   TestAccAzureRMAppService_requiresImport
--- SKIP: TestAccAzureRMAppService_requiresImport (0.00s)
    resource_arm_app_service_test.go:84: Skipping since resources aren't required to be imported
=== RUN   TestAccAzureRMAppService_freeTier
=== PAUSE TestAccAzureRMAppService_freeTier
=== RUN   TestAccAzureRMAppService_sharedTier
=== PAUSE TestAccAzureRMAppService_sharedTier
=== RUN   TestAccAzureRMAppService_32Bit
=== PAUSE TestAccAzureRMAppService_32Bit
=== RUN   TestAccAzureRMAppService_http2Enabled
=== PAUSE TestAccAzureRMAppService_http2Enabled
=== RUN   TestAccAzureRMAppService_alwaysOn
=== PAUSE TestAccAzureRMAppService_alwaysOn
=== RUN   TestAccAzureRMAppService_appCommandLine
=== PAUSE TestAccAzureRMAppService_appCommandLine
=== RUN   TestAccAzureRMAppService_httpsOnly
=== PAUSE TestAccAzureRMAppService_httpsOnly
=== RUN   TestAccAzureRMAppService_clientCertEnabled
=== PAUSE TestAccAzureRMAppService_clientCertEnabled
=== RUN   TestAccAzureRMAppService_appSettings
=== PAUSE TestAccAzureRMAppService_appSettings
=== RUN   TestAccAzureRMAppService_clientAffinityEnabled
=== PAUSE TestAccAzureRMAppService_clientAffinityEnabled
=== RUN   TestAccAzureRMAppService_clientAffinityDisabled
=== PAUSE TestAccAzureRMAppService_clientAffinityDisabled
=== RUN   TestAccAzureRMAppService_virtualNetwork
=== PAUSE TestAccAzureRMAppService_virtualNetwork
=== RUN   TestAccAzureRMAppService_enableManageServiceIdentity
=== PAUSE TestAccAzureRMAppService_enableManageServiceIdentity
=== RUN   TestAccAzureRMAppService_updateResourceByEnablingManageServiceIdentity
=== PAUSE TestAccAzureRMAppService_updateResourceByEnablingManageServiceIdentity
=== RUN   TestAccAzureRMAppService_clientAffinityUpdate
=== PAUSE TestAccAzureRMAppService_clientAffinityUpdate
=== RUN   TestAccAzureRMAppService_connectionStrings
=== PAUSE TestAccAzureRMAppService_connectionStrings
=== RUN   TestAccAzureRMAppService_oneIpRestriction
=== PAUSE TestAccAzureRMAppService_oneIpRestriction
=== RUN   TestAccAzureRMAppService_manyIpRestrictions
=== PAUSE TestAccAzureRMAppService_manyIpRestrictions
=== RUN   TestAccAzureRMAppService_defaultDocuments
=== PAUSE TestAccAzureRMAppService_defaultDocuments
=== RUN   TestAccAzureRMAppService_enabled
=== PAUSE TestAccAzureRMAppService_enabled
=== RUN   TestAccAzureRMAppService_localMySql
=== PAUSE TestAccAzureRMAppService_localMySql
=== RUN   TestAccAzureRMAppService_managedPipelineMode
=== PAUSE TestAccAzureRMAppService_managedPipelineMode
=== RUN   TestAccAzureRMAppService_tagsUpdate
=== PAUSE TestAccAzureRMAppService_tagsUpdate
=== RUN   TestAccAzureRMAppService_remoteDebugging
=== PAUSE TestAccAzureRMAppService_remoteDebugging
=== RUN   TestAccAzureRMAppService_windowsDotNet2
=== PAUSE TestAccAzureRMAppService_windowsDotNet2
=== RUN   TestAccAzureRMAppService_windowsDotNet4
=== PAUSE TestAccAzureRMAppService_windowsDotNet4
=== RUN   TestAccAzureRMAppService_windowsDotNetUpdate
=== PAUSE TestAccAzureRMAppService_windowsDotNetUpdate
=== RUN   TestAccAzureRMAppService_windowsJava7Jetty
=== PAUSE TestAccAzureRMAppService_windowsJava7Jetty
=== RUN   TestAccAzureRMAppService_windowsJava8Jetty
=== PAUSE TestAccAzureRMAppService_windowsJava8Jetty
=== RUN   TestAccAzureRMAppService_windowsJava7Tomcat
=== PAUSE TestAccAzureRMAppService_windowsJava7Tomcat
=== RUN   TestAccAzureRMAppService_windowsJava8Tomcat
=== PAUSE TestAccAzureRMAppService_windowsJava8Tomcat
=== RUN   TestAccAzureRMAppService_windowsPHP7
=== PAUSE TestAccAzureRMAppService_windowsPHP7
=== RUN   TestAccAzureRMAppService_windowsPython
=== PAUSE TestAccAzureRMAppService_windowsPython
=== RUN   TestAccAzureRMAppService_webSockets
=== PAUSE TestAccAzureRMAppService_webSockets
=== RUN   TestAccAzureRMAppService_scmType
=== PAUSE TestAccAzureRMAppService_scmType
=== RUN   TestAccAzureRMAppService_ftpsState
=== PAUSE TestAccAzureRMAppService_ftpsState
=== RUN   TestAccAzureRMAppService_linuxFxVersion
=== PAUSE TestAccAzureRMAppService_linuxFxVersion
=== RUN   TestAccAzureRMAppService_minTls
=== PAUSE TestAccAzureRMAppService_minTls
=== CONT  TestAccAzureRMAppServiceActiveSlot_basic
=== CONT  TestAccAzureRMAppServiceSlot_httpsOnlyUpdate
=== CONT  TestAccAzureRMAppServiceSlot_minTls
=== CONT  TestAccAzureRMAppService_minTls
=== CONT  TestAccAzureRMAppService_linuxFxVersion
=== CONT  TestAccAzureRMAppService_ftpsState
=== CONT  TestAccAzureRMAppService_scmType
=== CONT  TestAccAzureRMAppService_webSockets
--- PASS: TestAccAzureRMAppService_linuxFxVersion (140.54s)
=== CONT  TestAccAzureRMAppService_windowsPython
--- PASS: TestAccAzureRMAppService_webSockets (141.06s)
=== CONT  TestAccAzureRMAppService_windowsPHP7
--- PASS: TestAccAzureRMAppService_scmType (146.81s)
=== CONT  TestAccAzureRMAppService_windowsJava8Tomcat
--- PASS: TestAccAzureRMAppService_ftpsState (151.95s)
=== CONT  TestAccAzureRMAppService_windowsJava7Tomcat
--- PASS: TestAccAzureRMAppService_minTls (171.59s)
=== CONT  TestAccAzureRMAppService_windowsJava8Jetty
--- PASS: TestAccAzureRMAppServiceSlot_httpsOnlyUpdate (204.51s)
=== CONT  TestAccAzureRMAppService_windowsJava7Jetty
--- PASS: TestAccAzureRMAppServiceSlot_minTls (221.32s)
=== CONT  TestAccAzureRMAppService_windowsDotNetUpdate
--- PASS: TestAccAzureRMAppServiceActiveSlot_basic (222.00s)
=== CONT  TestAccAzureRMAppService_windowsDotNet4
--- PASS: TestAccAzureRMAppService_windowsPHP7 (143.34s)
=== CONT  TestAccAzureRMAppServiceSlot_alwaysOn
--- PASS: TestAccAzureRMAppService_windowsJava7Tomcat (142.13s)
=== CONT  TestAccAzureRMAppService_windowsDotNet2
--- PASS: TestAccAzureRMAppService_windowsPython (160.53s)
=== CONT  TestAccAzureRMAppServiceSlot_httpsOnly
--- PASS: TestAccAzureRMAppService_windowsJava8Tomcat (162.86s)
=== CONT  TestAccAzureRMAppService_remoteDebugging
--- PASS: TestAccAzureRMAppService_windowsJava8Jetty (147.19s)
=== CONT  TestAccAzureRMAppServiceSlot_enabledUpdate
--- PASS: TestAccAzureRMAppService_windowsJava7Jetty (153.20s)
=== CONT  TestAccAzureRMAppService_tagsUpdate
--- PASS: TestAccAzureRMAppService_windowsDotNet4 (162.16s)
=== CONT  TestAccAzureRMAppServiceSlot_enabled
--- PASS: TestAccAzureRMAppService_windowsDotNetUpdate (174.35s)
=== CONT  TestAccAzureRMAppService_managedPipelineMode
--- PASS: TestAccAzureRMAppService_windowsDotNet2 (137.32s)
=== CONT  TestAccAzureRMAppServiceSlot_defaultDocuments
--- PASS: TestAccAzureRMAppServiceSlot_alwaysOn (160.73s)
=== CONT  TestAccAzureRMAppService_localMySql
--- PASS: TestAccAzureRMAppService_remoteDebugging (154.15s)
=== CONT  TestAccAzureRMAppServiceSlot_connectionStrings
--- PASS: TestAccAzureRMAppServiceSlot_httpsOnly (190.42s)
=== CONT  TestAccAzureRMAppService_enabled
--- PASS: TestAccAzureRMAppServiceSlot_enabledUpdate (197.65s)
=== CONT  TestAccAzureRMAppServiceSlot_clientAffinityEnabledUpdate
--- PASS: TestAccAzureRMAppService_managedPipelineMode (124.03s)
=== CONT  TestAccAzureRMAppService_defaultDocuments
--- PASS: TestAccAzureRMAppService_tagsUpdate (169.91s)
=== CONT  TestAccAzureRMAppService_manyIpRestrictions
--- PASS: TestAccAzureRMAppServiceSlot_enabled (174.34s)
=== CONT  TestAccAzureRMAppService_oneIpRestriction
--- PASS: TestAccAzureRMAppService_localMySql (138.99s)
=== CONT  TestAccAzureRMAppService_connectionStrings
--- PASS: TestAccAzureRMAppServiceSlot_defaultDocuments (181.58s)
=== CONT  TestAccAzureRMAppService_clientAffinityUpdate
--- PASS: TestAccAzureRMAppService_enabled (125.53s)
=== CONT  TestAccAzureRMAppService_updateResourceByEnablingManageServiceIdentity
--- PASS: TestAccAzureRMAppService_defaultDocuments (138.47s)
=== CONT  TestAccAzureRMAppService_enableManageServiceIdentity
--- PASS: TestAccAzureRMAppServiceSlot_connectionStrings (201.32s)
=== CONT  TestAccAzureRMAppService_virtualNetwork
--- PASS: TestAccAzureRMAppService_manyIpRestrictions (144.87s)
=== CONT  TestAccAzureRMAppService_clientAffinityDisabled
--- PASS: TestAccAzureRMAppServiceSlot_clientAffinityEnabledUpdate (199.29s)
=== CONT  TestAccAzureRMAppService_clientAffinityEnabled
--- PASS: TestAccAzureRMAppService_oneIpRestriction (159.34s)
=== CONT  TestAccAzureRMAppService_http2Enabled
--- PASS: TestAccAzureRMAppService_connectionStrings (165.82s)
=== CONT  TestAccAzureRMAppService_32Bit
--- PASS: TestAccAzureRMAppService_updateResourceByEnablingManageServiceIdentity (164.53s)
=== CONT  TestAccAzureRMAppService_sharedTier
--- PASS: TestAccAzureRMAppService_enableManageServiceIdentity (133.50s)
=== CONT  TestAccAzureRMAppService_freeTier
--- PASS: TestAccAzureRMAppService_clientAffinityUpdate (190.73s)
=== CONT  TestAccAzureRMAppService_basic
--- PASS: TestAccAzureRMAppService_clientAffinityDisabled (157.16s)
=== CONT  TestAccAzureRMAppService_clientCertEnabled
--- PASS: TestAccAzureRMAppService_virtualNetwork (190.73s)
=== CONT  TestAccAzureRMAppService_appSettings
--- PASS: TestAccAzureRMAppService_http2Enabled (144.08s)
=== CONT  TestAccAzureRMAppService_httpsOnly
--- PASS: TestAccAzureRMAppService_clientAffinityEnabled (150.50s)
=== CONT  TestAccAzureRMAppService_appCommandLine
--- PASS: TestAccAzureRMAppService_32Bit (149.07s)
=== CONT  TestAccAzureRMAppServiceSlot_clientAffinityEnabled
--- PASS: TestAccAzureRMAppService_sharedTier (131.11s)
=== CONT  TestAccAzureRMAppServicePlan_premiumWindowsUpdated
--- PASS: TestAccAzureRMAppService_freeTier (139.84s)
=== CONT  TestAccAzureRMAppServiceSlot_appSettings
--- PASS: TestAccAzureRMAppService_basic (142.54s)
=== CONT  TestAccAzureRMAppServiceSlot_32Bit
--- PASS: TestAccAzureRMAppService_clientCertEnabled (150.55s)
=== CONT  TestAccAzureRMAppServiceSlot_appCommandLine
--- PASS: TestAccAzureRMAppService_appSettings (145.02s)
=== CONT  TestAccAzureRMAppService_alwaysOn
--- PASS: TestAccAzureRMAppService_httpsOnly (140.00s)
=== CONT  TestAccAzureRMAppServiceSlot_basic
--- PASS: TestAccAzureRMAppService_appCommandLine (148.00s)
=== CONT  TestAccAzureRMAppServicePlan_basicLinux
--- PASS: TestAccAzureRMAppServicePlan_premiumWindowsUpdated (120.90s)
=== CONT  TestAccAzureRMAppServicePlan_consumptionPlan
--- PASS: TestAccAzureRMAppServiceSlot_clientAffinityEnabled (171.95s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsDotNet4
--- PASS: TestAccAzureRMAppServiceSlot_appSettings (181.65s)
=== CONT  TestAccAzureRMAppServicePlan_premiumWindows
--- PASS: TestAccAzureRMAppServicePlan_consumptionPlan (80.47s)
=== CONT  TestAccAzureRMAppServicePlan_completeWindows
--- PASS: TestAccAzureRMAppServicePlan_basicLinux (115.57s)
=== CONT  TestAccAzureRMAppServicePlan_standardWindows
--- PASS: TestAccAzureRMAppServiceSlot_32Bit (187.08s)
=== CONT  TestAccAzureRMAppServiceSlot_enableManageServiceIdentity
--- PASS: TestAccAzureRMAppService_alwaysOn (139.82s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsJava8Tomcat
--- PASS: TestAccAzureRMAppServiceSlot_appCommandLine (162.92s)
=== CONT  TestAccAzureRMAppServiceSlot_managedPipelineMode
--- PASS: TestAccAzureRMAppServiceSlot_basic (174.79s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsJava7Jetty
--- PASS: TestAccAzureRMAppServicePlan_premiumWindows (106.03s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsDotNet2
--- PASS: TestAccAzureRMAppServiceSlot_windowsDotNet4 (155.11s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsDotNetUpdate
--- PASS: TestAccAzureRMAppServicePlan_standardWindows (98.52s)
=== CONT  TestAccAzureRMAppServiceSlot_webSockets
--- PASS: TestAccAzureRMAppServicePlan_completeWindows (117.23s)
=== CONT  TestAccAzureRMAppServiceSlot_virtualNetwork
--- PASS: TestAccAzureRMAppServiceSlot_enableManageServiceIdentity (153.30s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsPHP7
--- PASS: TestAccAzureRMAppServiceSlot_managedPipelineMode (165.04s)
=== CONT  TestAccAzureRMAppServiceSlot_remoteDebugging
--- PASS: TestAccAzureRMAppServiceSlot_windowsJava8Tomcat (189.46s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsPython
--- PASS: TestAccAzureRMAppServiceSlot_windowsJava7Jetty (175.51s)
=== CONT  TestAccAzureRMAppServiceSlot_tagsUpdate
--- PASS: TestAccAzureRMAppServiceSlot_webSockets (171.86s)
=== CONT  TestAccAzureRMAppServicePlan_basicWindows
--- PASS: TestAccAzureRMAppServiceSlot_windowsDotNet2 (182.75s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsJava7Tomcat
--- PASS: TestAccAzureRMAppServiceSlot_windowsDotNetUpdate (213.77s)
=== CONT  TestAccAzureRMAppServiceSlot_windowsJava8Jetty
--- PASS: TestAccAzureRMAppServiceSlot_virtualNetwork (219.67s)
=== CONT  TestAccAzureRMAppServiceSlot_oneIpRestriction
--- PASS: TestAccAzureRMAppServiceSlot_windowsPHP7 (169.78s)
=== CONT  TestAccAzureRMAppServiceSlot_http2Enabled
--- PASS: TestAccAzureRMAppServiceSlot_remoteDebugging (183.39s)
=== CONT  TestAccAzureRMAppServiceSlot_localMySql
--- PASS: TestAccAzureRMAppServiceSlot_windowsPython (171.24s)
=== CONT  TestAccAzureRMAppServiceActiveSlot_update
--- PASS: TestAccAzureRMAppServicePlan_basicWindows (102.34s)
=== CONT  TestAccAzureRMAppServiceSlot_manyIpRestrictions
--- PASS: TestAccAzureRMAppServiceSlot_tagsUpdate (201.04s)
--- PASS: TestAccAzureRMAppServiceSlot_windowsJava7Tomcat (170.96s)
--- PASS: TestAccAzureRMAppServiceSlot_oneIpRestriction (152.84s)
--- PASS: TestAccAzureRMAppServiceSlot_windowsJava8Jetty (182.86s)
--- PASS: TestAccAzureRMAppServiceSlot_http2Enabled (170.68s)
--- PASS: TestAccAzureRMAppServiceSlot_manyIpRestrictions (153.77s)
--- PASS: TestAccAzureRMAppServiceSlot_localMySql (169.01s)
--- PASS: TestAccAzureRMAppServiceActiveSlot_update (304.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       1805.735s
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/kubernetes   (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response     [no test files]
?       github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/set   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils (cached) [no tests to run]
```