### PR TITLE
Add deprecation warning about Classic SKU

### DIFF
--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -18,6 +18,8 @@ Manages an Azure Container Registry.
 
 ### Classic (unmanaged) Container Registry
 
+Warning : the Classic (unmanaged) SKU is deprecated in Azure since Mars 2019. Use Basic, Standard, or Premium for all new registries (see section below).
+
 When using the `Classic` SKU, you need to provide the Azure storage account.
 
 ```hcl

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -16,40 +16,6 @@ Manages an Azure Container Registry.
 
 ## Example Usage
 
-### Classic (unmanaged) Container Registry
-
-Warning : the Classic (unmanaged) SKU is deprecated in Azure since Mars 2019. Use Basic, Standard, or Premium for all new registries (see section below).
-
-When using the `Classic` SKU, you need to provide the Azure storage account.
-
-```hcl
-resource "azurerm_resource_group" "test" {
-  name     = "resourceGroup1"
-  location = "West US"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "storageaccount1"
-  resource_group_name      = "${azurerm_resource_group.test.name}"
-  location                 = "${azurerm_resource_group.test.location}"
-  account_tier             = "Standard"
-  account_replication_type = "GRS"
-}
-
-resource "azurerm_container_registry" "test" {
-  name                = "containerRegistry1"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-  admin_enabled       = true
-  sku                 = "Classic"
-  storage_account_id  = "${azurerm_storage_account.test.id}"
-}
-```
-
-### Managed Container Registry
-
-When using a SKU other than `Classic`, Azure Container Registry manages the storage account for you.
-
 ```hcl
 resource "azurerm_resource_group" "rg" {
   name     = "resourceGroup1"
@@ -81,6 +47,8 @@ The following arguments are supported:
 * `storage_account_id` - (Required for `Classic` Sku - Optional otherwise) The ID of a Storage Account which must be located in the same Azure Region as the Container Registry.
 
 * `sku` - (Optional) The SKU name of the the container registry. Possible values are `Classic` (which was previously `Basic`), `Basic`, `Standard` and `Premium`.
+
+~> **NOTE:** The `Classic` SKU is Deprecated and will no longer be available for new resources from the end of March 2019.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Creation of Classic SKU is deprecated since this month (Mars 2019): https://docs.microsoft.com/en-us/azure/container-registry/container-registry-skus
I just added a warning in the documentation.