### PR TITLE
App Service: adding an example of a Node.JS app

### DIFF
--- a/examples/app-service/linux-nodejs/README.md
+++ b/examples/app-service/linux-nodejs/README.md
@@ -1,0 +1,3 @@
+# Example: a Linux App Service with Node.JS
+
+This example provisions a basic Linux App Service configured for a Node.JS app.

--- a/examples/app-service/linux-nodejs/main.tf
+++ b/examples/app-service/linux-nodejs/main.tf
@@ -1,0 +1,32 @@
+provider "azurerm" {
+  # if you're using a Service Principal (shared account) then either set the environment variables, or fill these in:  # subscription_id = "..."  # client_id       = "..."  # client_secret   = "..."  # tenant_id       = "..."
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_app_service_plan" "main" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  kind                = "Linux"
+  reserved            = true
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "main" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.main.location}"
+  resource_group_name = "${azurerm_resource_group.main.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.main.id}"
+
+  site_config {
+    linux_fx_version = "NODE|10.14"
+  }
+}

--- a/examples/app-service/linux-nodejs/outputs.tf
+++ b/examples/app-service/linux-nodejs/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_name" {
+  value = "${azurerm_app_service.main.name}"
+}
+
+output "app_service_default_hostname" {
+  value = "https://${azurerm_app_service.main.default_site_hostname}"
+}

--- a/examples/app-service/linux-nodejs/variables.tf
+++ b/examples/app-service/linux-nodejs/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}


### PR DESCRIPTION
This PR adds an example of provisioning an App Service which supports Node.JS

This supersedes #2684 - since it appears this is possible to configure using the `linux_fx_version` parameter.