### PR TITLE
redis_firewall_rule: adding underscore to be allowed in firewall rule name

### DIFF
--- a/azurerm/resource_arm_redis_firewall_rule.go
+++ b/azurerm/resource_arm_redis_firewall_rule.go
@@ -161,7 +161,7 @@ func resourceArmRedisFirewallRuleDelete(d *schema.ResourceData, meta interface{}
 func validateRedisFirewallRuleName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^[0-9a-zA-Z]+$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z_]+$`).Match([]byte(value)); !matched {
 		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters", k))
 	}
 

--- a/azurerm/resource_arm_redis_firewall_rule_test.go
+++ b/azurerm/resource_arm_redis_firewall_rule_test.go
@@ -29,11 +29,11 @@ func TestAzureRMRedisFirewallRuleName_validation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    "hello-world",
-			ErrCount: 1,
+			Value:    "hello_world",
+			ErrCount: 0,
 		},
 		{
-			Value:    "hello_world",
+			Value:    "hello-world",
 			ErrCount: 1,
 		},
 		{


### PR DESCRIPTION
This PR introduces the ability to support underscores in the redis firewall rule name (requested in #2903)