### PR TITLE
Update connection_string validation count from 1 to 4

### DIFF
--- a/azurerm/resource_arm_cosmos_db_account_test.go
+++ b/azurerm/resource_arm_cosmos_db_account_test.go
@@ -230,7 +230,7 @@ func TestAccAzureRMCosmosDBAccount_mongoDB(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAccAzureRMCosmosDBAccount_basic(resourceName, testLocation(), string(documentdb.BoundedStaleness), 1),
 					resource.TestCheckResourceAttr(resourceName, "kind", "MongoDB"),
-					resource.TestCheckResourceAttr(resourceName, "connection_strings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "connection_strings.#", "4"),
 				),
 			},
 			{


### PR DESCRIPTION
HI team,
This is because of that connection string split to two types of keys. So that update validation count to make test accurate.
Read-write Keys
Read-only Keys

Relation test:
testAccAzureRMCosmosDBAccount_mongoDB