### PR TITLE
Fixing errors caught by the updated linter

### DIFF
--- a/azurerm/data_source_notification_hub.go
+++ b/azurerm/data_source_notification_hub.go
@@ -112,12 +112,12 @@ func dataSourceNotificationHubRead(d *schema.ResourceData, meta interface{}) err
 
 	if props := credentials.PnsCredentialsProperties; props != nil {
 		apns := flattenNotificationHubsDataSourceAPNSCredentials(props.ApnsCredential)
-		if d.Set("apns_credential", apns); err != nil {
+		if setErr := d.Set("apns_credential", apns); setErr != nil {
 			return fmt.Errorf("Error setting `apns_credential`: %+v", err)
 		}
 
 		gcm := flattenNotificationHubsDataSourceGCMCredentials(props.GcmCredential)
-		if d.Set("gcm_credential", gcm); err != nil {
+		if setErr := d.Set("gcm_credential", gcm); setErr != nil {
 			return fmt.Errorf("Error setting `gcm_credential`: %+v", err)
 		}
 	}

--- a/azurerm/encryption_settings.go
+++ b/azurerm/encryption_settings.go
@@ -119,7 +119,7 @@ func flattenManagedDiskEncryptionSettings(encryptionSettings *compute.Encryption
 
 		keys["key_url"] = *key.KeyURL
 
-		if vault := key.SourceVault; key != nil {
+		if vault := key.SourceVault; vault != nil {
 			keys["source_vault_id"] = *vault.ID
 		}
 

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -1060,7 +1060,7 @@ func resourceArmApplicationGatewayRead(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("Error setting `url_path_map`: %+v", setErr)
 		}
 
-		if setErr := d.Set("waf_configuration", flattenApplicationGatewayWafConfig(props.WebApplicationFirewallConfiguration)); err != nil {
+		if setErr := d.Set("waf_configuration", flattenApplicationGatewayWafConfig(props.WebApplicationFirewallConfiguration)); setErr != nil {
 			return fmt.Errorf("Error setting `waf_configuration`: %+v", setErr)
 		}
 	}
@@ -2227,7 +2227,7 @@ func flattenApplicationGatewayURLPathMaps(input *[]network.ApplicationGatewayURL
 						ruleOutput["name"] = *rule.Name
 					}
 
-					if ruleProps := rule.ApplicationGatewayPathRulePropertiesFormat; props != nil {
+					if ruleProps := rule.ApplicationGatewayPathRulePropertiesFormat; ruleProps != nil {
 						if pool := ruleProps.BackendAddressPool; pool != nil && pool.ID != nil {
 							poolId, err := parseAzureResourceID(*pool.ID)
 							if err != nil {

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -33,9 +33,6 @@ func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta inter
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if id == nil {
-		return []*schema.ResourceData{d}, fmt.Errorf("Unable to locate the Resource ID for the Key Vault at URL %q", id.KeyVaultBaseUrl)
-	}
 
 	d.Set("key_vault_id", kvid)
 

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -34,7 +34,7 @@ func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta inter
 		return []*schema.ResourceData{d}, fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
 	if id == nil {
-		return []*schema.ResourceData{d}, fmt.Errorf("Unable to locate the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return []*schema.ResourceData{d}, fmt.Errorf("Unable to locate the Resource ID for the Key Vault at URL %q", id.KeyVaultBaseUrl)
 	}
 
 	d.Set("key_vault_id", kvid)

--- a/azurerm/resource_arm_monitor_log_profile.go
+++ b/azurerm/resource_arm_monitor_log_profile.go
@@ -254,14 +254,12 @@ func flattenAzureRmLogProfileRetentionPolicy(input *insights.RetentionPolicy) []
 	}
 
 	result := make(map[string]interface{})
-	if input != nil {
-		if input.Enabled != nil {
-			result["enabled"] = *input.Enabled
-		}
+	if input.Enabled != nil {
+		result["enabled"] = *input.Enabled
+	}
 
-		if input.Days != nil {
-			result["days"] = *input.Days
-		}
+	if input.Days != nil {
+		result["days"] = *input.Days
 	}
 
 	return []interface{}{result}

--- a/azurerm/resource_arm_notification_hub.go
+++ b/azurerm/resource_arm_notification_hub.go
@@ -254,13 +254,13 @@ func resourceArmNotificationHubRead(d *schema.ResourceData, meta interface{}) er
 
 	if props := credentials.PnsCredentialsProperties; props != nil {
 		apns := flattenNotificationHubsAPNSCredentials(props.ApnsCredential)
-		if d.Set("apns_credential", apns); err != nil {
-			return fmt.Errorf("Error setting `apns_credential`: %+v", err)
+		if setErr := d.Set("apns_credential", apns); setErr != nil {
+			return fmt.Errorf("Error setting `apns_credential`: %+v", setErr)
 		}
 
 		gcm := flattenNotificationHubsGCMCredentials(props.GcmCredential)
-		if d.Set("gcm_credential", gcm); err != nil {
-			return fmt.Errorf("Error setting `gcm_credential`: %+v", err)
+		if setErr := d.Set("gcm_credential", gcm); setErr != nil {
+			return fmt.Errorf("Error setting `gcm_credential`: %+v", setErr)
 		}
 	}
 

--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -170,7 +170,7 @@ func resourceArmRoleAssignmentRead(d *schema.ResourceData, meta interface{}) err
 				return fmt.Errorf("Error loading Role Definition %q: %+v", *roleId, err)
 			}
 
-			if roleProps := roleResp.RoleDefinitionProperties; props != nil {
+			if roleProps := roleResp.RoleDefinitionProperties; roleProps != nil {
 				d.Set("role_definition_name", roleProps.RoleName)
 			}
 		}

--- a/azurerm/resource_arm_sql_database.go
+++ b/azurerm/resource_arm_sql_database.go
@@ -559,10 +559,6 @@ func resourceArmSqlDatabaseDelete(d *schema.ResourceData, meta interface{}) erro
 			return nil
 		}
 
-		return fmt.Errorf("Error making Read request on Sql Database %s: %+v", name, err)
-	}
-
-	if err != nil {
 		return fmt.Errorf("Error deleting SQL Database: %+v", err)
 	}
 

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -1911,7 +1911,7 @@ func determineVirtualMachineIPAddress(ctx context.Context, meta interface{}, pro
 						return "", fmt.Errorf("Error obtaining Public IP %q (Resource Group %q): %+v", name, resourceGroup, err)
 					}
 
-					if pipProps := pip.PublicIPAddressPropertiesFormat; props != nil {
+					if pipProps := pip.PublicIPAddressPropertiesFormat; pipProps != nil {
 						if ip := pipProps.IPAddress; ip != nil {
 							return *ip, nil
 						}


### PR DESCRIPTION
Fixes:

```
44.35s$ make lint
==> Checking source code against linters...
golangci-lint run ./...
azurerm/data_source_notification_hub.go:115:42: nilness: impossible condition: nil != nil (govet)
		if d.Set("apns_credential", apns); err != nil {
		                                       ^
azurerm/data_source_notification_hub.go:120:40: nilness: impossible condition: nil != nil (govet)
		if d.Set("gcm_credential", gcm); err != nil {
		                                     ^
azurerm/encryption_settings.go:122:36: nilness: tautological condition: non-nil != nil (govet)
		if vault := key.SourceVault; key != nil {
		                                 ^
azurerm/resource_arm_application_gateway.go:1063:127: nilness: impossible condition: nil != nil (govet)
		if setErr := d.Set("waf_configuration", flattenApplicationGatewayWafConfig(props.WebApplicationFirewallConfiguration)); err != nil {
		                                                                                                                            ^
azurerm/resource_arm_application_gateway.go:2230:77: nilness: tautological condition: non-nil != nil (govet)
					if ruleProps := rule.ApplicationGatewayPathRulePropertiesFormat; props != nil {
					                                                                       ^
azurerm/resource_arm_key_vault_certificate.go:37:119: nilness: nil dereference in field selection (govet)
		return []*schema.ResourceData{d}, fmt.Errorf("Unable to locate the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
		                                                                                                                    ^
azurerm/resource_arm_monitor_log_profile.go:257:11: nilness: tautological condition: non-nil != nil (govet)
	if input != nil {
	         ^
azurerm/resource_arm_notification_hub.go:257:42: nilness: impossible condition: nil != nil (govet)
		if d.Set("apns_credential", apns); err != nil {
		                                       ^
azurerm/resource_arm_notification_hub.go:262:40: nilness: impossible condition: nil != nil (govet)
		if d.Set("gcm_credential", gcm); err != nil {
		                                     ^
azurerm/resource_arm_role_assignment.go:173:61: nilness: tautological condition: non-nil != nil (govet)
			if roleProps := roleResp.RoleDefinitionProperties; props != nil {
			                                                         ^
azurerm/resource_arm_sql_database.go:565:9: nilness: impossible condition: nil != nil (govet)
	if err != nil {
	       ^
azurerm/resource_arm_virtual_machine.go:1914:64: nilness: tautological condition: non-nil != nil (govet)
					if pipProps := pip.PublicIPAddressPropertiesFormat; props != nil {
					                                                          ^
make: *** [lint] Error 1
The command "make lint" exited with 2.
```