### PR TITLE
New Resource/Data Source: `azurerm_api_management_product`

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -126,7 +126,8 @@ type ArmClient struct {
 	redisPatchSchedulesClient redis.PatchSchedulesClient
 
 	// API Management
-	apiManagementServiceClient apimanagement.ServiceClient
+	apiManagementProductsClient apimanagement.ProductClient
+	apiManagementServiceClient  apimanagement.ServiceClient
 
 	// Application Insights
 	appInsightsClient       appinsights.ComponentsClient
@@ -487,9 +488,13 @@ func getArmClient(c *authentication.Config, skipProviderRegistration bool, partn
 }
 
 func (c *ArmClient) registerApiManagementServiceClients(endpoint, subscriptionId string, auth autorest.Authorizer) {
-	ams := apimanagement.NewServiceClientWithBaseURI(endpoint, subscriptionId)
-	c.configureClient(&ams.Client, auth)
-	c.apiManagementServiceClient = ams
+	serviceClient := apimanagement.NewServiceClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&serviceClient.Client, auth)
+	c.apiManagementServiceClient = serviceClient
+
+	productsClient := apimanagement.NewProductClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&productsClient.Client, auth)
+	c.apiManagementProductsClient = productsClient
 }
 
 func (c *ArmClient) registerAppInsightsClients(endpoint, subscriptionId string, auth autorest.Authorizer) {

--- a/azurerm/data_source_api_management.go
+++ b/azurerm/data_source_api_management.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/apimanagement/mgmt/2018-06-01-preview/apimanagement"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -15,11 +15,7 @@ func dataSourceApiManagementService() *schema.Resource {
 		Read: dataSourceApiManagementRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validate.ApiManagementServiceName,
-			},
+			"name": azure.SchemaApiManagementDataSourceName(),
 
 			"resource_group_name": resourceGroupNameForDataSourceSchema(),
 

--- a/azurerm/data_source_api_management_product.go
+++ b/azurerm/data_source_api_management_product.go
@@ -14,10 +14,7 @@ func dataSourceApiManagementProduct() *schema.Resource {
 		Read: dataSourceApiManagementProductRead,
 
 		Schema: map[string]*schema.Schema{
-			"product_id": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
+			"product_id": azure.SchemaApiManagementProductDataSourceName(),
 
 			"api_management_name": azure.SchemaApiManagementDataSourceName(),
 

--- a/azurerm/data_source_api_management_product.go
+++ b/azurerm/data_source_api_management_product.go
@@ -1,0 +1,93 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/apimanagement/mgmt/2018-06-01-preview/apimanagement"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceApiManagementProduct() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceApiManagementProductRead,
+
+		Schema: map[string]*schema.Schema{
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"api_management_name": azure.SchemaApiManagementDataSourceName(),
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"subscription_required": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"approval_required": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"published": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"terms": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"subscriptions_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+func dataSourceApiManagementProductRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementProductsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("service_name").(string)
+	productId := d.Get("product_id").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, productId)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Product %q was not found in API Management Service %q / Resource Group %q", productId, serviceName, resourceGroup)
+		}
+
+		return fmt.Errorf("Error making Read request on Product %q (API Management Service %q / Resource Group %q): %+v", productId, serviceName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	if props := resp.ProductContractProperties; props != nil {
+		d.Set("approval_required", props.ApprovalRequired)
+		d.Set("description", props.Description)
+		d.Set("display_name", props.DisplayName)
+		d.Set("published", props.State == apimanagement.Published)
+		d.Set("subscriptions_limit", props.SubscriptionsLimit)
+		d.Set("subscription_required", props.SubscriptionRequired)
+		d.Set("terms", props.Terms)
+	}
+
+	return nil
+}

--- a/azurerm/data_source_api_management_product.go
+++ b/azurerm/data_source_api_management_product.go
@@ -62,7 +62,7 @@ func dataSourceApiManagementProductRead(d *schema.ResourceData, meta interface{}
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
-	serviceName := d.Get("service_name").(string)
+	serviceName := d.Get("api_management_name").(string)
 	productId := d.Get("product_id").(string)
 
 	resp, err := client.Get(ctx, resourceGroup, serviceName, productId)

--- a/azurerm/data_source_api_management_product_test.go
+++ b/azurerm/data_source_api_management_product_test.go
@@ -1,0 +1,76 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccDataSourceAzureRMApiManagementProduct_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_api_management_product.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceApiManagementProduct_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "product_id", "test-product"),
+					resource.TestCheckResourceAttr(dataSourceName, "display_name", "Test Product"),
+					resource.TestCheckResourceAttr(dataSourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "published", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "description", "This is an example description"),
+					resource.TestCheckResourceAttr(dataSourceName, "terms", "These are some example terms and conditions"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceApiManagementProduct_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "amtestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name            = "acctestAM-%d"
+  publisher_name  = "pub1"
+  publisher_email = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+
+resource "azurerm_api_management_product" "test" {
+  product_id            = "test-product"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  display_name          = "Test Product"
+  subscription_required = true
+  approval_required     = true
+  published             = true
+  description           = "This is an example description"
+  terms                 = "These are some example terms and conditions"
+}
+
+data "azurerm_api_management_product" "test" {
+  product_id          = "${azurerm_api_management_product.test.product_id}"
+  api_management_name = "${azurerm_api_management_product.test.api_management_name}"
+  resource_group_name = "${azurerm_api_management_product.test.resource_group_name}"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -21,3 +21,20 @@ func SchemaApiManagementDataSourceName() *schema.Schema {
 		ValidateFunc: validate.ApiManagementServiceName,
 	}
 }
+
+func SchemaApiManagementProductName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validate.ApiManagementProductName,
+	}
+}
+
+func SchemaApiManagementProductDataSourceName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validate.ApiManagementProductName,
+	}
+}

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -13,3 +13,11 @@ func SchemaApiManagementName() *schema.Schema {
 		ValidateFunc: validate.ApiManagementServiceName,
 	}
 }
