### PR TITLE
Updte the documentation for private_ip_address in firewall.

### DIFF
--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -96,7 +96,7 @@ A `ip_configuration` block exports the following:
 
 * `private_ip_address` - The private IP address of the Azure Firewall.
 
--> **NOTE** `ip_configuration` is list of single element, you need to use `ip_configuration.0.private_ip_address` to access the value.
+-> **NOTE** `ip_configuration` is list of single element, please use `ip_configuration.0.private_ip_address` to access the value.
 
 ## Import
 

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -96,6 +96,8 @@ A `ip_configuration` block exports the following:
 
 * `private_ip_address` - The private IP address of the Azure Firewall.
 
+-> **NOTE** `ip_configuration` is list of single element, you need to use `ip_configuration.0.private_ip_address` to access the value.
+
 ## Import
 
 Azure Firewalls can be imported using the `resource id`, e.g.

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `ip_configuration` - (Required) A `ip_configuration` block as documented below.
+* `ip_configuration` - (Required) A collection of `ip_configuration` blocks as documented below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -95,8 +95,6 @@ The following attributes are exported:
 A `ip_configuration` block exports the following:
 
 * `private_ip_address` - The private IP address of the Azure Firewall.
-
--> **NOTE** `ip_configuration` is list of single element, please use `ip_configuration.0.private_ip_address` to access the value.
 
 ## Import
 


### PR DESCRIPTION
This PR includes notice for user to follow up while referencing `private_ip_address` in configuration file.

Fixes #2769.