### PR TITLE
New Data Source: `azurerm_servicebus_namespace`

### DIFF
--- a/azurerm/data_source_servicebus_namespace.go
+++ b/azurerm/data_source_servicebus_namespace.go
@@ -1,0 +1,105 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmServiceBusNamespace() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmServiceBusNamespaceRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"sku": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"capacity": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"default_primary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"default_secondary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"default_primary_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"default_secondary_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"tags": tagsForDataSourceSchema(),
+		},
+	}
+}
+
+func dataSourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).serviceBusNamespacesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("ServiceBus Namespace %q was not found in Resource Group %q", name, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving ServiceBus Namespace %q (Resource Group %q): %s", name, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	if location := resp.Location; location != nil {
+		d.Set("location", azureRMNormalizeLocation(*location))
+	}
+
+	if sku := resp.Sku; sku != nil {
+		d.Set("sku", string(sku.Name))
+		d.Set("capacity", sku.Capacity)
+	}
+
+	keys, err := client.ListKeys(ctx, resourceGroup, name, serviceBusNamespaceDefaultAuthorizationRule)
+	if err != nil {
+		log.Printf("[WARN] Unable to List default keys for Namespace %q (Resource Group %q): %+v", name, resourceGroup, err)
+	} else {
+		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
+		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
+		d.Set("default_primary_key", keys.PrimaryKey)
+		d.Set("default_secondary_key", keys.SecondaryKey)
+	}
+
+	return nil
+}

--- a/azurerm/data_source_servicebus_namespace_test.go
+++ b/azurerm/data_source_servicebus_namespace_test.go
@@ -1,0 +1,87 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccDataSourceAzureRMServiceBusNamespace_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_servicebus_namespace.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMServiceBusNamespace_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusNamespaceExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "location"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "sku"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "capacity"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_primary_connection_string"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_secondary_connection_string"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_primary_key"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_secondary_key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMServiceBusNamespace_premium(t *testing.T) {
+	dataSourceName := "data.azurerm_servicebus_namespace.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMServiceBusNamespace_premium(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusNamespaceExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "location"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "sku"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "capacity"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_primary_connection_string"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_secondary_connection_string"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_primary_key"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "default_secondary_key"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMServiceBusNamespace_basic(rInt int, location string) string {
+	template := testAccAzureRMServiceBusNamespace_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_servicebus_namespace" "test" {
+  name                = "${azurerm_servicebus_namespace.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, template)
+}
+
+func testAccDataSourceAzureRMServiceBusNamespace_premium(rInt int, location string) string {
+	template := testAccAzureRMServiceBusNamespace_premium(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_servicebus_namespace" "test" {
+  name                = "${azurerm_servicebus_namespace.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, template)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -144,6 +144,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_role_definition":                       dataSourceArmRoleDefinition(),
 			"azurerm_route_table":                           dataSourceArmRouteTable(),
 			"azurerm_scheduler_job_collection":              dataSourceArmSchedulerJobCollection(),
+			"azurerm_servicebus_namespace":                  dataSourceArmServiceBusNamespace(),
 			"azurerm_shared_image_gallery":                  dataSourceArmSharedImageGallery(),
 			"azurerm_shared_image_version":                  dataSourceArmSharedImageVersion(),
 			"azurerm_shared_image":                          dataSourceArmSharedImage(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -235,6 +235,10 @@
                     <a href="/docs/providers/azurerm/d/scheduler_job_collection.html">azurerm_scheduler_job_collection</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-servicebus-namespace") %>>
+                    <a href="/docs/providers/azurerm/d/servicebus_namespace.html">azurerm_servicebus_namespace</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-shared-image-x") %>>
                     <a href="/docs/providers/azurerm/d/shared_image.html">azurerm_shared_image</a>
                 </li>

--- a/website/docs/d/servicebus_namespace.html.markdown
+++ b/website/docs/d/servicebus_namespace.html.markdown
@@ -31,4 +31,23 @@ output "location" {
 
 ## Attributes Reference
 
-* `location` - The location of the resource group.
+* `location` - The location of the Resource Group in which the ServiceBus Namespace exists.
+
+* `sku` - The Tier used for the ServiceBus Namespace.
+
+* `capacity` - The capacity of the ServiceBus Namespace.
+
+* `tags` - A mapping of tags assigned to the resource.
+
+The following attributes are exported only if there is an authorization rule named
+`RootManageSharedAccessKey` which is created automatically by Azure.
+
+* `default_primary_connection_string` - The primary connection string for the authorization
+    rule `RootManageSharedAccessKey`.
+
+* `default_secondary_connection_string` - The secondary connection string for the
+    authorization rule `RootManageSharedAccessKey`.
+
+* `default_primary_key` - The primary access key for the authorization rule `RootManageSharedAccessKey`.
+
+* `default_secondary_key` - The secondary access key for the authorization rule `RootManageSharedAccessKey`.

--- a/website/docs/d/servicebus_namespace.html.markdown
+++ b/website/docs/d/servicebus_namespace.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_servicebus_namespace"
+sidebar_current: "docs-azurerm-datasource-servicebus-namespace"
+description: |-
+  Gets information about an existing ServiceBus Namespace.
+---
+
+# Data Source: azurerm_servicebus_namespace
+
+Use this data source to access information about an existing ServiceBus Namespace.
+
+## Example Usage
+
+```hcl
+data "azurerm_servicebus_namespace" "test" {
+  name                = "examplenamespace"
+  resource_group_name = "example-resources"
+}
+
+output "location" {
+  value = "${data.azurerm_servicebus_namespace.test.location}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the name of the ServiceBus Namespace.
+
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the ServiceBus Namespace exists.
+
+## Attributes Reference
+
+* `location` - The location of the resource group.


### PR DESCRIPTION
Tests pass:

```
$ acctests azurerm TestAccDataSourceAzureRMServiceBusNamespace_
=== RUN   TestAccDataSourceAzureRMServiceBusNamespace_basic
=== PAUSE TestAccDataSourceAzureRMServiceBusNamespace_basic
=== RUN   TestAccDataSourceAzureRMServiceBusNamespace_premium
=== PAUSE TestAccDataSourceAzureRMServiceBusNamespace_premium
=== CONT  TestAccDataSourceAzureRMServiceBusNamespace_basic
--- PASS: TestAccDataSourceAzureRMServiceBusNamespace_basic (422.34s)
=== CONT  TestAccDataSourceAzureRMServiceBusNamespace_premium
--- PASS: TestAccDataSourceAzureRMServiceBusNamespace_premium (517.23s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	940.106s
```

Fixes #2833