### PR TITLE
fix spurious markdown in data source azurerm_policy_definition

### DIFF
--- a/website/docs/d/policy_definition.markdown
+++ b/website/docs/d/policy_definition.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_definition"
-**sidebar_current**: "docs-azurerm-datasource-policy-definition"
+sidebar_current: "docs-azurerm-datasource-policy-definition"
 description: |-
   Get information about a Policy Definition.
 ---


### PR DESCRIPTION
Hi,
I don't know how this crept in, but this page (https://www.terraform.io/docs/providers/azurerm/d/policy_definition.html) didnt render correctly without this fix.