### PR TITLE
Requiring Imports: PR 12/12

### DIFF
--- a/azurerm/resource_arm_network_interface_application_gateway_association.go
+++ b/azurerm/resource_arm_network_interface_application_gateway_association.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -100,12 +101,12 @@ func resourceArmNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationC
 	pools := make([]network.ApplicationGatewayBackendAddressPool, 0)
 
 	// first double-check it doesn't exist
+	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, backendAddressPoolId)
 	if p.ApplicationGatewayBackendAddressPools != nil {
 		for _, existingPool := range *p.ApplicationGatewayBackendAddressPools {
 			if id := existingPool.ID; id != nil {
 				if *id == backendAddressPoolId {
-					// TODO: switch to using the common error once https://github.com/terraform-providers/terraform-provider-azurerm/pull/1746 is merged
-					return fmt.Errorf("A Network Interface <-> Application Gateway Backend Address Pool association exists between %q and %q - please import it!", networkInterfaceId, backendAddressPoolId)
+					return tf.ImportAsExistsError("azurerm_network_interface_application_gateway_backend_address_pool_association", resourceId)
 				}
 
 				pools = append(pools, existingPool)
@@ -130,7 +131,6 @@ func resourceArmNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationC
 		return fmt.Errorf("Error waiting for completion of Application Gateway Backend Address Pool Association for NIC %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
 	}
 
-	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, backendAddressPoolId)
 	d.SetId(resourceId)
 
 	return resourceArmNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationRead(d, meta)

--- a/azurerm/resource_arm_network_interface_application_gateway_association_test.go
+++ b/azurerm/resource_arm_network_interface_application_gateway_association_test.go
@@ -30,6 +30,30 @@ func TestAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociati
 	})
 }
 
+func TestAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_requiresImport(t *testing.T) {
+	resourceName := "azurerm_network_interface_application_gateway_backend_address_pool_association.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_requiresImport(rInt, location),
+				ExpectError: testRequiresImportError("azurerm_network_interface_application_gateway_backend_address_pool_association"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_deleted(t *testing.T) {
 	resourceName := "azurerm_network_interface_application_gateway_backend_address_pool_association.test"
 	ri := tf.AccRandTimeInt()
@@ -275,4 +299,17 @@ resource "azurerm_network_interface_application_gateway_backend_address_pool_ass
   backend_address_pool_id = "${azurerm_application_gateway.test.backend_address_pool.0.id}"
 }
 `, rInt, location, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "import" {
+  network_interface_id    = "${azurerm_network_interface_application_gateway_backend_address_pool_association.test.network_interface_id}"
+  ip_configuration_name   = "${azurerm_network_interface_application_gateway_backend_address_pool_association.test.ip_configuration_name}"
+  backend_address_pool_id = "${azurerm_network_interface_application_gateway_backend_address_pool_association.test.backend_address_pool_id}"
+}
+`, template)
 }

--- a/azurerm/resource_arm_network_interface_application_security_group_association.go
+++ b/azurerm/resource_arm_network_interface_application_security_group_association.go
@@ -101,16 +101,14 @@ func resourceArmNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *sch
 	applicationSecurityGroups := make([]network.ApplicationSecurityGroup, 0)
 
 	// first double-check it doesn't exist
