### PR TITLE
Fix handling of creating an Access Policy for a non-existent Key Vault

### DIFF
--- a/azurerm/resource_arm_key_vault_access_policy.go
+++ b/azurerm/resource_arm_key_vault_access_policy.go
@@ -145,7 +145,11 @@ func resourceArmKeyVaultAccessPolicyCreateOrDelete(d *schema.ResourceData, meta 
 
 	keyVault, err := client.Get(ctx, resourceGroup, vaultName)
 	if err != nil {
-		if utils.ResponseWasNotFound(keyVault.Response) {
+		// If the key vault does not exist but this is not a new resource, the policy
+		// which previously existed was deleted with the key vault, so reflect that in
+		// state. If this is a new resource and key vault does not exist, it's likely
+		// a bad ID was given.
+		if utils.ResponseWasNotFound(keyVault.Response) && !d.IsNewResource() {
 			log.Printf("[DEBUG] Parent Key Vault %q was not found in Resource Group %q - removing from state!", vaultName, resourceGroup)
 			d.SetId("")
 			return nil

--- a/azurerm/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/resource_arm_key_vault_access_policy_test.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -170,6 +171,24 @@ func TestAccAzureRMKeyVaultAccessPolicy_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "key_permissions.0", "list"),
 					resource.TestCheckResourceAttr(resourceName, "key_permissions.1", "encrypt"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMKeyVaultAccessPolicy_nonExistentVault(t *testing.T) {
+	rs := acctest.RandString(6)
+	config := testAccAzureRMKeyVaultAccessPolicy_nonExistentVault(rs, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKeyVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`Error retrieving Key Vault`),
 			},
 		},
 	})
@@ -383,6 +402,48 @@ resource "azurerm_key_vault" "test" {
   tags {
     environment = "Production"
   }
+}
+`, rString, location, rString)
+}
+
+func testAccAzureRMKeyVaultAccessPolicy_nonExistentVault(rString string, location string) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%s"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
+
+  sku {
+    name = "standard"
+  }
+
+  tags {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "test" {
+  # Must appear to be URL, but not actually exist - appending a string works
+  key_vault_id = "${azurerm_key_vault.test.id}NOPE"
+
+  tenant_id = "${data.azurerm_client_config.current.tenant_id}"
+  object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+
+  key_permissions = [
+    "get",
+  ]
+
+  secret_permissions = [
+    "get",
+  ]
 }
 `, rString, location, rString)
 }


### PR DESCRIPTION
This pull request adds an acceptance test demonstrating the case where a key vault access policy resource is created with a bad key vault ID. Currently, the Terraform CLI gives the following output for this configuration:

```hcl
resource "azurerm_key_vault_access_policy" "policy" {
  # This ID shouldn't exist but must be in the URI-style format with enough components
  key_vault_id = "/subscriptions/redacted/resourceGroups/myrg/providers/Microsoft.KeyVault/vaults/idontexist"

  tenant_id = "00000000-0000-0000-0000-000000000000"
  object_id = "11111111-1111-1111-1111-111111111111"

  key_permissions = [
    "get",
  ]

  secret_permissions = [
    "get",
  ]
}
```

```
$ terraform apply                                                                                                                                               ⇡ master :: 19h :: ⬡

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  + azurerm_key_vault_access_policy.policy
      id:                   <computed>
      key_permissions.#:    "1"
      key_permissions.0:    "get"
      key_vault_id:         "/subscriptions/redacted/resourceGroups/myrg/providers/Microsoft.KeyVault/vaults/idontexist"
      object_id:            "11111111-1111-1111-1111-111111111111"
      resource_group_name:  <computed>
      secret_permissions.#: "1"
      secret_permissions.0: "get"
      tenant_id:            "00000000-0000-0000-0000-000000000000"
      vault_name:           <computed>


Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_key_vault_access_policy.policy: Creating...
  key_permissions.#:    "" => "1"
  key_permissions.0:    "" => "get"
  key_vault_id:         "" => "/subscriptions/redacted/resourceGroups/myrg/providers/Microsoft.KeyVault/vaults/idontexist"
  object_id:            "" => "11111111-1111-1111-1111-111111111111"
  resource_group_name:  "" => "<computed>"
  secret_permissions.#: "" => "1"
  secret_permissions.0: "" => "get"
  tenant_id:            "" => "00000000-0000-0000-0000-000000000000"
  vault_name:           "" => "<computed>"
azurerm_key_vault_access_policy.policy: Creation complete after 0s

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

However, state shows:

```json
{
    "version": 3,
    "terraform_version": "0.11.11",
    "serial": 1,
    "lineage": "74a73fbb-d75a-af7a-c1dc-6d73cc1e9a73",
    "modules": [
        {
            "path": [
                "root"
            ],
            "outputs": {},
            "resources": {},
            "depends_on": []
        }
    ]
}
```

The test reproduces this workflow, and the subsequent commit makes it pass by removing the branch at which a nil state and nil error is returned during creation.