### PR TITLE
New Resource/Data Source: `azurerm_api_management_user`

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -129,6 +129,7 @@ type ArmClient struct {
 	apiManagementGroupClient    apimanagement.GroupClient
 	apiManagementProductsClient apimanagement.ProductClient
 	apiManagementServiceClient  apimanagement.ServiceClient
+	apiManagementUsersClient    apimanagement.UserClient
 
 	// Application Insights
 	appInsightsClient       appinsights.ComponentsClient
@@ -500,6 +501,10 @@ func (c *ArmClient) registerApiManagementServiceClients(endpoint, subscriptionId
 	productsClient := apimanagement.NewProductClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&productsClient.Client, auth)
 	c.apiManagementProductsClient = productsClient
+
+	usersClient := apimanagement.NewUserClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&usersClient.Client, auth)
+	c.apiManagementUsersClient = usersClient
 }
 
 func (c *ArmClient) registerAppInsightsClients(endpoint, subscriptionId string, auth autorest.Authorizer) {

--- a/azurerm/data_source_api_management_user.go
+++ b/azurerm/data_source_api_management_user.go
@@ -1,0 +1,78 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmApiManagementUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmApiManagementUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"user_id": azure.SchemaApiManagementUserDataSourceName(),
+
+			"api_management_name": azure.SchemaApiManagementDataSourceName(),
+
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
+
+			"first_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"last_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"email": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"note": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementUsersClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	userId := d.Get("user_id").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, userId)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("User %q was not found in API Management Service %q / Resource Group %q", userId, serviceName, resourceGroup)
+		}
+
+		return fmt.Errorf("Error making Read request on User %q (API Management Service %q / Resource Group %q): %+v", userId, serviceName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	if props := resp.UserContractProperties; props != nil {
+		d.Set("first_name", props.FirstName)
+		d.Set("last_name", props.LastName)
+		d.Set("email", props.Email)
+		d.Set("note", props.Note)
+		d.Set("state", string(props.State))
+	}
+
+	return nil
+}

--- a/azurerm/data_source_api_management_user.go
+++ b/azurerm/data_source_api_management_user.go
@@ -24,22 +24,22 @@ func dataSourceArmApiManagementUser() *schema.Resource {
 				Computed: true,
 			},
 
-			"last_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"email": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"state": {
+			"last_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
 			"note": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/azurerm/data_source_api_management_user_test.go
