### PR TITLE
r/policy_definition: allowing the `metadata` field to be Computed

### DIFF
--- a/azurerm/resource_arm_policy_definition.go
+++ b/azurerm/resource_arm_policy_definition.go
@@ -86,6 +86,7 @@ func resourceArmPolicyDefinition() *schema.Resource {
 			"metadata": {
 				Type:             schema.TypeString,
 				Optional:         true,
+				Computed:         true,
 				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},


### PR DESCRIPTION
Before making this field Computed:

```
$ acctests azurerm TestAccAzureRMPolicyDefinition_computedMetadata
=== RUN   TestAccAzureRMPolicyDefinition_computedMetadata
=== PAUSE TestAccAzureRMPolicyDefinition_computedMetadata
=== CONT  TestAccAzureRMPolicyDefinition_computedMetadata
--- FAIL: TestAccAzureRMPolicyDefinition_computedMetadata (124.69s)
    testing.go:538: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: azurerm_policy_definition.test
          metadata: "{\"createdBy\":\"08235c12-5479-4b9b-9f0f-4dd1e700a4e0\",\"createdOn\":\"2019-02-22T16:31:04.2856389Z\",\"updatedBy\":null,\"updatedOn\":null}" => ""

        STATE:

        azurerm_policy_definition.test:
          ID = /subscriptions/c0a607b2-6372-4ef3-abdb-dbe52a7b56ba/providers/Microsoft.Authorization/policyDefinitions/acctest-190222173052556885
          provider = provider.azurerm
          description =
          display_name = DefaultTags
          management_group_id =
          metadata = {"createdBy":"08235c12-5479-4b9b-9f0f-4dd1e700a4e0","createdOn":"2019-02-22T16:31:04.2856389Z","updatedBy":null,"updatedOn":null}
          mode = Indexed
          name = acctest-190222173052556885
          policy_rule = {"if":{"exists":"false","field":"tags"},"then":{"details":[{"field":"tags","value":{"application":"Portal","environment":"D-137","implementor":"Morty","owner":"Rick"}}],"effect":"append"}}
          policy_type = Custom
FAIL
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	125.758s
```

After making this field Computed:

```
$ acctests azurerm TestAccAzureRMPolicyDefinition_computedMetadata
=== RUN   TestAccAzureRMPolicyDefinition_computedMetadata
=== PAUSE TestAccAzureRMPolicyDefinition_computedMetadata
=== CONT  TestAccAzureRMPolicyDefinition_computedMetadata
--- PASS: TestAccAzureRMPolicyDefinition_computedMetadata (138.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	139.786s
```

Fixes #2938 