### PR TITLE
Adding a default value to upload_file_size_limit

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -809,6 +809,7 @@ func resourceArmApplicationGateway() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 500),
+							Default:      100,
 						},
 					},
 				},


### PR DESCRIPTION
This PR Solves the [issue 3011](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3011).
It adds a default value (100) to the application gateway.file_upload_limit_mb. 