+++ b/azurerm/data_source_api_management_user_test.go
@@ -1,0 +1,74 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccDataSourceAzureRMApiManagementUser_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_api_management_user.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceApiManagementUser_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "user_id", "test-user"),
+					resource.TestCheckResourceAttr(dataSourceName, "first_name", "Acceptance"),
+					resource.TestCheckResourceAttr(dataSourceName, "last_name", "Test"),
+					resource.TestCheckResourceAttr(dataSourceName, "email", fmt.Sprintf("azure-acctest%d@hashicorptest.com", rInt)),
+					resource.TestCheckResourceAttr(dataSourceName, "state", "active"),
+					resource.TestCheckResourceAttr(dataSourceName, "notes", "Used for testing in dimension C-137."),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceApiManagementUser_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "amtestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name            = "acctestAM-%d"
+  publisher_name  = "pub1"
+  publisher_email = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "test-user"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance"
+  last_name             = "Test"
+  email                 = "azure-acctest%d@hashicorptest.com"
+  state                 = "active"
+  notes                 = "Used for testing in dimension C-137."
+}
+
+data "azurerm_api_management_user" "test" {
+  user_id             = "${azurerm_api_management_user.test.user_id}"
+  api_management_name = "${azurerm_api_management_user.test.api_management_name}"
+  resource_group_name = "${azurerm_api_management_user.test.resource_group_name}"
+}
+`, rInt, location, rInt, rInt)
+}

--- a/azurerm/data_source_api_management_user_test.go
+++ b/azurerm/data_source_api_management_user_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceAzureRMApiManagementUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "last_name", "Test"),
 					resource.TestCheckResourceAttr(dataSourceName, "email", fmt.Sprintf("azure-acctest%d@hashicorptest.com", rInt)),
 					resource.TestCheckResourceAttr(dataSourceName, "state", "active"),
-					resource.TestCheckResourceAttr(dataSourceName, "notes", "Used for testing in dimension C-137."),
+					resource.TestCheckResourceAttr(dataSourceName, "note", "Used for testing in dimension C-137."),
 				),
 			},
 		},
@@ -62,7 +62,7 @@ resource "azurerm_api_management_user" "test" {
   last_name             = "Test"
   email                 = "azure-acctest%d@hashicorptest.com"
   state                 = "active"
-  notes                 = "Used for testing in dimension C-137."
+  note                  = "Used for testing in dimension C-137."
 }
 
 data "azurerm_api_management_user" "test" {

--- a/azurerm/data_source_api_management_user_test.go
+++ b/azurerm/data_source_api_management_user_test.go
@@ -60,7 +60,7 @@ resource "azurerm_api_management_user" "test" {
   resource_group_name   = "${azurerm_resource_group.test.name}"
   first_name            = "Acceptance"
   last_name             = "Test"
-  email                 = "azure-acctest%d@hashicorptest.com"
+  email                 = "azure-acctest%d@example.com"
   state                 = "active"
   note                  = "Used for testing in dimension C-137."
 }

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -42,3 +42,12 @@ func SchemaApiManagementChildDataSourceName() *schema.Schema {
 		ValidateFunc: validate.ApiManagementChildName,
 	}
 }
+
+func SchemaApiManagementUserName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validate.ApiManagementUserName,
+	}
+}

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -51,3 +51,11 @@ func SchemaApiManagementUserName() *schema.Schema {
 		ValidateFunc: validate.ApiManagementUserName,
 	}
 }
+
+func SchemaApiManagementUserDataSourceName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validate.ApiManagementUserName,
+	}
+}

--- a/azurerm/helpers/validate/api_management.go
+++ b/azurerm/helpers/validate/api_management.go
@@ -26,6 +26,19 @@ func ApiManagementServiceName(v interface{}, k string) (warnings []string, error
 	return warnings, errors
 }
 
+func ApiManagementUserName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	// TODO: confirm this
+
+	// from the portal: `The field may contain only numbers, letters, and dash (-) sign when preceded and followed by number or a letter.`
+	if matched := regexp.MustCompile(`(^[a-zA-Z0-9])([a-zA-Z0-9-]{1,78})([a-zA-Z0-9]$)`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes up to 80 characters in length", k))
+	}
+
+	return warnings, errors
+}
+
 func ApiManagementServicePublisherName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -168,6 +168,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_api_management":                         resourceArmApiManagementService(),
 			"azurerm_api_management_group":                   resourceArmApiManagementGroup(),
 			"azurerm_api_management_product":                 resourceArmApiManagementProduct(),
+			"azurerm_api_management_user":                    resourceArmApiManagementUser(),
 			"azurerm_app_service_active_slot":                resourceArmAppServiceActiveSlot(),
 			"azurerm_app_service_custom_hostname_binding":    resourceArmAppServiceCustomHostnameBinding(),
 			"azurerm_app_service_plan":                       resourceArmAppServicePlan(),

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -101,6 +101,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_api_management":                        dataSourceApiManagementService(),
 			"azurerm_api_management_group":                  dataSourceApiManagementGroup(),
 			"azurerm_api_management_product":                dataSourceApiManagementProduct(),
+			"azurerm_api_management_user":                   dataSourceArmApiManagementUser(),
 			"azurerm_app_service_plan":                      dataSourceAppServicePlan(),
 			"azurerm_app_service":                           dataSourceArmAppService(),
 			"azurerm_application_insights":                  dataSourceArmApplicationInsights(),

--- a/azurerm/resource_arm_api_management_user.go
+++ b/azurerm/resource_arm_api_management_user.go
@@ -1,0 +1,218 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/apimanagement/mgmt/2018-06-01-preview/apimanagement"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementUserCreateUpdate,
+		Read:   resourceArmApiManagementUserRead,
+		Update: resourceArmApiManagementUserCreateUpdate,
+		Delete: resourceArmApiManagementUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"user_id": azure.SchemaApiManagementUserName(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"first_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"last_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"email": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(apimanagement.UserStateActive),
+					string(apimanagement.UserStateBlocked),
+					string(apimanagement.UserStatePending),
+				}, false),
+			},
+
+			"confirmation": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(apimanagement.Invite),
+					string(apimanagement.Signup),
+				}, false),
+			},
+
+			"note": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementUserCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementUsersClient
+	ctx := meta.(*ArmClient).StopContext
+
+	log.Printf("[INFO] preparing arguments for API Management User creation.")
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	userId := d.Get("user_id").(string)
+
+	firstName := d.Get("first_name").(string)
+	lastName := d.Get("last_name").(string)
+	email := d.Get("email").(string)
+	state := d.Get("state").(string)
+	note := d.Get("note").(string)
+	password := d.Get("password").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, serviceName, userId)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing User %q (API Management Service %q / Resource Group %q): %s", userId, serviceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management_user", *existing.ID)
+		}
+	}
+
+	properties := apimanagement.UserCreateParameters{
+		UserCreateParameterProperties: &apimanagement.UserCreateParameterProperties{
+			FirstName: utils.String(firstName),
+			LastName:  utils.String(lastName),
+			Email:     utils.String(email),
+		},
+	}
+
+	confirmation := d.Get("confirmation").(string)
+	if confirmation != "" {
+		properties.UserCreateParameterProperties.Confirmation = apimanagement.Confirmation(confirmation)
+	}
+	if note != "" {
+		properties.UserCreateParameterProperties.Note = utils.String(note)
+	}
+	if password != "" {
+		properties.UserCreateParameterProperties.Password = utils.String(password)
+	}
+	if state != "" {
+		properties.UserCreateParameterProperties.State = apimanagement.UserState(state)
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, userId, properties, ""); err != nil {
+		return fmt.Errorf("Error creating/updating User %q (API Management Service %q / Resource Group %q): %+v", userId, serviceName, resourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, resourceGroup, serviceName, userId)
+	if err != nil {
+		return fmt.Errorf("Error retrieving User %q (API Management Service %q / Resource Group %q): %+v", userId, serviceName, resourceGroup, err)
+	}
+
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read ID for User %q (API Management Service %q / Resource Group %q)", userId, serviceName, resourceGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmApiManagementUserRead(d, meta)
+}
+
+func resourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementUsersClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	userId := id.Path["users"]
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, userId)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("User %q was not found in API Management Service %q / Resource Group %q - removing from state!", userId, serviceName, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making Read request on User %q (API Management Service %q / Resource Group %q): %+v", userId, serviceName, resourceGroup, err)
+	}
+
+	d.Set("user_id", userId)
+	d.Set("api_management_name", serviceName)
+	d.Set("resource_group_name", resourceGroup)
+
+	if props := resp.UserContractProperties; props != nil {
+		d.Set("first_name", props.FirstName)
+		d.Set("last_name", props.LastName)
+		d.Set("email", props.Email)
+		d.Set("note", props.Note)
+		d.Set("state", string(props.State))
+	}
+
+	return nil
+}
+
+func resourceArmApiManagementUserDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementUsersClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	userId := id.Path["users"]
+
+	log.Printf("[DEBUG] Deleting User %q (API Management Service %q / Resource Grouo %q)", userId, serviceName, resourceGroup)
+	deleteSubscriptions := utils.Bool(true)
+	notify := utils.Bool(false)
+	resp, err := client.Delete(ctx, resourceGroup, serviceName, userId, "", deleteSubscriptions, notify)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error deleting User %q (API Management Service %q / Resource Group %q): %+v", userId, serviceName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_api_management_user.go
+++ b/azurerm/resource_arm_api_management_user.go
@@ -36,27 +36,16 @@ func resourceArmApiManagementUser() *schema.Resource {
 				ValidateFunc: validate.NoEmptyStrings,
 			},
 
-			"last_name": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validate.NoEmptyStrings,
-			},
-
 			"email": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validate.NoEmptyStrings,
 			},
 
-			"state": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(apimanagement.UserStateActive),
-					string(apimanagement.UserStateBlocked),
-					string(apimanagement.UserStatePending),
-				}, false),
+			"last_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 
 			"confirmation": {
@@ -78,6 +67,17 @@ func resourceArmApiManagementUser() *schema.Resource {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(apimanagement.UserStateActive),
+					string(apimanagement.UserStateBlocked),
+					string(apimanagement.UserStatePending),
+				}, false),
 			},
 		},
 	}

--- a/azurerm/resource_arm_api_management_user.go
+++ b/azurerm/resource_arm_api_management_user.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/apimanagement/mgmt/2018-06-01-preview/apimanagement"
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimanagement"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/resource_arm_api_management_user_test.go
+++ b/azurerm/resource_arm_api_management_user_test.go
@@ -1,0 +1,420 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMApiManagementUser_basic(t *testing.T) {
+	resourceName := "azurerm_api_management_user.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementUser_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "Acceptance"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementUser_requiresImport(t *testing.T) {
+	resourceName := "azurerm_api_management_user.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementUser_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMApiManagementUser_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_api_management_user"),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementUser_update(t *testing.T) {
+	resourceName := "azurerm_api_management_user.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementUser_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "Acceptance"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Test"),
+					resource.TestCheckResourceAttr(resourceName, "state", "pending"),
+				),
+			},
+			{
+				Config: testAccAzureRMApiManagementUser_updated(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "Acceptance Updated"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Test Updated"),
+					resource.TestCheckResourceAttr(resourceName, "state", "active"),
+				),
+			},
+			{
+				Config: testAccAzureRMApiManagementUser_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "Acceptance"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Test"),
+					resource.TestCheckResourceAttr(resourceName, "state", "pending"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementUser_password(t *testing.T) {
+	resourceName := "azurerm_api_management_user.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementUser_password(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "Acceptance"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementUser_invite(t *testing.T) {
+	resourceName := "azurerm_api_management_user.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementUser_invited(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// not returned
+					"confirmation",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementUser_signup(t *testing.T) {
+	resourceName := "azurerm_api_management_user.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementUser_signUp(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// not returned
+					"confirmation",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementUser_complete(t *testing.T) {
+	resourceName := "azurerm_api_management_user.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementUser_complete(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "Acceptance"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "Test"),
+					resource.TestCheckResourceAttr(resourceName, "note", "Used for testing in dimension C-137."),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// not returned
+					"confirmation",
+				},
+			},
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementUserDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).apiManagementUsersClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_user" {
+			continue
+		}
+
+		userId := rs.Primary.Attributes["user_id"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := conn.Get(ctx, resourceGroup, serviceName, userId)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testCheckAzureRMApiManagementUserExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		userId := rs.Primary.Attributes["user_id"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		conn := testAccProvider.Meta().(*ArmClient).apiManagementUsersClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := conn.Get(ctx, resourceGroup, serviceName, userId)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: User %q (API Management Service %q / Resource Group %q) does not exist", userId, serviceName, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on apiManagementUsersClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApiManagementUser_basic(rInt int, location string) string {
+	template := testAccAzureRMApiManagementUser_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "acctestuser%d"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance"
+  last_name             = "Test"
+  email                 = "azure-acctest%d@hashicorptest.com"
+}
+`, template, rInt, rInt)
+}
+
+func testAccAzureRMApiManagementUser_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMApiManagementUser_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "import" {
+  user_id               = "${azurerm_api_management_user.test.user_id}"
+  api_management_name   = "${azurerm_api_management_user.test.api_management_name}"
+  resource_group_name   = "${azurerm_api_management_user.test.resource_group_name}"
+  first_name            = "${azurerm_api_management_user.test.first_name}"
+  last_name             = "${azurerm_api_management_user.test.last_name}"
+  email                 = "${azurerm_api_management_user.test.email}"
+  state                 = "${azurerm_api_management_user.test.state}"
+}
+`, template)
+}
+
+func testAccAzureRMApiManagementUser_password(rInt int, location string) string {
+	template := testAccAzureRMApiManagementUser_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "acctestuser%d"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance"
+  last_name             = "Test"
+  email                 = "azure-acctest%d@hashicorptest.com"
+  state                 = "active"
+  password              = "3991bb15-282d-4b9b-9de3-3d5fc89eb530"
+}
+`, template, rInt, rInt)
+}
+
+func testAccAzureRMApiManagementUser_updated(rInt int, location string) string {
+	template := testAccAzureRMApiManagementUser_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "acctestuser%d"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance Updated"
+  last_name             = "Test Updated"
+  email                 = "azure-acctest%d@hashicorptest.com"
+  state                 = "blocked"
+}
+`, template, rInt, rInt)
+}
+
+func testAccAzureRMApiManagementUser_invited(rInt int, location string) string {
+	template := testAccAzureRMApiManagementUser_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "acctestuser%d"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance"
+  last_name             = "Test User"
+  email                 = "azure-acctest%d@hashicorptest.com"
+  state                 = "blocked"
+  confirmation          = "invite"
+}
+`, template, rInt, rInt)
+}
+
+func testAccAzureRMApiManagementUser_signUp(rInt int, location string) string {
+	template := testAccAzureRMApiManagementUser_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "acctestuser%d"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance"
+  last_name             = "Test User"
+  email                 = "azure-acctest%d@hashicorptest.com"
+  state                 = "blocked"
+  confirmation          = "signup"
+}
+`, template, rInt, rInt)
+}
+
+func testAccAzureRMApiManagementUser_complete(rInt int, location string) string {
+	template := testAccAzureRMApiManagementUser_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "acctestuser%d"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance"
+  last_name             = "Test"
+  email                 = "azure-acctest%d@hashicorptest.com"
+  state                 = "active"
+  confirmation          = "signup"
+  notes                 = "Used for testing in dimension C-137."
+}
+`, template, rInt, rInt)
+}
+
+func testAccAzureRMApiManagementUser_template(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/resource_arm_api_management_user_test.go
+++ b/azurerm/resource_arm_api_management_user_test.go
@@ -285,7 +285,7 @@ resource "azurerm_api_management_user" "test" {
   resource_group_name   = "${azurerm_resource_group.test.name}"
   first_name            = "Acceptance"
   last_name             = "Test"
-  email                 = "azure-acctest%d@hashicorptest.com"
+  email                 = "azure-acctest%d@example.com"
 }
 `, template, rInt, rInt)
 }
@@ -318,7 +318,7 @@ resource "azurerm_api_management_user" "test" {
   resource_group_name   = "${azurerm_resource_group.test.name}"
   first_name            = "Acceptance"
   last_name             = "Test"
-  email                 = "azure-acctest%d@hashicorptest.com"
+  email                 = "azure-acctest%d@example.com"
   state                 = "active"
   password              = "3991bb15-282d-4b9b-9de3-3d5fc89eb530"
 }
@@ -336,7 +336,7 @@ resource "azurerm_api_management_user" "test" {
   resource_group_name   = "${azurerm_resource_group.test.name}"
   first_name            = "Acceptance Updated"
   last_name             = "Test Updated"
-  email                 = "azure-acctest%d@hashicorptest.com"
+  email                 = "azure-acctest%d@example.com"
   state                 = "blocked"
 }
 `, template, rInt, rInt)
