### PR TITLE
azurerm_app_service: Adds authentication support

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -670,7 +670,6 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 	}
 
 	if v, ok := setting["active_directory"]; ok {
-
 		activeDirectorySettings := v.([]interface{})
 		activeDirectorySetting := activeDirectorySettings[0].(map[string]interface{})
 
@@ -691,6 +690,91 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 			}
 
 			siteAuthSettingsProperties.AllowedAudiences = &allowedAudiences
+		}
+	}
+
+	if v, ok := setting["facebook"]; ok {
+		facebookSettings := v.([]interface{})
+		facebookSetting := facebookSettings[0].(map[string]interface{})
+
+		if v, ok := facebookSetting["app_id"]; ok {
+			siteAuthSettingsProperties.FacebookAppID = utils.String(v.(string))
+		}
+
+		if v, ok := facebookSetting["app_secret"]; ok {
+			siteAuthSettingsProperties.FacebookAppSecret = utils.String(v.(string))
+		}
+
+		if v, ok := facebookSetting["oauth_scopes"]; ok {
+			input := v.([]interface{})
+
+			oauthScopes := make([]string, 0)
+			for _, param := range input {
+				oauthScopes = append(oauthScopes, param.(string))
+			}
+
+			siteAuthSettingsProperties.FacebookOAuthScopes = &oauthScopes
+		}
+	}
+
+	if v, ok := setting["google"]; ok {
+		googleSettings := v.([]interface{})
+		googleSetting := googleSettings[0].(map[string]interface{})
+
+		if v, ok := googleSetting["client_id"]; ok {
+			siteAuthSettingsProperties.GoogleClientID = utils.String(v.(string))
+		}
+
+		if v, ok := googleSetting["client_secret"]; ok {
+			siteAuthSettingsProperties.GoogleClientSecret = utils.String(v.(string))
+		}
+
+		if v, ok := googleSetting["oauth_scopes"]; ok {
+			input := v.([]interface{})
+
+			oauthScopes := make([]string, 0)
+			for _, param := range input {
+				oauthScopes = append(oauthScopes, param.(string))
+			}
+
+			siteAuthSettingsProperties.GoogleOAuthScopes = &oauthScopes
+		}
+	}
+
+	if v, ok := setting["microsoft"]; ok {
+		microsoftSettings := v.([]interface{})
+		microsoftSetting := microsoftSettings[0].(map[string]interface{})
+
+		if v, ok := microsoftSetting["client_id"]; ok {
+			siteAuthSettingsProperties.MicrosoftAccountClientID = utils.String(v.(string))
+		}
+
+		if v, ok := microsoftSetting["client_secret"]; ok {
+			siteAuthSettingsProperties.MicrosoftAccountClientSecret = utils.String(v.(string))
+		}
+
+		if v, ok := microsoftSetting["oauth_scopes"]; ok {
+			input := v.([]interface{})
+
+			oauthScopes := make([]string, 0)
+			for _, param := range input {
+				oauthScopes = append(oauthScopes, param.(string))
+			}
+
+			siteAuthSettingsProperties.MicrosoftAccountOAuthScopes = &oauthScopes
+		}
+	}
+
+	if v, ok := setting["twitter"]; ok {
+		twitterSettings := v.([]interface{})
+		twitterSetting := twitterSettings[0].(map[string]interface{})
+
+		if v, ok := twitterSetting["consumer_key"]; ok {
+			siteAuthSettingsProperties.TwitterConsumerKey = utils.String(v.(string))
+		}
+
+		if v, ok := twitterSetting["consumer_secret"]; ok {
+			siteAuthSettingsProperties.TwitterConsumerSecret = utils.String(v.(string))
 		}
 	}
 

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -704,25 +704,28 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 
 	if v, ok := setting["active_directory"]; ok {
 		activeDirectorySettings := v.([]interface{})
-		activeDirectorySetting := activeDirectorySettings[0].(map[string]interface{})
 
-		if v, ok := activeDirectorySetting["client_id"]; ok {
-			siteAuthSettingsProperties.ClientID = utils.String(v.(string))
-		}
+		if len(activeDirectorySettings) > 0 {
+			activeDirectorySetting := activeDirectorySettings[0].(map[string]interface{})
 
-		if v, ok := activeDirectorySetting["client_secret"]; ok {
-			siteAuthSettingsProperties.ClientSecret = utils.String(v.(string))
-		}
-
-		if v, ok := activeDirectorySetting["allowed_audiences"]; ok {
-			input := v.([]interface{})
-
-			allowedAudiences := make([]string, 0)
-			for _, param := range input {
-				allowedAudiences = append(allowedAudiences, param.(string))
+			if v, ok := activeDirectorySetting["client_id"]; ok {
+				siteAuthSettingsProperties.ClientID = utils.String(v.(string))
 			}
 
-			siteAuthSettingsProperties.AllowedAudiences = &allowedAudiences
+			if v, ok := activeDirectorySetting["client_secret"]; ok {
+				siteAuthSettingsProperties.ClientSecret = utils.String(v.(string))
+			}
+
+			if v, ok := activeDirectorySetting["allowed_audiences"]; ok {
+				input := v.([]interface{})
+
+				allowedAudiences := make([]string, 0)
+				for _, param := range input {
+					allowedAudiences = append(allowedAudiences, param.(string))
+				}
+
+				siteAuthSettingsProperties.AllowedAudiences = &allowedAudiences
+			}
 		}
 	}
 

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -544,6 +544,17 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 		if v, ok := activeDirectorySetting["client_secret"]; ok {
 			siteAuthSettingsProperties.ClientSecret = utils.String(v.(string))
 		}
+
+		if v, ok := activeDirectorySetting["allowed_audiences"]; ok {
+			input := v.([]interface{})
+
+			allowedAudiences := make([]string, 0)
+			for _, param := range input {
+				allowedAudiences = append(allowedAudiences, param.(string))
+			}
+
+			siteAuthSettingsProperties.AllowedAudiences = &allowedAudiences
+		}
 	}
 
 	return siteAuthSettingsProperties
@@ -573,6 +584,14 @@ func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []inte
 
 	if input.ClientID != nil {
 		activeDirectorySetting["client_id"] = input.ClientID
+	}
+
+	if input.ClientSecret != nil {
+		activeDirectorySetting["client_secret"] = input.ClientSecret
+	}
+
+	if s := input.AllowedAudiences; s != nil {
+		activeDirectorySetting["allowed_audiences"] = *s
 	}
 
 	result["active_directory"] = append(activeDirectorySettings, activeDirectorySetting)

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -804,11 +804,11 @@ func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []inte
 	activeDirectorySetting := make(map[string]interface{})
 
 	if input.ClientID != nil {
-		activeDirectorySetting["client_id"] = input.ClientID
+		activeDirectorySetting["client_id"] = *input.ClientID
 	}
 
 	if input.ClientSecret != nil {
-		activeDirectorySetting["client_secret"] = input.ClientSecret
+		activeDirectorySetting["client_secret"] = *input.ClientSecret
 	}
 
 	if s := input.AllowedAudiences; s != nil {
@@ -816,6 +816,70 @@ func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []inte
 	}
 
 	result["active_directory"] = append(activeDirectorySettings, activeDirectorySetting)
+
+	facebookSettings := make([]interface{}, 0)
+	facebookSetting := make(map[string]interface{})
+
+	if input.FacebookAppID != nil {
+		facebookSetting["app_id"] = *input.FacebookAppID
+	}
+
+	if input.FacebookAppSecret != nil {
+		facebookSetting["app_secret"] = *input.FacebookAppSecret
+	}
+
+	if s := input.FacebookOAuthScopes; s != nil {
+		facebookSetting["oauth_scopes"] = *s
+	}
+
+	result["facebook"] = append(facebookSettings, facebookSetting)
+
+	googleSettings := make([]interface{}, 0)
+	googleSetting := make(map[string]interface{})
+
+	if input.GoogleClientID != nil {
+		googleSetting["client_id"] = *input.GoogleClientID
+	}
+
+	if input.GoogleClientSecret != nil {
+		googleSetting["client_secret"] = *input.GoogleClientSecret
+	}
+
+	if s := input.GoogleOAuthScopes; s != nil {
+		googleSetting["oauth_scopes"] = *s
+	}
+
+	result["google"] = append(googleSettings, googleSetting)
+
+	microsoftSettings := make([]interface{}, 0)
+	microsoftSetting := make(map[string]interface{})
+
+	if input.MicrosoftAccountClientID != nil {
+		microsoftSetting["client_id"] = *input.MicrosoftAccountClientID
+	}
+
+	if input.MicrosoftAccountClientSecret != nil {
+		microsoftSetting["client_secret"] = *input.MicrosoftAccountClientSecret
+	}
+
+	if s := input.MicrosoftAccountOAuthScopes; s != nil {
+		microsoftSetting["oauth_scopes"] = *s
+	}
+
+	result["microsoft"] = append(microsoftSettings, microsoftSetting)
+
+	twitterSettings := make([]interface{}, 0)
+	twitterSetting := make(map[string]interface{})
+
+	if input.TwitterConsumerKey != nil {
+		twitterSetting["consumer_key"] = *input.TwitterConsumerKey
+	}
+
+	if input.TwitterConsumerSecret != nil {
+		twitterSetting["consumer_secret"] = *input.TwitterConsumerSecret
+	}
+
+	result["twitter"] = append(twitterSettings, twitterSetting)
 
 	return append(results, result)
 }

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -64,6 +64,32 @@ func SchemaAppServiceFacebookAuthSettings() *schema.Schema {
 	}
 }
 
