### PR TITLE
Add maxfragmentationmemory_reserved option to azurerm_redis_cache

### DIFF
--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -125,6 +125,13 @@ func resourceArmRedisCache() *schema.Resource {
 							Default:      "volatile-lru",
 							ValidateFunc: validateRedisMaxMemoryPolicy,
 						},
+
+						"maxfragmentationmemory_reserved": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+
 						"rdb_backup_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -575,6 +582,11 @@ func expandRedisConfiguration(d *schema.ResourceData) map[string]*string {
 		output["maxmemory-policy"] = utils.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("redis_configuration.0.maxfragmentationmemory_reserved"); ok {
+		delta := strconv.Itoa(v.(int))
+		output["maxfragmentationmemory-reserved"] = utils.String(delta)
+	}
+
 	// Backup
 	if v, ok := d.GetOk("redis_configuration.0.rdb_backup_enabled"); ok {
 		delta := strconv.FormatBool(v.(bool))
@@ -656,6 +668,14 @@ func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) 
 	}
 	if v := input["maxmemory-policy"]; v != nil {
 		outputs["maxmemory_policy"] = *v
+	}
+
+	if v := input["maxfragmentationmemory-reserved"]; v != nil {
+		i, err := strconv.Atoi(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `maxfragmentationmemory-reserved` %q: %+v", *v, err)
+		}
+		outputs["maxfragmentationmemory_reserved"] = i
 	}
 
 	// delta, reserved, enabled, frequency,, count,

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -661,7 +661,8 @@ resource "azurerm_redis_cache" "test" {
   enable_non_ssl_port = false
 
   redis_configuration {
-    maxmemory_reserved = 2
+	maxmemory_reserved = 2
+	maxfragmentationmemory_reserved = 2
     maxmemory_delta    = 2
     maxmemory_policy   = "allkeys-lru"
   }
@@ -688,6 +689,7 @@ resource "azurerm_redis_cache" "test" {
 
   redis_configuration {
     maxmemory_reserved = 2
+	maxfragmentationmemory_reserved = 2
     maxmemory_delta    = 2
     maxmemory_policy   = "allkeys-lru"
   }
@@ -714,6 +716,7 @@ resource "azurerm_redis_cache" "test" {
 
   redis_configuration {
     maxmemory_reserved = 2
+	maxfragmentationmemory_reserved = 2
     maxmemory_delta    = 2
     maxmemory_policy   = "allkeys-lru"
   }

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -158,6 +158,8 @@ The pricing group for the Redis Family - either "C" or "P" at present.
 * `maxmemory_delta` - (Optional) The max-memory delta for this Redis instance. Defaults are shown below.
 * `maxmemory_policy` - (Optional) How Redis will select what to remove when `maxmemory` is reached. Defaults are shown below.
 
+* `maxfragmentationmemory_reserved` - (Optional) Value in megabytes reserved to accommodate for memory fragmentation. Defaults are shown below.
+
 * `rdb_backup_enabled` - (Optional) Is Backup Enabled? Only supported on Premium SKU's.
 * `rdb_backup_frequency` - (Optional) The Backup Frequency in Minutes. Only supported on Premium SKU's. Possible values are: `15`, `30`, `60`, `360`, `720` and `1440`.
 * `rdb_backup_max_snapshot_count` - (Optional) The maximum number of snapshots to create as a backup. Only supported for Premium SKU's.
@@ -183,13 +185,14 @@ redis_configuration {
 ```
 
 ## Default Redis Configuration Values
-| Redis Value        | Basic        | Standard     | Premium      |
-| ------------------ | ------------ | ------------ | ------------ |
-| maxmemory_reserved | 2            | 50           | 200          |
-| maxmemory_delta    | 2            | 50           | 200          |
-| maxmemory_policy   | volatile-lru | volatile-lru | volatile-lru |
+| Redis Value                     | Basic        | Standard     | Premium      |
+| ------------------------------- | ------------ | ------------ | ------------ |
+| maxmemory_reserved              | 2            | 50           | 200          |
+| maxfragmentationmemory_reserved | 2            | 50           | 200          |
+| maxmemory_delta                 | 2            | 50           | 200          |
+| maxmemory_policy                | volatile-lru | volatile-lru | volatile-lru |
 
-_*Important*: The `maxmemory_reserved` and `maxmemory_delta` settings are only available for Standard and Premium caches. More details are available in the Relevant Links section below._
+_*Important*: The `maxmemory_reserved`, `maxmemory_delta` and `maxfragmentationmemory-reserved` settings are only available for Standard and Premium caches. More details are available in the Relevant Links section below._
 
 * `patch_schedule` supports the following:
 


### PR DESCRIPTION
This PR adds the missing `maxfragmentationmemory_reserved` option to `redis_configuration` block of `azurerm_redis_cache` resource