### PR TITLE
azurrm_virtual_network_gateway: fix panic if bgp_settings is set with 0 elements

### DIFF
--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -463,6 +463,10 @@ func getArmVirtualNetworkGatewayProperties(d *schema.ResourceData) (*network.Vir
 
 func expandArmVirtualNetworkGatewayBgpSettings(d *schema.ResourceData) *network.BgpSettings {
 	bgpSets := d.Get("bgp_settings").([]interface{})
+	if len(bgpSets) == 0 {
+		return nil
+	}
+
 	bgp := bgpSets[0].(map[string]interface{})
 
 	asn := int64(bgp["asn"].(int))


### PR DESCRIPTION
backport of [azurestack/71](https://github.com/terraform-providers/terraform-provider-azurestack/pull/71) fixing [azurestack/60](https://github.com/terraform-providers/terraform-provider-azurestack/pull/60)