### PR TITLE
Azure batch expose keys and account url

### DIFF
--- a/azurerm/data_source_batch_account.go
+++ b/azurerm/data_source_batch_account.go
@@ -29,12 +29,12 @@ func dataSourceArmBatchAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"primary_shared_key": {
+			"primary_access_key": {
 				Type:      schema.TypeString,
 				Sensitive: true,
 				Computed:  true,
 			},
-			"secondary_shared_key": {
+			"secondary_access_key": {
 				Type:      schema.TypeString,
 				Sensitive: true,
 				Computed:  true,
@@ -76,8 +76,8 @@ func dataSourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) err
 			return err
 		}
 
-		d.Set("primary_shared_key", keys.Primary)
-		d.Set("secondary_shared_key", keys.Secondary)
+		d.Set("primary_access_key", keys.Primary)
+		d.Set("secondary_access_key", keys.Secondary)
 	}
 
 	if location := resp.Location; location != nil {

--- a/azurerm/data_source_batch_account.go
+++ b/azurerm/data_source_batch_account.go
@@ -84,7 +84,7 @@ func dataSourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) err
 		keys, err := client.GetKeys(ctx, resourceGroup, name)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("Cannot read keys for Batch account %q (resource group %q): %v", name, resourceGroupName, err)
 		}
 
 		d.Set("primary_access_key", keys.Primary)

--- a/azurerm/data_source_batch_account.go
+++ b/azurerm/data_source_batch_account.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2017-09-01/batch"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -25,6 +26,20 @@ func dataSourceArmBatchAccount() *schema.Resource {
 				Computed: true,
 			},
 			"pool_allocation_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"primary_shared_key": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"secondary_shared_key": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"account_endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -52,6 +67,18 @@ func dataSourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)
+	d.Set("account_endpoint", resp.AccountEndpoint)
+
+	if d.Get("pool_allocation_mode") == string(batch.BatchService) {
+		keys, err := client.GetKeys(ctx, resourceGroup, name)
+
+		if err != nil {
+			return err
+		}
+
+		d.Set("primary_shared_key", keys.Primary)
+		d.Set("secondary_shared_key", keys.Secondary)
+	}
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azureRMNormalizeLocation(*location))

--- a/azurerm/data_source_batch_account.go
+++ b/azurerm/data_source_batch_account.go
@@ -84,7 +84,7 @@ func dataSourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) err
 		keys, err := client.GetKeys(ctx, resourceGroup, name)
 
 		if err != nil {
-			return fmt.Errorf("Cannot read keys for Batch account %q (resource group %q): %v", name, resourceGroupName, err)
+			return fmt.Errorf("Cannot read keys for Batch account %q (resource group %q): %v", name, resourceGroup, err)
 		}
 
 		d.Set("primary_access_key", keys.Primary)

--- a/azurerm/data_source_batch_account.go
+++ b/azurerm/data_source_batch_account.go
@@ -69,17 +69,6 @@ func dataSourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("resource_group_name", resourceGroup)
 	d.Set("account_endpoint", resp.AccountEndpoint)
 
-	if d.Get("pool_allocation_mode") == string(batch.BatchService) {
-		keys, err := client.GetKeys(ctx, resourceGroup, name)
-
-		if err != nil {
-			return err
-		}
-
-		d.Set("primary_access_key", keys.Primary)
-		d.Set("secondary_access_key", keys.Secondary)
-	}
-
 	if location := resp.Location; location != nil {
 		d.Set("location", azureRMNormalizeLocation(*location))
 	}
@@ -89,6 +78,17 @@ func dataSourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) err
 			d.Set("storage_account_id", autoStorage.StorageAccountID)
 		}
 		d.Set("pool_allocation_mode", props.PoolAllocationMode)
+	}
+
+	if d.Get("pool_allocation_mode").(string) == string(batch.BatchService) {
+		keys, err := client.GetKeys(ctx, resourceGroup, name)
+
+		if err != nil {
+			return err
+		}
+
+		d.Set("primary_access_key", keys.Primary)
+		d.Set("secondary_access_key", keys.Secondary)
 	}
 
 	flattenAndSetTags(d, resp.Tags)

--- a/azurerm/resource_arm_batch_account.go
+++ b/azurerm/resource_arm_batch_account.go
@@ -73,7 +73,7 @@ func resourceArmBatchAccountCreate(d *schema.ResourceData, meta interface{}) err
 
 	log.Printf("[INFO] preparing arguments for Azure Batch account creation.")
 
