### PR TITLE
r/log_analytics_linked_service: fixing bugs

### DIFF
--- a/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
+++ b/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
@@ -190,7 +190,7 @@ resource "azurerm_log_analytics_workspace_linked_service" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   workspace_name      = "${azurerm_log_analytics_workspace.test.name}"
   linked_service_name = "automation"
-  resource_id         = "${azurerm_automation_account.test.id}"}
+  resource_id         = "${azurerm_automation_account.test.id}"
 }
 `, template)
 }

--- a/website/docs/r/log_analytics_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_linked_service.html.markdown
@@ -82,5 +82,5 @@ The following attributes are exported:
 Log Analytics Workspaces can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_linked_service.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/linkedServices/automation
+terraform import azurerm_log_analytics_linked_service.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/linkedservices/automation
 ```

--- a/website/docs/r/log_analytics_workspace_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_workspace_linked_service.html.markdown
@@ -85,5 +85,5 @@ The following attributes are exported:
 Log Analytics Workspaces can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_workspace_linked_service.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/linkedServices/automation
+terraform import azurerm_log_analytics_workspace_linked_service.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/linkedservices/automation
 ```


### PR DESCRIPTION
This PR fixes a couple of issues in the Log Analytics (Workspace) Linked Service resources:

* the `linked_service_properties` block wasn't being set correctly, since the Schema was invalid. Whilst this is a breaking change it appears this didn't get set correctly before, so I think it's an acceptable breaking change (since IMO it's unlikely to be used as an output)
* the ID of the Linked Service is returned in a different case to that of the Swagger - such I've updated the ID parsing logic to account for this

Also turns out since the ID's are being returned lower-cased we can't refactor these in the short-term, so I've removed these TODO's for the moment.