### PR TITLE
r/shared_image_gallery: documenting the `unique_name` field

### DIFF
--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -54,6 +54,8 @@ The following attributes are exported:
 
 * `id` - The ID of the Shared Image Gallery.
 
+* `unique_name` - The Unique Name for this Shared Image Gallery.
+
 ## Import
 
 Shared Image Galleries can be imported using the `resource id`, e.g.


### PR DESCRIPTION
Noticed this was missing when passing through