-	resourceGroupName := d.Get("resource_group_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
 	location := azureRMNormalizeLocation(d.Get("location").(string))
 	storageAccountId := d.Get("storage_account_id").(string)
@@ -81,10 +81,10 @@ func resourceArmBatchAccountCreate(d *schema.ResourceData, meta interface{}) err
 	tags := d.Get("tags").(map[string]interface{})
 
 	if requireResourcesToBeImported && d.IsNewResource() {
-		existing, err := client.Get(ctx, resourceGroupName, name)
+		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Batch Account %q (Resource Group %q): %s", name, resourceGroupName, err)
+				return fmt.Errorf("Error checking for presence of existing Batch Account %q (Resource Group %q): %s", name, resourceGroup, err)
 			}
 		}
 
@@ -107,22 +107,22 @@ func resourceArmBatchAccountCreate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	future, err := client.Create(ctx, resourceGroupName, name, parameters)
+	future, err := client.Create(ctx, resourceGroup, name, parameters)
 	if err != nil {
-		return fmt.Errorf("Error creating Batch account %q (Resource Group %q): %+v", name, resourceGroupName, err)
+		return fmt.Errorf("Error creating Batch account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for creation of Batch account %q (Resource Group %q): %+v", name, resourceGroupName, err)
+		return fmt.Errorf("Error waiting for creation of Batch account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	read, err := client.Get(ctx, resourceGroupName, name)
+	read, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Batch account %q (Resource Group %q): %+v", name, resourceGroupName, err)
+		return fmt.Errorf("Error retrieving Batch account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Batch account %q (resource group %q) ID", name, resourceGroupName)
+		return fmt.Errorf("Cannot read Batch account %q (resource group %q) ID", name, resourceGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -139,20 +139,20 @@ func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 	name := id.Path["batchAccounts"]
-	resourceGroupName := id.ResourceGroup
+	resourceGroup := id.ResourceGroup
 
-	resp, err := client.Get(ctx, resourceGroupName, name)
+	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
-			log.Printf("[DEBUG] Batch Account %q was not found in Resource Group %q - removing from state!", name, resourceGroupName)
+			log.Printf("[DEBUG] Batch Account %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
 			return nil
 		}
 		return fmt.Errorf("Error reading the state of Batch account %q: %+v", name, err)
 	}
 
 	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resourceGroupName)
+	d.Set("resource_group_name", resourceGroup)
 	d.Set("account_endpoint", resp.AccountEndpoint)
 
 	if location := resp.Location; location != nil {
@@ -167,10 +167,10 @@ func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.Get("pool_allocation_mode").(string) == string(batch.BatchService) {
-		keys, err := client.GetKeys(ctx, resourceGroupName, name)
+		keys, err := client.GetKeys(ctx, resourceGroup, name)
 
 		if err != nil {
-			return fmt.Errorf("Cannot read keys for Batch account %q (resource group %q): %v", name, resourceGroupName, err)
+			return fmt.Errorf("Cannot read keys for Batch account %q (resource group %q): %v", name, resourceGroup, err)
 		}
 
 		d.Set("primary_access_key", keys.Primary)
@@ -193,7 +193,7 @@ func resourceArmBatchAccountUpdate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	name := id.Path["batchAccounts"]
-	resourceGroupName := id.ResourceGroup
+	resourceGroup := id.ResourceGroup
 
 	storageAccountId := d.Get("storage_account_id").(string)
 	tags := d.Get("tags").(map[string]interface{})
@@ -207,17 +207,17 @@ func resourceArmBatchAccountUpdate(d *schema.ResourceData, meta interface{}) err
 		Tags: expandTags(tags),
 	}
 
-	if _, err = client.Update(ctx, resourceGroupName, name, parameters); err != nil {
-		return fmt.Errorf("Error updating Batch account %q (Resource Group %q): %+v", name, resourceGroupName, err)
+	if _, err = client.Update(ctx, resourceGroup, name, parameters); err != nil {
+		return fmt.Errorf("Error updating Batch account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	read, err := client.Get(ctx, resourceGroupName, name)
+	read, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Batch account %q (Resource Group %q): %+v", name, resourceGroupName, err)
+		return fmt.Errorf("Error retrieving Batch account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Batch account %q (resource group %q) ID", name, resourceGroupName)
+		return fmt.Errorf("Cannot read Batch account %q (resource group %q) ID", name, resourceGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -234,16 +234,16 @@ func resourceArmBatchAccountDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	name := id.Path["batchAccounts"]
-	resourceGroupName := id.ResourceGroup
+	resourceGroup := id.ResourceGroup
 
-	future, err := client.Delete(ctx, resourceGroupName, name)
+	future, err := client.Delete(ctx, resourceGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Batch account %q (Resource Group %q): %+v", name, resourceGroupName, err)
+		return fmt.Errorf("Error deleting Batch account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("Error waiting for deletion of Batch account %q (Resource Group %q): %+v", name, resourceGroupName, err)
+			return fmt.Errorf("Error waiting for deletion of Batch account %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
 

--- a/azurerm/resource_arm_batch_account.go
+++ b/azurerm/resource_arm_batch_account.go
@@ -170,7 +170,7 @@ func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error
 		keys, err := client.GetKeys(ctx, resourceGroupName, name)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("Cannot read keys for Batch account %q (resource group %q): %v", name, resourceGroupName, err)
 		}
 
 		d.Set("primary_access_key", keys.Primary)

--- a/azurerm/resource_arm_batch_account.go
+++ b/azurerm/resource_arm_batch_account.go
@@ -48,12 +48,12 @@ func resourceArmBatchAccount() *schema.Resource {
 					string(batch.UserSubscription),
 				}, false),
 			},
-			"primary_shared_key": {
+			"primary_access_key": {
 				Type:      schema.TypeString,
 				Sensitive: true,
 				Computed:  true,
 			},
-			"secondary_shared_key": {
+			"secondary_access_key": {
 				Type:      schema.TypeString,
 				Sensitive: true,
 				Computed:  true,
@@ -158,8 +158,8 @@ func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error
 			return err
 		}
 
-		d.Set("primary_shared_key", keys.Primary)
-		d.Set("secondary_shared_key", keys.Secondary)
+		d.Set("primary_access_key", keys.Primary)
+		d.Set("secondary_access_key", keys.Secondary)
 	}
 
 	d.Set("name", resp.Name)

--- a/azurerm/resource_arm_batch_account.go
+++ b/azurerm/resource_arm_batch_account.go
@@ -151,17 +151,6 @@ func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error reading the state of Batch account %q: %+v", name, err)
 	}
 
-	if d.Get("pool_allocation_mode") == string(batch.BatchService) {
-		keys, err := client.GetKeys(ctx, resourceGroupName, name)
-
-		if err != nil {
-			return err
-		}
-
-		d.Set("primary_access_key", keys.Primary)
-		d.Set("secondary_access_key", keys.Secondary)
-	}
-
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resourceGroupName)
 	d.Set("account_endpoint", resp.AccountEndpoint)
@@ -175,6 +164,17 @@ func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error
 			d.Set("storage_account_id", autoStorage.StorageAccountID)
 		}
 		d.Set("pool_allocation_mode", props.PoolAllocationMode)
+	}
+
+	if d.Get("pool_allocation_mode").(string) == string(batch.BatchService) {
+		keys, err := client.GetKeys(ctx, resourceGroupName, name)
+
+		if err != nil {
+			return err
+		}
+
+		d.Set("primary_access_key", keys.Primary)
+		d.Set("secondary_access_key", keys.Secondary)
 	}
 
 	flattenAndSetTags(d, resp.Tags)

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -217,7 +217,7 @@ func TestAccAzureRMEventHubNamespace_BasicWithTagsUpdate(t *testing.T) {
 func TestAccAzureRMEventHubNamespace_BasicWithCapacity(t *testing.T) {
 	resourceName := "azurerm_eventhub_namespace.test"
 	ri := tf.AccRandTimeInt()
-	config := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 20)
+	config := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 100)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -238,7 +238,7 @@ func TestAccAzureRMEventHubNamespace_BasicWithCapacity(t *testing.T) {
 func TestAccAzureRMEventHubNamespace_BasicWithCapacityUpdate(t *testing.T) {
 	resourceName := "azurerm_eventhub_namespace.test"
 	ri := tf.AccRandTimeInt()
-	preConfig := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 20)
+	preConfig := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 100)
 	postConfig := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 2)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -494,7 +494,7 @@ resource "azurerm_eventhub_namespace" "test" {
   sku                      = "Standard"
   capacity                 = "2"
   auto_inflate_enabled     = true
-  maximum_throughput_units = 20
+  maximum_throughput_units = 100
 }
 `, rInt, location, rInt)
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.6.3 // indirect
 	github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363
 	github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7 // indirect
-	github.com/hashicorp/go-getter v0.0.0-20180226183729-64040d90d4ab // indirect
+	github.com/hashicorp/go-getter v0.0.0-20180226183729-64040d90d4ab
 	github.com/hashicorp/go-hclog v0.0.0-20170903163258-8105cc0a3736 // indirect
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-plugin v0.0.0-20170816151819-a5174f84d7f8 // indirect

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -44,4 +44,10 @@ The following attributes are exported:
 
 * `storage_account_id` - The ID of the Storage Account used for this Batch account.
 
+* `primary_shared_key` - The Batch account primary shared key.
+
+* `secondary_shared_key` - The Batch account secondary shared key.
+
+* `account_endpoint` - The account endpoint used to interact with the Batch service.
+
 * `tags` - A map of tags assigned to the Batch account.

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -52,4 +52,4 @@ The following attributes are exported:
 
 * `tags` - A map of tags assigned to the Batch account.
 
-~> **NOTE:** When `pool_allocation_mode` is set to `BatchService`, primary and secondary access keys can be retrieved after the batch account has been created. See [documentation](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics) for more information.
+~> **NOTE:** Primary and secondary access keys are only available when `pool_allocation_mode` is set to `BatchService`. See [documentation](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics) for more information.

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -44,9 +44,9 @@ The following attributes are exported:
 
 * `storage_account_id` - The ID of the Storage Account used for this Batch account.
 
-* `primary_shared_key` - The Batch account primary shared key.
+* `primary_access_key` - The Batch account primary access key.
 
-* `secondary_shared_key` - The Batch account secondary shared key.
+* `secondary_access_key` - The Batch account secondary access key.
 
 * `account_endpoint` - The account endpoint used to interact with the Batch service.
 

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -51,3 +51,5 @@ The following attributes are exported:
 * `account_endpoint` - The account endpoint used to interact with the Batch service.
 
 * `tags` - A map of tags assigned to the Batch account.
+
+~> **NOTE:** When `pool_allocation_mode` is set to `BatchService`, primary and secondary access keys can be retrieved after the batch account has been created. See [documentation](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics) for more information.

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -61,3 +61,9 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Batch account ID.
+
+* `primary_shared_key` - The Batch account primary shared key.
+
+* `secondary_shared_key` - The Batch account secondary shared key.
+
+* `account_endpoint` - The account endpoint used to interact with the Batch service.

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -68,4 +68,4 @@ The following attributes are exported:
 
 * `account_endpoint` - The account endpoint used to interact with the Batch service.
 
-~> **NOTE:** When `pool_allocation_mode` is set to `BatchService`, primary and secondary access keys can be retrieved after the batch account has been created. See [documentation](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics) for more information.
+~> **NOTE:** Primary and secondary access keys are only available when `pool_allocation_mode` is set to `BatchService`. See [documentation](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics) for more information.

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -62,8 +62,8 @@ The following attributes are exported:
 
 * `id` - The Batch account ID.
 
-* `primary_shared_key` - The Batch account primary shared key.
+* `primary_access_key` - The Batch account primary access key.
 
-* `secondary_shared_key` - The Batch account secondary shared key.
+* `secondary_access_key` - The Batch account secondary access key.
 
 * `account_endpoint` - The account endpoint used to interact with the Batch service.

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -67,3 +67,5 @@ The following attributes are exported:
 * `secondary_access_key` - The Batch account secondary access key.
 
 * `account_endpoint` - The account endpoint used to interact with the Batch service.
+
+~> **NOTE:** When `pool_allocation_mode` is set to `BatchService`, primary and secondary access keys can be retrieved after the batch account has been created. See [documentation](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics) for more information.


### PR DESCRIPTION
This PR exposes the primary access key, secondary access key and account endpoint in the `azurerm_batch_account` resource and data_source.  The documentation has also been updated, with a note that the keys are only available when the batch accounts `pool_allocation_mode` is `BatchService`.  If the allocation mode is `UserSubscription`, terraform will throw an error.