### PR TITLE
Update validation of managed disks to support up to 32TB

### DIFF
--- a/azurerm/resource_arm_managed_disk.go
+++ b/azurerm/resource_arm_managed_disk.go
@@ -106,9 +106,9 @@ func resourceArmManagedDisk() *schema.Resource {
 
 func validateDiskSizeGB(v interface{}, _ string) (warnings []string, errors []error) {
 	value := v.(int)
-	if value < 0 || value > 4095 {
+	if value < 0 || value > 32767 {
 		errors = append(errors, fmt.Errorf(
-			"The `disk_size_gb` can only be between 0 and 4095"))
+			"The `disk_size_gb` can only be between 0 and 32767"))
 	}
 	return warnings, errors
 }


### PR DESCRIPTION
Azure now supports up to 32TB of storage per disk (in preview as of this moment)
https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-types#premium-ssd