### PR TITLE
Switch Key Vault sub resources to use Key Vault ID instead of URL

### DIFF
--- a/azurerm/data_source_key_vault_key.go
+++ b/azurerm/data_source_key_vault_key.go
@@ -98,6 +98,7 @@ func dataSourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		keyVaultBaseUri = pKeyVaultBaseUrl
+		d.Set("vault_uri", keyVaultBaseUri)
 	} else {
 		id, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultClient, keyVaultBaseUri)
 		if err != nil {

--- a/azurerm/data_source_key_vault_key_test.go
+++ b/azurerm/data_source_key_vault_key_test.go
@@ -31,12 +31,13 @@ func TestAccDataSourceAzureRMKeyVaultKey_complete(t *testing.T) {
 }
 
 func testAccDataSourceKeyVaultKey_complete(rString string, location string) string {
+	t := testAccAzureRMKeyVaultKey_complete(rString, location)
 	return fmt.Sprintf(`
 %s
 
 data "azurerm_key_vault_key" "test" {
-  name      = "${azurerm_key_vault_key.test.name}"
-  vault_uri = "${azurerm_key_vault_key.test.vault_uri}"
+  name         = "${azurerm_key_vault_key.test.name}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 }
-`, testAccAzureRMKeyVaultKey_complete(rString, location))
+`, t)
 }

--- a/azurerm/data_source_key_vault_secret.go
+++ b/azurerm/data_source_key_vault_secret.go
@@ -21,11 +21,24 @@ func dataSourceArmKeyVaultSecret() *schema.Resource {
 				ValidateFunc: azure.ValidateKeyVaultChildName,
 			},
 
+			"key_vault_id": {
+				Type:          schema.TypeString,
+				Optional:      true, //todo required in 2.0
+				Computed:      true, //todo removed in 2.0
+				ForceNew:      true,
+				ValidateFunc:  azure.ValidateResourceID,
+				ConflictsWith: []string{"vault_uri"},
+			},
+
+			//todo remove in 2.0
 			"vault_uri": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.URLIsHTTPS,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				Deprecated:    "This property has been deprecated in favour of the key_vault_id property. This will prevent a class of bugs as described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/2396 and will be removed in version 2.0 of the provider",
+				ValidateFunc:  validate.URLIsHTTPS,
+				ConflictsWith: []string{"key_vault_id"},
 			},
 
 			"value": {
@@ -50,17 +63,38 @@ func dataSourceArmKeyVaultSecret() *schema.Resource {
 }
 
 func dataSourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) error {
+	vaultClient := meta.(*ArmClient).keyVaultClient
 	client := meta.(*ArmClient).keyVaultManagementClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
-	vaultUri := d.Get("vault_uri").(string)
+	keyVaultBaseUri := d.Get("vault_uri").(string)
+	keyVaultId := d.Get("key_vault_id").(string)
+
+	if keyVaultBaseUri == "" {
+		if keyVaultId == "" {
+			return fmt.Errorf("one of `key_vault_id` or `vault_uri` must be set")
+		}
+
+		pKeyVaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error looking up Secret %q vault url form id %q: %+v", name, keyVaultId, err)
+		}
+
+		keyVaultBaseUri = pKeyVaultBaseUrl
+	} else {
+		id, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultClient, keyVaultBaseUri)
+		if err != nil {
+			return fmt.Errorf("Error unable to find key vault ID from URL %q for certificate %q: %+v", keyVaultBaseUri, name, err)
+		}
+		d.Set("key_vault_id", id)
+	}
 
 	// we always want to get the latest version
-	resp, err := client.GetSecret(ctx, vaultUri, name, "")
+	resp, err := client.GetSecret(ctx, keyVaultBaseUri, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("KeyVault Secret %q (KeyVault URI %q) does not exist", name, vaultUri)
+			return fmt.Errorf("KeyVault Secret %q (KeyVault URI %q) does not exist", name, keyVaultBaseUri)
 		}
 		return fmt.Errorf("Error making Read request on Azure KeyVault Secret %s: %+v", name, err)
 	}

--- a/azurerm/data_source_key_vault_secret.go
+++ b/azurerm/data_source_key_vault_secret.go
@@ -82,6 +82,7 @@ func dataSourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) e
 		}
 
 		keyVaultBaseUri = pKeyVaultBaseUrl
+		d.Set("vault_uri", keyVaultBaseUri)
 	} else {
 		id, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultClient, keyVaultBaseUri)
 		if err != nil {

--- a/azurerm/data_source_key_vault_secret_test.go
+++ b/azurerm/data_source_key_vault_secret_test.go
@@ -59,8 +59,8 @@ func testAccDataSourceKeyVaultSecret_basic(rString string, location string) stri
 %s
 
 data "azurerm_key_vault_secret" "test" {
-  name      = "${azurerm_key_vault_secret.test.name}"
-  vault_uri = "${azurerm_key_vault_secret.test.vault_uri}"
+  name         = "${azurerm_key_vault_secret.test.name}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 }
 `, r)
 }
