### PR TITLE
[Image] zone resilient property addition

### DIFF
--- a/azurerm/data_source_image.go
+++ b/azurerm/data_source_image.go
@@ -196,6 +196,8 @@ func dataSourceArmImageRead(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("[DEBUG] Error setting AzureRM Image Data Disks error: %+v", err)
 			}
 		}
+
+		d.Set("zone_resilient", profile.ZoneResilient)
 	}
 
 	flattenAndSetTags(d, img.Tags)

--- a/azurerm/data_source_image.go
+++ b/azurerm/data_source_image.go
@@ -40,6 +40,11 @@ func dataSourceArmImage() *schema.Resource {
 
 			"location": locationForDataSourceSchema(),
 
+			"zone_resilient": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"os_disk": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/azurerm/resource_arm_image.go
+++ b/azurerm/resource_arm_image.go
@@ -298,12 +298,12 @@ func resourceArmImageRead(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("[DEBUG] Error setting AzureRM Image OS Disk error: %+v", err)
 			}
 		}
-
 		if disks := resp.StorageProfile.DataDisks; disks != nil {
 			if err := d.Set("data_disk", flattenAzureRmImageDataDisks(disks)); err != nil {
 				return fmt.Errorf("[DEBUG] Error setting AzureRM Image Data Disks error: %+v", err)
 			}
 		}
+		d.Set("zone_resilient", resp.StorageProfile.ZoneResilient)
 	}
 
 	flattenAndSetTags(d, resp.Tags)

--- a/azurerm/resource_arm_image.go
+++ b/azurerm/resource_arm_image.go
@@ -298,6 +298,7 @@ func resourceArmImageRead(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("[DEBUG] Error setting AzureRM Image OS Disk error: %+v", err)
 			}
 		}
+
 		if disks := resp.StorageProfile.DataDisks; disks != nil {
 			if err := d.Set("data_disk", flattenAzureRmImageDataDisks(disks)); err != nil {
 				return fmt.Errorf("[DEBUG] Error setting AzureRM Image Data Disks error: %+v", err)

--- a/azurerm/resource_arm_image.go
+++ b/azurerm/resource_arm_image.go
@@ -35,6 +35,13 @@ func resourceArmImage() *schema.Resource {
 
 			"resource_group_name": resourceGroupNameSchema(),
 
+			"zone_resilient": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
 			"source_virtual_machine_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -166,6 +173,7 @@ func resourceArmImageCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+	zoneResilient := d.Get("zone_resilient").(bool)
 
 	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name, "")
@@ -196,8 +204,9 @@ func resourceArmImageCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	storageProfile := compute.ImageStorageProfile{
-		OsDisk:    osDisk,
-		DataDisks: &dataDisks,
+		OsDisk:        osDisk,
+		DataDisks:     &dataDisks,
+		ZoneResilient: utils.Bool(zoneResilient),
 	}
 
 	sourceVM := compute.SubResource{}

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -22,8 +22,52 @@ func TestAccAzureRMImage_standaloneImage(t *testing.T) {
 	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
 	sshPort := "22"
 	location := testLocation()
-	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, location)
-	postConfig := testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName, location)
+	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, location, "LRS")
+	postConfig := testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName, location, "LRS")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				//need to create a vm and then reference it in the image creation
+				Config:  preConfig,
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureVMExists("azurerm_virtual_machine.testsource", true),
+					testGeneralizeVMImage(resourceGroup, "testsource", userName, password, hostName, sshPort, location),
+				),
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMImageExists("azurerm_image.test", true),
+				),
+			},
+			{
+				ResourceName:      "azurerm_image.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMImage_standaloneImageZoneRedundant(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
+	userName := "testadmin"
+	password := "Password1234!"
+	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
+	sshPort := "22"
+	location := testLocation()
+	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, location, "ZRS")
+	postConfig := testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName, location, "ZRS")
+
+	if !supportsZRS(location) {
+		t.Skip(fmt.Sprintf("Integration test skipped because location '%s' does not support zone-redundant storage", location))
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -75,7 +119,7 @@ func TestAccAzureRMImage_requiresImport(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				//need to create a vm and then reference it in the image creation
-				Config:  testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, location),
+				Config:  testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, location, "LRS"),
 				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureVMExists("azurerm_virtual_machine.testsource", true),
@@ -83,7 +127,7 @@ func TestAccAzureRMImage_requiresImport(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName, location),
+				Config: testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName, location, "LRS"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMImageExists("azurerm_image.test", true),
 				),
