### PR TITLE
[AKS] make service principal optional

### DIFF
--- a/azurerm/data_source_kubernetes_cluster_test.go
+++ b/azurerm/data_source_kubernetes_cluster_test.go
@@ -295,7 +295,7 @@ func TestAccDataSourceAzureRMKubernetesCluster_addOnProfileRouting(t *testing.T)
 }
 
 func testAccDataSourceAzureRMKubernetesCluster_basic(rInt int, clientId string, clientSecret string, location string) string {
-	r := testAccAzureRMKubernetesCluster_basic(rInt, clientId, clientSecret, location)
+	r := testAccAzureRMKubernetesCluster_basic(rInt, location)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -170,7 +170,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 			// TODO: 2.0 - we should be able to make this a List to be able to detect changes in the Client Secret
 			"service_principal": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -14,9 +14,7 @@ import (
 func TestAccAzureRMKubernetesCluster_basic(t *testing.T) {
 	resourceName := "azurerm_kubernetes_cluster.test"
 	ri := tf.AccRandTimeInt()
-	clientId := os.Getenv("ARM_CLIENT_ID")
-	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	config := testAccAzureRMKubernetesCluster_basic(ri, clientId, clientSecret, testLocation())
+	config := testAccAzureRMKubernetesCluster_basic(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -68,7 +66,7 @@ func TestAccAzureRMKubernetesCluster_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMKubernetesCluster_basic(ri, clientId, clientSecret, location),
+				Config: testAccAzureRMKubernetesCluster_basic(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(resourceName),
 				),
@@ -205,7 +203,7 @@ func TestAccAzureRMKubernetesCluster_addAgent(t *testing.T) {
 	ri := tf.AccRandTimeInt()
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
-	initConfig := testAccAzureRMKubernetesCluster_basic(ri, clientId, clientSecret, testLocation())
+	initConfig := testAccAzureRMKubernetesCluster_basic(ri, testLocation())
 	addAgentConfig := testAccAzureRMKubernetesCluster_addAgent(ri, clientId, clientSecret, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -508,7 +506,7 @@ func testCheckAzureRMKubernetesClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMKubernetesCluster_basic(rInt int, clientId string, clientSecret string, location string) string {
+func testAccAzureRMKubernetesCluster_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -526,17 +524,12 @@ resource "azurerm_kubernetes_cluster" "test" {
     count   = "1"
     vm_size = "Standard_DS2_v2"
   }
-
-  service_principal {
-    client_id     = "%s"
-    client_secret = "%s"
-  }
 }
-`, rInt, location, rInt, rInt, clientId, clientSecret)
+`, rInt, location, rInt, rInt)
 }
 
 func testAccAzureRMKubernetesCluster_requiresImport(rInt int, clientId, clientSecret, location string) string {
-	template := testAccAzureRMKubernetesCluster_basic(rInt, clientId, clientSecret, location)
+	template := testAccAzureRMKubernetesCluster_basic(rInt, location)
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 -> **NOTE:** The `dns_prefix` must contain between 3 and 45 characters, and can contain only letters, numbers, and hyphens. It must start with a letter and must end with a letter or a number.
 
-* `service_principal` - (Required) A `service_principal` block as documented below.
+* `service_principal` - (Optional) A `service_principal` block as documented below.  If not specified, a service principal will be auto-generated. For more details please visit [Service principals with Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/kubernetes-service-principal) 
 
 ---
 


### PR DESCRIPTION
This partially addresses https://github.com/terraform-providers/terraform-provider-azurerm/issues/2931

I will try to see what needs to be done for the SSH key piece in another PR.

The service principal is just made optional.  It looks like the handling of a nil service principal is the same as the already optional `linux_profile`, so it appeared all I needed to do was simply make it optional instead of required.