### PR TITLE
Eventhub property skip empty archives

### DIFF
--- a/azurerm/resource_arm_eventhub.go
+++ b/azurerm/resource_arm_eventhub.go
@@ -68,6 +68,11 @@ func resourceArmEventHub() *schema.Resource {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
+						"skip_empty_archives": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 						"encoding": {
 							Type:             schema.TypeString,
 							Required:         true,
@@ -310,12 +315,14 @@ func expandEventHubCaptureDescription(d *schema.ResourceData) (*eventhub.Capture
 	encoding := input["encoding"].(string)
 	intervalInSeconds := input["interval_in_seconds"].(int)
 	sizeLimitInBytes := input["size_limit_in_bytes"].(int)
+	skipEmptyArchives := input["skip_empty_archives"].(bool)
 
 	captureDescription := eventhub.CaptureDescription{
 		Enabled:           utils.Bool(enabled),
 		Encoding:          eventhub.EncodingCaptureDescription(encoding),
 		IntervalInSeconds: utils.Int32(int32(intervalInSeconds)),
 		SizeLimitInBytes:  utils.Int32(int32(sizeLimitInBytes)),
+		SkipEmptyArchives: utils.Bool(skipEmptyArchives),
 	}
 
 	if v, ok := input["destination"]; ok {
@@ -350,6 +357,10 @@ func flattenEventHubCaptureDescription(description *eventhub.CaptureDescription)
 
 		if enabled := description.Enabled; enabled != nil {
 			output["enabled"] = *enabled
+		}
+
+		if skipEmptyArchives := description.SkipEmptyArchives; skipEmptyArchives != nil {
+			output["skip_empty_archives"] = *skipEmptyArchives
 		}
 
 		output["encoding"] = string(description.Encoding)

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -546,8 +546,8 @@ resource "azurerm_eventhub" "test" {
     enabled             = %s
     encoding            = "Avro"
     interval_in_seconds = 60
-		size_limit_in_bytes = 10485760
-		skip_empty_archives = true
+    size_limit_in_bytes = 10485760
+    skip_empty_archives = true
 
     destination {
       name                = "EventHubArchive.AzureBlockBlob"

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"strconv"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -283,10 +281,14 @@ func TestAccAzureRMEventHub_captureDescription(t *testing.T) {
 		CheckDestroy: testCheckAzureRMEventHubDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMEventHub_captureDescription(ri, rs, testLocation(), true),
+				Config: testAccAzureRMEventHub_captureDescription(ri, rs, testLocation(), testDefaultCaptureDescription()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMEventHubExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "capture_description.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "capture_description.0.encoding", "Avro"),
+					resource.TestCheckResourceAttr(resourceName, "capture_description.0.skip_empty_archives", "true"),
+					resource.TestCheckResourceAttr(resourceName, "capture_description.0.size_limit_in_bytes", "10485760"),
+					resource.TestCheckResourceAttr(resourceName, "capture_description.0.interval_in_seconds", "60"),
 				),
 			},
 			{
@@ -304,8 +306,11 @@ func TestAccAzureRMEventHub_captureDescriptionDisabled(t *testing.T) {
 	rs := acctest.RandString(5)
 	location := testLocation()
 
-	config := testAccAzureRMEventHub_captureDescription(ri, rs, location, true)
-	updatedConfig := testAccAzureRMEventHub_captureDescription(ri, rs, location, false)
+	captureDescription := testDefaultCaptureDescription()
+	config := testAccAzureRMEventHub_captureDescription(ri, rs, location, captureDescription)
+	updateCaptureDescription = := testDefaultCaptureDescription()
+	updatedCaptureDescription.enabled = false
+	updatedConfig := testAccAzureRMEventHub_captureDescription(ri, rs, location, updatedCaptureDescription)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -324,6 +329,41 @@ func TestAccAzureRMEventHub_captureDescriptionDisabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMEventHubExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "capture_description.0.enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMEventHub_captureDescriptionSkipEmptyArchivesEnabled(t *testing.T) {
+	resourceName := "azurerm_eventhub.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(5)
+	location := testLocation()
+
+	captureDescription := testDefaultCaptureDescription()
+	config := testAccAzureRMEventHub_captureDescription(ri, rs, location, captureDescription)
+	updateCaptureDescription = := testDefaultCaptureDescription()
+	updatedCaptureDescription.skip_empty_archives = true
+	updatedConfig := testAccAzureRMEventHub_captureDescription(ri, rs, location, updatedCaptureDescription)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMEventHubDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMEventHubExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "capture_description.0.skip_empty_archives", "false"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMEventHubExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "capture_description.0.skip_empty_archives", "true"),
 				),
 			},
 		},
@@ -504,8 +544,24 @@ resource "azurerm_eventhub" "test" {
 `, rInt, location, rInt, rInt)
 }
 
-func testAccAzureRMEventHub_captureDescription(rInt int, rString string, location string, enabled bool) string {
-	enabledString := strconv.FormatBool(enabled)
+type captureDestination struct {
+	name                string
+	archive_name_format string
+	blob_container_name string
+	storage_account_id  string
+}
+
+type captureDescription struct {
+	enabled             bool
+	encoding            string
+	interval_in_seconds int
+	size_limit_in_bytes int
+	skip_empty_archives bool
+
+	destination *captureDestination
+}
+
+func testAccAzureRMEventHub_captureDescription(rInt int, rString string, location string, captureDescription *captureDescription) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -541,21 +597,45 @@ resource "azurerm_eventhub" "test" {
   partition_count     = 2
   message_retention   = 7
 
-  capture_description {
-    enabled             = %s
-    encoding            = "Avro"
-    interval_in_seconds = 60
-    size_limit_in_bytes = 10485760
+  %s
+}
+`, rInt, location, rString, rInt, rInt, testDefaultCaptureDescriptionString(captureDescription))
+}
+
+func testDefaultCaptureDescription() *captureDescription {
+	return &captureDescription{
+		enabled:             true,
+		encoding:            "Avro",
+		interval_in_seconds: 60,
+		size_limit_in_bytes: 10485760,
+		skip_empty_archives: true,
+
+		destination: &captureDestination{
+			name:                "EventHubArchive.AzureBlockBlob",
+			archive_name_format: "Prod_{EventHub}/{Namespace}\\{PartitionId}_{Year}_{Month}/{Day}/{Hour}/{Minute}/{Second}",
+			blob_container_name: "${azurerm_storage_container.test.name}",
+			storage_account_id:  "${azurerm_storage_account.test.id}",
+		},
+	}
+}
+
+func testDefaultCaptureDescriptionString(cd *captureDescription) string {
+	return fmt.Sprintf(`
+	capture_description {
+    enabled             = %t
+    encoding            = "%s"
+    interval_in_seconds = %d
+		size_limit_in_bytes = %d
+		skip_empty_archives = %t
 
     destination {
-      name                = "EventHubArchive.AzureBlockBlob"
-      archive_name_format = "Prod_{EventHub}/{Namespace}\\{PartitionId}_{Year}_{Month}/{Day}/{Hour}/{Minute}/{Second}"
-      blob_container_name = "${azurerm_storage_container.test.name}"
-      storage_account_id  = "${azurerm_storage_account.test.id}"
+      name                = "%s"
+      archive_name_format = "%s"
+      blob_container_name = "%s"
+      storage_account_id  = "%s"
     }
   }
-}
-`, rInt, location, rString, rInt, rInt, enabledString)
+	`, cd.enabled, cd.encoding, cd.interval_in_seconds, cd.size_limit_in_bytes, cd.skip_empty_archives, cd.destination.name, cd.destination.archive_name_format, cd.destination.blob_container_name, cd.destination.storage_account_id)
 }
 
 func testAccAzureRMEventHub_messageRetentionUpdate(rInt int, location string) string {

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -286,7 +286,7 @@ func TestAccAzureRMEventHub_captureDescription(t *testing.T) {
 					testCheckAzureRMEventHubExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "capture_description.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "capture_description.0.encoding", "Avro"),
-					resource.TestCheckResourceAttr(resourceName, "capture_description.0.skip_empty_archives", "true"),
+					resource.TestCheckResourceAttr(resourceName, "capture_description.0.skip_empty_archives", "false"),
 					resource.TestCheckResourceAttr(resourceName, "capture_description.0.size_limit_in_bytes", "10485760"),
 					resource.TestCheckResourceAttr(resourceName, "capture_description.0.interval_in_seconds", "60"),
 				),
@@ -308,7 +308,7 @@ func TestAccAzureRMEventHub_captureDescriptionDisabled(t *testing.T) {
 
 	captureDescription := testDefaultCaptureDescription()
 	config := testAccAzureRMEventHub_captureDescription(ri, rs, location, captureDescription)
-	updateCaptureDescription = := testDefaultCaptureDescription()
+	updatedCaptureDescription := testDefaultCaptureDescription()
 	updatedCaptureDescription.enabled = false
 	updatedConfig := testAccAzureRMEventHub_captureDescription(ri, rs, location, updatedCaptureDescription)
 
@@ -343,7 +343,7 @@ func TestAccAzureRMEventHub_captureDescriptionSkipEmptyArchivesEnabled(t *testin
 
 	captureDescription := testDefaultCaptureDescription()
 	config := testAccAzureRMEventHub_captureDescription(ri, rs, location, captureDescription)
-	updateCaptureDescription = := testDefaultCaptureDescription()
+	updatedCaptureDescription := testDefaultCaptureDescription()
 	updatedCaptureDescription.skip_empty_archives = true
 	updatedConfig := testAccAzureRMEventHub_captureDescription(ri, rs, location, updatedCaptureDescription)
 
@@ -596,7 +596,6 @@ resource "azurerm_eventhub" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   partition_count     = 2
   message_retention   = 7
-
   %s
 }
 `, rInt, location, rString, rInt, rInt, testDefaultCaptureDescriptionString(captureDescription))
@@ -608,11 +607,11 @@ func testDefaultCaptureDescription() *captureDescription {
 		encoding:            "Avro",
 		interval_in_seconds: 60,
 		size_limit_in_bytes: 10485760,
-		skip_empty_archives: true,
+		skip_empty_archives: false,
 
 		destination: &captureDestination{
 			name:                "EventHubArchive.AzureBlockBlob",
-			archive_name_format: "Prod_{EventHub}/{Namespace}\\{PartitionId}_{Year}_{Month}/{Day}/{Hour}/{Minute}/{Second}",
+			archive_name_format: `Prod_{EventHub}/{Namespace}\\{PartitionId}_{Year}_{Month}/{Day}/{Hour}/{Minute}/{Second}`,
 			blob_container_name: "${azurerm_storage_container.test.name}",
 			storage_account_id:  "${azurerm_storage_account.test.id}",
 		},
@@ -621,21 +620,21 @@ func testDefaultCaptureDescription() *captureDescription {
 
 func testDefaultCaptureDescriptionString(cd *captureDescription) string {
 	return fmt.Sprintf(`
-	capture_description {
-    enabled             = %t
-    encoding            = "%s"
-    interval_in_seconds = %d
-		size_limit_in_bytes = %d
-		skip_empty_archives = %t
-
-    destination {
-      name                = "%s"
-      archive_name_format = "%s"
-      blob_container_name = "%s"
-      storage_account_id  = "%s"
-    }
+capture_description {
+  enabled             = %t
+  encoding            = "%s"
+  interval_in_seconds = %d
+  size_limit_in_bytes = %d
+  skip_empty_archives = %t  
+	
+  destination {
+    name                = "%s"
+    archive_name_format = "%s"
+    blob_container_name = "%s"
+    storage_account_id  = "%s"
   }
-	`, cd.enabled, cd.encoding, cd.interval_in_seconds, cd.size_limit_in_bytes, cd.skip_empty_archives, cd.destination.name, cd.destination.archive_name_format, cd.destination.blob_container_name, cd.destination.storage_account_id)
+}
+`, cd.enabled, cd.encoding, cd.interval_in_seconds, cd.size_limit_in_bytes, cd.skip_empty_archives, cd.destination.name, cd.destination.archive_name_format, cd.destination.blob_container_name, cd.destination.storage_account_id)
 }
 
 func testAccAzureRMEventHub_messageRetentionUpdate(rInt int, location string) string {

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMEventHubPartitionCount_validation(t *testing.T) {
@@ -310,7 +311,7 @@ func TestAccAzureRMEventHub_captureDescriptionDisabled(t *testing.T) {
 	captureDescription := testDefaultCaptureDescription()
 	config := testAccAzureRMEventHub_captureDescription(ri, rs, location, captureDescription)
 	updatedCaptureDescription := testDefaultCaptureDescription()
-	updatedCaptureDescription.enabled = false
+	updatedCaptureDescription.Enabled = utils.Bool(false)
 	updatedConfig := testAccAzureRMEventHub_captureDescription(ri, rs, location, updatedCaptureDescription)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -345,7 +346,7 @@ func TestAccAzureRMEventHub_captureDescriptionSkipEmptyArchivesEnabled(t *testin
 	captureDescription := testDefaultCaptureDescription()
 	config := testAccAzureRMEventHub_captureDescription(ri, rs, location, captureDescription)
 	updatedCaptureDescription := testDefaultCaptureDescription()
-	updatedCaptureDescription.skip_empty_archives = true
+	updatedCaptureDescription.SkipEmptyArchives = utils.Bool(true)
 	updatedConfig := testAccAzureRMEventHub_captureDescription(ri, rs, location, updatedCaptureDescription)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -587,18 +588,18 @@ resource "azurerm_eventhub" "test" {
 
 func testDefaultCaptureDescription() *eventhub.CaptureDescription {
 	return &eventhub.CaptureDescription{
-		Enabled:           true,
+		Enabled:           utils.Bool(true),
 		Encoding:          "Avro",
-		IntervalInSeconds: 60,
-		SizeLimitInBytes:  10485760,
-		SkipEmptyArchives: false,
+		IntervalInSeconds: utils.Int32(60),
+		SizeLimitInBytes:  utils.Int32(10485760),
+		SkipEmptyArchives: utils.Bool(false),
 
 		Destination: &eventhub.Destination{
-			Name: "EventHubArchive.AzureBlockBlob",
+			Name: utils.String("EventHubArchive.AzureBlockBlob"),
 			DestinationProperties: &eventhub.DestinationProperties{
-				ArchiveNameFormat:        `Prod_{EventHub}/{Namespace}\\{PartitionId}_{Year}_{Month}/{Day}/{Hour}/{Minute}/{Second}`,
-				BlobContainer:            "${azurerm_storage_container.test.name}",
-				StorageAccountResourceID: "${azurerm_storage_account.test.id}",
+				ArchiveNameFormat:        utils.String(`Prod_{EventHub}/{Namespace}\\{PartitionId}_{Year}_{Month}/{Day}/{Hour}/{Minute}/{Second}`),
+				BlobContainer:            utils.String("${azurerm_storage_container.test.name}"),
+				StorageAccountResourceID: utils.String("${azurerm_storage_account.test.id}"),
 			},
 		},
 	}
@@ -620,7 +621,7 @@ capture_description {
     storage_account_id  = "%s"
   }
 }
-`, cd.Enabled, cd.Encoding, cd.IntervalInSeconds, cd.SizeLimitInBytes, cd.SkipEmptyArchives, cd.Destination.Name, cd.Destination.DestinationProperties.ArchiveNameFormat, cd.Destination.DestinationProperties.BlobContainer, cd.Destination.DestinationProperties.StorageAccountResourceID)
+`, *cd.Enabled, cd.Encoding, *cd.IntervalInSeconds, *cd.SizeLimitInBytes, *cd.SkipEmptyArchives, *cd.Destination.Name, *cd.Destination.DestinationProperties.ArchiveNameFormat, *cd.Destination.DestinationProperties.BlobContainer, *cd.Destination.DestinationProperties.StorageAccountResourceID)
 }
 
 func testAccAzureRMEventHub_messageRetentionUpdate(rInt int, location string) string {

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -62,13 +62,13 @@ A `capture_description` block supports the following:
 
 * `enabled` - (Required) Specifies if the Capture Description is Enabled.
 
-* `skip_empty_archives` - (Optional) Specifies if empty files should not be emitted if no events occur during the Capture time window.  Defaults to `false`.
-
 * `encoding` - (Required) Specifies the Encoding used for the Capture Description. Possible values are `Avro` and `AvroDeflate`.
 
 * `interval_in_seconds` - (Optional) Specifies the time interval in seconds at which the capture will happen. Values can be between `60` and `900` seconds. Defaults to `300` seconds.
 
 * `size_limit_in_bytes` - (Optional) Specifies the amount of data built up in your EventHub before a Capture Operation occurs. Value should be between `10485760` and `524288000`  bytes. Defaults to `314572800` bytes.
+
+* `skip_empty_archives` - (Optional) Specifies if empty files should not be emitted if no events occur during the Capture time window.  Defaults to `false`.
 
 * `destination` - (Required) A `destination` block as defined below.
 

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -62,6 +62,8 @@ A `capture_description` block supports the following:
 
 * `enabled` - (Required) Specifies if the Capture Description is Enabled.
 
+* `skip_empty_archives` - (Optional) Specifies if empty files should not be emitted if no events occur during the Capture time window.  Defaults to `false`.
+
 * `encoding` - (Required) Specifies the Encoding used for the Capture Description. Possible values are `Avro` and `AvroDeflate`.
 
 * `interval_in_seconds` - (Optional) Specifies the time interval in seconds at which the capture will happen. Values can be between `60` and `900` seconds. Defaults to `300` seconds.


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/3057

Two questions
1) ~~I've altered the event hub tests to use a fully-configurable capture description (in case we want to expand on test cases later on down the road).  I first tried just re-created the capture description struct to match the struct in the resource itself, then I pulled in the `github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub` dependency and relied directly on the source models.  Which is best practice?~~ (Opted to simplify testing for sake of ease-of-understanding)

2) The field itself is a bit hard to describe without using a double negative.  The SDK referred to it as `SkipEmptyArchives`, which will not emit empty files if no events occur in the capture window.  Any suggestions for verbiage or this is easy enough to read?

Feel free to review and I can adjust accordingly.