-	if requireResourcesToBeImported {
-		if p.ApplicationSecurityGroups != nil {
-			for _, existingGroup := range *p.ApplicationSecurityGroups {
-				if id := existingGroup.ID; id != nil {
-					if *id == applicationSecurityGroupId {
-						return tf.ImportAsExistsError("azurerm_network_interface_application_security_group_association", *id)
-					}
-
-					applicationSecurityGroups = append(applicationSecurityGroups, existingGroup)
+	if p.ApplicationSecurityGroups != nil {
+		for _, existingGroup := range *p.ApplicationSecurityGroups {
+			if id := existingGroup.ID; id != nil {
+				if *id == applicationSecurityGroupId {
+					return tf.ImportAsExistsError("azurerm_network_interface_application_security_group_association", *id)
 				}
+
+				applicationSecurityGroups = append(applicationSecurityGroups, existingGroup)
 			}
 		}
 	}

--- a/azurerm/resource_arm_network_interface_application_security_group_association_test.go
+++ b/azurerm/resource_arm_network_interface_application_security_group_association_test.go
@@ -31,11 +31,6 @@ func TestAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(t *
 }
 
 func TestAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
-		t.Skip("Skipping since resources aren't required to be imported")
-		return
-	}
-
 	resourceName := "azurerm_network_interface_application_security_group_association.test"
 	rInt := tf.AccRandTimeInt()
 	location := testLocation()

--- a/azurerm/resource_arm_network_interface_nat_rule_association.go
+++ b/azurerm/resource_arm_network_interface_nat_rule_association.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -100,12 +101,12 @@ func resourceArmNetworkInterfaceNatRuleAssociationCreate(d *schema.ResourceData,
 	rules := make([]network.InboundNatRule, 0)
 
 	// first double-check it doesn't exist
+	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, natRuleId)
 	if p.LoadBalancerInboundNatRules != nil {
 		for _, existingRule := range *p.LoadBalancerInboundNatRules {
 			if id := existingRule.ID; id != nil {
 				if *id == natRuleId {
-					// TODO: switch to using the common error once https://github.com/terraform-providers/terraform-provider-azurerm/pull/1746 is merged
-					return fmt.Errorf("A Network Interface <-> Load Balancer NAT Rule association exists between %q and %q - please import it!", networkInterfaceId, natRuleId)
+					return tf.ImportAsExistsError("azurerm_network_interface_nat_rule_association", resourceId)
 				}
 
 				rules = append(rules, existingRule)
@@ -130,7 +131,6 @@ func resourceArmNetworkInterfaceNatRuleAssociationCreate(d *schema.ResourceData,
 		return fmt.Errorf("Error waiting for completion of NAT Rule Association for NIC %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
 	}
 
-	resourceId := fmt.Sprintf("%s/ipConfigurations/%s|%s", networkInterfaceId, ipConfigurationName, natRuleId)
 	d.SetId(resourceId)
 
 	return resourceArmNetworkInterfaceNatRuleAssociationRead(d, meta)

--- a/azurerm/resource_arm_network_interface_nat_rule_association_test.go
+++ b/azurerm/resource_arm_network_interface_nat_rule_association_test.go
@@ -30,6 +30,30 @@ func TestAccAzureRMNetworkInterfaceNATRuleAssociation_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterfaceNATRuleAssociation_requiresImport(t *testing.T) {
+	resourceName := "azurerm_network_interface_nat_rule_association.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceNATRuleAssociation_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceNATRuleAssociationExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMNetworkInterfaceNATRuleAssociation_requiresImport(rInt, location),
+				ExpectError: testRequiresImportError("azurerm_network_interface_nat_rule_association"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterfaceNATRuleAssociation_deleted(t *testing.T) {
 	resourceName := "azurerm_network_interface_nat_rule_association.test"
 	ri := tf.AccRandTimeInt()
@@ -225,4 +249,17 @@ resource "azurerm_network_interface_nat_rule_association" "test" {
   nat_rule_id           = "${azurerm_lb_nat_rule.test.id}"
 }
 `, rInt, location, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMNetworkInterfaceNATRuleAssociation_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMNetworkInterfaceNATRuleAssociation_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface_nat_rule_association" "import" {
+  network_interface_id  = "${azurerm_network_interface_nat_rule_association.test.network_interface_id}"
+  ip_configuration_name = "${azurerm_network_interface_nat_rule_association.test.ip_configuration_name}"
+  nat_rule_id           = "${azurerm_network_interface_nat_rule_association.test.nat_rule_id}"
+}
+`, template)
 }

--- a/azurerm/resource_arm_storage_queue.go
+++ b/azurerm/resource_arm_storage_queue.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 )
 
 func resourceArmStorageQueue() *schema.Resource {
@@ -85,15 +86,26 @@ func resourceArmStorageQueueCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Storage Account %q Not Found", storageAccountName)
 	}
 
-	log.Printf("[INFO] Creating queue %q in storage account %q", name, storageAccountName)
 	queueReference := queueClient.GetQueueReference(name)
+	id := fmt.Sprintf("https://%s.queue.%s/%s", storageAccountName, environment.StorageEndpointSuffix, name)
+	if requireResourcesToBeImported {
+		exists, e := queueReference.Exists()
+		if e != nil {
+			return fmt.Errorf("Error checking if Queue %q exists (Account %q / Resource Group %q): %s", name, storageAccountName, resourceGroupName, e)
+		}
+
+		if exists {
+			return tf.ImportAsExistsError("azurerm_storage_queue", id)
+		}
+	}
+
+	log.Printf("[INFO] Creating queue %q in storage account %q", name, storageAccountName)
 	options := &storage.QueueServiceOptions{}
 	err = queueReference.Create(options)
 	if err != nil {
 		return fmt.Errorf("Error creating storage queue on Azure: %s", err)
 	}
 
-	id := fmt.Sprintf("https://%s.queue.%s/%s", storageAccountName, environment.StorageEndpointSuffix, name)
 	d.SetId(id)
 	return resourceArmStorageQueueRead(d, meta)
 }

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -77,6 +77,36 @@ func TestAccAzureRMStorageQueue_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageQueue_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_storage_queue.test"
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageQueue_basic(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageQueueExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMStorageQueue_requiresImport(ri, rs, location),
+				ExpectError: testRequiresImportError("azurerm_storage_queue"),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMStorageQueueExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -178,4 +208,17 @@ resource "azurerm_storage_queue" "test" {
   storage_account_name = "${azurerm_storage_account.test.name}"
 }
 `, rInt, location, rString, rInt)
+}
+
+func testAccAzureRMStorageQueue_requiresImport(rInt int, rString string, location string) string {
+	template := testAccAzureRMStorageQueue_basic(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_queue" "import" {
+  name                 = "${azurerm_storage_queue.test.name}"
+  resource_group_name  = "${azurerm_storage_queue.test.resource_group_name}"
+  storage_account_name = "${azurerm_storage_queue.test.storage_account_name}"
+}
+`, template)
 }

--- a/azurerm/resource_arm_storage_share.go
+++ b/azurerm/resource_arm_storage_share.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -71,6 +72,19 @@ func resourceArmStorageShareCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] Creating share %q in storage account %q", name, storageAccountName)
 	reference := fileClient.GetShareReference(name)
+
+	id := fmt.Sprintf("%s/%s/%s", name, resourceGroupName, storageAccountName)
+	if requireResourcesToBeImported {
+		exists, e := reference.Exists()
+		if e != nil {
+			return fmt.Errorf("Error checking if Share %q exists (Account %q / Resource Group %q): %s", name, storageAccountName, resourceGroupName, e)
+		}
+
+		if exists {
+			return tf.ImportAsExistsError("azurerm_storage_share", id)
+		}
+	}
+
 	err = reference.Create(options)
 	if err != nil {
 		return fmt.Errorf("Error creating Storage Share %q reference (storage account: %q) : %+v", name, storageAccountName, err)
@@ -90,7 +104,7 @@ func resourceArmStorageShareCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting properties on Storage Share %q: %+v", name, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s/%s", name, resourceGroupName, storageAccountName))
+	d.SetId(id)
 	return resourceArmStorageShareRead(d, meta)
 }
 

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -41,6 +41,38 @@ func TestAccAzureRMStorageShare_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageShare_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	var sS storage.Share
+
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	location := testLocation()
+	resourceName := "azurerm_storage_share.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageShareDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageShare_basic(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageShareExists(resourceName, &sS),
+				),
+			},
+			{
+				Config:      testAccAzureRMStorageShare_requiresImport(ri, rs, location),
+				ExpectError: testRequiresImportError("azurerm_storage_share"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMStorageShare_disappears(t *testing.T) {
 	var sS storage.Share
 
@@ -263,6 +295,19 @@ resource "azurerm_storage_share" "test" {
   storage_account_name = "${azurerm_storage_account.test.name}"
 }
 `, rInt, location, rString)
+}
+
+func testAccAzureRMStorageShare_requiresImport(rInt int, rString string, location string) string {
+	template := testAccAzureRMStorageShare_basic(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_share" "import" {
+  name                 = "${azurerm_storage_share.test.name}"
+  resource_group_name  = "${azurerm_storage_share.test.resource_group_name}"
+  storage_account_name = "${azurerm_storage_share.test.storage_account_name}"
+}
+`, template)
 }
 
 func testAccAzureRMStorageShare_updateQuota(rInt int, rString string, location string) string {

--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 )
 
 func resourceArmStorageTable() *schema.Resource {
@@ -73,9 +74,24 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	table := tableClient.GetTableReference(name)
+	id := fmt.Sprintf("https://%s.table.%s/%s", storageAccountName, environment.StorageEndpointSuffix, name)
+
+	if requireResourcesToBeImported {
+		metaDataLevel := storage.MinimalMetadata
+		options := &storage.QueryTablesOptions{}
+		tables, e := tableClient.QueryTables(metaDataLevel, options)
+		if e != nil {
+			return fmt.Errorf("Error checking if Table %q exists (Account %q / Resource Group %q): %s", name, storageAccountName, resourceGroupName, e)
+		}
+
+		for _, table := range tables.Tables {
+			if table.Name == name {
+				return tf.ImportAsExistsError("azurerm_storage_table", id)
+			}
+		}
+	}
 
 	log.Printf("[INFO] Creating table %q in storage account %q.", name, storageAccountName)
-
 	timeout := uint(60)
 	options := &storage.TableOptions{}
 	err = table.Create(timeout, storage.NoMetadata, options)
@@ -83,7 +99,6 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error creating table %q in storage account %q: %s", name, storageAccountName, err)
 	}
 
-	id := fmt.Sprintf("https://%s.table.%s/%s", storageAccountName, environment.StorageEndpointSuffix, name)
 	d.SetId(id)
 	return resourceArmStorageTableRead(d, meta)
 }

