### PR TITLE
increase max capacity for eventhub namespaces to 100

### DIFF
--- a/azurerm/resource_arm_eventhub_namespace.go
+++ b/azurerm/resource_arm_eventhub_namespace.go
@@ -58,7 +58,7 @@ func resourceArmEventHubNamespace() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      1,
-				ValidateFunc: validation.IntBetween(1, 20),
+				ValidateFunc: validation.IntBetween(1, 100),
 			},
 
 			"auto_inflate_enabled": {
@@ -77,7 +77,7 @@ func resourceArmEventHubNamespace() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(0, 20),
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 
 			"default_primary_connection_string": {

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -228,7 +228,7 @@ func TestAccAzureRMEventHubNamespace_BasicWithCapacity(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMEventHubNamespaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "capacity", "20"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "100"),
 				),
 			},
 		},
@@ -250,7 +250,7 @@ func TestAccAzureRMEventHubNamespace_BasicWithCapacityUpdate(t *testing.T) {
 				Config: preConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMEventHubNamespaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "capacity", "20"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "100"),
 				),
 			},
 			{
@@ -311,7 +311,7 @@ func TestAccAzureRMEventHubNamespace_maximumThroughputUnitsUpdate(t *testing.T) 
 					testCheckAzureRMEventHubNamespaceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "sku", "Standard"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "2"),
-					resource.TestCheckResourceAttr(resourceName, "maximum_throughput_units", "20"),
+					resource.TestCheckResourceAttr(resourceName, "maximum_throughput_units", "100"),
 				),
 			},
 			{


### PR DESCRIPTION
I increased the max capacity of event namespaces. The actual limit is 100 if you contact the azure support.