### PR TITLE
azurerm_function_app (website): Add line between linux_fx_version and separator

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -135,7 +135,9 @@ The following arguments are supported:
 ~> **Note:** when using an App Service Plan in the `Free` or `Shared` Tiers `use_32_bit_worker_process` must be set to `true`.
 
 * `websockets_enabled` - (Optional) Should WebSockets be enabled?
+
 * `linux_fx_version` - (Optional) Linux App Framework and version for the AppService, e.g. `DOCKER|(golang:latest)`.
+
 ---
 
 `identity` supports the following:


### PR DESCRIPTION
This PR fixes #2862 

Adds a space between `linux_fx_version` and the seperator `---` so that the ruby markdown parser can parse it correctly.