@@ -71,8 +71,8 @@ func testAccDataSourceKeyVaultSecret_complete(rString string, location string) s
 %s
 
 data "azurerm_key_vault_secret" "test" {
-  name      = "${azurerm_key_vault_secret.test.name}"
-  vault_uri = "${azurerm_key_vault_secret.test.vault_uri}"
+  name         = "${azurerm_key_vault_secret.test.name}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 }
 `, r)
 }

--- a/azurerm/helpers/azure/key_vault.go
+++ b/azurerm/helpers/azure/key_vault.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -38,6 +39,53 @@ func GetKeyVaultBaseUrlFromID(ctx context.Context, client keyvault.VaultsClient,
 	}
 
 	return *resp.Properties.VaultURI, nil
+}
+
+func GetKeyVaultIDFromBaseUrl(ctx context.Context, client keyvault.VaultsClient, keyVaultUrl string) (string, error) {
+
+	list, err := client.ListComplete(ctx, utils.Int32(1))
+	if err != nil {
+		return "", fmt.Errorf("Error GetKeyVaultId unable to list Key Vaults %v", err)
+	}
+
+	for list.NotDone() {
+		v := list.Value()
+		if v.ID == nil {
+			log.Printf("[DEBUG]GetKeyVaultId: v.ID was nil, continuing")
+			continue
+		}
+
+		vid, err := ParseAzureResourceID(*v.ID)
+		if err != nil {
+			log.Printf("[DEBUG] GetKeyVaultId: unable to parse v.ID (%s): %v", *v.ID, err)
+			continue
+		}
+		resourceGroup := vid.ResourceGroup
+		name := vid.Path["vaults"]
+
+		//resp does not appear to contain the vault properties, so lets fech them
+		get, err := client.Get(ctx, resourceGroup, name)
+		if err != nil {
+			log.Printf("[DEBUG] GetKeyVaultId: Error making Read request on KeyVault %q (Resource Group %q): %+v", name, resourceGroup, err)
+			continue
+		}
+
+		if get.ID == nil || get.Properties == nil || get.Properties.VaultURI == nil {
+			log.Printf("[DEBUG] GetKeyVaultId: KeyVault %q (Resource Group %q) has nil ID, properties or vault URI", name, resourceGroup)
+			continue
+		}
+
+		if keyVaultUrl == *get.Properties.VaultURI {
+			return *get.ID, nil
+		}
+
+		e := list.NextWithContext(ctx)
+		if e != nil {
+			return "", fmt.Errorf("Error GetKeyVaultId: Error getting next value on KeyVault %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
+	}
+
+	return "", fmt.Errorf("Error GetKeyVaultId unable to find Key Vault with url %q", keyVaultUrl)
 }
 
 func KeyVaultExists(ctx context.Context, client keyvault.VaultsClient, keyVaultId string) (bool, error) {

--- a/azurerm/helpers/azure/key_vault.go
+++ b/azurerm/helpers/azure/key_vault.go
@@ -23,7 +23,7 @@ func GetKeyVaultBaseUrlFromID(ctx context.Context, client keyvault.VaultsClient,
 
 	vaultName, ok := id.Path["vaults"]
 	if !ok {
-		return "", fmt.Errorf("resource id does not contain `valuts`: %q", keyVaultId)
+		return "", fmt.Errorf("resource id does not contain `vaults`: %q", keyVaultId)
 	}
 
 	resp, err := client.Get(ctx, resourceGroup, vaultName)
@@ -43,7 +43,7 @@ func GetKeyVaultBaseUrlFromID(ctx context.Context, client keyvault.VaultsClient,
 
 func GetKeyVaultIDFromBaseUrl(ctx context.Context, client keyvault.VaultsClient, keyVaultUrl string) (string, error) {
 
-	list, err := client.ListComplete(ctx, utils.Int32(1))
+	list, err := client.ListComplete(ctx, utils.Int32(1000))
 	if err != nil {
 		return "", fmt.Errorf("Error GetKeyVaultId unable to list Key Vaults %v", err)
 	}
@@ -102,7 +102,7 @@ func KeyVaultExists(ctx context.Context, client keyvault.VaultsClient, keyVaultI
 
 	vaultName, ok := id.Path["vaults"]
 	if !ok {
-		return false, fmt.Errorf("resource id does not contain `valuts`: %q", keyVaultId)
+		return false, fmt.Errorf("resource id does not contain `vaults`: %q", keyVaultId)
 	}
 
 	resp, err := client.Get(ctx, resourceGroup, vaultName)

--- a/azurerm/helpers/azure/key_vault.go
+++ b/azurerm/helpers/azure/key_vault.go
@@ -1,0 +1,73 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func GetKeyVaultBaseUrlFromID(ctx context.Context, client keyvault.VaultsClient, keyVaultId string) (string, error) {
+
+	if keyVaultId == "" {
+		return "", fmt.Errorf("keyVaultId is empty")
+	}
+
+	id, err := ParseAzureResourceID(keyVaultId)
+	if err != nil {
+		return "", err
+	}
+	resourceGroup := id.ResourceGroup
+
+	vaultName, ok := id.Path["vaults"]
+	if !ok {
+		return "", fmt.Errorf("resource id does not contain `valuts`: %q", keyVaultId)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, vaultName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return "", fmt.Errorf("Error unable to find KeyVault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
+		}
+		return "", fmt.Errorf("Error making Read request on KeyVault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
+	}
+
+	if resp.Properties == nil || resp.Properties.VaultURI == nil {
+		return "", fmt.Errorf("vault (%s) response properties or VaultURI is nil", keyVaultId)
+	}
+
+	return *resp.Properties.VaultURI, nil
+}
+
+func KeyVaultExists(ctx context.Context, client keyvault.VaultsClient, keyVaultId string) (bool, error) {
+
+	if keyVaultId == "" {
+		return false, fmt.Errorf("keyVaultId is empty")
+	}
+
+	id, err := ParseAzureResourceID(keyVaultId)
+	if err != nil {
+		return false, err
+	}
+	resourceGroup := id.ResourceGroup
+
+	vaultName, ok := id.Path["vaults"]
+	if !ok {
+		return false, fmt.Errorf("resource id does not contain `valuts`: %q", keyVaultId)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, vaultName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return false, nil
+		}
+		return false, fmt.Errorf("Error making Read request on KeyVault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
+	}
+
+	if resp.Properties == nil || resp.Properties.VaultURI == nil {
+		return false, fmt.Errorf("vault (%s) response properties or VaultURI is nil", keyVaultId)
+	}
+
+	return true, nil
+}

--- a/azurerm/helpers/azure/key_vault_access_policy.go
+++ b/azurerm/helpers/azure/key_vault_access_policy.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 )
 

--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/set"

--- a/azurerm/resource_arm_key_vault_access_policy.go
+++ b/azurerm/resource_arm_key_vault_access_policy.go
@@ -3,11 +3,14 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
+
+	"github.com/satori/go.uuid"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -24,13 +27,52 @@ func resourceArmKeyVaultAccessPolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"vault_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"key_vault_id": {
+				Type:          schema.TypeString,
+				Optional:      true, //todo required in 2.0
+				Computed:      true, //todo removed in 2.0
+				ForceNew:      true,
+				ValidateFunc:  azure.ValidateResourceID,
+				ConflictsWith: []string{"vault_name"},
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			//todo remove in 2.0
+			"vault_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				Deprecated:    "This property has been deprecated in favour of the key_vault_id property. This will prevent a class of bugs as described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/2396 and will be removed in version 2.0 of the provider",
+				ValidateFunc:  validate.NoEmptyStrings,
+				ConflictsWith: []string{"key_vault_id"},
+			},
+
+			//todo remove in 2.0
+			"resource_group_name": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "This property has been deprecated as the resource group is now pulled from the vault ID and will be removed in version 2.0 of the provider",
+				ValidateFunc: func(v interface{}, k string) (warnings []string, errors []error) {
+					value := v.(string)
+
+					if len(value) > 80 {
+						errors = append(errors, fmt.Errorf("%q may not exceed 80 characters in length", k))
+					}
+
+					if strings.HasSuffix(value, ".") {
+						errors = append(errors, fmt.Errorf("%q may not end with a period", k))
+					}
+
+					// regex pulled from https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate
+					if matched := regexp.MustCompile(`^[-\w\._\(\)]+$`).Match([]byte(value)); !matched {
+						errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, dash, underscores, parentheses and periods", k))
+					}
+
+					return warnings, errors
+				},
+			},
 
 			"tenant_id": {
 				Type:         schema.TypeString,
@@ -67,8 +109,9 @@ func resourceArmKeyVaultAccessPolicyCreateOrDelete(d *schema.ResourceData, meta 
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] Preparing arguments for Key Vault Access Policy: %s.", action)
 
+	vaultId := d.Get("key_vault_id").(string)
 	vaultName := d.Get("vault_name").(string)
-	resGroup := d.Get("resource_group_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
 
 	tenantIdRaw := d.Get("tenant_id").(string)
 	tenantId, err := uuid.FromString(tenantIdRaw)
@@ -79,15 +122,36 @@ func resourceArmKeyVaultAccessPolicyCreateOrDelete(d *schema.ResourceData, meta 
 	applicationIdRaw := d.Get("application_id").(string)
 	objectId := d.Get("object_id").(string)
 
-	keyVault, err := client.Get(ctx, resGroup, vaultName)
+	if vaultName == "" {
+		if vaultId == "" {
+			return fmt.Errorf("one of `key_vault_id` or `vault_name` must be set")
+		}
+		id, err2 := azure.ParseAzureResourceID(vaultId)
+		if err2 != nil {
+			return err2
+		}
+
+		resourceGroup = id.ResourceGroup
+
+		vaultNameTemp, ok := id.Path["vaults"]
+		if !ok {
+			return fmt.Errorf("key_value_id does not contain `vaults`: %q", vaultId)
+		}
+		vaultName = vaultNameTemp
+
+	} else if resourceGroup == "" {
+		return fmt.Errorf("one of `resource_group_name` must be set when `vault_name` is used")
+	}
+
+	keyVault, err := client.Get(ctx, resourceGroup, vaultName)
 	if err != nil {
 		if utils.ResponseWasNotFound(keyVault.Response) {
-			log.Printf("[DEBUG] Parent Key Vault %q was not found in Resource Group %q - removing from state!", vaultName, resGroup)
+			log.Printf("[DEBUG] Parent Key Vault %q was not found in Resource Group %q - removing from state!", vaultName, resourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Key Vault %q (Resource Group %q): %+v", vaultName, resGroup, err)
+		return fmt.Errorf("Error retrieving Key Vault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
 	}
 
 	// This is because azure doesn't have an 'id' for a keyvault access policy
@@ -168,18 +232,17 @@ func resourceArmKeyVaultAccessPolicyCreateOrDelete(d *schema.ResourceData, meta 
 		},
 	}
 
-	_, err = client.UpdateAccessPolicy(ctx, resGroup, vaultName, action, parameters)
-	if err != nil {
-		return fmt.Errorf("Error updating Access Policy (Object ID %q / Application ID %q) for Key Vault %q (Resource Group %q): %+v", objectId, applicationIdRaw, vaultName, resGroup, err)
+	if _, err = client.UpdateAccessPolicy(ctx, resourceGroup, vaultName, action, parameters); err != nil {
+		return fmt.Errorf("Error updating Access Policy (Object ID %q / Application ID %q) for Key Vault %q (Resource Group %q): %+v", objectId, applicationIdRaw, vaultName, resourceGroup, err)
 	}
 
-	read, err := client.Get(ctx, resGroup, vaultName)
+	read, err := client.Get(ctx, resourceGroup, vaultName)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Key Vault %q (Resource Group %q): %+v", vaultName, resGroup, err)
+		return fmt.Errorf("Error retrieving Key Vault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
 	}
 
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read KeyVault %q (Resource Group %q) ID", vaultName, resGroup)
+		return fmt.Errorf("Cannot read KeyVault %q (Resource Group %q) ID", vaultName, resourceGroup)
 	}
 
 	if d.IsNewResource() {
@@ -237,6 +300,7 @@ func resourceArmKeyVaultAccessPolicyRead(d *schema.ResourceData, meta interface{
 		return nil
 	}
 
+	d.Set("key_vault_id", resp.ID)
 	d.Set("vault_name", resp.Name)
 	d.Set("resource_group_name", resGroup)
 	d.Set("object_id", objectId)

--- a/azurerm/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/resource_arm_key_vault_access_policy_test.go
@@ -144,19 +144,25 @@ func TestAccAzureRMKeyVaultAccessPolicy_update(t *testing.T) {
 
 func testCheckAzureRMKeyVaultAccessPolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*ArmClient).keyVaultClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		vaultName := rs.Primary.Attributes["vault_name"]
-		resGroup := rs.Primary.Attributes["resource_group_name"]
+		id, err := parseAzureResourceID(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+		resGroup := id.ResourceGroup
+		vaultName := id.Path["vaults"]
+
 		objectId := rs.Primary.Attributes["object_id"]
 		applicationId := rs.Primary.Attributes["application_id"]
-
-		client := testAccProvider.Meta().(*ArmClient).keyVaultClient
-		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resGroup, vaultName)
 		if err != nil {
@@ -185,8 +191,7 @@ func testAccAzureRMKeyVaultAccessPolicy_basic(rString string, location string) s
 %s
 
 resource "azurerm_key_vault_access_policy" "test" {
-  vault_name          = "${azurerm_key_vault.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   key_permissions = [
     "get",
@@ -209,10 +214,9 @@ func testAccAzureRMKeyVaultAccessPolicy_requiresImport(rString string, location 
 %s
 
 resource "azurerm_key_vault_access_policy" "import" {
-  vault_name          = "${azurerm_key_vault_access_policy.test.vault_name}"
-  resource_group_name = "${azurerm_key_vault_access_policy.test.resource_group_name}"
-  tenant_id           = "${azurerm_key_vault_access_policy.test.tenant_id}"
-  object_id           = "${azurerm_key_vault_access_policy.test.object_id}"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
+  tenant_id     = "${azurerm_key_vault_access_policy.test.tenant_id}"
+  object_id     = "${azurerm_key_vault_access_policy.test.object_id}"
 
   key_permissions = [
     "get",
@@ -232,8 +236,7 @@ func testAccAzureRMKeyVaultAccessPolicy_multiple(rString string, location string
 %s
 
 resource "azurerm_key_vault_access_policy" "test_with_application_id" {
-  vault_name          = "${azurerm_key_vault.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   key_permissions = [
     "create",
@@ -256,8 +259,7 @@ resource "azurerm_key_vault_access_policy" "test_with_application_id" {
 }
 
 resource "azurerm_key_vault_access_policy" "test_no_application_id" {
-  vault_name          = "${azurerm_key_vault.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   key_permissions = [
     "list",

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -62,7 +62,7 @@ func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta inter
 		}
 
 		if id.KeyVaultBaseUrl == *get.Properties.VaultURI {
-			d.Set("vault_id", *get.ID)
+			d.Set("vault_id", get.ID)
 			break
 		}
 

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -19,6 +19,62 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+//todo refactor and find a home for this wayward func
+func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*ArmClient).keyVaultClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := azure.ParseKeyVaultChildID(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("Error Unable to parse ID (%s) for Key Vault Child import: %v", d.Id(), err)
+	}
+
+	list, err := client.ListComplete(ctx, utils.Int32(1))
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("Error Unable to list Key Vaults for Key Vault Child import: %v", err)
+	}
+
+	for list.NotDone() {
+		v := list.Value()
+		if v.ID == nil {
+			log.Printf("[DEBUG] Key Vault Child import: v.ID was nil, continuing")
+			continue
+		}
+
+		vid, err := parseAzureResourceID(*v.ID)
+		if err != nil {
+			log.Printf("[DEBUG] Key Vault Child import: unable to parse v.ID (%s): %v", *v.ID, err)
+			continue
+		}
+		resourceGroup := vid.ResourceGroup
+		name := vid.Path["vaults"]
+
+		//resp does not appear to contain the vault properties, so lets fech them
+		get, err := client.Get(ctx, resourceGroup, name)
+		if err != nil {
+			log.Printf("[DEBUG] Key Vault Child import: Error making Read request on KeyVault %q (Resource Group %q): %+v", name, resourceGroup, err)
+			continue
+		}
+
+		if get.ID == nil || get.Properties == nil || get.Properties.VaultURI == nil {
+			log.Printf("[DEBUG] Key Vault Child import: KeyVault %q (Resource Group %q) has nil ID, properties or vault URI", name, resourceGroup)
+			continue
+		}
+
+		if id.KeyVaultBaseUrl == *get.Properties.VaultURI {
+			d.Set("vault_id", *get.ID)
+			break
+		}
+
+		e := list.NextWithContext(ctx)
+		if e != nil {
+			return []*schema.ResourceData{d}, e
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
+
 func resourceArmKeyVaultCertificate() *schema.Resource {
 	return &schema.Resource{
 		// TODO: support Updating once we have more information about what can be updated
@@ -26,7 +82,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 		Read:   resourceArmKeyVaultCertificateRead,
 		Delete: resourceArmKeyVaultCertificateDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceArmKeyVaultChildResourceImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -37,10 +93,20 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 				ValidateFunc: azure.ValidateKeyVaultChildName,
 			},
 
+			"vault_id": {
+				Type:         schema.TypeString,
+				Optional:     true, //todo required in 2.0
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			//todo remove in 2.0
 			"vault_uri": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
+				Computed:     true,
+				Deprecated:   "This property has been deprecated in favour of the vault_id property. This will prevent a class of bugs as described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/2396 and will be removed in version 2.0 of the provider",
 				ValidateFunc: validate.URLIsHTTPS,
 			},
 
@@ -298,11 +364,26 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 }
 
 func resourceArmKeyVaultCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+	vaultClient := meta.(*ArmClient).keyVaultClient
 	client := meta.(*ArmClient).keyVaultManagementClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
+	keyVaultId := d.Get("vault_id").(string)
 	keyVaultBaseUrl := d.Get("vault_uri").(string)
+
+	if keyVaultBaseUrl == "" {
+		if keyVaultId == "" {
+			return fmt.Errorf("one of `vault_id` or `vault_uri` must be set")
+		}
+
+		pKeyVaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error looking up Certificate %q vault url form id %q: %+v", name, keyVaultId, err)
+		}
+
+		keyVaultBaseUrl = pKeyVaultBaseUrl
+	}
 
 	if requireResourcesToBeImported {
 		existing, err := client.GetCertificate(ctx, keyVaultBaseUrl, name, "")
@@ -384,13 +465,23 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 	client := meta.(*ArmClient).keyVaultManagementClient
 	ctx := meta.(*ArmClient).StopContext
 
+	keyVaultId := d.Get("vault_id").(string)
 	id, err := azure.ParseKeyVaultChildID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	cert, err := client.GetCertificate(ctx, id.KeyVaultBaseUrl, id.Name, "")
+	ok, err := azure.KeyVaultExists(ctx, meta.(*ArmClient).keyVaultClient, keyVaultId)
+	if err != nil {
+		fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
+	}
+	if !ok {
+		log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, keyVaultId, id.KeyVaultBaseUrl)
+		d.SetId("")
+		return nil
+	}
 
+	cert, err := client.GetCertificate(ctx, id.KeyVaultBaseUrl, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(cert.Response) {
 			log.Printf("[DEBUG] Certificate %q was not found in Key Vault at URI %q - removing from state", id.Name, id.KeyVaultBaseUrl)
@@ -398,7 +489,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return err
+		return fmt.Errorf("Error reading Key Vault Certificate Policy: %+v", err)
 	}
 
 	d.Set("name", id.Name)
@@ -434,9 +525,20 @@ func resourceArmKeyVaultCertificateDelete(d *schema.ResourceData, meta interface
 	client := meta.(*ArmClient).keyVaultManagementClient
 	ctx := meta.(*ArmClient).StopContext
 
+	keyVaultId := d.Get("vault_id").(string)
 	id, err := azure.ParseKeyVaultChildID(d.Id())
 	if err != nil {
 		return err
+	}
+
+	ok, err := azure.KeyVaultExists(ctx, meta.(*ArmClient).keyVaultClient, keyVaultId)
+	if err != nil {
+		fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
+	}
+	if !ok {
+		log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, keyVaultId, id.KeyVaultBaseUrl)
+		d.SetId("")
+		return nil
 	}
 
 	resp, err := client.DeleteCertificate(ctx, id.KeyVaultBaseUrl, id.Name)

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -29,7 +29,7 @@ func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta inter
 		return []*schema.ResourceData{d}, fmt.Errorf("Error Unable to parse ID (%s) for Key Vault Child import: %v", d.Id(), err)
 	}
 
-	list, err := client.ListComplete(ctx, utils.Int32(1))
+	list, err := client.ListComplete(ctx, utils.Int32(1000))
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("Error Unable to list Key Vaults for Key Vault Child import: %v", err)
 	}
@@ -496,7 +496,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 
-		return fmt.Errorf("Error reading Key Vault Certificate Policy: %+v", err)
+		return fmt.Errorf("Error reading Key Vault Certificate: %+v", err)
 	}
 
 	d.Set("name", id.Name)

--- a/azurerm/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/resource_arm_key_vault_certificate_test.go
@@ -228,7 +228,7 @@ func testCheckAzureRMKeyVaultCertificateDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -267,7 +267,7 @@ func testCheckAzureRMKeyVaultCertificateExists(resourceName string) resource.Tes
 
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -303,7 +303,7 @@ func testCheckAzureRMKeyVaultCertificateDisappears(resourceName string) resource
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -368,7 +368,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_certificate" "test" {
   name     = "acctestcert%s"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   certificate {
     contents = "${base64encode(file("testdata/keyvaultcert.pfx"))}"
@@ -402,7 +402,7 @@ func testAccAzureRMKeyVaultCertificate_requiresImport(rString string, location s
 
 resource "azurerm_key_vault_certificate" "import" {
   name     = "${azurerm_key_vault_certificate.test.name}"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   certificate {
     contents = "${base64encode(file("testdata/keyvaultcert.pfx"))}"
@@ -470,7 +470,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_certificate" "test" {
   name      = "acctestcert%s"
-  vault_id  = "${azurerm_key_vault.test.id}"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {
@@ -558,7 +558,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_certificate" "test" {
   name     = "acctestcert%s"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {
@@ -653,7 +653,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_certificate" "test" {
   name     = "acctestcert%s"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {

--- a/azurerm/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/resource_arm_key_vault_certificate_test.go
@@ -333,8 +333,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_certificate" "test" {
-  name      = "acctestcert%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  name     = "acctestcert%s"
+  vault_id = "${azurerm_key_vault.test.id}"
 
   certificate {
     contents = "${base64encode(file("testdata/keyvaultcert.pfx"))}"
@@ -367,8 +367,8 @@ func testAccAzureRMKeyVaultCertificate_requiresImport(rString string, location s
 %s
 
 resource "azurerm_key_vault_certificate" "import" {
-  name      = "${azurerm_key_vault_certificate.test.name}"
-  vault_uri = "${azurerm_key_vault_certificate.test.vault_uri}"
+  name     = "${azurerm_key_vault_certificate.test.name}"
+  vault_id = "${azurerm_key_vault.test.id}"
 
   certificate {
     contents = "${base64encode(file("testdata/keyvaultcert.pfx"))}"
@@ -436,7 +436,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_certificate" "test" {
   name      = "acctestcert%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {
@@ -523,8 +523,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_certificate" "test" {
-  name      = "acctestcert%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  name     = "acctestcert%s"
+  vault_id = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {
@@ -618,8 +618,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_certificate" "test" {
-  name      = "acctestcert%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  name     = "acctestcert%s"
+  vault_id = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {

--- a/azurerm/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/resource_arm_key_vault_certificate_test.go
@@ -2,7 +2,10 @@ package azurerm
 
 import (
 	"fmt"
+	"log"
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -225,6 +228,16 @@ func testCheckAzureRMKeyVaultCertificateDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
+		keyVaultId := rs.Primary.Attributes["vault_id"]
+
+		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
 
 		// get the latest version
 		resp, err := client.GetCertificate(ctx, vaultBaseUrl, name, "")
@@ -232,7 +245,7 @@ func testCheckAzureRMKeyVaultCertificateDestroy(s *terraform.State) error {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return nil
 			}
-			return err
+			return fmt.Errorf("Bad: Get on keyVault certificate: %+v", err)
 		}
 
 		return fmt.Errorf("Key Vault Certificate still exists:\n%#v", resp)
@@ -243,16 +256,27 @@ func testCheckAzureRMKeyVaultCertificateDestroy(s *terraform.State) error {
 
 func testCheckAzureRMKeyVaultCertificateExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
+
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
+		keyVaultId := rs.Primary.Attributes["vault_id"]
 
-		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
-		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
 
 		resp, err := client.GetCertificate(ctx, vaultBaseUrl, name, "")
 		if err != nil {
@@ -260,7 +284,7 @@ func testCheckAzureRMKeyVaultCertificateExists(resourceName string) resource.Tes
 				return fmt.Errorf("Bad: Key Vault Certificate %q (resource group: %q) does not exist", name, vaultBaseUrl)
 			}
 
-			return fmt.Errorf("Bad: Get on keyVaultManagementClient: %+v", err)
+			return fmt.Errorf("Bad: Get on keyVault certificate: %+v", err)
 		}
 
 		return nil
@@ -269,6 +293,9 @@ func testCheckAzureRMKeyVaultCertificateExists(resourceName string) resource.Tes
 
 func testCheckAzureRMKeyVaultCertificateDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -276,9 +303,16 @@ func testCheckAzureRMKeyVaultCertificateDisappears(resourceName string) resource
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
+		keyVaultId := rs.Primary.Attributes["vault_id"]
 
-		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
-		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
 
 		resp, err := client.DeleteCertificate(ctx, vaultBaseUrl, name)
 		if err != nil {

--- a/azurerm/resource_arm_key_vault_key_test.go
+++ b/azurerm/resource_arm_key_vault_key_test.go
@@ -233,7 +233,7 @@ func testCheckAzureRMKeyVaultKeyDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -271,7 +271,7 @@ func testCheckAzureRMKeyVaultKeyExists(resourceName string) resource.TestCheckFu
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -308,7 +308,7 @@ func testCheckAzureRMKeyVaultKeyDisappears(resourceName string) resource.TestChe
 
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -375,7 +375,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "test" {
   name      = "key-%s"
-  vault_id  = "${azurerm_key_vault.test.id}"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "EC"
   key_size  = 2048
 
@@ -394,7 +394,7 @@ func testAccAzureRMKeyVaultKey_requiresImport(rString string, location string) s
 
 resource "azurerm_key_vault_key" "import" {
   name      = "${azurerm_key_vault_key.test.name}"
-  vault_id  = "${azurerm_key_vault.test.id}"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "EC"
   key_size  = 2048
 
@@ -450,7 +450,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "test" {
   name      = "key-%s"
-  vault_id  = "${azurerm_key_vault.test.id}"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "RSA"
   key_size  = 2048
 
@@ -509,7 +509,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "test" {
   name      = "key-%s"
-  vault_id  = "${azurerm_key_vault.test.id}"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "RSA-HSM"
   key_size  = 2048
 
@@ -567,10 +567,10 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name      = "key-%s"
-  vault_id  = "${azurerm_key_vault.test.id}"
-  key_type  = "RSA"
-  key_size  = 2048
+  name          = "key-%s"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
+  key_type      = "RSA"
+  key_size      = 2048
 
   key_opts = [
     "decrypt",

--- a/azurerm/resource_arm_key_vault_key_test.go
+++ b/azurerm/resource_arm_key_vault_key_test.go
@@ -342,7 +342,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "test" {
   name      = "key-%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "EC"
   key_size  = 2048
 
@@ -361,7 +361,7 @@ func testAccAzureRMKeyVaultKey_requiresImport(rString string, location string) s
 
 resource "azurerm_key_vault_key" "import" {
   name      = "${azurerm_key_vault_key.test.name}"
-  vault_uri = "${azurerm_key_vault_key.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "EC"
   key_size  = 2048
 
@@ -417,7 +417,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "test" {
   name      = "key-%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "RSA"
   key_size  = 2048
 
@@ -476,7 +476,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "test" {
   name      = "key-%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "RSA-HSM"
   key_size  = 2048
 
@@ -535,7 +535,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "test" {
   name      = "key-%s"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault.test.id}"
   key_type  = "RSA"
   key_size  = 2048
 

--- a/azurerm/resource_arm_key_vault_secret.go
+++ b/azurerm/resource_arm_key_vault_secret.go
@@ -30,22 +30,24 @@ func resourceArmKeyVaultSecret() *schema.Resource {
 				ValidateFunc: azure.ValidateKeyVaultChildName,
 			},
 
-			"vault_id": {
-				Type:         schema.TypeString,
-				Optional:     true, //todo required in 2.0
-				Computed:     true, //todo required in 2.0
-				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+			"key_vault_id": {
+				Type:          schema.TypeString,
+				Optional:      true, //todo required in 2.0
+				Computed:      true, //todo removed in 2.0
+				ForceNew:      true,
+				ValidateFunc:  azure.ValidateResourceID,
+				ConflictsWith: []string{"vault_uri"},
 			},
 
 			//todo remove in 2.0
 			"vault_uri": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Computed:     true,
-				Deprecated:   "This property has been deprecated in favour of the vault_id property. This will prevent a class of bugs as described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/2396 and will be removed in version 2.0 of the provider",
-				ValidateFunc: validate.URLIsHTTPS,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				Deprecated:    "This property has been deprecated in favour of the key_vault_id property. This will prevent a class of bugs as described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/2396 and will be removed in version 2.0 of the provider",
+				ValidateFunc:  validate.URLIsHTTPS,
+				ConflictsWith: []string{"key_vault_id"},
 			},
 
 			"value": {
@@ -78,11 +80,11 @@ func resourceArmKeyVaultSecretCreate(d *schema.ResourceData, meta interface{}) e
 
 	name := d.Get("name").(string)
 	keyVaultBaseUrl := d.Get("vault_uri").(string)
-	keyVaultId := d.Get("vault_id").(string)
+	keyVaultId := d.Get("key_vault_id").(string)
 
 	if keyVaultBaseUrl == "" {
 		if keyVaultId == "" {
-			return fmt.Errorf("one of `vault_id` or `vault_uri` must be set")
+			return fmt.Errorf("one of `key_vault_id` or `vault_uri` must be set")
 		}
 
 		pKeyVaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
@@ -96,7 +98,7 @@ func resourceArmKeyVaultSecretCreate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("Error unable to find key vault ID from URL %q for certificate %q: %+v", keyVaultBaseUrl, name, err)
 		}
-		d.Set("vault_id", id)
+		d.Set("key_vault_id", id)
 	}
 
 	if requireResourcesToBeImported {
@@ -145,7 +147,7 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 	ctx := meta.(*ArmClient).StopContext
 	log.Print("[INFO] preparing arguments for AzureRM KeyVault Secret update.")
 
-	keyVaultId := d.Get("vault_id").(string)
+	keyVaultId := d.Get("key_vault_id").(string)
 	id, err := azure.ParseKeyVaultChildID(d.Id())
 	if err != nil {
 		return err
@@ -207,7 +209,7 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 	client := meta.(*ArmClient).keyVaultManagementClient
 	ctx := meta.(*ArmClient).StopContext
 
-	keyVaultId := d.Get("vault_id").(string)
+	keyVaultId := d.Get("key_vault_id").(string)
 	id, err := azure.ParseKeyVaultChildID(d.Id())
 	if err != nil {
 		return err
@@ -254,7 +256,7 @@ func resourceArmKeyVaultSecretDelete(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*ArmClient).keyVaultManagementClient
 	ctx := meta.(*ArmClient).StopContext
 
-	keyVaultId := d.Get("vault_id").(string)
+	keyVaultId := d.Get("key_vault_id").(string)
 	id, err := azure.ParseKeyVaultChildID(d.Id())
 	if err != nil {
 		return err

--- a/azurerm/resource_arm_key_vault_secret_test.go
+++ b/azurerm/resource_arm_key_vault_secret_test.go
@@ -179,7 +179,7 @@ func testCheckAzureRMKeyVaultSecretDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -217,7 +217,7 @@ func testCheckAzureRMKeyVaultSecretExists(resourceName string) resource.TestChec
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -253,7 +253,7 @@ func testCheckAzureRMKeyVaultSecretDisappears(resourceName string) resource.Test
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
-		keyVaultId := rs.Primary.Attributes["vault_id"]
+		keyVaultId := rs.Primary.Attributes["key_vault_id"]
 
 		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
 		if err != nil {
@@ -319,7 +319,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_secret" "test" {
   name      = "secret-%s"
   value     = "rick-and-morty"
-  vault_id  = "${azurerm_key_vault.test.id}"
+  key_vault_id  = "${azurerm_key_vault.test.id}"
 }
 `, rString, location, rString, rString)
 }
