### PR TITLE
Add Monitoring Metrics Publisher role assignment to Kubernetes cluster for Azure Monitor

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -724,7 +724,7 @@ func resourceArmKubernetesClusterDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func azureMonitorRoleAssignment(d *schema.ResourceData, meta interface{}) error {
+func azureMonitorRoleAssignment(d *schema.ResourceData, meta interface{}) {
 	servicePrincipalProfile := expandAzureRmKubernetesClusterServicePrincipal(d)
 
 	// Get the root roleDefinitionID full path (i.e. providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb)
@@ -732,7 +732,7 @@ func azureMonitorRoleAssignment(d *schema.ResourceData, meta interface{}) error 
 
 	if rootRoleDefinitionID == "" {
 		log.Printf("[INFO] Unable to locate 'Monitoring Metrics Publisher' Root Role Definition Id\n")
-		return nil
+		return
 	}
 
 	// Set the scope to the AKS cluster (i.e. subscriptions/<subscription id>/resourcegroups/<resource group name>/providers/Microsoft.ContainerService/managedClusters/<resource name>)
@@ -751,7 +751,7 @@ func azureMonitorRoleAssignment(d *schema.ResourceData, meta interface{}) error 
 
 	if clientServicePrincipalObjectId == "" {
 		log.Printf("[DEBUG] Unable to lookup Service Principal Object ID\n")
-		return nil
+		return
 	}
 
 	properties := authorization.RoleAssignmentCreateParameters{
@@ -765,8 +765,6 @@ func azureMonitorRoleAssignment(d *schema.ResourceData, meta interface{}) error 
 	if err := resource.Retry(300*time.Second, retryAzureMonitorRoleAssignment(scope, name, properties, meta)); err != nil {
 		log.Printf("[DEBUG] Error adding Role Assignment to AKS cluster: %+v\n", err)
 	}
-
-	return nil
 }
 
 func getServicePrincipalObjectID(applicationId string, meta interface{}) string {

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -596,10 +596,8 @@ func resourceArmKubernetesClusterCreateUpdate(d *schema.ResourceData, meta inter
 	d.SetId(*read.ID)
 
 	if addonProfiles != nil && *addonProfiles["omsagent"].Enabled {
-		log.Printf("[INFO] adding role assignment for visualization of custom metrics in Azure Monitor.")
-		if err := azureMonitorRoleAssignment(d, meta); err != nil {
-			log.Printf("[INFO] Error adding Azure Monitor Role Assignment: %+v", err)
-		}
+		log.Printf("[INFO] adding role assignment for visualization of custom metrics in Azure Monitor.\n")
+		azureMonitorRoleAssignment(d, meta)
 	}
 
 	return resourceArmKubernetesClusterRead(d, meta)
@@ -751,7 +749,7 @@ func azureMonitorRoleAssignment(d *schema.ResourceData, meta interface{}) error 
 	clientServicePrincipalObjectId := getServicePrincipalObjectID(*servicePrincipalProfile.ClientID, meta)
 	log.Printf("[INFO] Service Principal Object ID: %s\n", clientServicePrincipalObjectId)
 
-	if clientServicePrincipalObjectId == nil {
+	if clientServicePrincipalObjectId == "" {
 		log.Printf("[DEBUG] Unable to lookup Service Principal Object ID\n")
 		return nil
 	}

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -597,10 +597,8 @@ func resourceArmKubernetesClusterCreateUpdate(d *schema.ResourceData, meta inter
 
 	if addonProfiles != nil && *addonProfiles["omsagent"].Enabled {
 		log.Printf("[INFO] adding role assignment for visualization of custom metrics in Azure Monitor.")
-		// clients needed to assign
 		if err := azureMonitorRoleAssignment(d, meta); err != nil {
-			log.Printf("[INFO] Error adding azure monitor role assignment: %+v", err)
-			return fmt.Errorf("Error adding azure monitor role assignment Managed Kubernetes Cluster %q (Resource Group %q): %+v", name, resGroup, err)
+			log.Printf("[INFO] Error adding Azure Monitor Role Assignment: %+v", err)
 		}
 	}
 

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -760,7 +760,7 @@ func azureMonitorRoleAssignment(d *schema.ResourceData, meta interface{}) error 
 		RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
 			// Monitoring Metrics Publisher Role
 			RoleDefinitionID: utils.String(roleDefinitionID),
-			PrincipalID:      utils.String(clientServicePrincipalObjectId), //"b218e0c1-118b-4d8a-bebe-3e31a3c3ec37"
+			PrincipalID:      utils.String(clientServicePrincipalObjectId),
 		},
 	}
 


### PR DESCRIPTION
Enabling the ability to see custom Metrics in Azure Monitor in addition to the Metrics and logs in Azure Log Analytics Workspace. This functionality has been enabled in PowerShell and the Azure CLI tools, the service team requested Terraform also support this functionality. Per the service team, since the subscription provisioning the Kubernetes cluster will be required to have the `Microsoft.Authorization/roleAssignments/write` permission to grant the `Monitoring Metrics Publisher` role assignment, they are requesting that this not be a breaking failure. If the role assignment fails allow the deployment of the Kubernetes cluster should continue and silently fail the role assignment.