+func SchemaAppServiceGoogleAuthSettings() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"client_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"client_secret": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"oauth_scopes": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
 func SchemaAppServiceAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -728,86 +728,98 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 
 	if v, ok := setting["facebook"]; ok {
 		facebookSettings := v.([]interface{})
-		facebookSetting := facebookSettings[0].(map[string]interface{})
 
-		if v, ok := facebookSetting["app_id"]; ok {
-			siteAuthSettingsProperties.FacebookAppID = utils.String(v.(string))
-		}
+		if len(facebookSettings) > 0 {
+			facebookSetting := facebookSettings[0].(map[string]interface{})
 
-		if v, ok := facebookSetting["app_secret"]; ok {
-			siteAuthSettingsProperties.FacebookAppSecret = utils.String(v.(string))
-		}
-
-		if v, ok := facebookSetting["oauth_scopes"]; ok {
-			input := v.([]interface{})
-
-			oauthScopes := make([]string, 0)
-			for _, param := range input {
-				oauthScopes = append(oauthScopes, param.(string))
+			if v, ok := facebookSetting["app_id"]; ok {
+				siteAuthSettingsProperties.FacebookAppID = utils.String(v.(string))
 			}
 
-			siteAuthSettingsProperties.FacebookOAuthScopes = &oauthScopes
+			if v, ok := facebookSetting["app_secret"]; ok {
+				siteAuthSettingsProperties.FacebookAppSecret = utils.String(v.(string))
+			}
+
+			if v, ok := facebookSetting["oauth_scopes"]; ok {
+				input := v.([]interface{})
+
+				oauthScopes := make([]string, 0)
+				for _, param := range input {
+					oauthScopes = append(oauthScopes, param.(string))
+				}
+
+				siteAuthSettingsProperties.FacebookOAuthScopes = &oauthScopes
+			}
 		}
 	}
 
 	if v, ok := setting["google"]; ok {
 		googleSettings := v.([]interface{})
-		googleSetting := googleSettings[0].(map[string]interface{})
 
-		if v, ok := googleSetting["client_id"]; ok {
-			siteAuthSettingsProperties.GoogleClientID = utils.String(v.(string))
-		}
+		if len(googleSettings) > 0 {
+			googleSetting := googleSettings[0].(map[string]interface{})
 
-		if v, ok := googleSetting["client_secret"]; ok {
-			siteAuthSettingsProperties.GoogleClientSecret = utils.String(v.(string))
-		}
-
-		if v, ok := googleSetting["oauth_scopes"]; ok {
-			input := v.([]interface{})
-
-			oauthScopes := make([]string, 0)
-			for _, param := range input {
-				oauthScopes = append(oauthScopes, param.(string))
+			if v, ok := googleSetting["client_id"]; ok {
+				siteAuthSettingsProperties.GoogleClientID = utils.String(v.(string))
 			}
 
-			siteAuthSettingsProperties.GoogleOAuthScopes = &oauthScopes
+			if v, ok := googleSetting["client_secret"]; ok {
+				siteAuthSettingsProperties.GoogleClientSecret = utils.String(v.(string))
+			}
+
+			if v, ok := googleSetting["oauth_scopes"]; ok {
+				input := v.([]interface{})
+
+				oauthScopes := make([]string, 0)
+				for _, param := range input {
+					oauthScopes = append(oauthScopes, param.(string))
+				}
+
+				siteAuthSettingsProperties.GoogleOAuthScopes = &oauthScopes
+			}
 		}
 	}
 
 	if v, ok := setting["microsoft"]; ok {
 		microsoftSettings := v.([]interface{})
-		microsoftSetting := microsoftSettings[0].(map[string]interface{})
 
-		if v, ok := microsoftSetting["client_id"]; ok {
-			siteAuthSettingsProperties.MicrosoftAccountClientID = utils.String(v.(string))
-		}
+		if len(microsoftSettings) > 0 {
+			microsoftSetting := microsoftSettings[0].(map[string]interface{})
 
-		if v, ok := microsoftSetting["client_secret"]; ok {
-			siteAuthSettingsProperties.MicrosoftAccountClientSecret = utils.String(v.(string))
-		}
-
-		if v, ok := microsoftSetting["oauth_scopes"]; ok {
-			input := v.([]interface{})
-
-			oauthScopes := make([]string, 0)
-			for _, param := range input {
-				oauthScopes = append(oauthScopes, param.(string))
+			if v, ok := microsoftSetting["client_id"]; ok {
+				siteAuthSettingsProperties.MicrosoftAccountClientID = utils.String(v.(string))
 			}
 
-			siteAuthSettingsProperties.MicrosoftAccountOAuthScopes = &oauthScopes
+			if v, ok := microsoftSetting["client_secret"]; ok {
+				siteAuthSettingsProperties.MicrosoftAccountClientSecret = utils.String(v.(string))
+			}
+
+			if v, ok := microsoftSetting["oauth_scopes"]; ok {
+				input := v.([]interface{})
+
+				oauthScopes := make([]string, 0)
+				for _, param := range input {
+					oauthScopes = append(oauthScopes, param.(string))
+				}
+
+				siteAuthSettingsProperties.MicrosoftAccountOAuthScopes = &oauthScopes
+			}
 		}
 	}
 
 	if v, ok := setting["twitter"]; ok {
 		twitterSettings := v.([]interface{})
-		twitterSetting := twitterSettings[0].(map[string]interface{})
 
-		if v, ok := twitterSetting["consumer_key"]; ok {
-			siteAuthSettingsProperties.TwitterConsumerKey = utils.String(v.(string))
-		}
+		if len(twitterSettings) > 0 {
+			twitterSetting := twitterSettings[0].(map[string]interface{})
 
-		if v, ok := twitterSetting["consumer_secret"]; ok {
-			siteAuthSettingsProperties.TwitterConsumerSecret = utils.String(v.(string))
+			if v, ok := twitterSetting["consumer_key"]; ok {
+				siteAuthSettingsProperties.TwitterConsumerKey = utils.String(v.(string))
+			}
+
+			if v, ok := twitterSetting["consumer_secret"]; ok {
+				siteAuthSettingsProperties.TwitterConsumerSecret = utils.String(v.(string))
+			}
 		}
 	}
 

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -164,11 +164,11 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					Type:     schema.TypeString,
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						"AzureActiveDirectory",
-						"Facebook",
-						"Google",
-						"MicrosoftAccount",
-						"Twitter",
+						string(web.AzureActiveDirectory),
+						string(web.Facebook),
+						string(web.Google),
+						string(web.MicrosoftAccount),
+						string(web.Twitter),
 					}, true),
 					DiffSuppressFunc: suppress.CaseDifference,
 				},
@@ -181,7 +181,7 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					Optional: true,
 				},
 				"token_refresh_extension_hours": {
-					Type:     schema.TypeInt,
+					Type:     schema.TypeFloat,
 					Optional: true,
 					Default:  72,
 				},
@@ -189,8 +189,8 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					Type:     schema.TypeString,
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
-						"AllowAnonymous",
-						"RedirectToLoginPage",
+						string(web.AllowAnonymous),
+						string(web.RedirectToLoginPage),
 					}, true),
 					DiffSuppressFunc: suppress.CaseDifference,
 				},