@@ -332,7 +332,7 @@ func testAccAzureRMKeyVaultSecret_requiresImport(rString string, location string
 resource "azurerm_key_vault_secret" "import" {
   name      = "${azurerm_key_vault_secret.test.name}"
   value     = "${azurerm_key_vault_secret.test.value}"
-  vault_id  = "${azurerm_key_vault_secret.test.vault_id}"
+  key_vault_id  = "${azurerm_key_vault_secret.test.key_vault_id}"
 }
 `, template)
 }
@@ -379,7 +379,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_secret" "test" {
   name         = "secret-%s"
   value        = "<rick><morty /></rick>"
-  vault_id     = "${azurerm_key_vault.test.id}"
+  key_vault_id     = "${azurerm_key_vault.test.id}"
   content_type = "application/xml"
 
   tags {

--- a/azurerm/resource_arm_key_vault_secret_test.go
+++ b/azurerm/resource_arm_key_vault_secret_test.go
@@ -2,7 +2,10 @@ package azurerm
 
 import (
 	"fmt"
+	"log"
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -176,6 +179,16 @@ func testCheckAzureRMKeyVaultSecretDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
+		keyVaultId := rs.Primary.Attributes["vault_id"]
+
+		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
 
 		// get the latest version
 		resp, err := client.GetSecret(ctx, vaultBaseUrl, name, "")
@@ -194,6 +207,9 @@ func testCheckAzureRMKeyVaultSecretDestroy(s *terraform.State) error {
 
 func testCheckAzureRMKeyVaultSecretExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -201,9 +217,16 @@ func testCheckAzureRMKeyVaultSecretExists(resourceName string) resource.TestChec
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
+		keyVaultId := rs.Primary.Attributes["vault_id"]
 
-		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
-		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
 
 		resp, err := client.GetSecret(ctx, vaultBaseUrl, name, "")
 		if err != nil {
@@ -220,6 +243,9 @@ func testCheckAzureRMKeyVaultSecretExists(resourceName string) resource.TestChec
 
 func testCheckAzureRMKeyVaultSecretDisappears(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
 		// Ensure we have enough information in state to look up in API
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -227,9 +253,16 @@ func testCheckAzureRMKeyVaultSecretDisappears(resourceName string) resource.Test
 		}
 		name := rs.Primary.Attributes["name"]
 		vaultBaseUrl := rs.Primary.Attributes["vault_uri"]
+		keyVaultId := rs.Primary.Attributes["vault_id"]
 
-		client := testAccProvider.Meta().(*ArmClient).keyVaultManagementClient
-		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		ok, err := azure.KeyVaultExists(ctx, testAccProvider.Meta().(*ArmClient).keyVaultClient, keyVaultId)
+		if err != nil {
+			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+		}
+		if !ok {
+			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			return nil
+		}
 
 		resp, err := client.DeleteSecret(ctx, vaultBaseUrl, name)
 		if err != nil {
@@ -286,7 +319,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_secret" "test" {
   name      = "secret-%s"
   value     = "rick-and-morty"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault.test.id}"
 }
 `, rString, location, rString, rString)
 }
