### PR TITLE
Added keys to output for cog service account

### DIFF
--- a/azurerm/resource_arm_cognitive_account.go
+++ b/azurerm/resource_arm_cognitive_account.go
@@ -232,7 +232,7 @@ func resourceArmCognitiveAccountRead(d *schema.ResourceData, meta interface{}) e
 
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Cognitive Services Account %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			log.Printf("[DEBUG] Not able to obtain keys for Cognitive Services Account %q in Resource Group %q - removing from state!", name, resourceGroup)
 			d.SetId("")
 			return nil
 		}

--- a/azurerm/resource_arm_cognitive_account.go
+++ b/azurerm/resource_arm_cognitive_account.go
@@ -100,6 +100,16 @@ func resourceArmCognitiveAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"key1": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"key2": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -192,6 +202,7 @@ func resourceArmCognitiveAccountRead(d *schema.ResourceData, meta interface{}) e
 	name := id.Path["accounts"]
 
 	resp, err := client.GetProperties(ctx, resourceGroup, name)
+
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			log.Printf("[DEBUG] Cognitive Services Account %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
@@ -215,6 +226,25 @@ func resourceArmCognitiveAccountRead(d *schema.ResourceData, meta interface{}) e
 
 	if props := resp.AccountProperties; props != nil {
 		d.Set("endpoint", props.Endpoint)
+	}
+
+	keys, err := client.ListKeys(ctx, resourceGroup, name)
+
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Cognitive Services Account %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if key1 := keys.Key1; key1 != nil {
+		d.Set("key1", key1)
+	}
+
+	if key2 := keys.Key2; key2 != nil {
+		d.Set("key2", key2)
 	}
 
 	flattenAndSetTags(d, resp.Tags)


### PR DESCRIPTION
When creating a cognitive service account the keys were not returned so you were unable to configure downstream services. 

Related Issue #2567 

Key things to note:
- I couldn't see tests around the other outputs so haven't modified them, i.e. "endpoint" happy to add if it is felt to be required.
- I also noticed that some resource change the terminology around key names for eg. key1 -> primary key but I have left to match the RESTful api and GO SDK.