@@ -397,7 +441,7 @@ func testCheckAzureRMImageDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMImage_standaloneImage_setup(rInt int, userName string, password string, hostName string, location string) string {
+func testAccAzureRMImage_standaloneImage_setup(rInt int, userName string, password string, hostName string, location string, storageType string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -444,7 +488,7 @@ resource "azurerm_storage_account" "test" {
   resource_group_name      = "${azurerm_resource_group.test.name}"
   location                 = "${azurerm_resource_group.test.location}"
   account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_replication_type = "%s"
 
   tags = {
     environment = "Dev"
@@ -495,10 +539,10 @@ resource "azurerm_virtual_machine" "testsource" {
     cost-center = "Ops"
   }
 }
-`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password)
+`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, storageType, userName, password)
 }
 
-func testAccAzureRMImage_standaloneImage_provision(rInt int, userName string, password string, hostName string, location string) string {
+func testAccAzureRMImage_standaloneImage_provision(rInt int, userName string, password string, hostName string, location string, storageType string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -545,7 +589,7 @@ resource "azurerm_storage_account" "test" {
   resource_group_name      = "${azurerm_resource_group.test.name}"
   location                 = "${azurerm_resource_group.test.location}"
   account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_replication_type = "%s"
 
   tags = {
     environment = "Dev"
@@ -601,6 +645,7 @@ resource "azurerm_image" "test" {
   name                = "accteste"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+  zone_redundant      = %t
 
   os_disk {
     os_type  = "Linux"
@@ -615,11 +660,11 @@ resource "azurerm_image" "test" {
     cost-center = "Ops"
   }
 }
-`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password)
+`, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, storageType, userName, password, storageType == "ZRS")
 }
 
 func testAccAzureRMImage_standaloneImage_requiresImport(rInt int, userName string, password string, hostName string, location string) string {
-	template := testAccAzureRMImage_standaloneImage_provision(rInt, userName, password, hostName, location)
+	template := testAccAzureRMImage_standaloneImage_provision(rInt, userName, password, hostName, location, "LRS")
 	return fmt.Sprintf(`
 %s
 
@@ -1387,4 +1432,14 @@ resource "azurerm_virtual_machine_scale_set" "testdestination" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password, rInt, userName, password, rInt)
+}
+
+func supportsZRS(location string) bool {
+	zrsRegions := []string{"westus2", "westus", "southeastasia", "westeurope", "northeurope", "japaneast", "uksouth", "eastus", "eastus2", "centralus"}
+	for _, region := range zrsRegions {
+		if region == location {
+			return true
+		}
+	}
+	return false
 }

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -1434,6 +1434,7 @@ resource "azurerm_virtual_machine_scale_set" "testdestination" {
 `, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password, rInt, userName, password, rInt)
 }
 
+// Region list pulled from https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy-zrs
 func supportsZRS(location string) bool {
 	zrsRegions := []string{"westus2", "westus", "southeastasia", "westeurope", "northeurope", "japaneast", "uksouth", "eastus", "eastus2", "centralus"}
 	for _, region := range zrsRegions {

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -1436,7 +1436,7 @@ resource "azurerm_virtual_machine_scale_set" "testdestination" {
 
 // Region list pulled from https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy-zrs
 func supportsZRS(location string) bool {
-	zrsRegions := []string{"westus2", "westus", "southeastasia", "westeurope", "northeurope", "japaneast", "uksouth", "eastus", "eastus2", "centralus"}
+	zrsRegions := []string{"westus2", "francecentral", "southeastasia", "westeurope", "northeurope", "japaneast", "uksouth", "eastus", "eastus2", "centralus"}
 	for _, region := range zrsRegions {
 		if region == location {
 			return true

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -641,7 +641,7 @@ resource "azurerm_image" "test" {
   name                = "accteste"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  zone_redundant      = %t
+  zone_resilient      = %t
 
   os_disk {
     os_type  = "Linux"

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -65,10 +65,6 @@ func TestAccAzureRMImage_standaloneImageZoneRedundant(t *testing.T) {
 	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, location, "ZRS")
 	postConfig := testAccAzureRMImage_standaloneImage_provision(ri, userName, password, hostName, location, "ZRS")
 
-	if !supportsZRS(location) {
-		t.Skip(fmt.Sprintf("Integration test skipped because location '%s' does not support zone-redundant storage", location))
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -1432,15 +1428,4 @@ resource "azurerm_virtual_machine_scale_set" "testdestination" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, hostName, rInt, rInt, userName, password, rInt, userName, password, rInt)
-}
-
-// Region list pulled from https://docs.microsoft.com/en-us/azure/storage/common/storage-redundancy-zrs
-func supportsZRS(location string) bool {
-	zrsRegions := []string{"westus2", "francecentral", "southeastasia", "westeurope", "northeurope", "japaneast", "uksouth", "eastus", "eastus2", "centralus"}
-	for _, region := range zrsRegions {
-		if region == location {
-			return true
-		}
-	}
-	return false
 }

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -166,11 +166,11 @@ func testCheckAzureRMSharedImageVersionExists(resourceName string) resource.Test
 }
 
 func testAccAzureRMSharedImageVersion_setup(rInt int, location, username, password, hostname string) string {
-	return testAccAzureRMImage_standaloneImage_setup(rInt, username, password, hostname, location)
+	return testAccAzureRMImage_standaloneImage_setup(rInt, username, password, hostname, location, "LRS")
 }
 
 func testAccAzureRMSharedImageVersion_provision(rInt int, location, username, password, hostname string) string {
-	template := testAccAzureRMImage_standaloneImage_provision(rInt, username, password, hostname, location)
+	template := testAccAzureRMImage_standaloneImage_provision(rInt, username, password, hostname, location, "LRS")
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -507,7 +507,7 @@ func TestAccAzureRMVirtualMachineScaleSet_customImage(t *testing.T) {
 	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
 	sshPort := "22"
 	config := testAccAzureRMVirtualMachineScaleSet_customImage(ri, testLocation(), userName, password, hostName)
-	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, testLocation())
+	preConfig := testAccAzureRMImage_standaloneImage_setup(ri, userName, password, hostName, testLocation(), "LRS")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -37,6 +37,7 @@ output "image_id" {
 * `location` - the Azure Location where this Image exists.
 * `os_disk` - a `os_disk` block as defined below.
 * `data_disk` - a collection of `data_disk` blocks as defined below.
+* `zone_resilient` - is zone resiliency enabled?
 * `tags` - a mapping of tags to assigned to the resource.
 
 `os_disk` supports the following:

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -33,12 +33,12 @@ output "image_id" {
 
 ## Attributes Reference
 
+* `data_disk` - a collection of `data_disk` blocks as defined below.
 * `name` - the name of the Image.
 * `location` - the Azure Location where this Image exists.
 * `os_disk` - a `os_disk` block as defined below.
-* `data_disk` - a collection of `data_disk` blocks as defined below.
-* `zone_resilient` - is zone resiliency enabled?
 * `tags` - a mapping of tags to assigned to the resource.
+* `zone_resilient` - is zone resiliency enabled?
 
 `os_disk` supports the following:
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -58,10 +58,13 @@ The following arguments are supported:
     the image. Changing this forces a new resource to be created.
 * `location` - (Required) Specified the supported Azure location where the resource exists.
     Changing this forces a new resource to be created.
+* `zone_resilient` - (Optional) Is zone resiliency enabled?  Defaults to `false`.  Changing this forces a new resource to be created.
 * `source_virtual_machine_id` - (Optional) The Virtual Machine ID from which to create the image.
 * `os_disk` - (Optional) One or more `os_disk` elements as defined below.
 * `data_disk` - (Optional) One or more `data_disk` elements as defined below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+~> **Note**: `zone_resilient` can only be set to `true` if the image is stored in a region that supports availability zones.
 
 `os_disk` supports the following:
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -58,11 +58,11 @@ The following arguments are supported:
     the image. Changing this forces a new resource to be created.
 * `location` - (Required) Specified the supported Azure location where the resource exists.
     Changing this forces a new resource to be created.
-* `zone_resilient` - (Optional) Is zone resiliency enabled?  Defaults to `false`.  Changing this forces a new resource to be created.
 * `source_virtual_machine_id` - (Optional) The Virtual Machine ID from which to create the image.
 * `os_disk` - (Optional) One or more `os_disk` elements as defined below.
 * `data_disk` - (Optional) One or more `data_disk` elements as defined below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `zone_resilient` - (Optional) Is zone resiliency enabled?  Defaults to `false`.  Changing this forces a new resource to be created.
 
 ~> **Note**: `zone_resilient` can only be set to `true` if the image is stored in a region that supports availability zones.
 


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/1581

Updated documentation.  Note about where zone resiliency can be used comes from the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/capture-image-resource#create-an-image-of-a-vm-using-powershell)

Added a property to an existing test function which specifies the storage type so that it could be reused for the `zone_redundant` test.  Added a possible skip to the test, as not all zones support ZRS and did not want false positives interfering with the test.