### PR TITLE
New Resource: `azurerm_network_interface_application_security_group_association`

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -272,6 +272,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_mysql_server":                           resourceArmMySqlServer(),
 			"azurerm_mysql_virtual_network_rule":             resourceArmMySqlVirtualNetworkRule(),
 			"azurerm_network_interface_application_gateway_backend_address_pool_association": resourceArmNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation(),
+			"azurerm_network_interface_application_security_group_association":               resourceArmNetworkInterfaceApplicationSecurityGroupAssociation(),
 			"azurerm_network_interface_backend_address_pool_association":                     resourceArmNetworkInterfaceBackendAddressPoolAssociation(),
 			"azurerm_network_interface_nat_rule_association":                                 resourceArmNetworkInterfaceNatRuleAssociation(),
 			"azurerm_network_interface":                                                      resourceArmNetworkInterface(),

--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -146,11 +146,11 @@ func resourceArmNetworkInterface() *schema.Resource {
 							Set: schema.HashString,
 						},
 
-						// TODO: does this want deprecating & a virtual resource for 2.0?
 						"application_security_group_ids": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							Computed: true,
+							Type:       schema.TypeSet,
+							Optional:   true,
+							Computed:   true,
+							Deprecated: "This field has been deprecated in favour of the `azurerm_network_interface_application_security_group_association` resource.",
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
 								ValidateFunc: azure.ValidateResourceID,

