### PR TITLE
AKS : Advanced Networking / Calico Network Policy

### DIFF
--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -618,7 +618,7 @@ func flattenKubernetesClusterDataSourceNetworkProfile(profile *containerservice.
 	values["network_plugin"] = profile.NetworkPlugin
 
 	if profile.NetworkPolicy != "" {
-		values["network_policy"] = profile.NetworkPolicy
+		values["network_policy"] = string(profile.NetworkPolicy)
 	}
 
 	if profile.ServiceCidr != nil {

--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -249,6 +249,11 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 							Computed: true,
 						},
 
+						"network_policy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"service_cidr": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -611,6 +616,10 @@ func flattenKubernetesClusterDataSourceNetworkProfile(profile *containerservice.
 	values := make(map[string]interface{})
 
 	values["network_plugin"] = profile.NetworkPlugin
+
+	if profile.NetworkPolicy != "" {
+		values["network_policy"] = profile.NetworkPolicy
+	}
 
 	if profile.ServiceCidr != nil {
 		values["service_cidr"] = *profile.ServiceCidr

--- a/azurerm/data_source_kubernetes_cluster_test.go
+++ b/azurerm/data_source_kubernetes_cluster_test.go
@@ -152,6 +152,36 @@ func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzure(t *testin
 		},
 	})
 }
