### PR TITLE
Fixing HCL so the example runs successfully

### DIFF
--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -99,7 +99,7 @@ resource "azurerm_managed_disk" "test" {
 
 resource "azurerm_virtual_machine_data_disk_attachment" "test" {
   managed_disk_id    = "${azurerm_managed_disk.test.id}"
-  virtual_machine_id = "${azurerm_virtual_machine.windows.id}"
+  virtual_machine_id = "${azurerm_virtual_machine.test.id}"
   lun                = "10"
   caching            = "ReadWrite"
 }


### PR DESCRIPTION
The HCL example for the `virtual_machine_disk_attachment` resource does not run due to incorrect syntax. This pull requests fixes that.