### PR TITLE
r/key_vault_access_policy: fixing a test failure

### DIFF
--- a/azurerm/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/resource_arm_key_vault_access_policy_test.go
@@ -247,7 +247,8 @@ func testAccAzureRMKeyVaultAccessPolicy_basicClassic(rString string, location st
 %s
 
 resource "azurerm_key_vault_access_policy" "test" {
-  vault_uri = "${azurerm_key_vault.test.vault_uri}"
+  vault_name          = "${azurerm_key_vault.test.name}"
+  resource_group_name = "${azurerm_key_vault.test.resource_group_name}"
 
   key_permissions = [
     "get",


### PR DESCRIPTION
Tests pass:
```
$ acctests azurerm TestAccAzureRMKeyVaultAccessPolicy_basicClassic
=== RUN   TestAccAzureRMKeyVaultAccessPolicy_basicClassic
=== PAUSE TestAccAzureRMKeyVaultAccessPolicy_basicClassic
=== CONT  TestAccAzureRMKeyVaultAccessPolicy_basicClassic
--- PASS: TestAccAzureRMKeyVaultAccessPolicy_basicClassic (252.79s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	254.648s
```