@@ -353,7 +353,7 @@ resource "azurerm_api_management_user" "test" {
   resource_group_name   = "${azurerm_resource_group.test.name}"
   first_name            = "Acceptance"
   last_name             = "Test User"
-  email                 = "azure-acctest%d@hashicorptest.com"
+  email                 = "azure-acctest%d@example.com"
   state                 = "blocked"
   confirmation          = "invite"
 }
@@ -371,7 +371,7 @@ resource "azurerm_api_management_user" "test" {
   resource_group_name   = "${azurerm_resource_group.test.name}"
   first_name            = "Acceptance"
   last_name             = "Test User"
-  email                 = "azure-acctest%d@hashicorptest.com"
+  email                 = "azure-acctest%d@example.com"
   state                 = "blocked"
   confirmation          = "signup"
 }
@@ -389,7 +389,7 @@ resource "azurerm_api_management_user" "test" {
   resource_group_name   = "${azurerm_resource_group.test.name}"
   first_name            = "Acceptance"
   last_name             = "Test"
-  email                 = "azure-acctest%d@hashicorptest.com"
+  email                 = "azure-acctest%d@example.com"
   state                 = "active"
   confirmation          = "signup"
   note                  = "Used for testing in dimension C-137."

--- a/azurerm/resource_arm_api_management_user_test.go
+++ b/azurerm/resource_arm_api_management_user_test.go
@@ -392,7 +392,7 @@ resource "azurerm_api_management_user" "test" {
   email                 = "azure-acctest%d@hashicorptest.com"
   state                 = "active"
   confirmation          = "signup"
-  notes                 = "Used for testing in dimension C-137."
+  note                  = "Used for testing in dimension C-137."
 }
 `, template, rInt, rInt)
 }

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -71,6 +71,10 @@
                     <a href="/docs/providers/azurerm/d/api_management_product.html">azurerm_api_management_product</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-api-management-user") %>>
+                    <a href="/docs/providers/azurerm/d/api_management_user.html">azurerm_api_management_user</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-network-application-security-group") %>>
                     <a href="/docs/providers/azurerm/d/application_security_group.html">azurerm_application_security_group</a>
                 </li>

--- a/website/docs/d/api_management_user.html.markdown
+++ b/website/docs/d/api_management_user.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_user"
+sidebar_current: "docs-azurerm-datasource-api-management-user"
+description: |-
+  Gets information about an existing API Management User.
+---
+
+# Data Source: azurerm_api_management_user
+
+Use this data source to access information about an existing API Management User.
+
+## Example Usage
+
+```hcl
+data "azurerm_api_management_user" "test" {
+  user_id             = "my-user"
+  api_management_name = "example-apim
+  resource_group_name = "search-service"
+}
+
+output "notes" {
+  value = "${data.azurerm_api_management_user.test.notes}"
+}
+```
+
+## Argument Reference
+
+* `api_management_name` - (Required) The Name of the API Management Service in which this User exists.
+
+* `resource_group_name` - (Required) The Name of the Resource Group in which the API Management Service exists.
+
+* `user_id` - (Required) The Identifier for the User.
+
+## Attributes Reference
+
+* `id` - The ID of the API Management User.
+
+* `first_name` - The First Name for the User.
+
+* `last_name` - The Last Name for the User.
+
+* `email` - The Email Address used for this User.
+
+* `note` - Any notes about this User.
+
+* `state` - The current state of this User, for example `active`, `blocked` or `pending`.

--- a/website/docs/r/api_management_user.html.markdown
+++ b/website/docs/r/api_management_user.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_user"
+sidebar_current: "docs-azurerm-resource-api-management-user"
+description: |-
+  Manages an API Management User.
+---
+
+# azurerm_api_management_user
+
+Manages an API Management User.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "example-apim"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "5931a75ae4bbd512288c680b"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Example"
+  last_name             = "User"
+  email                 = "tom+tfdev@hashicorp.com"
+  state                 = "active"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+* `api_management_name` - (Required) The name of the API Management Service in which the User should be created. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service exists. Changing this forces a new resource to be created.
+
+* `email` - (Required) The email address associated with this user.
+
+* `first_name` - (Required) The first name for this user.
+
+* `last_name` - (Required) The last name for this user.
+
+* `user_id` - (Required) The Identifier for this User, which must be unique within the API Management Service. Changing this forces a new resource to be created.
+
+---
+
+* `confirmation` - (Optional) The kind of confirmation email which will be sent to this user. Possible values are `invite` and `signup`. Changing this forces a new resource to be created.
+
+* `note` - (Optional) A note about this user.
+
+* `password` - (Optional) The password associated with this user.
+
+* `state` - (Optional) The state of this user. Possible values are `active`, `blocked` and `pending`.
+
+-> **NOTE:** the State can be changed from Pending -> Active/Blocked but not from Active/Blocked -> Pending. 
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the API Management User.
+
+## Import
+
+API Management Users can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_user.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/users/abc123
+```


### PR DESCRIPTION
This PR adds support for creating Users inside an API Management Service, which is dependent on #2953.

Whilst the tests for this were working prior to the breaking API change, this is currently also blocked on #2945