@@ -667,6 +667,37 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 		}
 
 		siteAuthSettingsProperties.AdditionalLoginParams = &additionalLoginParams
+	}
+
+	if v, ok := setting["allowed_external_redirect_urls"]; ok {
+		input := v.([]interface{})
+
+		allowedExternalRedirectUrls := make([]string, 0)
+		for _, param := range input {
+			allowedExternalRedirectUrls = append(allowedExternalRedirectUrls, param.(string))
+		}
+
+		siteAuthSettingsProperties.AllowedExternalRedirectUrls = &allowedExternalRedirectUrls
+	}
+
+	if v, ok := setting["default_provider"]; ok {
+		siteAuthSettingsProperties.DefaultProvider = web.BuiltInAuthenticationProvider(v.(string))
+	}
+
+	if v, ok := setting["issuer"]; ok {
+		siteAuthSettingsProperties.Issuer = utils.String(v.(string))
+	}
+
+	if v, ok := setting["runtime_version"]; ok {
+		siteAuthSettingsProperties.RuntimeVersion = utils.String(v.(string))
+	}
+
+	if v, ok := setting["token_refresh_extension_hours"]; ok {
+		siteAuthSettingsProperties.TokenRefreshExtensionHours = utils.Float(v.(float64))
+	}
+
+	if v, ok := setting["unauthenticated_client_action"]; ok {
+		siteAuthSettingsProperties.UnauthenticatedClientAction = web.UnauthenticatedClientAction(v.(string))
 	}
 
 	if v, ok := setting["active_directory"]; ok {

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -38,6 +38,32 @@ func SchemaAppServiceAadAuthSettings() *schema.Schema {
 	}
 }
 
+func SchemaAppServiceFacebookSettings() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"app_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"app_secret": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"oauth_scopes": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
 func SchemaAppServiceAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -18,7 +18,6 @@ func SchemaAppServiceAadAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -27,8 +26,9 @@ func SchemaAppServiceAadAuthSettings() *schema.Schema {
 					Required: true,
 				},
 				"client_secret": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Type:      schema.TypeString,
+					Optional:  true,
+					Sensitive: true,
 				},
 				"allowed_audiences": {
 					Type:     schema.TypeList,
@@ -44,7 +44,6 @@ func SchemaAppServiceFacebookAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -53,8 +52,9 @@ func SchemaAppServiceFacebookAuthSettings() *schema.Schema {
 					Required: true,
 				},
 				"app_secret": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					Sensitive: true,
 				},
 				"oauth_scopes": {
 					Type:     schema.TypeList,
@@ -70,7 +70,6 @@ func SchemaAppServiceGoogleAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -79,8 +78,9 @@ func SchemaAppServiceGoogleAuthSettings() *schema.Schema {
 					Required: true,
 				},
 				"client_secret": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					Sensitive: true,
 				},
 				"oauth_scopes": {
 					Type:     schema.TypeList,
@@ -96,7 +96,6 @@ func SchemaAppServiceMicrosoftAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -105,8 +104,9 @@ func SchemaAppServiceMicrosoftAuthSettings() *schema.Schema {
 					Required: true,
 				},
 				"client_secret": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					Sensitive: true,
 				},
 				"oauth_scopes": {
 					Type:     schema.TypeList,
@@ -122,7 +122,6 @@ func SchemaAppServiceTwitterAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -131,8 +130,9 @@ func SchemaAppServiceTwitterAuthSettings() *schema.Schema {
 					Required: true,
 				},
 				"consumer_secret": {
-					Type:     schema.TypeString,
-					Required: true,
+					Type:      schema.TypeString,
+					Required:  true,
+					Sensitive: true,
 				},
 			},
 		},
@@ -143,14 +143,12 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
-					Type:      schema.TypeBool,
-					Required:  true,
-					Sensitive: false,
+					Type:     schema.TypeBool,
+					Required: true,
 				},
 				"additional_login_params": {
 					Type:     schema.TypeMap,
@@ -170,8 +168,7 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 						string(web.Google),
 						string(web.MicrosoftAccount),
 						string(web.Twitter),
-					}, true),
-					DiffSuppressFunc: suppress.CaseDifference,
+					}, false),
 				},
 				"issuer": {
 					Type:         schema.TypeString,
@@ -198,8 +195,7 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					ValidateFunc: validation.StringInSlice([]string{
 						string(web.AllowAnonymous),
 						string(web.RedirectToLoginPage),
-					}, true),
-					DiffSuppressFunc: suppress.CaseDifference,
+					}, false),
 				},
 				"active_directory": SchemaAppServiceAadAuthSettings(),
 				"facebook":         SchemaAppServiceFacebookAuthSettings(),