@@ -299,7 +332,7 @@ func testAccAzureRMKeyVaultSecret_requiresImport(rString string, location string
 resource "azurerm_key_vault_secret" "import" {
   name      = "${azurerm_key_vault_secret.test.name}"
   value     = "${azurerm_key_vault_secret.test.value}"
-  vault_uri = "${azurerm_key_vault_secret.test.vault_uri}"
+  vault_id  = "${azurerm_key_vault_secret.test.vault_id}"
 }
 `, template)
 }
@@ -346,7 +379,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_secret" "test" {
   name         = "secret-%s"
   value        = "<rick><morty /></rick>"
-  vault_uri    = "${azurerm_key_vault.test.vault_uri}"
+  vault_id     = "${azurerm_key_vault.test.id}"
   content_type = "application/xml"
 
   tags {

--- a/azurerm/resource_arm_sql_administrator.go
+++ b/azurerm/resource_arm_sql_administrator.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2015-05-01-preview/sql"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )

--- a/azurerm/resource_arm_sql_database.go
+++ b/azurerm/resource_arm_sql_database.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
-	"github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Key.
 
-* `vault_uri` - (Required) Specifies the URI used to access the Key Vault instance, available on the `azurerm_key_vault` Data Source / Resource.
+* `vault_uri` - (Required) Specifies the ID of the Key Vault Key Vault instance where the Key resides, available on the `azurerm_key_vault` Data Source / Resource.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Secret.
 
-* `vault_uri` - (Required) Specifies the URI used to access the Key Vault instance, available on the `azurerm_key_vault` Data Source / Resource.
+* `vault_uri` - (Required) Specifies the ID of the Key Vault Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
 
 
 ## Attributes Reference

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -225,7 +225,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Certificate. Changing this forces a new resource to be created.
 
-* `vault_id` - (Required) Specifies the ID of the Key Vault instance the certificate resides in, available from the `azurerm_key_vault.id` property.
+* `vault_id` - (Required) The ID of the Key Vault where the Certificate should be created.
 
 * `certificate` - (Optional) A `certificate` block as defined below, used to Import an existing certificate.
 

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -90,7 +90,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_certificate" "test" {
   name     = "imported-cert"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   certificate {
     contents = "${base64encode(file("certificate-to-import.pfx"))}"
@@ -165,7 +165,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_certificate" "test" {
   name     = "generated-cert"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {
@@ -225,7 +225,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Certificate. Changing this forces a new resource to be created.
 
-* `vault_id` - (Required) The ID of the Key Vault where the Certificate should be created.
+* `key_vault_id` - (Required) The ID of the Key Vault where the Certificate should be created.
 
 * `certificate` - (Optional) A `certificate` block as defined below, used to Import an existing certificate.
 

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -89,8 +89,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_certificate" "test" {
-  name      = "imported-cert"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  name     = "imported-cert"
+  vault_id = "${azurerm_key_vault.test.id}"
 
   certificate {
     contents = "${base64encode(file("certificate-to-import.pfx"))}"
@@ -164,8 +164,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_certificate" "test" {
-  name      = "generated-cert"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  name     = "generated-cert"
+  vault_id = "${azurerm_key_vault.test.id}"
 
   certificate_policy {
     issuer_parameters {
@@ -225,7 +225,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Certificate. Changing this forces a new resource to be created.
 
-* `vault_uri` - (Required) Specifies the URI used to access the Key Vault instance, available on the `azurerm_key_vault` resource.
+* `vault_id` - (Required) Specifies the ID of the Key Vault instance the certificate resides in, available from the `azurerm_key_vault.id` property.
 
 * `certificate` - (Optional) A `certificate` block as defined below, used to Import an existing certificate.
 

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -60,7 +60,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "generated" {
   name      = "generated-certificate"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
   key_type  = "RSA"
   key_size  = 2048
 
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Key. Changing this forces a new resource to be created.
 
-* `vault_id` - (Required) The ID of the Key Vault where the Key should be created.
+* `key_vault_id` - (Required) The ID of the Key Vault where the Key should be created.
 
 * `key_type` - (Required) Specifies the Key Type to use for this Key Vault Key. Possible values are `EC` (Elliptic Curve), `Oct` (Octet), `RSA` and `RSA-HSM`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -30,7 +30,7 @@ resource "random_id" "server" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "${format("%s%s", "kv", random_id.server.hex)}"
+  name                = "keyvaultkeyexample"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
@@ -60,7 +60,7 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_key" "generated" {
   name      = "generated-certificate"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_id = "${azurerm_key_vault.test.id}"
   key_type  = "RSA"
   key_size  = 2048
 
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Key. Changing this forces a new resource to be created.
 
-* `vault_uri` - (Required) Specifies the URI used to access the Key Vault instance, available on the `azurerm_key_vault` resource.
+* `vault_id` - (Required) Specifies the ID of the Key Vault instance the certificate resides in, available from the `azurerm_key_vault.id` property.
 
 * `key_type` - (Required) Specifies the Key Type to use for this Key Vault Key. Possible values are `EC` (Elliptic Curve), `Oct` (Octet), `RSA` and `RSA-HSM`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Key. Changing this forces a new resource to be created.
 
-* `vault_id` - (Required) Specifies the ID of the Key Vault instance the certificate resides in, available from the `azurerm_key_vault.id` property.
+* `vault_id` - (Required) The ID of the Key Vault where the Key should be created.
 
 * `key_type` - (Required) Specifies the Key Type to use for this Key Vault Key. Possible values are `EC` (Elliptic Curve), `Oct` (Octet), `RSA` and `RSA-HSM`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `value` - (Required) Specifies the value of the Key Vault Secret.
 
-* `vault_id` - (Required) Specifies the ID of the Key Vault instance the certificate resides in, available from the `azurerm_key_vault.id` property.
+* `vault_id` - (Required) The ID of the Key Vault where the Secret should be created.
 
 * `content_type` - (Optional) Specifies the content type for the Key Vault Secret.
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -64,9 +64,9 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_secret" "test" {
-  name      = "secret-sauce"
-  value     = "szechuan"
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  name     = "secret-sauce"
+  value    = "szechuan"
+  vault_id = "${azurerm_key_vault.test.id}"
 
   tags {
     environment = "Production"
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `value` - (Required) Specifies the value of the Key Vault Secret.
 
-* `vault_uri` - (Required) Specifies the URI used to access the Key Vault instance, available on the `azurerm_key_vault` resource.
+* `vault_id` - (Required) Specifies the ID of the Key Vault instance the certificate resides in, available from the `azurerm_key_vault.id` property.
 
 * `content_type` - (Optional) Specifies the content type for the Key Vault Secret.
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -66,7 +66,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_secret" "test" {
   name     = "secret-sauce"
   value    = "szechuan"
-  vault_id = "${azurerm_key_vault.test.id}"
+  key_vault_id = "${azurerm_key_vault.test.id}"
 
   tags {
     environment = "Production"
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `value` - (Required) Specifies the value of the Key Vault Secret.
 
-* `vault_id` - (Required) The ID of the Key Vault where the Secret should be created.
+* `key_vault_id` - (Required) The ID of the Key Vault where the Secret should be created.
 
 * `content_type` - (Optional) Specifies the content type for the Key Vault Secret.
 


### PR DESCRIPTION
This will allow us to easily check if the key vault exists before doing a update/read/delete on it causing a NXDOMAIN error (as the domain used for the API call vanishes when the key vault is deleted)

fixes #2396