+
+func SchemaApiManagementDataSourceName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validate.ApiManagementServiceName,
+	}
+}

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -1,0 +1,15 @@
+package azure
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+)
+
+func SchemaApiManagementName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validate.ApiManagementServiceName,
+	}
+}

--- a/azurerm/helpers/validate/api_management.go
+++ b/azurerm/helpers/validate/api_management.go
@@ -5,6 +5,17 @@ import (
 	"regexp"
 )
 
+func ApiManagementProductName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	// from the portal: `The field may contain only numbers, letters, and dash (-) sign when preceded and followed by number or a letter.`
+	if matched := regexp.MustCompile(`(^[a-zA-Z0-9])([a-zA-Z0-9-]{1,78})([a-zA-Z0-9]$)`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes up to 80 characters in length", k))
+	}
+
+	return warnings, errors
+}
+
 func ApiManagementServiceName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -99,6 +99,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"azurerm_api_management":                        dataSourceApiManagementService(),
+			"azurerm_api_management_product":                dataSourceApiManagementProduct(),
 			"azurerm_app_service_plan":                      dataSourceAppServicePlan(),
 			"azurerm_app_service":                           dataSourceArmAppService(),
 			"azurerm_application_insights":                  dataSourceArmApplicationInsights(),

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -164,6 +164,7 @@ func Provider() terraform.ResourceProvider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"azurerm_api_management":                         resourceArmApiManagementService(),
+			"azurerm_api_management_product":                 resourceArmApiManagementProduct(),
 			"azurerm_app_service_active_slot":                resourceArmAppServiceActiveSlot(),
 			"azurerm_app_service_custom_hostname_binding":    resourceArmAppServiceCustomHostnameBinding(),
 			"azurerm_app_service_plan":                       resourceArmAppServicePlan(),

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -34,12 +34,7 @@ func resourceArmApiManagementService() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.ApiManagementServiceName,
-			},
+			"name": azure.SchemaApiManagementName(),
 
 			"resource_group_name": resourceGroupNameSchema(),
 