--- a/azurerm/resource_arm_network_interface_application_security_group_association.go
+++ b/azurerm/resource_arm_network_interface_application_security_group_association.go
@@ -1,0 +1,295 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmNetworkInterfaceApplicationSecurityGroupAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmNetworkInterfaceApplicationSecurityGroupAssociationCreate,
+		Read:   resourceArmNetworkInterfaceApplicationSecurityGroupAssociationRead,
+		Delete: resourceArmNetworkInterfaceApplicationSecurityGroupAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"network_interface_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"ip_configuration_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"application_security_group_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+		},
+	}
+}
+
+func resourceArmNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).ifaceClient
+	ctx := meta.(*ArmClient).StopContext
+
+	log.Printf("[INFO] preparing arguments for Network Interface <-> Application Security Group Association creation.")
+
+	networkInterfaceId := d.Get("network_interface_id").(string)
+	ipConfigurationName := d.Get("ip_configuration_name").(string)
+	applicationSecurityGroupId := d.Get("application_security_group_id").(string)
+
+	id, err := parseAzureResourceID(networkInterfaceId)
+	if err != nil {
+		return err
+	}
+
+	networkInterfaceName := id.Path["networkInterfaces"]
+	resourceGroup := id.ResourceGroup
+
+	azureRMLockByName(networkInterfaceName, networkInterfaceResourceName)
+	defer azureRMUnlockByName(networkInterfaceName, networkInterfaceResourceName)
+
+	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(read.Response) {
+			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	props := read.InterfacePropertiesFormat
+	if props == nil {
+		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	ipConfigs := props.IPConfigurations
+	if ipConfigs == nil {
+		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	c := azure.FindNetworkInterfaceIPConfiguration(props.IPConfigurations, ipConfigurationName)
+	if c == nil {
+		return fmt.Errorf("Error: IP Configuration %q was not found on Network Interface %q (Resource Group %q)", ipConfigurationName, networkInterfaceName, resourceGroup)
+	}
+
+	config := *c
+	p := config.InterfaceIPConfigurationPropertiesFormat
+	if p == nil {
+		return fmt.Errorf("Error: `IPConfiguration.properties` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	applicationSecurityGroups := make([]network.ApplicationSecurityGroup, 0)
+
+	// first double-check it doesn't exist
+	if requireResourcesToBeImported {
+		if p.ApplicationSecurityGroups != nil {
+			for _, existingGroup := range *p.ApplicationSecurityGroups {
+				if id := existingGroup.ID; id != nil {
+					if *id == applicationSecurityGroupId {
+						return tf.ImportAsExistsError("azurerm_network_interface_application_security_group_association", *id)
+					}
+
+					applicationSecurityGroups = append(applicationSecurityGroups, existingGroup)
+				}
+			}
+		}
+	}
+
+	group := network.ApplicationSecurityGroup{
+		ID: utils.String(applicationSecurityGroupId),
+	}
+	applicationSecurityGroups = append(applicationSecurityGroups, group)
+	p.ApplicationSecurityGroups = &applicationSecurityGroups
+
+	props.IPConfigurations = azure.UpdateNetworkInterfaceIPConfiguration(config, props.IPConfigurations)
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, networkInterfaceName, read)
+	if err != nil {
+		return fmt.Errorf("Error updating Application Security Group Association for Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for completion of Application Security Group Association for NIC %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, applicationSecurityGroupId)
+	d.SetId(resourceId)
+
+	return resourceArmNetworkInterfaceApplicationSecurityGroupAssociationRead(d, meta)
+}
+
+func resourceArmNetworkInterfaceApplicationSecurityGroupAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).ifaceClient
+	ctx := meta.(*ArmClient).StopContext
+
+	splitId := strings.Split(d.Id(), "|")
+	if len(splitId) != 2 {
+		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{applicationSecurityGroupId} but got %q", d.Id())
+	}
+
+	nicID, err := parseAzureResourceID(splitId[0])
+	if err != nil {
+		return err
+	}
+
+	ipConfigurationName := nicID.Path["ipConfigurations"]
+	networkInterfaceName := nicID.Path["networkInterfaces"]
+	resourceGroup := nicID.ResourceGroup
+	applicationSecurityGroupId := splitId[1]
+
+	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(read.Response) {
+			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	nicProps := read.InterfacePropertiesFormat
+	if nicProps == nil {
+		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	ipConfigs := nicProps.IPConfigurations
+	if ipConfigs == nil {
+		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	c := azure.FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, ipConfigurationName)
+	if c == nil {
+		log.Printf("IP Configuration %q was not found in Network Interface %q (Resource Group %q) - removing from state!", ipConfigurationName, networkInterfaceName, resourceGroup)
+		d.SetId("")
+		return nil
+	}
+	config := *c
+
+	found := false
+	if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
+		if groups := props.ApplicationSecurityGroups; groups != nil {
+			for _, group := range *groups {
+				if group.ID == nil {
+					continue
+				}
+
+				if *group.ID == applicationSecurityGroupId {
+					found = true
+					break
+				}
+			}
+		}
+	}
+
+	if !found {
+		log.Printf("[DEBUG] Association between Network Interface %q (Resource Group %q) and Application Security Group %q was not found - removing from state!", networkInterfaceName, resourceGroup, applicationSecurityGroupId)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("application_security_group_id", applicationSecurityGroupId)
+	d.Set("ip_configuration_name", ipConfigurationName)
+	if id := read.ID; id != nil {
+		d.Set("network_interface_id", *id)
+	}
+
+	return nil
+}
+
+func resourceArmNetworkInterfaceApplicationSecurityGroupAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).ifaceClient
+	ctx := meta.(*ArmClient).StopContext
+
+	splitId := strings.Split(d.Id(), "|")
+	if len(splitId) != 2 {
+		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{applicationSecurityGroupId} but got %q", d.Id())
+	}
+
+	nicID, err := parseAzureResourceID(splitId[0])
+	if err != nil {
+		return err
+	}
+
+	ipConfigurationName := nicID.Path["ipConfigurations"]
+	networkInterfaceName := nicID.Path["networkInterfaces"]
+	resourceGroup := nicID.ResourceGroup
+	applicationSecurityGroupId := splitId[1]
+
+	azureRMLockByName(networkInterfaceName, networkInterfaceResourceName)
+	defer azureRMUnlockByName(networkInterfaceName, networkInterfaceResourceName)
+
+	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(read.Response) {
+			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	nicProps := read.InterfacePropertiesFormat
+	if nicProps == nil {
+		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	ipConfigs := nicProps.IPConfigurations
+	if ipConfigs == nil {
+		return fmt.Errorf("Error: `properties.IPConfigurations` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	c := azure.FindNetworkInterfaceIPConfiguration(nicProps.IPConfigurations, ipConfigurationName)
+	if c == nil {
+		return fmt.Errorf("Error: IP Configuration %q was not found on Network Interface %q (Resource Group %q)", ipConfigurationName, networkInterfaceName, resourceGroup)
+	}
+	config := *c
+
+	props := config.InterfaceIPConfigurationPropertiesFormat
+	if props == nil {
+		return fmt.Errorf("Error: Properties for IPConfiguration %q was nil for Network Interface %q (Resource Group %q)", ipConfigurationName, networkInterfaceName, resourceGroup)
+	}
+
+	applicationSecurityGroups := make([]network.ApplicationSecurityGroup, 0)
+	if groups := props.ApplicationSecurityGroups; groups != nil {
+		for _, pool := range *groups {
+			if pool.ID == nil {
+				continue
+			}
+
+			if *pool.ID != applicationSecurityGroupId {
+				applicationSecurityGroups = append(applicationSecurityGroups, pool)
+			}
+		}
+	}
+	props.ApplicationSecurityGroups = &applicationSecurityGroups
+	nicProps.IPConfigurations = azure.UpdateNetworkInterfaceIPConfiguration(config, nicProps.IPConfigurations)
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, networkInterfaceName, read)
+	if err != nil {
+		return fmt.Errorf("Error removing Application Security Group for Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for removal of Application Security Group for NIC %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_network_interface_application_security_group_association_test.go
+++ b/azurerm/resource_arm_network_interface_application_security_group_association_test.go
@@ -1,0 +1,249 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(t *testing.T) {
+	resourceName := "azurerm_network_interface_application_security_group_association.test"
+	rInt := tf.AccRandTimeInt()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(rInt, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceApplicationSecurityGroupAssociationExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_network_interface_application_security_group_association.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceApplicationSecurityGroupAssociationExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_requiresImport(rInt, location),
+				ExpectError: testRequiresImportError("azurerm_network_interface_application_security_group_association"),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_deleted(t *testing.T) {
+	resourceName := "azurerm_network_interface_application_security_group_association.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceApplicationSecurityGroupAssociationExists(resourceName),
+					testCheckAzureRMNetworkInterfaceApplicationSecurityGroupAssociationDisappears(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMNetworkInterfaceApplicationSecurityGroupAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
+		if err != nil {
+			return err
+		}
+
+		nicName := nicID.Path["networkInterfaces"]
+		resourceGroup := nicID.ResourceGroup
+		applicationSecurityGroupId := rs.Primary.Attributes["application_security_group_id"]
+		ipConfigurationName := rs.Primary.Attributes["ip_configuration_name"]
+
+		client := testAccProvider.Meta().(*ArmClient).ifaceClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		read, err := client.Get(ctx, resourceGroup, nicName, "")
+		if err != nil {
+			return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		c := azure.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
+		if c == nil {
+			return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
+		}
+		config := *c
+
+		found := false
+		if config.InterfaceIPConfigurationPropertiesFormat.ApplicationSecurityGroups != nil {
+			for _, group := range *config.InterfaceIPConfigurationPropertiesFormat.ApplicationSecurityGroups {
+				if *group.ID == applicationSecurityGroupId {
+					found = true
+					break
+				}
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Association between NIC %q and Application Security Group %q was not found!", nicName, applicationSecurityGroupId)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMNetworkInterfaceApplicationSecurityGroupAssociationDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		nicID, err := parseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
+		if err != nil {
+			return err
+		}
+
+		nicName := nicID.Path["networkInterfaces"]
+		resourceGroup := nicID.ResourceGroup
+		applicationSecurityGroupId := rs.Primary.Attributes["application_security_group_id"]
+		ipConfigurationName := rs.Primary.Attributes["ip_configuration_name"]
+
+		client := testAccProvider.Meta().(*ArmClient).ifaceClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		read, err := client.Get(ctx, resourceGroup, nicName, "")
+		if err != nil {
+			return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		c := azure.FindNetworkInterfaceIPConfiguration(read.InterfacePropertiesFormat.IPConfigurations, ipConfigurationName)
+		if c == nil {
+			return fmt.Errorf("IP Configuration %q wasn't found for Network Interface %q (Resource Group %q)", ipConfigurationName, nicName, resourceGroup)
+		}
+		config := *c
+
+		updatedGroups := make([]network.ApplicationSecurityGroup, 0)
+		if config.InterfaceIPConfigurationPropertiesFormat.ApplicationSecurityGroups != nil {
+			for _, group := range *config.InterfaceIPConfigurationPropertiesFormat.ApplicationSecurityGroups {
+				if *group.ID != applicationSecurityGroupId {
+					updatedGroups = append(updatedGroups, group)
+				}
+			}
+		}
+		config.InterfaceIPConfigurationPropertiesFormat.ApplicationSecurityGroups = &updatedGroups
+
+		future, err := client.CreateOrUpdate(ctx, resourceGroup, nicName, read)
+		if err != nil {
+			return fmt.Errorf("Error removing Application Security Group Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for removal of Application Security Group Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_application_security_group" "test" {
+  name                = "acctest-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                           = "testconfiguration1"
+    subnet_id                      = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation  = "Dynamic"
+    application_security_group_ids = [ "${azurerm_application_security_group.test.id}" ]
+  }
+}
+
+resource "azurerm_network_interface_application_security_group_association" "test" {
+  network_interface_id          = "${azurerm_network_interface.test.id}"
+  ip_configuration_name         = "testconfiguration1"
+  application_security_group_id = "${azurerm_application_security_group.test.id}"
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface_application_security_group_association" "import" {
+  network_interface_id          = "${azurerm_network_interface_application_security_group_association.test.network_interface_id}"
+  ip_configuration_name         = "${azurerm_network_interface_application_security_group_association.test.ip_configuration_name}"
+  application_security_group_id = "${azurerm_network_interface_application_security_group_association.test.application_security_group_id}"
+}
+`, template)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -988,6 +988,10 @@
                   <a href="/docs/providers/azurerm/r/network_interface_application_gateway_backend_address_pool_association.html">azurerm_network_interface_application_gateway_backend_address_pool_association</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-network-interface-application-security-group-association") %>>
+                  <a href="/docs/providers/azurerm/r/network_interface_application_security_group_association.html">azurerm_network_interface_application_security_group_association</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-resource-network-interface-backend-address-pool-association") %>>
                   <a href="/docs/providers/azurerm/r/network_interface_backend_address_pool_association.html">azurerm_network_interface_backend_address_pool_association</a>
                 </li>

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -92,17 +92,19 @@ The `ip_configuration` block supports:
 
 * `application_gateway_backend_address_pools_ids` - (Optional / **Deprecated**) List of Application Gateway Backend Address Pool IDs references to which this NIC belongs
 
--> **NOTE:** At this time Network Interface <-> Application Gateway Backend Address Pool associations need to be configured both using this field (which is now Deprecated) and/or using the `azurerm_network_interface_application_gateway_backend_address_pool_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
+-> **NOTE:** At this time Network Interface <-> Application Gateway Backend Address Pool associations need to be configured both using this field (which is now Deprecated) and using the `azurerm_network_interface_application_gateway_backend_address_pool_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
 
 * `load_balancer_backend_address_pools_ids` - (Optional / **Deprecated**) List of Load Balancer Backend Address Pool IDs references to which this NIC belongs
 
--> **NOTE:** At this time Network Interface <-> Load Balancer Backend Address Pool associations need to be configured both using this field (which is now Deprecated) and/or using the `azurerm_network_interface_backend_address_pool_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
+-> **NOTE:** At this time Network Interface <-> Load Balancer Backend Address Pool associations need to be configured both using this field (which is now Deprecated) and using the `azurerm_network_interface_backend_address_pool_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
 
 * `load_balancer_inbound_nat_rules_ids` - (Optional / **Deprecated**) List of Load Balancer Inbound Nat Rules IDs involving this NIC
 
--> **NOTE:** At this time Network Interface <-> Load Balancer Inbound NAT Rule associations need to be configured both using this field (which is now Deprecated) and/or using the `azurerm_network_interface_nat_rule_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
+-> **NOTE:** At this time Network Interface <-> Load Balancer Inbound NAT Rule associations need to be configured both using this field (which is now Deprecated) and using the `azurerm_network_interface_nat_rule_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
 
-* `application_security_group_ids` - (Optional) List of Application Security Group IDs which should be attached to this NIC
+* `application_security_group_ids` - (Optional / **Deprecated**) List of Application Security Group IDs which should be attached to this NIC
+
+-> **NOTE:** At this time Network Interface <-> Application Security Group associations need to be configured both using this field (which is now Deprecated) and using the `azurerm_network_interface_application_security_group_association` resource. This field is deprecated and will be removed in favour of that resource in the next major version (2.0) of the AzureRM Provider.
 
 * `primary` - (Optional) Is this the Primary Network Interface? If set to `true` this should be the first `ip_configuration` in the array.
 

--- a/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
@@ -144,15 +144,15 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The (Terraform specific) ID of the Association between the Network Interface and the Load Balancers Backend Address Pool.
+* `id` - The (Terraform specific) ID of the Association between the Network Interface and the Application Gateway Backend Address Pool.
 
 ## Import
 
-Associations between Network Interfaces and Load Balancer Backend Address Pools can be imported using the `resource id`, e.g.
+Associations between Network Interfaces and Application Gateway Backend Address Pools can be imported using the `resource id`, e.g.
 
 
 ```shell
-terraform import azurerm_network_interface_application_gateway_backend_address_pool_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1/ipConfigurations/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/pool1
+terraform import azurerm_network_interface_application_gateway_backend_address_pool_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1/ipConfigurations/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/applicationGateways/gateway1/backendAddressPools/pool1
 ```
 
 -> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{backendAddressPoolId}`.

--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -1,0 +1,87 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_network_interface_application_security_group_association"
+sidebar_current: "docs-azurerm-resource-network-interface-application-security-group-association"
+description: |-
+  Manages the association between a Network Interface and a Application Security Group
+
+---
+
+# azurerm_network_interface_application_security_group_association
+
+Manages the association between a Network Interface and a Application Security Group.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "example-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_application_security_group" "test" {
+  name                = "example-asg"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "example-nic"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                           = "testconfiguration1"
+    subnet_id                      = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation  = "Dynamic"
+    application_security_group_ids = [ "${azurerm_application_security_group.test.id}" ]
+  }
+}
+
+resource "azurerm_network_interface_application_security_group_association" "test" {
+  network_interface_id          = "${azurerm_network_interface.test.id}"
+  ip_configuration_name         = "testconfiguration1"
+  application_security_group_id = "${azurerm_application_security_group.test.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `network_interface_id` - (Required) The ID of the Network Interface. Changing this forces a new resource to be created.
+
+* `ip_configuration_name` - (Required) The Name of the IP Configuration within the Network Interface which should be connected to the Application Security Group. Changing this forces a new resource to be created.
+
+* `application_security_group_id` - (Required) The ID of the Application Security Group which this Network Interface which should be connected to. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The (Terraform specific) ID of the Association between the Network Interface and the Application Security Group.
+
+## Import
+
+Associations between Network Interfaces and Application Security Groups can be imported using the `resource id`, e.g.
+
+
+```shell
+terraform import azurerm_network_interface_application_security_group_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1/ipConfigurations/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/applicationSecurityGroups/securityGroup1
+```
+
+-> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{applicationSecurityGroupId}`.


### PR DESCRIPTION
This PR introduces a new resource which associations Network Interfaces to Application Security Groups. At this time this association needs to be configured both on the `azurerm_network_interface` resource and using the `azurerm_network_interface_application_security_group_association ` resource.

Come 2.0 the existing `application_security_group_ids` field in the `azurerm_network_interface ` resource will be removed (as will the other deprecated fields) and the `azurerm_network_interface_application_security_group_association ` resource will be the only way to configure these. Whilst this isn't ideal from a UX perspective in the short-term it mirrors the other fields, which ensures the UX is the same for all the fields.