### PR TITLE
Update redux firewall rule name to allow underscores - resolves #2903

### DIFF
--- a/azurerm/resource_arm_redis_firewall_rule.go
+++ b/azurerm/resource_arm_redis_firewall_rule.go
@@ -161,7 +161,7 @@ func resourceArmRedisFirewallRuleDelete(d *schema.ResourceData, meta interface{}
 func validateRedisFirewallRuleName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^[0-9a-zA-Z]+$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z_]+$`).Match([]byte(value)); !matched {
 		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters", k))
 	}
 

--- a/azurerm/resource_arm_redis_firewall_rule.go
+++ b/azurerm/resource_arm_redis_firewall_rule.go
@@ -162,7 +162,7 @@ func validateRedisFirewallRuleName(v interface{}, k string) (warnings []string, 
 	value := v.(string)
 
 	if matched := regexp.MustCompile(`^[0-9a-zA-Z_]+$`).Match([]byte(value)); !matched {
-		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters", k))
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and underscores", k))
 	}
 
 	return warnings, errors

--- a/azurerm/resource_arm_redis_firewall_rule_test.go
+++ b/azurerm/resource_arm_redis_firewall_rule_test.go
@@ -34,7 +34,7 @@ func TestAzureRMRedisFirewallRuleName_validation(t *testing.T) {
 		},
 		{
 			Value:    "hello_world",
-			ErrCount: 1,
+			ErrCount: 0,
 		},
 		{
 			Value:    "helloworld21!",


### PR DESCRIPTION
Update the regex validation to allow underscores in redux firewall rules, this is supported by azure