--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -127,6 +128,20 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 	name := d.Get("name").(string)
 	vnetName := d.Get("virtual_network_name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, vnetName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Subnet %q (Virtual Network %q / Resource Group %q): %s", name, vnetName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_subnet", *existing.ID)
+		}
+	}
+
 	addressPrefix := d.Get("address_prefix").(string)
 
 	azureRMLockByName(vnetName, virtualNetworkResourceName)
@@ -183,11 +198,11 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, vnetName, name, subnet)
 	if err != nil {
-		return fmt.Errorf("Error Creating/Updating Subnet %q (VN %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
+		return fmt.Errorf("Error Creating/Updating Subnet %q (Virtual Network %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for completion of Subnet %q (VN %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
+		return fmt.Errorf("Error waiting for completion of Subnet %q (Virtual Network %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
 	}
 
 	read, err := client.Get(ctx, resGroup, vnetName, name, "")
@@ -195,7 +210,7 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read ID of Subnet %q (VN %q / Resource Group %q)", vnetName, name, resGroup)
+		return fmt.Errorf("Cannot read ID of Subnet %q (Virtual Network %q / Resource Group %q)", vnetName, name, resGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -305,11 +320,11 @@ func resourceArmSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	future, err := client.Delete(ctx, resGroup, vnetName, name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Subnet %q (VN %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
+		return fmt.Errorf("Error deleting Subnet %q (Virtual Network %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for completion for Subnet %q (VN %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
+		return fmt.Errorf("Error waiting for completion for Subnet %q (Virtual Network %q / Resource Group %q): %+v", name, vnetName, resGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_subnet_network_security_group_association.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -76,6 +77,15 @@ func resourceArmSubnetNetworkSecurityGroupAssociationCreate(d *schema.ResourceDa
 	}
 
 	if props := subnet.SubnetPropertiesFormat; props != nil {
+		if requireResourcesToBeImported {
+			if nsg := props.NetworkSecurityGroup; nsg != nil {
+				// we're intentionally not checking the ID - if there's a NSG, it needs to be imported
+				if nsg.ID != nil && subnet.ID != nil {
+					return tf.ImportAsExistsError("azurerm_subnet_network_security_group_association", *subnet.ID)
+				}
+			}
+		}
+
 		props.NetworkSecurityGroup = &network.SecurityGroup{
 			ID: utils.String(networkSecurityGroupId),
 		}

--- a/azurerm/resource_arm_subnet_network_security_group_association_test.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association_test.go
@@ -36,6 +36,36 @@ func TestAccAzureRMSubnetNetworkSecurityGroupAssociation_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSubnetNetworkSecurityGroupAssociation_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_subnet_network_security_group_association.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSubnetNetworkSecurityGroupAssociation_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetNetworkSecurityGroupAssociationExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMSubnetNetworkSecurityGroupAssociation_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_subnet_network_security_group_association"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMSubnetNetworkSecurityGroupAssociation_deleted(t *testing.T) {
 	resourceName := "azurerm_subnet_network_security_group_association.test"
 	ri := tf.AccRandTimeInt()
@@ -230,4 +260,12 @@ resource "azurerm_subnet_network_security_group_association" "test" {
   network_security_group_id = "${azurerm_network_security_group.test.id}"
 }
 `, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMSubnetNetworkSecurityGroupAssociation_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMSubnetNetworkSecurityGroupAssociation_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+`, template)
 }

--- a/azurerm/resource_arm_subnet_route_table_association.go
+++ b/azurerm/resource_arm_subnet_route_table_association.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -76,6 +77,15 @@ func resourceArmSubnetRouteTableAssociationCreate(d *schema.ResourceData, meta i
 	}
 
 	if props := subnet.SubnetPropertiesFormat; props != nil {
+		if requireResourcesToBeImported {
+			if rt := props.RouteTable; rt != nil {
+				// we're intentionally not checking the ID - if there's a RouteTable, it needs to be imported
+				if rt.ID != nil && subnet.ID != nil {
+					return tf.ImportAsExistsError("azurerm_subnet_route_table_association", *subnet.ID)
+				}
+			}
+		}
+
 		props.RouteTable = &network.RouteTable{
 			ID: utils.String(routeTableId),
 		}

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 	"golang.org/x/net/context"
 )
@@ -560,8 +561,22 @@ func resourceArmVirtualMachineCreateUpdate(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] preparing arguments for Azure ARM Virtual Machine creation.")
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Virtual Machine %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_virtual_machine", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 	expandedTags := expandTags(tags)
 	zones := expandZones(d.Get("zones").([]interface{}))

--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -112,6 +113,7 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 	}
 
 	name := *managedDisk.Name
+	resourceId := fmt.Sprintf("%s/dataDisks/%s", virtualMachineId, name)
 	lun := int32(d.Get("lun").(int))
 	caching := d.Get("caching").(string)
 	createOption := compute.DiskCreateOptionTypes(d.Get("create_option").(string))
@@ -130,18 +132,24 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 	}
 
 	disks := *virtualMachine.StorageProfile.DataDisks
+
+	existingIndex := -1
+	for i, disk := range disks {
+		if *disk.Name == name {
+			existingIndex = i
+			break
+		}
+	}
+
 	if d.IsNewResource() {
-		disks = append(disks, expandedDisk)
-	} else {
-		// iterate over the disks and swap it out in-place
-		existingIndex := -1
-		for i, disk := range disks {
-			if *disk.Name == name {
-				existingIndex = i
-				break
+		if requireResourcesToBeImported {
+			if existingIndex != -1 {
+				return tf.ImportAsExistsError("azurerm_virtual_machine_data_disk_attachment", resourceId)
 			}
 		}
 
+		disks = append(disks, expandedDisk)
+	} else {
 		if existingIndex == -1 {
 			return fmt.Errorf("Unable to find Disk %q attached to Virtual Machine %q (Resource Group %q)", name, virtualMachineName, resourceGroup)
 		}
@@ -166,8 +174,7 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 		return fmt.Errorf("Error waiting for Virtual Machine %q (Resource Group %q) to finish updating Disk %q: %+v", virtualMachineName, resourceGroup, name, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s/dataDisks/%s", virtualMachineId, name))
-
+	d.SetId(resourceId)
 	return resourceArmVirtualMachineDataDiskAttachmentRead(d, meta)
 }
 

--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
@@ -40,6 +40,34 @@ func TestAccAzureRMVirtualMachineDataDiskAttachment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineDataDiskAttachment_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_virtual_machine_data_disk_attachment.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDataDiskAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineDataDiskAttachment_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineDataDiskAttachmentExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMVirtualMachineDataDiskAttachment_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_virtual_machine_data_disk_attachment"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineDataDiskAttachment_multipleDisks(t *testing.T) {
 	firstResourceName := "azurerm_virtual_machine_data_disk_attachment.first"
 	secondResourceName := "azurerm_virtual_machine_data_disk_attachment.second"
@@ -277,6 +305,20 @@ resource "azurerm_virtual_machine_data_disk_attachment" "test" {
   virtual_machine_id = "${azurerm_virtual_machine.test.id}"
   lun                = "0"
   caching            = "None"
+}
+`, template)
+}
+
+func testAccAzureRMVirtualMachineDataDiskAttachment_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineDataDiskAttachment_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_data_disk_attachment" "import" {
+  managed_disk_id    = "${azurerm_virtual_machine_data_disk_attachment.test.managed_disk_id}"
+  virtual_machine_id = "${azurerm_virtual_machine_data_disk_attachment.test.virtual_machine_id}"
+  lun                = "${azurerm_virtual_machine_data_disk_attachment.test.lun}"
+  caching            = "${azurerm_virtual_machine_data_disk_attachment.test.caching}"
 }
 `, template)
 }

--- a/azurerm/resource_arm_virtual_machine_extension.go
+++ b/azurerm/resource_arm_virtual_machine_extension.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/structure"
 	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -83,9 +84,23 @@ func resourceArmVirtualMachineExtensionsCreateUpdate(d *schema.ResourceData, met
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
 	vmName := d.Get("virtual_machine_name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, vmName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Extension %q (Virtual Machine %q / Resource Group %q): %s", name, vmName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_virtual_machine_extension", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	publisher := d.Get("publisher").(string)
 	extensionType := d.Get("type").(string)
 	typeHandlerVersion := d.Get("type_handler_version").(string)

--- a/azurerm/resource_arm_virtual_machine_extension_test.go
+++ b/azurerm/resource_arm_virtual_machine_extension_test.go
@@ -47,6 +47,35 @@ func TestAccAzureRMVirtualMachineExtension_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineExtension_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_virtual_machine_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineExtension_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExtensionExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMVirtualMachineExtension_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_virtual_machine_extension"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineExtension_concurrent(t *testing.T) {
 	firstResourceName := "azurerm_virtual_machine_extension.test"
 	secondResourceName := "azurerm_virtual_machine_extension.test2"
@@ -249,6 +278,26 @@ SETTINGS
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineExtension_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineExtension_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+
+resource "azurerm_virtual_machine_extension" "import" {
+  name                 = "${azurerm_virtual_machine_extension.test.name}"
+  resource_group_name  = "${azurerm_virtual_machine_extension.test.resource_group_name}"
+  virtual_machine_name = "${azurerm_virtual_machine_extension.test.virtual_machine_name}"
+  location             = "${azurerm_virtual_machine_extension.test.location}"
+  publisher            = "${azurerm_virtual_machine_extension.test.publisher}"
+  type                 = "${azurerm_virtual_machine_extension.test.type}"
+  type_handler_version = "${azurerm_virtual_machine_extension.test.type_handler_version}"
+  settings             = "${azurerm_virtual_machine_extension.test.settings}"
+  tags                 = "${azurerm_virtual_machine_extension.test.tags}"
+}
+`, template)
 }
 
 func testAccAzureRMVirtualMachineExtension_basicUpdate(rInt int, location string) string {

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -746,8 +747,22 @@ func resourceArmVirtualMachineScaleSetCreateUpdate(d *schema.ResourceData, meta 
 	log.Printf("[INFO] preparing arguments for Azure ARM Virtual Machine Scale Set creation.")
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Virtual Machine Scale Set %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_virtual_machine_scale_set", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 	zones := expandZones(d.Get("zones").([]interface{}))
 

--- a/azurerm/resource_arm_virtual_network.go
+++ b/azurerm/resource_arm_virtual_network.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -119,8 +120,22 @@ func resourceArmVirtualNetworkCreateUpdate(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] preparing arguments for Azure ARM virtual network creation.")
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Virtual Network %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_virtual_network", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 	vnetProperties, vnetPropsErr := expandVirtualNetworkProperties(ctx, d, meta)
 	if vnetPropsErr != nil {

--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -273,8 +274,22 @@ func resourceArmVirtualNetworkGatewayCreateUpdate(d *schema.ResourceData, meta i
 	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway creation.")
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Virtual Network Gateway %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_virtual_network_gateway", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 
 	properties, err := getArmVirtualNetworkGatewayProperties(d)

--- a/azurerm/resource_arm_virtual_network_gateway_connection.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -231,8 +232,22 @@ func resourceArmVirtualNetworkGatewayConnectionCreateUpdate(d *schema.ResourceDa
 	log.Printf("[INFO] preparing arguments for AzureRM Virtual Network Gateway Connection creation.")
 
 	name := d.Get("name").(string)
-	location := azureRMNormalizeLocation(d.Get("location").(string))
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Virtual Network Gateway Connection %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_virtual_network_gateway_connection", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
 	tags := d.Get("tags").(map[string]interface{})
 
 	properties, err := getArmVirtualNetworkGatewayConnectionProperties(d)

--- a/azurerm/resource_arm_virtual_network_gateway_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_test.go
@@ -36,6 +36,35 @@ func TestAccAzureRMVirtualNetworkGateway_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetworkGateway_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_virtual_network_gateway.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualNetworkGateway_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkGatewayExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMVirtualNetworkGateway_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_virtual_network_gateway"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualNetworkGateway_lowerCaseSubnetName(t *testing.T) {
 	ri := tf.AccRandTimeInt()
 	resourceName := "azurerm_virtual_network_gateway.test"
@@ -346,6 +375,28 @@ resource "azurerm_virtual_network_gateway" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualNetworkGateway_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMVirtualNetworkGateway_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network_gateway" "import" {
+  name                = "${azurerm_virtual_network_gateway.test.name}"
+  location            = "${azurerm_virtual_network_gateway.test.location}"
+  resource_group_name = "${azurerm_virtual_network_gateway.test.resource_group_name}"
+  type                = "${azurerm_virtual_network_gateway.test.type}"
+  vpn_type            = "${azurerm_virtual_network_gateway.test.vpn_type}"
+  sku                 = "${azurerm_virtual_network_gateway.test.sku}"
+
+  ip_configuration {
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+  }
+}
+`, template)
 }
 
 func testAccAzureRMVirtualNetworkGateway_lowerCaseSubnetName(rInt int, location string) string {

--- a/azurerm/resource_arm_virtual_network_peering.go
+++ b/azurerm/resource_arm_virtual_network_peering.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-08-01/network"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -81,6 +82,19 @@ func resourceArmVirtualNetworkPeeringCreateUpdate(d *schema.ResourceData, meta i
 	name := d.Get("name").(string)
 	vnetName := d.Get("virtual_network_name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, vnetName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Peering %q (Virtual Network %q / Resource Group %q): %s", name, vnetName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_virtual_network_peering", *existing.ID)
+		}
+	}
 
 	peer := network.VirtualNetworkPeering{
 		Name:                                  &name,

--- a/azurerm/resource_arm_virtual_network_peering_test.go
+++ b/azurerm/resource_arm_virtual_network_peering_test.go
@@ -40,6 +40,37 @@ func TestAccAzureRMVirtualNetworkPeering_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetworkPeering_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	firstResourceName := "azurerm_virtual_network_peering.test1"
+	secondResourceName := "azurerm_virtual_network_peering.test2"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualNetworkPeering_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkPeeringExists(firstResourceName),
+					testCheckAzureRMVirtualNetworkPeeringExists(secondResourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMVirtualNetworkPeering_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_virtual_network_peering"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualNetworkPeering_disappears(t *testing.T) {
 	firstResourceName := "azurerm_virtual_network_peering.test1"
 	secondResourceName := "azurerm_virtual_network_peering.test2"
@@ -234,6 +265,21 @@ resource "azurerm_virtual_network_peering" "test2" {
   allow_virtual_network_access = true
 }
 `, rInt, location, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualNetworkPeering_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMVirtualNetworkPeering_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network_peering" "import" {
+  name                         = "${azurerm_virtual_network_peering.test1.name}"
+  resource_group_name          = "${azurerm_virtual_network_peering.test1.resource_group_name}"
+  virtual_network_name         = "${azurerm_virtual_network_peering.test1.virtual_network_name}"
+  remote_virtual_network_id    = "${azurerm_virtual_network_peering.test1.remote_virtual_network_id}"
+  allow_virtual_network_access = "${azurerm_virtual_network_peering.test1.allow_virtual_network_access}"
+}
+`, template)
 }
 
 func testAccAzureRMVirtualNetworkPeering_basicUpdate(rInt int, location string) string {

--- a/azurerm/resource_arm_virtual_network_test.go
+++ b/azurerm/resource_arm_virtual_network_test.go
@@ -38,6 +38,35 @@ func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetwork_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_virtual_network.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualNetwork_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMVirtualNetwork_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_virtual_network"),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualNetwork_ddosProtectionPlan(t *testing.T) {
 	resourceName := "azurerm_virtual_network.test"
 	ri := tf.AccRandTimeInt()
@@ -251,6 +280,25 @@ resource "azurerm_virtual_network" "test" {
   }
 }
 `, rInt, location, rInt)
+}
+
+func testAccAzureRMVirtualNetwork_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMVirtualNetwork_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_network" "import" {
+  name                = "${azurerm_virtual_network.test.name}"
+  location            = "${azurerm_virtual_network.test.location}"
+  resource_group_name = "${azurerm_virtual_network.test.resource_group_name}"
+  address_space       = ["10.0.0.0/16"]
+
+  subnet {
+    name           = "subnet1"
+    address_prefix = "10.0.1.0/24"
+  }
+}
+`, template)
 }
 
 func testAccAzureRMVirtualNetwork_ddosProtectionPlan(rInt int, location string) string {


### PR DESCRIPTION
Adding Requires Import support to the remaining resources

NOTE: the multi-association virtual resources (e.g. NIC <-> NSG) already support Requiring Imports - as such it's intentionally not featured toggled off for these resources.