--- a/azurerm/resource_arm_api_management_product.go
+++ b/azurerm/resource_arm_api_management_product.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -29,8 +30,9 @@ func resourceArmApiManagementProduct() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"display_name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 
 			"subscription_required": {
@@ -38,14 +40,14 @@ func resourceArmApiManagementProduct() *schema.Resource {
 				Required: true,
 			},
 
-			"approval_required": {
+			"published": {
 				Type:     schema.TypeBool,
 				Required: true,
 			},
 
-			"published": {
+			"approval_required": {
 				Type:     schema.TypeBool,
-				Required: true,
+				Optional: true,
 			},
 
 			"description": {

--- a/azurerm/resource_arm_api_management_product.go
+++ b/azurerm/resource_arm_api_management_product.go
@@ -103,7 +103,6 @@ func resourceArmApiManagementProductCreateUpdate(d *schema.ResourceData, meta in
 
 	properties := apimanagement.ProductContract{
 		ProductContractProperties: &apimanagement.ProductContractProperties{
-			ApprovalRequired:     utils.Bool(approvalRequired),
 			Description:          utils.String(description),
 			DisplayName:          utils.String(displayName),
 			State:                publishedVal,
@@ -112,8 +111,10 @@ func resourceArmApiManagementProductCreateUpdate(d *schema.ResourceData, meta in
 		},
 	}
 
-	// Can be present only if subscriptionRequired property is present and has a value of false.
-	if !subscriptionRequired && subscriptionsLimit > 0 {
+	// Swagger says: Can be present only if subscriptionRequired property is present and has a value of false.
+	// API/Portal says: Cannot provide values for approvalRequired and subscriptionsLimit when subscriptionRequired is set to false in the request payload
+	if subscriptionRequired && subscriptionsLimit > 0 {
+		properties.ProductContractProperties.ApprovalRequired = utils.Bool(approvalRequired)
 		properties.ProductContractProperties.SubscriptionsLimit = utils.Int32(int32(subscriptionsLimit))
 	}
 

--- a/azurerm/resource_arm_api_management_product.go
+++ b/azurerm/resource_arm_api_management_product.go
@@ -22,17 +22,7 @@ func resourceArmApiManagementProduct() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"product_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				/*
-					Constraints: []validation.Constraint{{Target: "productID", Name: validation.MaxLength, Rule: 80, Chain: nil},
-					{Target: "productID", Name: validation.MinLength, Rule: 1, Chain: nil},
-					{Target: "productID", Name: validation.Pattern, Rule: `(^[\w]+$)|(^[\w][\w\-]+[\w]$)`, Chain: nil}}},
-				*/
-				// TODO: validation
-			},
+			"product_id": azure.SchemaApiManagementProductName(),
 
 			"api_management_name": azure.SchemaApiManagementName(),
 

--- a/azurerm/resource_arm_api_management_product.go
+++ b/azurerm/resource_arm_api_management_product.go
@@ -1,0 +1,211 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/apimanagement/mgmt/2018-06-01-preview/apimanagement"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementProduct() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementProductCreateUpdate,
+		Read:   resourceArmApiManagementProductRead,
+		Update: resourceArmApiManagementProductCreateUpdate,
+		Delete: resourceArmApiManagementProductDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				/*
+					Constraints: []validation.Constraint{{Target: "productID", Name: validation.MaxLength, Rule: 80, Chain: nil},
+					{Target: "productID", Name: validation.MinLength, Rule: 1, Chain: nil},
+					{Target: "productID", Name: validation.Pattern, Rule: `(^[\w]+$)|(^[\w][\w\-]+[\w]$)`, Chain: nil}}},
+				*/
+				// TODO: validation
+			},
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"subscription_required": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+
+			"approval_required": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+
+			"published": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"terms": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"subscriptions_limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementProductCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementProductsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	log.Printf("[INFO] preparing arguments for API Management Product creation.")
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	productId := d.Get("product_id").(string)
+
+	displayName := d.Get("display_name").(string)
+	description := d.Get("description").(string)
+	terms := d.Get("terms").(string)
+	subscriptionRequired := d.Get("subscription_required").(bool)
+	approvalRequired := d.Get("approval_required").(bool)
+	subscriptionsLimit := d.Get("subscriptions_limit").(int)
+	published := d.Get("published").(bool)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, serviceName, productId)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Product %q (API Management Service %q / Resource Group %q): %s", productId, serviceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management_product", *existing.ID)
+		}
+	}
+	publishedVal := apimanagement.NotPublished
+	if published {
+		publishedVal = apimanagement.Published
+	}
+
+	properties := apimanagement.ProductContract{
+		ProductContractProperties: &apimanagement.ProductContractProperties{
+			ApprovalRequired:     utils.Bool(approvalRequired),
+			Description:          utils.String(description),
+			DisplayName:          utils.String(displayName),
+			State:                publishedVal,
+			SubscriptionRequired: utils.Bool(subscriptionRequired),
+			Terms:                utils.String(terms),
+		},
+	}
+
+	// Can be present only if subscriptionRequired property is present and has a value of false.
+	if !subscriptionRequired && subscriptionsLimit > 0 {
+		properties.ProductContractProperties.SubscriptionsLimit = utils.Int32(int32(subscriptionsLimit))
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, productId, properties, ""); err != nil {
+		return fmt.Errorf("Error creating/updating Product %q (API Management Service %q / Resource Group %q): %+v", productId, serviceName, resourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, resourceGroup, serviceName, productId)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Product %q (API Management Service %q / Resource Group %q): %+v", productId, serviceName, resourceGroup, err)
+	}
+
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read ID for Product %q (API Management Service %q / Resource Group %q)", productId, serviceName, resourceGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmApiManagementProductRead(d, meta)
+}
+
+func resourceArmApiManagementProductRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementProductsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	productId := id.Path["products"]
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, productId)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("Product %q was not found in API Management Service %q / Resource Group %q - removing from state!", productId, serviceName, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making Read request on Product %q (API Management Service %q / Resource Group %q): %+v", productId, serviceName, resourceGroup, err)
+	}
+
+	d.Set("product_id", productId)
+	d.Set("api_management_name", serviceName)
+	d.Set("resource_group_name", resourceGroup)
+
+	if props := resp.ProductContractProperties; props != nil {
+		d.Set("approval_required", props.ApprovalRequired)
+		d.Set("description", props.Description)
+		d.Set("display_name", props.DisplayName)
+		d.Set("published", props.State == apimanagement.Published)
+		d.Set("subscriptions_limit", props.SubscriptionsLimit)
+		d.Set("subscription_required", props.SubscriptionRequired)
+		d.Set("terms", props.Terms)
+	}
+
+	return nil
+}
+
+func resourceArmApiManagementProductDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementProductsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	productId := id.Path["products"]
+
+	log.Printf("[DEBUG] Deleting Product %q (API Management Service %q / Resource Grouo %q)", productId, serviceName, resourceGroup)
+	deleteSubscriptions := true
+	resp, err := client.Delete(ctx, resourceGroup, serviceName, productId, "", utils.Bool(deleteSubscriptions))
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error deleting Product %q (API Management Service %q / Resource Group %q): %+v", productId, serviceName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -1,0 +1,396 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMApiManagementProduct_basic(t *testing.T) {
+	resourceName := "azurerm_api_management_product.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementProductDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
+					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
+					resource.TestCheckResourceAttr(resourceName, "published", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "terms", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementProduct_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_api_management_product.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementProductDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMApiManagementProduct_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_api_management_product"),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementProductDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).apiManagementProductsClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_product" {
+			continue
+		}
+
+		productId := rs.Primary.Attributes["product_id"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := conn.Get(ctx, resourceGroup, serviceName, productId)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func TestAccAzureRMApiManagementProduct_update(t *testing.T) {
+	resourceName := "azurerm_api_management_product.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementProductDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
+					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
+					resource.TestCheckResourceAttr(resourceName, "published", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "terms", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAzureRMApiManagementProduct_updated(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Updated Product"),
+					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
+					resource.TestCheckResourceAttr(resourceName, "published", "false"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "terms", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
+					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
+					resource.TestCheckResourceAttr(resourceName, "published", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "terms", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementProduct_subscriptionlimits(t *testing.T) {
+	resourceName := "azurerm_api_management_product.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementProductDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementProduct_subscriptionLimits(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_limits", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementProduct_complete(t *testing.T) {
+	resourceName := "azurerm_api_management_product.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementProductDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementProduct_complete(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", "This is an example description"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
+					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
+					resource.TestCheckResourceAttr(resourceName, "published", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "terms", "These are some example terms and conditions"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementProductExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		productId := rs.Primary.Attributes["product_id"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		conn := testAccProvider.Meta().(*ArmClient).apiManagementProductsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := conn.Get(ctx, resourceGroup, serviceName, productId)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Product %q (API Management Service %q / Resource Group %q) does not exist", productId, serviceName, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on apiManagementProductsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApiManagementProduct_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+
+resource "azurerm_api_management_product" "test" {
+  product_id            = "test-product"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  display_name          = "Test Product"
+  subscription_required = true
+  approval_required     = true
+  published             = true
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMApiManagementProduct_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMApiManagementProduct_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_product" "import" {
+  product_id            = "${azurerm_api_management_product.test.product_id}"
+  api_management_name   = "${azurerm_api_management_product.test.api_management_name}"
+  resource_group_name   = "${azurerm_api_management_product.test.resource_group_name}"
+  display_name          = "${azurerm_api_management_product.test.display_name}"
+  subscription_required = "${azurerm_api_management_product.test.subscription_required}"
+  approval_required     = "${azurerm_api_management_product.test.approval_required}"
+  published             = "${azurerm_api_management_product.test.published}"
+}
+`, template)
+}
+
+func testAccAzureRMApiManagementProduct_updated(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+
+resource "azurerm_api_management_product" "test" {
+  product_id            = "test-product"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  display_name          = "Test Updated Product"
+  subscription_required = false
+  approval_required     = false
+  published             = false
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMApiManagementProduct_subscriptionLimits(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+
+resource "azurerm_api_management_product" "test" {
+  product_id            = "test-product"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  display_name          = "Test Product"
+  subscription_required = false
+  approval_required     = false
+  subscription_limits   = 2
+  published             = false
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMApiManagementProduct_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+
+resource "azurerm_api_management_product" "test" {
+  product_id            = "test-product"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  display_name          = "Test Product"
+  subscription_required = true
+  approval_required     = true
+  published             = true
+  description           = "This is an example description"
+  terms                 = "These are some example terms and conditions"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -24,12 +24,12 @@ func TestAccAzureRMApiManagementProduct_basic(t *testing.T) {
 				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementProductExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
 					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
-					resource.TestCheckResourceAttr(resourceName, "published", "true"),
-					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "published", "false"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "false"),
 					resource.TestCheckResourceAttr(resourceName, "terms", ""),
 				),
 			},
@@ -112,27 +112,9 @@ func TestAccAzureRMApiManagementProduct_update(t *testing.T) {
 				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementProductExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
-					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
-					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
-					resource.TestCheckResourceAttr(resourceName, "published", "true"),
-					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
-					resource.TestCheckResourceAttr(resourceName, "terms", ""),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccAzureRMApiManagementProduct_updated(ri, location),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMApiManagementProductExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "approval_required", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Updated Product"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
 					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
 					resource.TestCheckResourceAttr(resourceName, "published", "false"),
 					resource.TestCheckResourceAttr(resourceName, "subscription_required", "false"),
@@ -145,15 +127,33 @@ func TestAccAzureRMApiManagementProduct_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
+				Config: testAccAzureRMApiManagementProduct_updated(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementProductExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
-					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Updated Product"),
 					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
 					resource.TestCheckResourceAttr(resourceName, "published", "true"),
 					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "terms", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAzureRMApiManagementProduct_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementProductExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
+					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
+					resource.TestCheckResourceAttr(resourceName, "published", "false"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "false"),
 					resource.TestCheckResourceAttr(resourceName, "terms", ""),
 				),
 			},
@@ -208,6 +208,7 @@ func TestAccAzureRMApiManagementProduct_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Product"),
 					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
 					resource.TestCheckResourceAttr(resourceName, "published", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subscriptions_limit", "2"),
 					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
 					resource.TestCheckResourceAttr(resourceName, "terms", "These are some example terms and conditions"),
 				),
@@ -273,9 +274,8 @@ resource "azurerm_api_management_product" "test" {
   api_management_name   = "${azurerm_api_management.test.name}"
   resource_group_name   = "${azurerm_resource_group.test.name}"
   display_name          = "Test Product"
-  subscription_required = true
-  approval_required     = true
-  published             = true
+  subscription_required = false
+  published             = false
 }
 `, rInt, location, rInt)
 }
@@ -390,6 +390,7 @@ resource "azurerm_api_management_product" "test" {
   subscription_required = true
   approval_required     = true
   published             = true
+  subscriptions_limit   = 2
   description           = "This is an example description"
   terms                 = "These are some example terms and conditions"
 }

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -161,7 +161,7 @@ func TestAccAzureRMApiManagementProduct_update(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMApiManagementProduct_subscriptionlimits(t *testing.T) {
+func TestAccAzureRMApiManagementProduct_subscriptionsLimit(t *testing.T) {
 	resourceName := "azurerm_api_management_product.test"
 	ri := tf.AccRandTimeInt()
 	location := testLocation()
@@ -175,8 +175,9 @@ func TestAccAzureRMApiManagementProduct_subscriptionlimits(t *testing.T) {
 				Config: testAccAzureRMApiManagementProduct_subscriptionLimits(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementProductExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "subscription_required", "false"),
-					resource.TestCheckResourceAttr(resourceName, "subscription_limits", "2"),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "subscriptions_limit", "2"),
 				),
 			},
 			{
@@ -353,9 +354,9 @@ resource "azurerm_api_management_product" "test" {
   api_management_name   = "${azurerm_api_management.test.name}"
   resource_group_name   = "${azurerm_resource_group.test.name}"
   display_name          = "Test Product"
-  subscription_required = false
-  approval_required     = false
-  subscription_limits   = 2
+  subscription_required = true
+  approval_required     = true
+  subscriptions_limit   = 2
   published             = false
 }
 `, rInt, location, rInt)

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -130,7 +130,7 @@ func TestAccAzureRMApiManagementProduct_update(t *testing.T) {
 				Config: testAccAzureRMApiManagementProduct_updated(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementProductExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "approval_required", "false"),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Updated Product"),
 					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),
@@ -322,9 +322,9 @@ resource "azurerm_api_management_product" "test" {
   api_management_name   = "${azurerm_api_management.test.name}"
   resource_group_name   = "${azurerm_resource_group.test.name}"
   display_name          = "Test Updated Product"
-  subscription_required = false
-  approval_required     = false
-  published             = false
+  subscription_required = true
+  approval_required     = true
+  published             = true
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -130,7 +130,7 @@ func TestAccAzureRMApiManagementProduct_update(t *testing.T) {
 				Config: testAccAzureRMApiManagementProduct_updated(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementProductExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "approval_required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "approval_required", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "display_name", "Test Updated Product"),
 					resource.TestCheckResourceAttr(resourceName, "product_id", "test-product"),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -59,8 +59,11 @@
             <li<%= sidebar_current("docs-azurerm-datasource") %>>
               <a href="#">Data Sources</a>
               <ul class="nav nav-visible">
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management") %>>
+                <li<%= sidebar_current("docs-azurerm-datasource-api-management-x") %>>
                     <a href="/docs/providers/azurerm/d/api_management.html">azurerm_api_management</a>
+                </li>
+                <li<%= sidebar_current("docs-azurerm-datasource-api-management-product") %>>
+                    <a href="/docs/providers/azurerm/d/api_management_product.html">azurerm_api_management_product</a>
                 </li>
 
                 <li<%= sidebar_current("docs-azurerm-datasource-network-application-security-group") %>>

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -314,9 +314,15 @@
             <li<%= sidebar_current("docs-azurerm-resource-api-management") %>>
               <a href="#">API Management Resources</a>
               <ul class="nav nav-visible">
+
                 <li<%= sidebar_current("docs-azurerm-resource-api-management-x") %>>
                   <a href="/docs/providers/azurerm/r/api_management.html">azurerm_api_management</a>
                 </li>
+
+                <li<%= sidebar_current("docs-azurerm-resource-api-management-product") %>>
+                  <a href="/docs/providers/azurerm/r/api_management_product.html">azurerm_api_management_product</a>
+                </li>
+
               </ul>
             </li>
 

--- a/website/docs/d/api_management.html.markdown
+++ b/website/docs/d/api_management.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management"
-sidebar_current: "docs-azurerm-datasource-api-management"
+sidebar_current: "docs-azurerm-datasource-api-management-x"
 description: |-
   Gets information about an existing API Management Service.
 ---

--- a/website/docs/d/api_management_product.html.markdown
+++ b/website/docs/d/api_management_product.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_product"
+sidebar_current: "docs-azurerm-datasource-api-management-product"
+description: |-
+  Gets information about an existing API Management Product.
+---
+
+# Data Source: azurerm_api_management_product
+
+Use this data source to access information about an existing API Management Product.
+
+## Example Usage
+
+```hcl
+data "azurerm_api_management_product" "test" {
+  product_id          = "my-product"
+  api_management_name = "example-apim
+  resource_group_name = "search-service"
+}
+
+output "product_terms" {
+  value = "${data.azurerm_api_management_product.test.terms}"
+}
+```
+
+## Argument Reference
+
+* `api_management_name` - (Required) The Name of the API Management Service in which this Product exists.
+
+* `product_id` - (Required) The Identifier for the API Management Product.
+
+* `resource_group_name` - (Required) The Name of the Resource Group in which the API Management Service exists.
+
+## Attributes Reference
+
+* `id` - The ID of the API Management Product.
+
+* `approval_required` - Do subscribers need to be approved prior to being able to use the Product?
+
+* `display_name` - The Display Name for this API Management Product.
+
+* `published` - Is this Product Published?
+
+* `subscription_required` - Is a Subscription required to access API's included in this Product?
+
+* `description` - The description of this Product, which may include HTML formatting tags.
+
+* `subscriptions_limit` - The number of subscriptions a user can have to this Product at the same time.
+
+* `terms` - Any Terms and Conditions for this Product, which must be accepted by Developers before they can begin the Subscription process.

--- a/website/docs/r/api_management_product.html.markdown
+++ b/website/docs/r/api_management_product.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `api_management_name` - (Required) The name of the API Management Service. Changing this forces a new resource to be created.
 
-* `approval_required` - (Required) Do subscribers need to be approved prior to being able to use the Product?
+* `approval_required` - (Optional) Do subscribers need to be approved prior to being able to use the Product?
 
 -> **NOTE:** `approval_required` can only be set when `subscription_required` is set to `true`.
 

--- a/website/docs/r/api_management_product.html.markdown
+++ b/website/docs/r/api_management_product.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_product"
+sidebar_current: "docs-azurerm-resource-api-management-product"
+description: |-
+  Manages an API Management Product.
+---
+
+# azurerm_api_management_product
+
+Manages an API Management Product.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "example-apim"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+
+resource "azurerm_api_management_product" "test" {
+  product_id            = "test-product"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  display_name          = "Test Product"
+  subscription_required = true
+  approval_required     = true
+  published             = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `api_management_name` - (Required) The name of the API Management Service. Changing this forces a new resource to be created.
+
+* `approval_required` - (Required) Do subscribers need to be approved prior to being able to use the Product?
+
+* `display_name` - (Required) The Display Name for this API Management Product.
+
+* `product_id` - (Required) The Identifier for this Product, which must be unique within the API Management Service. Changing this forces a new resource to be created.
+
+* `published` - (Required) Is this Product Published?
+
+* `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service should be exist. Changing this forces a new resource to be created.
+
+* `subscription_required` - (Required) Is a Subscription required to access API's included in this Product?
+
+---
+
+* `description` - (Optional) A description of this Product, which may include HTML formatting tags.
+
+* `subscriptions_limit` - (Optional) The number of subscriptions a user can have to this Product at the same time.
+
+-> **NOTE:** `subscriptions_limit` can only be set when `subscription_required` is set to `false`. 
+
+* `terms` - (Optional) The Terms and Conditions for this Product, which must be accepted by Developers before they can begin the Subscription process.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the API Management Product.
+
+## Import
+
+API Management Products can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_product.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/products/myproduct
+```

--- a/website/docs/r/api_management_product.html.markdown
+++ b/website/docs/r/api_management_product.html.markdown
@@ -50,6 +50,8 @@ The following arguments are supported:
 
 * `approval_required` - (Required) Do subscribers need to be approved prior to being able to use the Product?
 
+-> **NOTE:** `approval_required` can only be set when `subscription_required` is set to `true`.
+
 * `display_name` - (Required) The Display Name for this API Management Product.
 
 * `product_id` - (Required) The Identifier for this Product, which must be unique within the API Management Service. Changing this forces a new resource to be created.
@@ -66,7 +68,7 @@ The following arguments are supported:
 
 * `subscriptions_limit` - (Optional) The number of subscriptions a user can have to this Product at the same time.
 
--> **NOTE:** `subscriptions_limit` can only be set when `subscription_required` is set to `false`. 
+-> **NOTE:** `subscriptions_limit` can only be set when `subscription_required` is set to `true`. 
 
 * `terms` - (Optional) The Terms and Conditions for this Product, which must be accepted by Developers before they can begin the Subscription process.
 


### PR DESCRIPTION
This PR adds support for creating Products within an API Management Service - both as a Resource and a Data Source.

Whilst the tests for this were working prior to the breaking API change, this is currently blocked on #2945