@@ -746,10 +742,6 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 		facebookSettings := v.([]interface{})
 
 		for _, setting := range facebookSettings {
-			if setting == nil {
-				continue
-			}
-
 			facebookSetting := setting.(map[string]interface{})
 
 			if v, ok := facebookSetting["app_id"]; ok {
@@ -777,10 +769,6 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 		googleSettings := v.([]interface{})
 
 		for _, setting := range googleSettings {
-			if setting == nil {
-				continue
-			}
-
 			googleSetting := setting.(map[string]interface{})
 
 			if v, ok := googleSetting["client_id"]; ok {
@@ -808,10 +796,6 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 		microsoftSettings := v.([]interface{})
 
 		for _, setting := range microsoftSettings {
-			if setting == nil {
-				continue
-			}
-
 			microsoftSetting := setting.(map[string]interface{})
 
 			if v, ok := microsoftSetting["client_id"]; ok {
@@ -839,10 +823,6 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 		twitterSettings := v.([]interface{})
 
 		for _, setting := range twitterSettings {
-			if setting == nil {
-				continue
-			}
-
 			twitterSetting := setting.(map[string]interface{})
 
 			if v, ok := twitterSetting["consumer_key"]; ok {
@@ -877,7 +857,6 @@ func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []inte
 	result := make(map[string]interface{})
 
 	if input == nil {
-		log.Printf("[DEBUG] AuthSettings is nil")
 		return results
 	}
 
@@ -918,85 +897,100 @@ func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []inte
 	}
 
 	activeDirectorySettings := make([]interface{}, 0)
-	activeDirectorySetting := make(map[string]interface{})
 
 	if input.ClientID != nil {
+		activeDirectorySetting := make(map[string]interface{})
+
 		activeDirectorySetting["client_id"] = *input.ClientID
+
+		if input.ClientSecret != nil {
+			activeDirectorySetting["client_secret"] = *input.ClientSecret
+		}
+
+		if input.AllowedAudiences != nil {
+			activeDirectorySetting["allowed_audiences"] = *input.AllowedAudiences
+		}
+
+		activeDirectorySettings = append(activeDirectorySettings, activeDirectorySetting)
 	}
 
-	if input.ClientSecret != nil {
-		activeDirectorySetting["client_secret"] = *input.ClientSecret
-	}
-
-	if s := input.AllowedAudiences; s != nil {
-		activeDirectorySetting["allowed_audiences"] = *s
-	}
-
-	result["active_directory"] = append(activeDirectorySettings, activeDirectorySetting)
+	result["active_directory"] = activeDirectorySettings
 
 	facebookSettings := make([]interface{}, 0)
-	facebookSetting := make(map[string]interface{})
 
 	if input.FacebookAppID != nil {
+		facebookSetting := make(map[string]interface{})
+
 		facebookSetting["app_id"] = *input.FacebookAppID
+
+		if input.FacebookAppSecret != nil {
+			facebookSetting["app_secret"] = *input.FacebookAppSecret
+		}
+
+		if input.FacebookOAuthScopes != nil {
+			facebookSetting["oauth_scopes"] = *input.FacebookOAuthScopes
+		}
+
+		facebookSettings = append(facebookSettings, facebookSetting)
 	}
 
-	if input.FacebookAppSecret != nil {
-		facebookSetting["app_secret"] = *input.FacebookAppSecret
-	}
-
-	if s := input.FacebookOAuthScopes; s != nil {
-		facebookSetting["oauth_scopes"] = *s
-	}
-
-	result["facebook"] = append(facebookSettings, facebookSetting)
+	result["facebook"] = facebookSettings
 
 	googleSettings := make([]interface{}, 0)
-	googleSetting := make(map[string]interface{})
 
 	if input.GoogleClientID != nil {
+		googleSetting := make(map[string]interface{})
+
 		googleSetting["client_id"] = *input.GoogleClientID
+
+		if input.GoogleClientSecret != nil {
+			googleSetting["client_secret"] = *input.GoogleClientSecret
+		}
+
+		if input.GoogleOAuthScopes != nil {
+			googleSetting["oauth_scopes"] = *input.GoogleOAuthScopes
+		}
+
+		googleSettings = append(googleSettings, googleSetting)
 	}
 
-	if input.GoogleClientSecret != nil {
-		googleSetting["client_secret"] = *input.GoogleClientSecret
-	}
-
-	if s := input.GoogleOAuthScopes; s != nil {
-		googleSetting["oauth_scopes"] = *s
-	}
-
-	result["google"] = append(googleSettings, googleSetting)
+	result["google"] = googleSettings
 
 	microsoftSettings := make([]interface{}, 0)
-	microsoftSetting := make(map[string]interface{})
 
 	if input.MicrosoftAccountClientID != nil {
+		microsoftSetting := make(map[string]interface{})
+
 		microsoftSetting["client_id"] = *input.MicrosoftAccountClientID
+
+		if input.MicrosoftAccountClientSecret != nil {
+			microsoftSetting["client_secret"] = *input.MicrosoftAccountClientSecret
+		}
+
+		if input.MicrosoftAccountOAuthScopes != nil {
+			microsoftSetting["oauth_scopes"] = *input.MicrosoftAccountOAuthScopes
+		}
+
+		microsoftSettings = append(microsoftSettings, microsoftSetting)
 	}
 
-	if input.MicrosoftAccountClientSecret != nil {
-		microsoftSetting["client_secret"] = *input.MicrosoftAccountClientSecret
-	}
-
-	if s := input.MicrosoftAccountOAuthScopes; s != nil {
-		microsoftSetting["oauth_scopes"] = *s
-	}
-
-	result["microsoft"] = append(microsoftSettings, microsoftSetting)
+	result["microsoft"] = microsoftSettings
 
 	twitterSettings := make([]interface{}, 0)
-	twitterSetting := make(map[string]interface{})
 
 	if input.TwitterConsumerKey != nil {
+		twitterSetting := make(map[string]interface{})
+
 		twitterSetting["consumer_key"] = *input.TwitterConsumerKey
+
+		if input.TwitterConsumerSecret != nil {
+			twitterSetting["consumer_secret"] = *input.TwitterConsumerSecret
+		}
+
+		twitterSettings = append(twitterSettings, twitterSetting)
 	}
 
-	if input.TwitterConsumerSecret != nil {
-		twitterSetting["consumer_secret"] = *input.TwitterConsumerSecret
-	}
-
-	result["twitter"] = append(twitterSettings, twitterSetting)
+	result["twitter"] = twitterSettings
 
 	return append(results, result)
 }

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -173,8 +174,9 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					DiffSuppressFunc: suppress.CaseDifference,
 				},
 				"issuer": {
-					Type:     schema.TypeString,
-					Optional: true,
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validate.URLIsHTTPOrHTTPS,
 				},
 				"runtime_version": {
 					Type:     schema.TypeString,
@@ -830,6 +832,32 @@ func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []inte
 		additionalLoginParams = *s
 	}
 	result["additional_login_params"] = additionalLoginParams
+
+	allowedExternalRedirectUrls := make([]string, 0)
+	if s := input.AllowedExternalRedirectUrls; s != nil {
+		allowedExternalRedirectUrls = *s
+	}
+	result["allowed_external_redirect_urls"] = allowedExternalRedirectUrls
+
+	if input.DefaultProvider != "" {
+		result["default_provider"] = input.DefaultProvider
+	}
+
+	if input.Issuer != nil {
+		result["issuer"] = *input.Issuer
+	}
+
+	if input.RuntimeVersion != nil {
+		result["runtime_version"] = *input.RuntimeVersion
+	}
+
+	if input.TokenRefreshExtensionHours != nil {
+		result["token_refresh_extension_hours"] = *input.TokenRefreshExtensionHours
+	}
+
+	if input.UnauthenticatedClientAction != "" {
+		result["unauthenticated_client_action"] = input.UnauthenticatedClientAction
+	}
 
 	activeDirectorySettings := make([]interface{}, 0)
 	activeDirectorySetting := make(map[string]interface{})

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -160,6 +160,40 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					Optional: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
+				"default_provider": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"AzureActiveDirectory",
+						"Facebook",
+						"Google",
+						"MicrosoftAccount",
+						"Twitter",
+					}, true),
+					DiffSuppressFunc: suppress.CaseDifference,
+				},
+				"issuer": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"runtime_version": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"token_refresh_extension_hours": {
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  72,
+				},
+				"unauthenticated_client_action": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"AllowAnonymous",
+						"RedirectToLoginPage",
+					}, true),
+					DiffSuppressFunc: suppress.CaseDifference,
+				},
 				"active_directory": SchemaAppServiceAadAuthSettings(),
 				"facebook":         SchemaAppServiceFacebookAuthSettings(),
 				"google":           SchemaAppServiceGoogleAuthSettings(),

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -838,7 +838,7 @@ func ExpandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 }
 
 func FlattenAdditionalLoginParams(input *[]string) map[string]interface{} {
-	result := make(map[string]interface{}, 0)
+	result := make(map[string]interface{})
 
 	if input == nil {
 		return result

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -116,6 +116,27 @@ func SchemaAppServiceMicrosoftAuthSettings() *schema.Schema {
 	}
 }
 
+func SchemaAppServiceTwitterAuthSettings() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"consumer_key": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"consumer_secret": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
 func SchemaAppServiceAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
@@ -143,6 +164,7 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 				"facebook":         SchemaAppServiceFacebookAuthSettings(),
 				"google":           SchemaAppServiceGoogleAuthSettings(),
 				"microsoft":        SchemaAppServiceMicrosoftAuthSettings(),
+				"twitter":          SchemaAppServiceTwitterAuthSettings(),
 			},
 		},
 	}

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -705,8 +705,12 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 	if v, ok := setting["active_directory"]; ok {
 		activeDirectorySettings := v.([]interface{})
 
-		if len(activeDirectorySettings) > 0 {
-			activeDirectorySetting := activeDirectorySettings[0].(map[string]interface{})
+		for _, setting := range activeDirectorySettings {
+			if setting == nil {
+				continue
+			}
+
+			activeDirectorySetting := setting.(map[string]interface{})
 
 			if v, ok := activeDirectorySetting["client_id"]; ok {
 				siteAuthSettingsProperties.ClientID = utils.String(v.(string))
@@ -732,8 +736,12 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 	if v, ok := setting["facebook"]; ok {
 		facebookSettings := v.([]interface{})
 
-		if len(facebookSettings) > 0 {
-			facebookSetting := facebookSettings[0].(map[string]interface{})
+		for _, setting := range facebookSettings {
+			if setting == nil {
+				continue
+			}
+
+			facebookSetting := setting.(map[string]interface{})
 
 			if v, ok := facebookSetting["app_id"]; ok {
 				siteAuthSettingsProperties.FacebookAppID = utils.String(v.(string))
@@ -759,8 +767,12 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 	if v, ok := setting["google"]; ok {
 		googleSettings := v.([]interface{})
 
-		if len(googleSettings) > 0 {
-			googleSetting := googleSettings[0].(map[string]interface{})
+		for _, setting := range googleSettings {
+			if setting == nil {
+				continue
+			}
+
+			googleSetting := setting.(map[string]interface{})
 
 			if v, ok := googleSetting["client_id"]; ok {
 				siteAuthSettingsProperties.GoogleClientID = utils.String(v.(string))
@@ -786,8 +798,12 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 	if v, ok := setting["microsoft"]; ok {
 		microsoftSettings := v.([]interface{})
 
-		if len(microsoftSettings) > 0 {
-			microsoftSetting := microsoftSettings[0].(map[string]interface{})
+		for _, setting := range microsoftSettings {
+			if setting == nil {
+				continue
+			}
+
+			microsoftSetting := setting.(map[string]interface{})
 
 			if v, ok := microsoftSetting["client_id"]; ok {
 				siteAuthSettingsProperties.MicrosoftAccountClientID = utils.String(v.(string))
@@ -813,8 +829,12 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 	if v, ok := setting["twitter"]; ok {
 		twitterSettings := v.([]interface{})
 
-		if len(twitterSettings) > 0 {
-			twitterSetting := twitterSettings[0].(map[string]interface{})
+		for _, setting := range twitterSettings {
+			if setting == nil {
+				continue
+			}
+
+			twitterSetting := setting.(map[string]interface{})
 
 			if v, ok := twitterSetting["consumer_key"]; ok {
 				siteAuthSettingsProperties.TwitterConsumerKey = utils.String(v.(string))

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -187,6 +187,11 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					Optional: true,
 					Default:  72,
 				},
+				"token_store_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
 				"unauthenticated_client_action": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -698,6 +703,10 @@ func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsPropert
 		siteAuthSettingsProperties.TokenRefreshExtensionHours = utils.Float(v.(float64))
 	}
 
+	if v, ok := setting["token_store_enabled"]; ok {
+		siteAuthSettingsProperties.TokenStoreEnabled = utils.Bool(v.(bool))
+	}
+
 	if v, ok := setting["unauthenticated_client_action"]; ok {
 		siteAuthSettingsProperties.UnauthenticatedClientAction = web.UnauthenticatedClientAction(v.(string))
 	}
@@ -888,6 +897,10 @@ func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []inte
 
 	if input.TokenRefreshExtensionHours != nil {
 		result["token_refresh_extension_hours"] = *input.TokenRefreshExtensionHours
+	}
+
+	if input.TokenStoreEnabled != nil {
+		result["token_store_enabled"] = *input.TokenStoreEnabled
 	}
 
 	if input.UnauthenticatedClientAction != "" {

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -647,15 +647,14 @@ func FlattenAppServiceCorsSettings(input *web.CorsSettings) []interface{} {
 	return append(results, result)
 }
 
-func ExpandAppServiceAuthSettings(input interface{}) web.SiteAuthSettingsProperties {
-	settings := input.([]interface{})
+func ExpandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsProperties {
 	siteAuthSettingsProperties := web.SiteAuthSettingsProperties{}
 
-	if len(settings) == 0 {
+	if len(input) == 0 {
 		return siteAuthSettingsProperties
 	}
 
-	setting := settings[0].(map[string]interface{})
+	setting := input[0].(map[string]interface{})
 
 	if v, ok := setting["enabled"]; ok {
 		siteAuthSettingsProperties.Enabled = utils.Bool(v.(bool))

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -38,7 +38,7 @@ func SchemaAppServiceAadAuthSettings() *schema.Schema {
 	}
 }
 
-func SchemaAppServiceFacebookSettings() *schema.Schema {
+func SchemaAppServiceFacebookAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -140,6 +140,9 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
 				"active_directory": SchemaAppServiceAadAuthSettings(),
+				"facebook":         SchemaAppServiceFacebookAuthSettings(),
+				"google":           SchemaAppServiceGoogleAuthSettings(),
+				"microsoft":        SchemaAppServiceMicrosoftAuthSettings(),
 			},
 		},
 	}

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -90,6 +90,32 @@ func SchemaAppServiceGoogleAuthSettings() *schema.Schema {
 	}
 }
 
+func SchemaAppServiceMicrosoftAuthSettings() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"client_id": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"client_secret": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"oauth_scopes": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
 func SchemaAppServiceAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -52,7 +52,7 @@ func SchemaAppServiceFacebookAuthSettings() *schema.Schema {
 				},
 				"app_secret": {
 					Type:     schema.TypeString,
-					Optional: true,
+					Required: true,
 				},
 				"oauth_scopes": {
 					Type:     schema.TypeList,

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -838,10 +838,17 @@ func ExpandAppServiceAuthSettings(input []interface{}) web.SiteAuthSettingsPrope
 }
 
 func FlattenAdditionalLoginParams(input *[]string) map[string]interface{} {
-	result := make(map[string]interface{}, len(*input))
+	result := make(map[string]interface{}, 0)
+
+	if input == nil {
+		return result
+	}
 
 	for _, k := range *input {
 		parts := strings.Split(k, "=")
+		if len(parts) != 2 {
+			continue // Params not following the format `key=value` is considered malformed and will be ignored.
+		}
 		key := parts[0]
 		value := parts[1]
 

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -143,6 +143,7 @@ func SchemaAppServiceAuthSettings() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Optional: true,
+		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -860,11 +861,11 @@ func FlattenAdditionalLoginParams(input *[]string) map[string]interface{} {
 
 func FlattenAppServiceAuthSettings(input *web.SiteAuthSettingsProperties) []interface{} {
 	results := make([]interface{}, 0)
-	result := make(map[string]interface{})
-
 	if input == nil {
 		return results
 	}
+
+	result := make(map[string]interface{})
 
 	if input.Enabled != nil {
 		result["enabled"] = *input.Enabled

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -287,7 +287,9 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 		ID:                         read.ID,
 		SiteAuthSettingsProperties: &authSettings}
 
-	client.UpdateAuthSettings(ctx, resGroup, name, auth)
+	if _, err := client.UpdateAuthSettings(ctx, resGroup, name, auth); err != nil {
+		return err
+	}
 
 	return resourceArmAppServiceUpdate(d, meta)
 }

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -281,7 +281,8 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(*read.ID)
 
-	authSettings := azure.ExpandAppServiceAuthSettings(d.Get("auth_settings"))
+	authSettingsRaw := d.Get("auth_settings").([]interface{})
+	authSettings := azure.ExpandAppServiceAuthSettings(authSettingsRaw)
 
 	auth := web.SiteAuthSettings{
 		ID:                         read.ID,
@@ -351,7 +352,8 @@ func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("auth_settings") {
-		authSettingsProperties := azure.ExpandAppServiceAuthSettings(d.Get("auth_settings"))
+		authSettingsRaw := d.Get("auth_settings").([]interface{})
+		authSettingsProperties := azure.ExpandAppServiceAuthSettings(authSettingsRaw)
 		id := d.Id()
 		authSettings := web.SiteAuthSettings{
 			ID:                         &id,

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -289,7 +289,7 @@ func resourceArmAppServiceCreate(d *schema.ResourceData, meta interface{}) error
 		SiteAuthSettingsProperties: &authSettings}
 
 	if _, err := client.UpdateAuthSettings(ctx, resGroup, name, auth); err != nil {
-		return err
+		return fmt.Errorf("Error updating auth settings for App Service %q (Resource Group %q): %+s", name, resGroup, err)
 	}
 
 	return resourceArmAppServiceUpdate(d, meta)
@@ -462,7 +462,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	authResp, err := client.GetAuthSettings(ctx, resGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on AzureRM App Service AuthSettings %q: %+v", name, err)
+		return fmt.Errorf("Error retrieving the AuthSettings for App Service %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	appSettingsResp, err := client.ListApplicationSettings(ctx, resGroup, name)
@@ -530,7 +530,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	authSettings := azure.FlattenAppServiceAuthSettings(authResp.SiteAuthSettingsProperties)
 	if err := d.Set("auth_settings", authSettings); err != nil {
-		return err
+		return fmt.Errorf("Error setting `auth_settings`: %+s", err)
 	}
 
 	scm := flattenAppServiceSourceControl(scmResp.SiteSourceControlProperties)

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -530,7 +530,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	authSettings := azure.FlattenAppServiceAuthSettings(authResp.SiteAuthSettingsProperties)
 	if err := d.Set("auth_settings", authSettings); err != nil {
-		return fmt.Errorf("Error setting `auth_settings`: %+s", err)
+		return fmt.Errorf("Error setting `auth_settings`: %s", err)
 	}
 
 	scm := flattenAppServiceSourceControl(scmResp.SiteSourceControlProperties)

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1419,6 +1419,35 @@ func TestAccAzureRMAppService_googleAuthSettings(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_microsoftAuthSettings(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_microsoftAuthSettings(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.microsoft.0.client_id", "microsoftclientid"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.microsoft.0.client_secret", "microsoftclientsecret"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.microsoft.0.oauth_scopes.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMAppServiceDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
@@ -2876,6 +2905,49 @@ resource "azurerm_app_service" "test" {
 
       oauth_scopes = [
         "googlescope",
+      ]
+    }
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_microsoftAuthSettings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestRG-%d"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctestRG-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    always_on = true
+  }
+
+  auth_settings {
+    enabled = true
+    microsoft {
+      client_id     = "microsoftclientid"
+      client_secret = "microsoftclientsecret"
+
+      oauth_scopes = [
+        "microsoftscope",
       ]
     }
   }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1448,6 +1448,34 @@ func TestAccAzureRMAppService_microsoftAuthSettings(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_twitterAuthSettings(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMAppService_twitterAuthSettings(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.twitter.0.consumer_key", "twitterconsumerkey"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.twitter.0.consumer_secret", "twitterconsumersecret"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMAppServiceDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).appServicesClient
 
@@ -2949,6 +2977,45 @@ resource "azurerm_app_service" "test" {
       oauth_scopes = [
         "microsoftscope",
       ]
+    }
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_twitterAuthSettings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestRG-%d"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctestRG-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    always_on = true
+  }
+
+  auth_settings {
+    enabled = true
+    twitter {
+      consumer_key     = "twitterconsumerkey"
+      consumer_secret  = "twitterconsumersecret"
     }
   }
 }

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
@@ -1332,7 +1331,7 @@ func TestAccAzureRMAppService_corsSettings(t *testing.T) {
 
 func TestAccAzureRMAppService_aadAuthSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
+	ri := tf.AccRandTimeInt()
 	tenantID := os.Getenv("ARM_TENANT_ID")
 	config := testAccAzureRMAppService_aadAuthSettings(ri, testLocation(), tenantID)
 
@@ -1363,7 +1362,7 @@ func TestAccAzureRMAppService_aadAuthSettings(t *testing.T) {
 
 func TestAccAzureRMAppService_facebookAuthSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
+	ri := tf.AccRandTimeInt()
 	config := testAccAzureRMAppService_facebookAuthSettings(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1392,7 +1391,7 @@ func TestAccAzureRMAppService_facebookAuthSettings(t *testing.T) {
 
 func TestAccAzureRMAppService_googleAuthSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
+	ri := tf.AccRandTimeInt()
 	config := testAccAzureRMAppService_googleAuthSettings(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1421,7 +1420,7 @@ func TestAccAzureRMAppService_googleAuthSettings(t *testing.T) {
 
 func TestAccAzureRMAppService_microsoftAuthSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
+	ri := tf.AccRandTimeInt()
 	config := testAccAzureRMAppService_microsoftAuthSettings(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1450,7 +1449,7 @@ func TestAccAzureRMAppService_microsoftAuthSettings(t *testing.T) {
 
 func TestAccAzureRMAppService_twitterAuthSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
-	ri := acctest.RandInt()
+	ri := tf.AccRandTimeInt()
 	config := testAccAzureRMAppService_twitterAuthSettings(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1331,6 +1331,136 @@ func TestAccAzureRMAppService_corsSettings(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppService_authSettingsAdditionalLoginParams(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	tenantID := os.Getenv("ARM_TENANT_ID")
+	config := testAccAzureRMAppService_authSettingsAdditionalLoginParams(ri, testLocation(), tenantID)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.additional_login_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.additional_login_params.0", "someloginparam"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.issuer", fmt.Sprintf("https://sts.windows.net/%s", tenantID)),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_id", "aadclientid"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_secret", "aadsecret"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.allowed_audiences.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_authSettingsAdditionalAllowedExternalRedirectUrls(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	tenantID := os.Getenv("ARM_TENANT_ID")
+	config := testAccAzureRMAppService_authSettingsAdditionalAllowedExternalRedirectUrls(ri, testLocation(), tenantID)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.allowed_external_redirect_urls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.allowed_external_redirect_urls.0", "https://terra.form"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.issuer", fmt.Sprintf("https://sts.windows.net/%s", tenantID)),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_id", "aadclientid"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_secret", "aadsecret"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.allowed_audiences.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_authSettingsTokenRefreshExtensionHours(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	tenantID := os.Getenv("ARM_TENANT_ID")
+	config := testAccAzureRMAppService_authSettingsTokenRefreshExtensionHours(ri, testLocation(), tenantID)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.token_refresh_extension_hours", "75"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.issuer", fmt.Sprintf("https://sts.windows.net/%s", tenantID)),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_id", "aadclientid"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_secret", "aadsecret"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.allowed_audiences.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppService_authSettingsUnauthenticatedClientAction(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	tenantID := os.Getenv("ARM_TENANT_ID")
+	config := testAccAzureRMAppService_authSettingsUnauthenticatedClientAction(ri, testLocation(), tenantID)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.unauthenticated_client_action", "RedirectToLoginPage"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.issuer", fmt.Sprintf("https://sts.windows.net/%s", tenantID)),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_id", "aadclientid"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_secret", "aadsecret"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.allowed_audiences.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_aadAuthSettings(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := tf.AccRandTimeInt()
@@ -2860,6 +2990,242 @@ resource "azurerm_app_service" "test" {
   }
 }
 `, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMAppService_authSettingsAdditionalLoginParams(rInt int, location string, tenantID string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestRG-%d"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctestRG-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    always_on = true
+  }
+
+  auth_settings {
+    enabled = true
+    issuer  = "https://sts.windows.net/%s"
+
+    additional_login_params = [
+      "someloginparam"
+    ]
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "activedirectorytokenaudiences",
+      ]
+    }
+  }
+}
+`, rInt, location, rInt, rInt, tenantID)
+}
+
+func testAccAzureRMAppService_authSettingsAdditionalAllowedExternalRedirectUrls(rInt int, location string, tenantID string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestRG-%d"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctestRG-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    always_on = true
+  }
+
+  auth_settings {
+    enabled = true
+    issuer  = "https://sts.windows.net/%s"
+          
+    allowed_external_redirect_urls = [
+      "https://terra.form"
+    ]
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "activedirectorytokenaudiences",
+      ]
+    }
+  }
+}
+`, rInt, location, rInt, rInt, tenantID)
+}
+
+func testAccAzureRMAppService_authSettingsRuntimeVersion(rInt int, location string, tenantID string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestRG-%d"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctestRG-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    always_on = true
+  }
+
+  auth_settings {
+    enabled = true
+    issuer  = "https://sts.windows.net/%s"
+    runtime_version = "1.0"
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "activedirectorytokenaudiences",
+      ]
+    }
+  }
+}
+`, rInt, location, rInt, rInt, tenantID)
+}
+
+func testAccAzureRMAppService_authSettingsTokenRefreshExtensionHours(rInt int, location string, tenantID string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestRG-%d"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctestRG-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    always_on = true
+  }
+
+  auth_settings {
+    enabled = true
+    issuer  = "https://sts.windows.net/%s"
+    token_refresh_extension_hours = 75
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "activedirectorytokenaudiences",
+      ]
+    }
+  }
+}
+`, rInt, location, rInt, rInt, tenantID)
+}
+
+func testAccAzureRMAppService_authSettingsUnauthenticatedClientAction(rInt int, location string, tenantID string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestRG-%d"
+  kind                = "Linux"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctestRG-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  site_config {
+    always_on = true
+  }
+
+  auth_settings {
+    enabled = true
+    issuer  = "https://sts.windows.net/%s"
+    unauthenticated_client_action = "RedirectToLoginPage"
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "activedirectorytokenaudiences",
+      ]
+    }
+  }
+}
+`, rInt, location, rInt, rInt, tenantID)
 }
 
 func testAccAzureRMAppService_aadAuthSettings(rInt int, location string, tenantID string) string {

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1347,8 +1347,7 @@ func TestAccAzureRMAppService_authSettingsAdditionalLoginParams(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.additional_login_params.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.additional_login_params.0", "someloginparam"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.additional_login_params.test_key", "test_value"),
 					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.issuer", fmt.Sprintf("https://sts.windows.net/%s", tenantID)),
 					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_id", "aadclientid"),
 					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_secret", "aadsecret"),
@@ -3088,9 +3087,9 @@ resource "azurerm_app_service" "test" {
     enabled = true
     issuer  = "https://sts.windows.net/%s"
 
-    additional_login_params = [
-      "someloginparam"
-    ]
+    additional_login_params = {
+			test_key = "test_value"
+		}
 
     active_directory {
       client_id     = "aadclientid"

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -3067,12 +3067,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3088,8 +3090,8 @@ resource "azurerm_app_service" "test" {
     issuer  = "https://sts.windows.net/%s"
 
     additional_login_params = {
-			test_key = "test_value"
-		}
+      test_key = "test_value"
+    }
 
     active_directory {
       client_id     = "aadclientid"
@@ -3116,12 +3118,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3165,12 +3169,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3211,12 +3217,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3257,12 +3265,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3303,12 +3313,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3349,12 +3361,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3393,12 +3407,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3436,12 +3452,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3479,6 +3497,7 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
@@ -3522,12 +3541,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"
@@ -3561,12 +3582,14 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   name                = "acctestRG-%d"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
   }
 }
+
 resource "azurerm_app_service" "test" {
   name                = "acctestRG-%d"
   location            = "${azurerm_resource_group.test.location}"

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -1397,6 +1397,38 @@ func TestAccAzureRMAppService_authSettingsAdditionalAllowedExternalRedirectUrls(
 	})
 }
 
+func TestAccAzureRMAppService_authSettingsRuntimeVersion(t *testing.T) {
+	resourceName := "azurerm_app_service.test"
+	ri := tf.AccRandTimeInt()
+	tenantID := os.Getenv("ARM_TENANT_ID")
+	config := testAccAzureRMAppService_authSettingsRuntimeVersion(ri, testLocation(), tenantID)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.runtime_version", "1.0"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.issuer", fmt.Sprintf("https://sts.windows.net/%s", tenantID)),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_id", "aadclientid"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.client_secret", "aadsecret"),
+					resource.TestCheckResourceAttr(resourceName, "auth_settings.0.active_directory.0.allowed_audiences.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMAppService_authSettingsTokenRefreshExtensionHours(t *testing.T) {
 	resourceName := "azurerm_app_service.test"
 	ri := tf.AccRandTimeInt()

--- a/examples/app-service/docker-authentication/README.md
+++ b/examples/app-service/docker-authentication/README.md
@@ -1,0 +1,25 @@
+# Example: a Linux App Service running a Docker container with AD and Microsoft authentication enabled.
+
+This example provisions a Linux App Service which runs a single Docker container with AD and Microsoft authentication enabled.
+
+### Notes
+
+* The Container is launched on the first HTTP Request, which can take a while.
+* Continuous Deployment of a single Docker Container can be achieved using the App Setting `DOCKER_ENABLE_CI` to `true`.
+* If you're not using App Service Slots and Deployments are handled outside of Terraform - [it's possible to ignore changes to specific fields in the configuration using `ignore_changes` within Terraform's `lifecycle` block](https://www.terraform.io/docs/configuration/resources.html#lifecycle), for example:
+
+```hcl
+resource "azurerm_app_service" "test" {
+  # ...
+  site_config = {
+    # ...
+    linux_fx_version = "DOCKER|appsvcsample/python-helloworld:0.1.2"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      "site_config.0.linux_fx_version", # deployments are made outside of Terraform
+    ]
+  }
+}
+```

--- a/examples/app-service/docker-authentication/main.tf
+++ b/examples/app-service/docker-authentication/main.tf
@@ -1,0 +1,59 @@
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_app_service_plan" "main" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "main" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.main.id}"
+
+  site_config {
+    app_command_line = ""
+    linux_fx_version = "DOCKER|appsvcsample/python-helloworld:latest"
+  }
+
+  app_settings = {
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+    "DOCKER_REGISTRY_SERVER_URL"          = "https://index.docker.io"
+  }
+
+  auth_settings {
+    enabled                       = true
+    issuer                        = "https://sts.windows.net/d13958f6-b541-4dad-97b9-5a39c6b01297"
+    default_provider              = "AzureActiveDirectory"
+    unauthenticated_client_action = "RedirectToLoginPage"
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "someallowedaudience",
+      ]
+    }
+    
+    microsoft {
+      client_id     = "microsoftclientid"
+      client_secret = "microsoftclientsecret"
+
+      oauth_scopes = [
+        "somescope",
+      ]
+    }
+  }
+}

--- a/examples/app-service/docker-authentication/outputs.tf
+++ b/examples/app-service/docker-authentication/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_name" {
+  value = "${azurerm_app_service.main.name}"
+}
+
+output "app_service_default_hostname" {
+  value = "https://${azurerm_app_service.main.default_site_hostname}"
+}

--- a/examples/app-service/docker-authentication/variables.tf
+++ b/examples/app-service/docker-authentication/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}

--- a/examples/app-service/linux-authentication/README.md
+++ b/examples/app-service/linux-authentication/README.md
@@ -1,0 +1,3 @@
+# Example: a Basic Linux App Service with AD and Microsoft authentication enabled.
+
+This example provisions a basic Linux App Service with AD and Microsoft authentication enabled.

--- a/examples/app-service/linux-authentication/main.tf
+++ b/examples/app-service/linux-authentication/main.tf
@@ -1,0 +1,55 @@
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_app_service_plan" "main" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "main" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.main.id}"
+
+  site_config {
+    dotnet_framework_version = "v4.0"
+    remote_debugging_enabled = true
+    remote_debugging_version = "VS2015"
+  }
+
+  auth_settings {
+    enabled                       = true
+    issuer                        = "https://sts.windows.net/d13958f6-b541-4dad-97b9-5a39c6b01297"
+    default_provider              = "AzureActiveDirectory"
+    unauthenticated_client_action = "RedirectToLoginPage"
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "someallowedaudience",
+      ]
+    }
+    
+    microsoft {
+      client_id     = "microsoftclientid"
+      client_secret = "microsoftclientsecret"
+
+      oauth_scopes = [
+        "somescope",
+      ]
+    }
+  }
+}

--- a/examples/app-service/linux-authentication/outputs.tf
+++ b/examples/app-service/linux-authentication/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_name" {
+  value = "${azurerm_app_service.main.name}"
+}
+
+output "app_service_default_hostname" {
+  value = "https://${azurerm_app_service.main.default_site_hostname}"
+}

--- a/examples/app-service/linux-authentication/variables.tf
+++ b/examples/app-service/linux-authentication/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}

--- a/examples/app-service/windows-authentication/README.md
+++ b/examples/app-service/windows-authentication/README.md
@@ -1,0 +1,3 @@
+# Example: a Basic (Windows) App Service with AD and Microsoft authentication enabled.
+
+This example provisions a basic Windows App Service with AD and Microsoft authentication enabled.

--- a/examples/app-service/windows-authentication/main.tf
+++ b/examples/app-service/windows-authentication/main.tf
@@ -1,0 +1,53 @@
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_app_service_plan" "main" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+
+  sku {
+    tier = "Basic"
+    size = "B1"
+  }
+}
+
+resource "azurerm_app_service" "main" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.main.id}"
+
+  site_config {
+    dotnet_framework_version = "v4.0"
+    remote_debugging_enabled = true
+    remote_debugging_version = "VS2015"
+  }
+
+  auth_settings {
+    enabled                       = true
+    issuer                        = "https://sts.windows.net/d13958f6-b541-4dad-97b9-5a39c6b01297"
+    default_provider              = "AzureActiveDirectory"
+    unauthenticated_client_action = "RedirectToLoginPage"
+
+    active_directory {
+      client_id     = "aadclientid"
+      client_secret = "aadsecret"
+
+      allowed_audiences = [
+        "someallowedaudience",
+      ]
+    }
+    
+    microsoft {
+      client_id     = "microsoftclientid"
+      client_secret = "microsoftclientsecret"
+
+      oauth_scopes = [
+        "somescope",
+      ]
+    }
+  }
+}

--- a/examples/app-service/windows-authentication/outputs.tf
+++ b/examples/app-service/windows-authentication/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_name" {
+  value = "${azurerm_app_service.main.name}"
+}
+
+output "app_service_default_hostname" {
+  value = "https://${azurerm_app_service.main.default_site_hostname}"
+}

--- a/examples/app-service/windows-authentication/variables.tf
+++ b/examples/app-service/windows-authentication/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -295,6 +295,8 @@ Elements of `ip_restriction` support:
 
 * `token_refresh_extension_hours` - (Optional) The number of hours after session token expiration that a session token can be used to call the token refresh API. Defaults to 72.
 
+* `token_store_enabled` - (Optional) If enabled the module will durably store platform-specific security tokens that are obtained during login flows. Defaults to false.
+
 * `unauthenticated_client_action` - (Optional) The action to take when an unauthenticated client attempts to access the app. Possible values are `AllowAnonymous` and `RedirectToLoginPage`.
 
 * `active_directory` - (Optional) Active directory Authentication configuration.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -57,48 +57,6 @@ resource "azurerm_app_service" "test" {
 }
 ```
 
-## Example Usage (Java 1.8)
-
-```hcl
-resource "random_id" "server" {
-  keepers = {
-    azi_id = 1
-  }
-
-  byte_length = 8
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "some-resource-group"
-  location = "West Europe"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "some-app-service-plan"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "${random_id.server.hex}"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-
-  site_config {
-    java_version           = "1.8"
-    java_container         = "JETTY"
-    java_container_version = "9.3"
-    scm_type               = "LocalGit"
-  }
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -213,20 +171,27 @@ A `cors` block supports the following:
 
 ---
 
-Elements of `ip_restriction` support:
-`auth_settings` supports the following:
+A `auth_settings` block supports the following:
 
 * `enabled` - (Required) Is Authentication enabled?
+
+* `active_directory` - (Optional) A `active_directory` block as defined below.
 
 * `additional_login_params` - (Optional) Login parameters to send to the OpenID Connect authorization endpoint when a user logs in. Each parameter must be in the form "key=value".
 
 * `allowed_external_redirect_urls` - (Optional) External URLs that can be redirected to as part of logging in or logging out of the app.
 
-~> **NOTE:** When providing multiple providers, the default provider must be set for settings like `unauthenticated_client_action` to work. 
-
 * `default_provider` - (Optional) The default provider to use when multiple providers have been set up. Possible values are `AzureActiveDirectory`, `Facebook`, `Google`, `MicrosoftAccount` and `Twitter`.
 
+~> **NOTE:** When using multiple providers, the default provider must be set for settings like `unauthenticated_client_action` to work. 
+
+* `facebook` - (Optional) A `facebook` block as defined below.
+
+* `google` - (Optional) A `google` block as defined below.
+
 * `issuer` - (Optional) Issuer URI. When using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://sts.windows.net/{tenant-guid}/.
+
+* `microsoft` - (Optional) A `microsoft` block as defined below.
 
 * `runtime_version` - (Optional) The runtime version of the Authentication/Authorization module.
 
@@ -234,21 +199,13 @@ Elements of `ip_restriction` support:
 
 * `token_store_enabled` - (Optional) If enabled the module will durably store platform-specific security tokens that are obtained during login flows. Defaults to false.
 
+* `twitter` - (Optional) A `twitter` block as defined below.
+
 * `unauthenticated_client_action` - (Optional) The action to take when an unauthenticated client attempts to access the app. Possible values are `AllowAnonymous` and `RedirectToLoginPage`.
-
-* `active_directory` - (Optional) Active directory Authentication configuration.
-
-* `facebook` - (Optional) Facebook Authentication configuration.
-
-* `google` - (Optional) Google Authentication configuration.
-
-* `microsoft` - (Optional) Microsoft Account Authentication configuration.
-
-* `twitter` - (Optional) Twitter Authentication configuration.
 
 ---
 
-`active_directory` supports the following:
+A `active_directory` block supports the following:
 
 * `client_id` - (Required) The Client ID of this relying party application. Enables OpenIDConnection authentication with Azure Active Directory.
 
@@ -258,7 +215,7 @@ Elements of `ip_restriction` support:
 
 ---
 
-`facebook` supports the following:
+A `facebook` block supports the following:
 
 * `app_id` - (Required) The App ID of the Facebook app used for login
 
@@ -268,7 +225,7 @@ Elements of `ip_restriction` support:
 
 ---
 
-`google` supports the following:
+A `google` block supports the following:
 
 * `client_id` - (Required) The OpenID Connect Client ID for the Google web application.
 
@@ -278,21 +235,21 @@ Elements of `ip_restriction` support:
 
 ---
 
-`microsoft` supports the following:
+A `ip_restriction` block supports the following:
+
+* `ip_address` - (Required) The IP Address used for this IP Restriction.
+
+* `subnet_mask` - (Optional) The Subnet mask used for this IP Restriction. Defaults to `255.255.255.255`.
+
+---
+
+A `microsoft` block supports the following:
 
 * `client_id` - (Required) The OAuth 2.0 client ID that was created for the app used for authentication.
 
 * `client_secret` - (Required) The OAuth 2.0 client secret that was created for the app used for authentication.
 
 * `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. https://msdn.microsoft.com/en-us/library/dn631845.aspx
-
----
-
-`ip_restriction` supports the following:
-
-* `ip_address` - (Required) The IP Address used for this IP Restriction.
-
-* `subnet_mask` - (Optional) The Subnet mask used for this IP Restriction. Defaults to `255.255.255.255`.
 
 ## Attributes Reference
 
@@ -314,7 +271,7 @@ The following attributes are exported:
 
 ---
 
-`identity` exports the following:
+A `identity` block exports the following:
 
 * `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
@@ -324,7 +281,7 @@ The following attributes are exported:
 
 ---
 
-`site_credential` exports the following:
+A `site_credential` block exports the following:
 
 * `username` - The username which can be used to publish to this App Service
 * `password` - The password associated with the username, which can be used to publish to this App Service.
@@ -333,7 +290,7 @@ The following attributes are exported:
 
 ---
 
-`source_control` exports the following:
+A `source_control` block exports the following:
 
 * `repo_url` - URL of the Git repository for this App Service.
 * `branch` - Branch name of the Git repository for this App Service.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -99,69 +99,6 @@ resource "azurerm_app_service" "test" {
 }
 ```
 
-## Example Usage (Authentication)
-
-```hcl
-resource "random_id" "server" {
-  keepers = {
-    azi_id = 1
-  }
-
-  byte_length = 8
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "some-resource-group"
-  location = "West Europe"
-}
-
-resource "azurerm_app_service_plan" "test" {
-  name                = "some-app-service-plan"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-
-resource "azurerm_app_service" "test" {
-  name                = "${random_id.server.hex}"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-
-  site_config {
-    always_on = true
-  }
-
-  auth_settings {
-    enabled                       = true
-    issuer                        = "https://sts.windows.net/d13958f6-b541-4dad-97b9-5a39c6b01297"
-    default_provider              = "AzureActiveDirectory"
-    unauthenticated_client_action = "RedirectToLoginPage"
-
-    active_directory {
-      client_id     = "aadclientid"
-      client_secret = "aadsecret"
-
-      allowed_audiences = [
-        "someallowedaudience",
-      ]
-    }
-    
-    microsoft {
-      client_id     = "microsoftclientid"
-      client_secret = "microsoftclientsecret"
-
-      oauth_scopes = [
-        "somescope",
-      ]
-    }
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
This PR fixes #1992 and allows users to configure authentication for `azurerm_app_service`. This PR supports all of the providers in azure (Active Directory, Facebook, Google, Microsoft, Twitter).

It uses the `UpdateAuthSetting` as mentioned in the issue. More information about the API here: [Web Apps - Update Auth Settings
](https://docs.microsoft.com/en-us/rest/api/appservice/webapps/updateauthsettings)

Each provider is defined in it's own block inside of an `auth_settings` section.
Example:

```
auth_settings {
  enabled                       = true
  issuer                        = "https://sts.windows.net/d13958f6-b541-4dad-97b9-5a39c6b01297"
  default_provider              = "AzureActiveDirectory"
  unauthenticated_client_action = "RedirectToLoginPage"

  active_directory {
    client_id     = "aadclientid"
    client_secret = "aadsecret"

    allowed_audiences = [
      "someallowedaudience",
    ]
  }
    
  microsoft {
    client_id     = "microsoftclientid"
    client_secret = "microsoftclientsecret"

    oauth_scopes = [
      "somescope",
    ]
  }
}
```