### PR TITLE
[Application Gateway] Add WAF properties for request body checking

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -811,6 +811,17 @@ func resourceArmApplicationGateway() *schema.Resource {
 							ValidateFunc: validation.IntBetween(1, 500),
 							Default:      100,
 						},
+						"request_body_check": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"max_request_body_size_kb": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 128),
+							Default:      128,
+						},
 					},
 				},
 			},
@@ -2278,13 +2289,17 @@ func expandApplicationGatewayWafConfig(d *schema.ResourceData) *network.Applicat
 	ruleSetType := v["rule_set_type"].(string)
 	ruleSetVersion := v["rule_set_version"].(string)
 	fileUploadLimitInMb := v["file_upload_limit_mb"].(int)
+	requestBodyCheck := v["request_body_check"].(bool)
+	maxRequestBodySizeInKb := v["max_request_body_size_kb"].(int)
 
 	return &network.ApplicationGatewayWebApplicationFirewallConfiguration{
-		Enabled:             utils.Bool(enabled),
-		FirewallMode:        network.ApplicationGatewayFirewallMode(mode),
-		RuleSetType:         utils.String(ruleSetType),
-		RuleSetVersion:      utils.String(ruleSetVersion),
-		FileUploadLimitInMb: utils.Int32(int32(fileUploadLimitInMb)),
+		Enabled:                utils.Bool(enabled),
+		FirewallMode:           network.ApplicationGatewayFirewallMode(mode),
+		RuleSetType:            utils.String(ruleSetType),
+		RuleSetVersion:         utils.String(ruleSetVersion),
+		FileUploadLimitInMb:    utils.Int32(int32(fileUploadLimitInMb)),
+		RequestBodyCheck:       utils.Bool(requestBodyCheck),
+		MaxRequestBodySizeInKb: utils.Int32(int32(maxRequestBodySizeInKb)),
 	}
 }
 
@@ -2312,6 +2327,14 @@ func flattenApplicationGatewayWafConfig(input *network.ApplicationGatewayWebAppl
 
 	if input.FileUploadLimitInMb != nil {
 		output["file_upload_limit_mb"] = int(*input.FileUploadLimitInMb)
+	}
+
+	if input.RequestBodyCheck != nil {
+		output["request_body_check"] = *input.RequestBodyCheck
+	}
+
+	if input.MaxRequestBodySizeInKb != nil {
+		output["max_request_body_size_kb"] = int(*input.MaxRequestBodySizeInKb)
 	}
 
 	results = append(results, output)

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -351,6 +351,8 @@ func TestAccAzureRMApplicationGateway_webApplicationFirewall(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.rule_set_type", "OWASP"),
 					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.rule_set_version", "3.0"),
 					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.file_upload_limit_mb", "100"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.request_body_check", "true"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.max_request_body_size_kb", "100"),
 				),
 			},
 		},
@@ -1435,6 +1437,8 @@ resource "azurerm_application_gateway" "test" {
     rule_set_type    = "OWASP"
     rule_set_version = "3.0"
     file_upload_limit_mb = 100
+    request_body_check = true
+    max_request_body_size_kb = 100
   }
 
   gateway_ip_configuration {

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -377,6 +377,10 @@ A `waf_configuration` block supports the following:
 
 * `file_upload_limit_mb` - (Optional) The File Upload Limit in MB. Accepted values are in the range `1`MB to `500`MB. Defaults to `100`MB.
 
+* `request_body_check` - (Optional) Is Request Body Inspection enabled?  Defaults to `true`.
+
+* `max_request_body_size_kb` - (Optional) The Maximum Request Body Size in KB.  Accepted values are in the range `1`KB to `128`KB.  Defaults to `128`KB.
+
 ---
 
 A `custom_error_configuration` block supports the following:


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/3088 by including `request_body_check` and `max_request_body_size_kb` properties.  WAF test within the application gateway test suite has been updated to verify the new configuration values.  Documentation has been updated to align with [the WAF documentation](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-waf-configuration#waf-request-size-limits).