### PR TITLE
Add host attribute for endpoints of blob, table, queue, and file.

### DIFF
--- a/azurerm/data_source_storage_account.go
+++ b/azurerm/data_source_storage_account.go
@@ -91,7 +91,17 @@ func dataSourceArmStorageAccount() *schema.Resource {
 				Computed: true,
 			},
 
+			"primary_blob_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"secondary_blob_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"secondary_blob_host": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -101,7 +111,17 @@ func dataSourceArmStorageAccount() *schema.Resource {
 				Computed: true,
 			},
 
+			"primary_queue_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"secondary_queue_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"secondary_queue_host": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -111,13 +131,28 @@ func dataSourceArmStorageAccount() *schema.Resource {
 				Computed: true,
 			},
 
+			"primary_table_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"secondary_table_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"secondary_table_host": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
 			// NOTE: The API does not appear to expose a secondary file endpoint
 			"primary_file_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"primary_file_host": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -2,12 +2,12 @@ package azurerm
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-getter/helper/url"
 	"log"
 	"regexp"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2017-10-01/storage"
+	"github.com/hashicorp/go-getter/helper/url"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -990,7 +990,7 @@ func flattenAzureRmStorageAccountPrimaryEndpoints(d *schema.ResourceData, primar
 	if v := primary.Blob; v != nil {
 		blobEndpoint = *v
 
-		if u, err := url.Parse(*v); err != nil {
+		if u, err := url.Parse(*v); err == nil {
 			blobHost = u.Host
 		} else {
 			return fmt.Errorf("invalid blob endpoint for parsing: %q", *v)
@@ -1006,7 +1006,7 @@ func flattenAzureRmStorageAccountPrimaryEndpoints(d *schema.ResourceData, primar
 	if v := primary.Queue; v != nil {
 		queueEndpoint = *v
 
-		if u, err := url.Parse(*v); err != nil {
+		if u, err := url.Parse(*v); err == nil {
 			queueHost = u.Host
 		} else {
 			return fmt.Errorf("invalid queue endpoint for parsing: %q", *v)
@@ -1019,7 +1019,7 @@ func flattenAzureRmStorageAccountPrimaryEndpoints(d *schema.ResourceData, primar
 	if v := primary.Table; v != nil {
 		tableEndpoint = *v
 
-		if u, err := url.Parse(*v); err != nil {
+		if u, err := url.Parse(*v); err == nil {
 			tableHost = u.Host
 		} else {
 			return fmt.Errorf("invalid table endpoint for parsing: %q", *v)
@@ -1032,7 +1032,7 @@ func flattenAzureRmStorageAccountPrimaryEndpoints(d *schema.ResourceData, primar
 	if v := primary.File; v != nil {
 		fileEndpoint = *v
 
-		if u, err := url.Parse(*v); err != nil {
+		if u, err := url.Parse(*v); err == nil {
 			fileHost = u.Host
 		} else {
 			return fmt.Errorf("invalid file endpoint for parsing: %q", *v)
@@ -1046,14 +1046,14 @@ func flattenAzureRmStorageAccountPrimaryEndpoints(d *schema.ResourceData, primar
 
 func flattenAzureRmStorageAccountSecondaryEndpoints(d *schema.ResourceData, secondary *storage.Endpoints, acctName *string, acctKey *string) error {
 	if secondary == nil {
-		return fmt.Errorf("secondary Endpoints should not be empty")
+		return nil
 	}
 
 	var blobEndpoint, blobHost, blobConnectionStr string
 	if v := secondary.Blob; v != nil {
 		blobEndpoint = *v
 
-		if u, err := url.Parse(*v); err != nil {
+		if u, err := url.Parse(*v); err == nil {
 			blobHost = u.Host
 		} else {
 			return fmt.Errorf("invalid blob endpoint for parsing: %q", *v)
@@ -1069,7 +1069,7 @@ func flattenAzureRmStorageAccountSecondaryEndpoints(d *schema.ResourceData, seco
 	if v := secondary.Queue; v != nil {
 		queueEndpoint = *v
 
-		if u, err := url.Parse(*v); err != nil {
+		if u, err := url.Parse(*v); err == nil {
 			queueHost = u.Host
 		} else {
 			return fmt.Errorf("invalid queue endpoint for parsing: %q", *v)
@@ -1082,7 +1082,7 @@ func flattenAzureRmStorageAccountSecondaryEndpoints(d *schema.ResourceData, seco
 	if v := secondary.Table; v != nil {
 		tableEndpoint = *v
 
-		if u, err := url.Parse(*v); err != nil {
+		if u, err := url.Parse(*v); err == nil {
 			tableHost = u.Host
 		} else {
 			return fmt.Errorf("invalid table endpoint for parsing: %q", *v)

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1005,61 +1005,69 @@ func getBlobConnectionString(blobEndpoint *string, acctName *string, acctKey *st
 }
 
 func flattenAndSetAzureRmStorageAccountPrimaryEndpoints(d *schema.ResourceData, primary *storage.Endpoints) error {
-	if primary == nil {
-		return fmt.Errorf("primary endpoints should not be empty")
-	}
-
 	var blobEndpoint, blobHost string
-	if v := primary.Blob; v != nil {
-		blobEndpoint = *v
+	if primary != nil {
+		if v := primary.Blob; v != nil {
+			blobEndpoint = *v
 
-		u, err := url.Parse(*v)
-		if err != nil {
-			return fmt.Errorf("invalid blob endpoint for parsing: %q", *v)
+			u, err := url.Parse(*v)
+			if err != nil {
+				return fmt.Errorf("invalid blob endpoint for parsing: %q", *v)
+			}
+			blobHost = u.Host
 		}
-		blobHost = u.Host
 	}
 	d.Set("primary_blob_endpoint", blobEndpoint)
 	d.Set("primary_blob_host", blobHost)
 
 	var queueEndpoint, queueHost string
-	if v := primary.Queue; v != nil {
-		queueEndpoint = *v
+	if primary != nil {
+		if v := primary.Queue; v != nil {
+			queueEndpoint = *v
 
-		u, err := url.Parse(*v)
-		if err != nil {
-			return fmt.Errorf("invalid queue endpoint for parsing: %q", *v)
+			u, err := url.Parse(*v)
+			if err != nil {
+				return fmt.Errorf("invalid queue endpoint for parsing: %q", *v)
+			}
+			queueHost = u.Host
 		}
-		queueHost = u.Host
 	}
 	d.Set("primary_queue_endpoint", queueEndpoint)
 	d.Set("primary_queue_host", queueHost)
 
 	var tableEndpoint, tableHost string
-	if v := primary.Table; v != nil {
-		tableEndpoint = *v
+	if primary != nil {
+		if v := primary.Table; v != nil {
+			tableEndpoint = *v
 
-		u, err := url.Parse(*v)
-		if err != nil {
-			return fmt.Errorf("invalid table endpoint for parsing: %q", *v)
+			u, err := url.Parse(*v)
+			if err != nil {
+				return fmt.Errorf("invalid table endpoint for parsing: %q", *v)
+			}
+			tableHost = u.Host
 		}
-		tableHost = u.Host
 	}
 	d.Set("primary_table_endpoint", tableEndpoint)
 	d.Set("primary_table_host", tableHost)
 
 	var fileEndpoint, fileHost string
-	if v := primary.File; v != nil {
-		fileEndpoint = *v
+	if primary != nil {
+		if v := primary.File; v != nil {
+			fileEndpoint = *v
 
-		u, err := url.Parse(*v)
-		if err != nil {
-			return fmt.Errorf("invalid file endpoint for parsing: %q", *v)
+			u, err := url.Parse(*v)
+			if err != nil {
+				return fmt.Errorf("invalid file endpoint for parsing: %q", *v)
+			}
+			fileHost = u.Host
 		}
-		fileHost = u.Host
 	}
 	d.Set("primary_file_endpoint", fileEndpoint)
 	d.Set("primary_file_host", fileHost)
+
+	if primary == nil {
+		return fmt.Errorf("primary endpoints should not be empty")
+	}
 
 	return nil
 }

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -64,31 +64,31 @@ output "storage_account_tier" {
 
 * `primary_blob_endpoint` - The endpoint URL for blob storage in the primary location.
 
-* `primary_blob_host` - The host for blob storage in the primary location.
+* `primary_blob_host` - The `host` or `host:port` for blob storage in the primary location.
 
 * `secondary_blob_endpoint` - The endpoint URL for blob storage in the secondary location.
 
-* `secondary_blob_host` - The host for blob storage in the secondary location.
+* `secondary_blob_host` - The `host` or `host:port` for blob storage in the secondary location.
 
 * `primary_queue_endpoint` - The endpoint URL for queue storage in the primary location.
 
-* `primary_queue_host` - The host for queue storage in the primary location.
+* `primary_queue_host` - The `host` or `host:port` for queue storage in the primary location.
 
 * `secondary_queue_endpoint` - The endpoint URL for queue storage in the secondary location.
 
-* `secondary_queue_host` - The host for queue storage in the secondary location.
+* `secondary_queue_host` - The `host` or `host:port` for queue storage in the secondary location.
 
 * `primary_table_endpoint` - The endpoint URL for table storage in the primary location.
 
-* `primary_table_host` - The host for table storage in the primary location.
+* `primary_table_host` - The `host` or `host:port` for table storage in the primary location.
 
 * `secondary_table_endpoint` - The endpoint URL for table storage in the secondary location.
 
-* `secondary_table_host` - The host for table storage in the secondary location.
+* `secondary_table_host` - The `host` or `host:port` for table storage in the secondary location.
 
 * `primary_file_endpoint` - The endpoint URL for file storage in the primary location.
 
-* `primary_file_host` - The host for file storage in the primary location.
+* `primary_file_host` - The `host` or `host:port` for file storage in the primary location.
 
 * `primary_access_key` - The primary access key for the Storage Account.
 

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -64,31 +64,31 @@ output "storage_account_tier" {
 
 * `primary_blob_endpoint` - The endpoint URL for blob storage in the primary location.
 
-* `primary_blob_host` - The `host` or `host:port` for blob storage in the primary location.
+* `primary_blob_host` - The hostname with port if applicable for blob storage in the primary location.
 
 * `secondary_blob_endpoint` - The endpoint URL for blob storage in the secondary location.
 
-* `secondary_blob_host` - The `host` or `host:port` for blob storage in the secondary location.
+* `secondary_blob_host` - The hostname with port if applicable for blob storage in the secondary location.
 
 * `primary_queue_endpoint` - The endpoint URL for queue storage in the primary location.
 
-* `primary_queue_host` - The `host` or `host:port` for queue storage in the primary location.
+* `primary_queue_host` - The hostname with port if applicable for queue storage in the primary location.
 
 * `secondary_queue_endpoint` - The endpoint URL for queue storage in the secondary location.
 
-* `secondary_queue_host` - The `host` or `host:port` for queue storage in the secondary location.
+* `secondary_queue_host` - The hostname with port if applicable for queue storage in the secondary location.
 
 * `primary_table_endpoint` - The endpoint URL for table storage in the primary location.
 
-* `primary_table_host` - The `host` or `host:port` for table storage in the primary location.
+* `primary_table_host` - The hostname with port if applicable for table storage in the primary location.
 
 * `secondary_table_endpoint` - The endpoint URL for table storage in the secondary location.
 
-* `secondary_table_host` - The `host` or `host:port` for table storage in the secondary location.
+* `secondary_table_host` - The hostname with port if applicable for table storage in the secondary location.
 
 * `primary_file_endpoint` - The endpoint URL for file storage in the primary location.
 
-* `primary_file_host` - The `host` or `host:port` for file storage in the primary location.
+* `primary_file_host` - The hostname with port if applicable for file storage in the primary location.
 
 * `primary_access_key` - The primary access key for the Storage Account.
 

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -64,17 +64,31 @@ output "storage_account_tier" {
 
 * `primary_blob_endpoint` - The endpoint URL for blob storage in the primary location.
 
+* `primary_blob_host` - The host for blob storage in the primary location.
+
 * `secondary_blob_endpoint` - The endpoint URL for blob storage in the secondary location.
+
+* `secondary_blob_host` - The host for blob storage in the secondary location.
 
 * `primary_queue_endpoint` - The endpoint URL for queue storage in the primary location.
 
+* `primary_queue_host` - The host for queue storage in the primary location.
+
 * `secondary_queue_endpoint` - The endpoint URL for queue storage in the secondary location.
+
+* `secondary_queue_host` - The host for queue storage in the secondary location.
 
 * `primary_table_endpoint` - The endpoint URL for table storage in the primary location.
 
+* `primary_table_host` - The host for table storage in the primary location.
+
 * `secondary_table_endpoint` - The endpoint URL for table storage in the secondary location.
 
+* `secondary_table_host` - The host for table storage in the secondary location.
+
 * `primary_file_endpoint` - The endpoint URL for file storage in the primary location.
+
+* `primary_file_host` - The host for file storage in the primary location.
 
 * `primary_access_key` - The primary access key for the Storage Account.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -1,3 +1,4 @@
+
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account"
@@ -145,21 +146,51 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The storage account Resource ID.
+
 * `primary_location` - The primary location of the storage account.
+
 * `secondary_location` - The secondary location of the storage account.
+
 * `primary_blob_endpoint` - The endpoint URL for blob storage in the primary location.
+
+* `primary_blob_host` - The `host` or `host:port` for blob storage in the primary location.
+
 * `secondary_blob_endpoint` - The endpoint URL for blob storage in the secondary location.
+
+* `secondary_blob_host` - The `host` or `host:port`for blob storage in the secondary location.
+
 * `primary_queue_endpoint` - The endpoint URL for queue storage in the primary location.
+
+* `primary_queue_host` - The `host` or `host:port`for queue storage in the primary location.
+
 * `secondary_queue_endpoint` - The endpoint URL for queue storage in the secondary location.
+
+* `secondary_queue_host` - The `host` or `host:port`for queue storage in the secondary location.
+
 * `primary_table_endpoint` - The endpoint URL for table storage in the primary location.
+
+* `primary_table_host` - The `host` or `host:port`for table storage in the primary location.
+
 * `secondary_table_endpoint` - The endpoint URL for table storage in the secondary location.
+
+* `secondary_table_host` - The `host` or `host:port`for table storage in the secondary location.
+
 * `primary_file_endpoint` - The endpoint URL for file storage in the primary location.
-* `primary_access_key` - The primary access key for the storage account
-* `secondary_access_key` - The secondary access key for the storage account
-* `primary_connection_string` - The connection string associated with the primary location
-* `secondary_connection_string` - The connection string associated with the secondary location
-* `primary_blob_connection_string` - The connection string associated with the primary blob location
-* `secondary_blob_connection_string` - The connection string associated with the secondary blob location
+
+* `primary_file_host` - The `host` or `host:port`for file storage in the primary location.
+
+* `primary_access_key` - The primary access key for the storage account.
+
+* `secondary_access_key` - The secondary access key for the storage account.
+
+* `primary_connection_string` - The connection string associated with the primary location.
+
+* `secondary_connection_string` - The connection string associated with the secondary location.
+
+* `primary_blob_connection_string` - The connection string associated with the primary blob location.
+
+* `secondary_blob_connection_string` - The connection string associated with the secondary blob location.
+
 * `identity` - An `identity` block as defined below, which contains the Identity information for this Storage Account.
 
 ---

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -153,31 +153,31 @@ The following attributes are exported in addition to the arguments listed above:
 
 * `primary_blob_endpoint` - The endpoint URL for blob storage in the primary location.
 
-* `primary_blob_host` - The `host` or `host:port` for blob storage in the primary location.
+* `primary_blob_host` - The hostname with port if applicable for blob storage in the primary location.
 
 * `secondary_blob_endpoint` - The endpoint URL for blob storage in the secondary location.
 
-* `secondary_blob_host` - The `host` or `host:port`for blob storage in the secondary location.
+* `secondary_blob_host` - The hostname with port if applicable for blob storage in the secondary location.
 
 * `primary_queue_endpoint` - The endpoint URL for queue storage in the primary location.
 
-* `primary_queue_host` - The `host` or `host:port`for queue storage in the primary location.
+* `primary_queue_host` - The hostname with port if applicable for queue storage in the primary location.
 
 * `secondary_queue_endpoint` - The endpoint URL for queue storage in the secondary location.
 
-* `secondary_queue_host` - The `host` or `host:port`for queue storage in the secondary location.
+* `secondary_queue_host` - The hostname with port if applicable for queue storage in the secondary location.
 
 * `primary_table_endpoint` - The endpoint URL for table storage in the primary location.
 
-* `primary_table_host` - The `host` or `host:port`for table storage in the primary location.
+* `primary_table_host` - The hostname with port if applicable for table storage in the primary location.
 
 * `secondary_table_endpoint` - The endpoint URL for table storage in the secondary location.
 
-* `secondary_table_host` - The `host` or `host:port`for table storage in the secondary location.
+* `secondary_table_host` - The hostname with port if applicable for table storage in the secondary location.
 
 * `primary_file_endpoint` - The endpoint URL for file storage in the primary location.
 
-* `primary_file_host` - The `host` or `host:port`for file storage in the primary location.
+* `primary_file_host` - The hostname with port if applicable for file storage in the primary location.
 
 * `primary_access_key` - The primary access key for the storage account.
 


### PR DESCRIPTION
This PR is to export `host` attributes for storage account resource, covers primary/secondary endpoints for table, file, queue, and blob.

Fixes #2785 