+func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicy(t *testing.T) {
+	dataSourceName := "data.azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	location := testLocation()
+	config := testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicy(ri, clientId, clientSecret, location)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agent_pool_profile.0.vnet_subnet_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_profile.0.network_plugin", "azure"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_profile.0.network_policy", "calico"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.network_plugin"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.network_policy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.dns_service_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.docker_bridge_cidr"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.service_cidr"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t *testing.T) {
 	dataSourceName := "data.azurerm_kubernetes_cluster.test"
@@ -173,6 +203,37 @@ func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t
 					resource.TestCheckResourceAttrSet(dataSourceName, "agent_pool_profile.0.vnet_subnet_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "network_profile.0.network_plugin", "azure"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.network_plugin"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.dns_service_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.docker_bridge_cidr"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.service_cidr"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete(t *testing.T) {
+	dataSourceName := "data.azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	location := testLocation()
+	config := testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete(ri, clientId, clientSecret, location)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agent_pool_profile.0.vnet_subnet_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_profile.0.network_plugin", "azure"),
+					resource.TestCheckResourceAttr(dataSourceName, "network_profile.0.network_policy", "calico"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.network_plugin"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.network_policy"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.dns_service_ip"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.docker_bridge_cidr"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "network_profile.0.service_cidr"),
@@ -354,8 +415,32 @@ data "azurerm_kubernetes_cluster" "test" {
 `, r)
 }
 
+func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicy(rInt int, clientId string, clientSecret string, location string) string {
+	r := testAccAzureRMKubernetesCluster_advancedNetworkingWithPolicy(rInt, clientId, clientSecret, location, "azure", "calico")
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = "${azurerm_kubernetes_cluster.test.name}"
+  resource_group_name = "${azurerm_kubernetes_cluster.test.resource_group_name}"
+}
+`, r)
+}
+
 func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureComplete(rInt int, clientId string, clientSecret string, location string) string {
 	r := testAccAzureRMKubernetesCluster_advancedNetworkingComplete(rInt, clientId, clientSecret, location, "azure")
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = "${azurerm_kubernetes_cluster.test.name}"
+  resource_group_name = "${azurerm_kubernetes_cluster.test.resource_group_name}"
+}
+`, r)
+}
+
+func testAccDataSourceAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete(rInt int, clientId string, clientSecret string, location string) string {
+	r := testAccAzureRMKubernetesCluster_advancedNetworkingWithPolicyComplete(rInt, clientId, clientSecret, location, "azure", "calico")
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -43,12 +43,6 @@ func resourceArmKubernetesCluster() *schema.Resource {
 					return nil
 				}
 
-				networkPolicy := profile["network_policy"].(string)
-
-				if networkPolicy != "calico" {
-					return nil
-				}
-
 				dockerBridgeCidr := profile["docker_bridge_cidr"].(string)
 				dnsServiceIP := profile["dns_service_ip"].(string)
 				serviceCidr := profile["service_cidr"].(string)
@@ -1069,7 +1063,7 @@ func flattenKubernetesClusterNetworkProfile(profile *containerservice.NetworkPro
 	values["network_plugin"] = profile.NetworkPlugin
 
 	if profile.NetworkPolicy != "" {
-		values["network_policy"] = profile.NetworkPolicy
+		values["network_policy"] = string(profile.NetworkPolicy)
 	}
 
 	if profile.ServiceCidr != nil {

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -1224,7 +1224,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   network_profile {
     network_plugin = "%s"
-		network_policy = "%s"
+    network_policy = "%s"
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkPlugin, networkPolicy)
@@ -1301,8 +1301,8 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 
   network_profile {
-		network_plugin     = "%s"
-		network_policy     = "%s"
+    network_plugin     = "%s"
+    network_policy     = "%s"
     dns_service_ip     = "10.10.0.10"
     docker_bridge_cidr = "172.18.0.1/16"
     service_cidr       = "10.10.0.0/16"

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -452,6 +452,54 @@ func TestAccAzureRMKubernetesCluster_advancedNetworkingAzureComplete(t *testing.
 	})
 }
 
+func TestAccAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicy(t *testing.T) {
+	resourceName := "azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingWithPolicy(ri, clientId, clientSecret, testLocation(), "azure", "calico")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "network_profile.0.network_plugin", "azure"),
+					resource.TestCheckResourceAttr(resourceName, "network_profile.0.network_policy", "calico"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMKubernetesCluster_advancedNetworkingAzureCalicoPolicyComplete(t *testing.T) {
+	resourceName := "azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMKubernetesCluster_advancedNetworkingWithPolicyComplete(ri, clientId, clientSecret, testLocation(), "azure", "calico")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "network_profile.0.network_plugin", "azure"),
+					resource.TestCheckResourceAttr(resourceName, "network_profile.0.network_policy", "calico"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMKubernetesClusterExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -1121,4 +1169,144 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkPlugin)
+}
+
+func testAccAzureRMKubernetesCluster_advancedNetworkingWithPolicy(rInt int, clientId string, clientSecret string, location string, networkPlugin string, networkPolicy string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.1.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  tags {
+    environment = "Testing"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.1.0.0/24"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  agent_pool_profile {
+    name           = "default"
+    count          = "2"
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  service_principal {
+    client_id     = "%s"
+    client_secret = "%s"
+  }
+
+  network_profile {
+    network_plugin = "%s"
+		network_policy = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkPlugin, networkPolicy)
+}
+
+func testAccAzureRMKubernetesCluster_advancedNetworkingWithPolicyComplete(rInt int, clientId string, clientSecret string, location string, networkPlugin string, networkPolicy string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "akc-routetable-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  route {
+    name                   = "akc-route-%d"
+    address_prefix         = "10.100.0.0/14"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.1.1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.1.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  tags {
+    environment = "Testing"
+  }
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.1.0.0/24"
+  route_table_id       = "${azurerm_route_table.test.id}"
+}
+
+resource "azurerm_subnet_route_table_association" "test" {
+  subnet_id      = "${azurerm_subnet.test.id}"
+  route_table_id = "${azurerm_route_table.test.id}"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  agent_pool_profile {
+    name           = "default"
+    count          = "2"
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  service_principal {
+    client_id     = "%s"
+    client_secret = "%s"
+  }
+
+  network_profile {
+		network_plugin     = "%s"
+		network_policy     = "%s"
+    dns_service_ip     = "10.10.0.10"
+    docker_bridge_cidr = "172.18.0.1/16"
+    service_cidr       = "10.10.0.0/16"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret, networkPlugin, networkPolicy)
 }

--- a/examples/kubernetes/advanced-networking-calico-policy/main.tf
+++ b/examples/kubernetes/advanced-networking-calico-policy/main.tf
@@ -1,0 +1,75 @@
+resource "azurerm_resource_group" "test" {
+  name     = "${var.prefix}-anw-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "${var.prefix}-routetable"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  route {
+    name                   = "default"
+    address_prefix         = "10.100.0.0/14"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.1.1"
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "${var.prefix}-network"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  address_space       = ["10.1.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  address_prefix       = "10.1.0.0/24"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+
+  # this field is deprecated and will be removed in 2.0 - but is required until then
+  route_table_id = "${azurerm_route_table.test.id}"
+}
+
+resource "azurerm_subnet_route_table_association" "test" {
+  subnet_id      = "${azurerm_subnet.test.id}"
+  route_table_id = "${azurerm_route_table.test.id}"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "${var.prefix}-anw"
+  location            = "${azurerm_resource_group.test.location}"
+  dns_prefix          = "${var.prefix}-anw"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  linux_profile {
+    admin_username = "acctestuser1"
+
+    ssh_key {
+      key_data = "${file(var.public_ssh_key_path)}"
+    }
+  }
+
+  agent_pool_profile {
+    name            = "agentpool"
+    count           = "2"
+    vm_size         = "Standard_DS2_v2"
+    os_type         = "Linux"
+    os_disk_size_gb = 30
+
+    # Required for advanced networking
+    vnet_subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  service_principal {
+    client_id     = "${var.kubernetes_client_id}"
+    client_secret = "${var.kubernetes_client_secret}"
+  }
+
+  network_profile {
+    network_plugin = "azure"
+    network_policy = "calico"
+  }
+}

--- a/examples/kubernetes/advanced-networking-calico-policy/outputs.tf
+++ b/examples/kubernetes/advanced-networking-calico-policy/outputs.tf
@@ -1,0 +1,27 @@
+output "subnet_id" {
+  value = "${azurerm_kubernetes_cluster.test.agent_pool_profile.0.vnet_subnet_id}"
+}
+
+output "network_plugin" {
+  value = "${azurerm_kubernetes_cluster.test.network_profile.0.network_plugin}"
+}
+
+output "network_policy" {
+  value = "${azurerm_kubernetes_cluster.test.network_profile.0.network_policy}"
+}
+
+output "service_cidr" {
+  value = "${azurerm_kubernetes_cluster.test.network_profile.0.service_cidr}"
+}
+
+output "dns_service_ip" {
+  value = "${azurerm_kubernetes_cluster.test.network_profile.0.dns_service_ip}"
+}
+
+output "docker_bridge_cidr" {
+  value = "${azurerm_kubernetes_cluster.test.network_profile.0.docker_bridge_cidr}"
+}
+
+output "pod_cidr" {
+  value = "${azurerm_kubernetes_cluster.test.network_profile.0.pod_cidr}"
+}

--- a/examples/kubernetes/advanced-networking-calico-policy/variables.tf
+++ b/examples/kubernetes/advanced-networking-calico-policy/variables.tf
@@ -1,0 +1,21 @@
+variable "prefix" {
+  description = "A prefix used for all resources in this example"
+}
+
+variable "location" {
+  default     = "West Europe"
+  description = "The Azure Region in which all resources in this example should be provisioned"
+}
+
+variable "kubernetes_client_id" {
+  description = "The Client ID for the Service Principal to use for this Managed Kubernetes Cluster"
+}
+
+variable "kubernetes_client_secret" {
+  description = "The Client Secret for the Service Principal to use for this Managed Kubernetes Cluster"
+}
+
+variable "public_ssh_key_path" {
+  description = "The Path at which your Public SSH Key is located. Defaults to ~/.ssh/id_rsa.pub"
+  default     = "~/.ssh/id_rsa.pub"
+}

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -159,6 +159,8 @@ A `network_profile` block exports the following:
 
 * `network_plugin` - Network plugin used such as `azure` or `kubenet`.
 
+* `network_policy` - Network policy to be used with Azure CNI. Eg: `calico`
+
 * `pod_cidr` - The CIDR used for pod IP addresses.
 
 * `service_cidr` - Network range used by the Kubernetes service.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -146,7 +146,7 @@ A `network_profile` block supports the following:
 
 -> **NOTE:** When `network_plugin` is set to `azure` - the `vnet_subnet_id` field in the `agent_pool_profile` block must be set.
 
-* `network_policy` - (Optional) Sets up network policy to be used with Azure CNI. [Network policy allows us to control the traffic flow between pods](https://docs.microsoft.com/en-us/azure/aks/use-network-policies). This field can only be set when `network_plugin` is set to `azure`. Currently only accepted value is `calico` which installs Calico daemonset. Changing this forces a new resource to be created.
+* `network_policy` - (Optional) Sets up network policy to be used with Azure CNI. [Network policy allows us to control the traffic flow between pods](https://docs.microsoft.com/en-us/azure/aks/use-network-policies). This field can only be set when `network_plugin` is set to `azure`. Currently the only accepted value is `calico` which installs Calico daemonset. Changing this forces a new resource to be created.
 
 * `dns_service_ip` - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). This is required when `network_plugin` is set to `azure`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -146,6 +146,8 @@ A `network_profile` block supports the following:
 
 -> **NOTE:** When `network_plugin` is set to `azure` - the `vnet_subnet_id` field in the `agent_pool_profile` block must be set.
 
+* `network_policy` - (Optional) Sets up network policy to be used with Azure CNI. [Network policy allows us to control the traffic flow between pods](https://docs.microsoft.com/en-us/azure/aks/use-network-policies). This field can only be set when `network_plugin` is set to `azure`. Currently only accepted value is `calico` which installs Calico daemonset. Changing this forces a new resource to be created.
+
 * `dns_service_ip` - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). This is required when `network_plugin` is set to `azure`. Changing this forces a new resource to be created.
 
 * `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. This is required when `network_plugin` is set to `azure`. Changing this forces a new resource to be created.


### PR DESCRIPTION
This PR aims to add Calico Network policy to AKS as described in [MS Docs](https://docs.microsoft.com/en-us/azure/aks/use-network-policies).

Added `network_policy` to `kubernetes_cluster` resource.

PR Inspiration: https://github.com/terraform-providers/terraform-provider-azurerm/pull/1479