### PR TITLE
New Resource: `azurerm_api_management_subscription`

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -136,6 +136,7 @@ type ArmClient struct {
 	apiManagementProductGroupsClient apimanagement.ProductGroupClient
 	apiManagementPropertyClient      apimanagement.PropertyClient
 	apiManagementServiceClient       apimanagement.ServiceClient
+	apiManagementSubscriptionsClient apimanagement.SubscriptionClient
 	apiManagementUsersClient         apimanagement.UserClient
 
 	// Application Insights
@@ -532,6 +533,10 @@ func (c *ArmClient) registerApiManagementServiceClients(endpoint, subscriptionId
 	propertiesClient := apimanagement.NewPropertyClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&propertiesClient.Client, auth)
 	c.apiManagementPropertyClient = propertiesClient
+
+	subscriptionsClient := apimanagement.NewSubscriptionClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&subscriptionsClient.Client, auth)
+	c.apiManagementSubscriptionsClient = subscriptionsClient
 
 	usersClient := apimanagement.NewUserClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&usersClient.Client, auth)

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -22,6 +22,17 @@ func SchemaApiManagementDataSourceName() *schema.Schema {
 	}
 }
 
+// SchemaApiManagementChildID returns the Schema for the identifier
+// used by resources within nested under the API Management Service resource
+func SchemaApiManagementChildID() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: ValidateResourceID,
+	}
+}
+
 // SchemaApiManagementChildName returns the Schema for the identifier
 // used by resources within nested under the API Management Service resource
 func SchemaApiManagementChildName() *schema.Schema {

--- a/azurerm/helpers/azure/resourceid_test.go
+++ b/azurerm/helpers/azure/resourceid_test.go
@@ -127,6 +127,19 @@ func TestParseAzureResourceID(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/example-resources/providers/Microsoft.ApiManagement/service/service1/subscriptions/22222222-2222-2222-2222-222222222222",
+			&ResourceID{
+				SubscriptionID: "11111111-1111-1111-1111-111111111111",
+				ResourceGroup:  "example-resources",
+				Provider:       "Microsoft.ApiManagement",
+				Path: map[string]string{
+					"service":       "service1",
+					"subscriptions": "22222222-2222-2222-2222-222222222222",
+				},
+			},
+			false,
+		},
 	}
 
 	for _, test := range testCases {

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -177,6 +177,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_api_management_product_api":             resourceArmApiManagementProductApi(),
 			"azurerm_api_management_product_group":           resourceArmApiManagementProductGroup(),
 			"azurerm_api_management_property":                resourceArmApiManagementProperty(),
+			"azurerm_api_management_subscription":            resourceArmApiManagementSubscription(),
 			"azurerm_api_management_user":                    resourceArmApiManagementUser(),
 			"azurerm_app_service_active_slot":                resourceArmAppServiceActiveSlot(),
 			"azurerm_app_service_custom_hostname_binding":    resourceArmAppServiceCustomHostnameBinding(),

--- a/azurerm/resource_arm_api_management_subscription.go
+++ b/azurerm/resource_arm_api_management_subscription.go
@@ -1,0 +1,201 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimanagement"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/satori/uuid"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementSubscription() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementSubscriptionCreateUpdate,
+		Read:   resourceArmApiManagementSubscriptionRead,
+		Update: resourceArmApiManagementSubscriptionCreateUpdate,
+		Delete: resourceArmApiManagementSubscriptionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"subscription_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.UUIDOrEmpty,
+			},
+
+			"user_id": azure.SchemaApiManagementChildID(),
+
+			"product_id": azure.SchemaApiManagementChildID(),
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"display_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(apimanagement.Submitted),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(apimanagement.Active),
+					string(apimanagement.Cancelled),
+					string(apimanagement.Expired),
+					string(apimanagement.Rejected),
+					string(apimanagement.Submitted),
+					string(apimanagement.Suspended),
+				}, false),
+			},
+
+			"primary_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementSubscriptionsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	subscriptionId := d.Get("subscription_id").(string)
+	if subscriptionId == "" {
+		subscriptionId = uuid.NewV4().String()
+	}
+
+	if requireResourcesToBeImported {
+		resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Error checking for present of existing Subscription %q (API Management Service %q / Resource Group %q): %+v", subscriptionId, serviceName, resourceGroup, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return tf.ImportAsExistsError("azurerm_api_management_subscription", *resp.ID)
+		}
+	}
+
+	displayName := d.Get("display_name").(string)
+	productId := d.Get("product_id").(string)
+	state := d.Get("state").(string)
+	userId := d.Get("user_id").(string)
+
+	params := apimanagement.SubscriptionCreateParameters{
+		SubscriptionCreateParameterProperties: &apimanagement.SubscriptionCreateParameterProperties{
+			DisplayName: utils.String(displayName),
+			ProductID:   utils.String(productId),
+			State:       apimanagement.SubscriptionState(state),
+			UserID:      utils.String(userId),
+		},
+	}
+
+	if v, ok := d.GetOk("primary_key"); ok {
+		params.SubscriptionCreateParameterProperties.PrimaryKey = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("secondary_key"); ok {
+		params.SubscriptionCreateParameterProperties.SecondaryKey = utils.String(v.(string))
+	}
+
+	sendEmail := utils.Bool(false)
+	_, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, subscriptionId, params, sendEmail, "")
+	if err != nil {
+		return fmt.Errorf("Error creating/updating Subscription %q (API Management Service %q / Resource Group %q): %+v", subscriptionId, serviceName, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Subscription %q (API Management Service %q / Resource Group %q): %+v", subscriptionId, serviceName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmApiManagementSubscriptionRead(d, meta)
+}
+
+func resourceArmApiManagementSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementSubscriptionsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	subscriptionId := id.Path["subscriptions"]
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Subscription %q was not found in API Management Service %q / Resource Group %q - removing from state!", subscriptionId, serviceName, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Subscription %q (API Management Service %q / Resource Group %q): %+v", subscriptionId, serviceName, resourceGroup, err)
+	}
+
+	d.Set("subscription_id", subscriptionId)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("api_management_name", serviceName)
+
+	if props := resp.SubscriptionContractProperties; props != nil {
+		d.Set("display_name", props.DisplayName)
+		d.Set("primary_key", props.PrimaryKey)
+		d.Set("secondary_key", props.SecondaryKey)
+		d.Set("state", string(props.State))
+		d.Set("product_id", props.ProductID)
+		d.Set("user_id", props.UserID)
+	}
+
+	return nil
+}
+
+func resourceArmApiManagementSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).apiManagementSubscriptionsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	subscriptionId := id.Path["subscriptions"]
+
+	if resp, err := client.Delete(ctx, resourceGroup, serviceName, subscriptionId, ""); err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error removing Subscription %q (API Management Service %q / Resource Group %q): %+v", subscriptionId, serviceName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_api_management_subscription_test.go
+++ b/azurerm/resource_arm_api_management_subscription_test.go
@@ -163,8 +163,6 @@ func testCheckAzureRMAPIManagementSubscriptionDestroy(s *terraform.State) error 
 				return err
 			}
 		}
-
-		return nil
 	}
 	return nil
 }

--- a/azurerm/resource_arm_api_management_subscription_test.go
+++ b/azurerm/resource_arm_api_management_subscription_test.go
@@ -1,0 +1,298 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMAPIManagementSubscription_basic(t *testing.T) {
+	resourceName := "azurerm_api_management_subscription.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAPIManagementSubscription_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAPIManagementSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "subscription_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_key"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAPIManagementSubscription_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_api_management_subscription.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAPIManagementSubscription_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAPIManagementSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "subscription_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_key"),
+				),
+			},
+			{
+				Config:      testAccAzureRMAPIManagementSubscription_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_api_management_subscription"),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAPIManagementSubscription_update(t *testing.T) {
+	resourceName := "azurerm_api_management_subscription.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAPIManagementSubscription_update(ri, location, "submitted"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAPIManagementSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", "submitted"),
+					resource.TestCheckResourceAttrSet(resourceName, "subscription_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_key"),
+				),
+			},
+			{
+				Config: testAccAzureRMAPIManagementSubscription_update(ri, location, "active"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAPIManagementSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", "active"),
+				),
+			},
+			{
+				Config: testAccAzureRMAPIManagementSubscription_update(ri, location, "suspended"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAPIManagementSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", "suspended"),
+				),
+			},
+			{
+				Config: testAccAzureRMAPIManagementSubscription_update(ri, location, "cancelled"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAPIManagementSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", "cancelled"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAPIManagementSubscription_complete(t *testing.T) {
+	resourceName := "azurerm_api_management_subscription.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAPIManagementSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAPIManagementSubscription_complete(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAPIManagementSubscriptionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "state", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "subscription_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_key"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMAPIManagementSubscriptionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ArmClient).apiManagementSubscriptionsClient
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_subscription" {
+			continue
+		}
+
+		subscriptionId := rs.Primary.Attributes["subscription_id"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
+
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+	return nil
+}
+
+func testCheckAzureRMAPIManagementSubscriptionExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		subscriptionId := rs.Primary.Attributes["subscription_id"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		client := testAccProvider.Meta().(*ArmClient).apiManagementSubscriptionsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Subscription %q (API Management Service %q / Resource Group %q) does not exist", subscriptionId, serviceName, resourceGroup)
+			}
+			return fmt.Errorf("Bad: Get on apiManagementSubscriptionsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMAPIManagementSubscription_basic(rInt int, location string) string {
+	template := testAccAzureRMAPIManagementSubscription_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_subscription" "test" {
+  resource_group_name = "${azurerm_api_management.test.resource_group_name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  user_id             = "${azurerm_api_management_user.test.id}"
+  product_id          = "${azurerm_api_management_product.test.id}"
+  display_name        = "Butter Parser API Enterprise Edition"
+}
+`, template)
+}
+
+func testAccAzureRMAPIManagementSubscription_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMAPIManagementSubscription_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_subscription" "import" {
+  resource_group_name = "${azurerm_api_management_subscription.test.resource_group_name}"
+  api_management_name = "${azurerm_api_management_subscription.test.api_management_name}"
+  user_id             = "${azurerm_api_management_subscription.test.user_id}"
+  product_id          = "${azurerm_api_management_subscription.test.product_id}"
+  display_name        = "${azurerm_api_management_subscription.test.display_name}"
+}
+`, template)
+}
+
+func testAccAzureRMAPIManagementSubscription_update(rInt int, location, state string) string {
+	template := testAccAzureRMAPIManagementSubscription_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_subscription" "test" {
+  resource_group_name = "${azurerm_api_management.test.resource_group_name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  user_id             = "${azurerm_api_management_user.test.id}"
+  product_id          = "${azurerm_api_management_product.test.id}"
+  display_name        = "Butter Parser API Enterprise Edition"
+  state               = "%s"
+}
+`, template, state)
+}
+
+func testAccAzureRMAPIManagementSubscription_complete(rInt int, location string) string {
+	template := testAccAzureRMAPIManagementSubscription_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_subscription" "test" {
+  resource_group_name = "${azurerm_api_management.test.resource_group_name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  user_id             = "${azurerm_api_management_user.test.id}"
+  product_id          = "${azurerm_api_management_product.test.id}"
+  display_name        = "Butter Parser API Enterprise Edition"
+  state               = "active"
+}
+`, template)
+}
+
+func testAccAzureRMAPIManagementSubscription_template(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+}
+
+resource "azurerm_api_management_product" "test" {
+  product_id            = "test-product"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  display_name          = "Test Product"
+  subscription_required = true
+  approval_required     = false
+  published             = true
+}
+
+resource "azurerm_api_management_user" "test" {
+  user_id               = "acctestuser%d"
+  api_management_name   = "${azurerm_api_management.test.name}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  first_name            = "Acceptance"
+  last_name             = "Test"
+  email                 = "azure-acctest%d@example.com"
+}
+`, rInt, location, rInt, rInt, rInt)
+}

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -1,0 +1,53 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_subscription"
+sidebar_current: "docs-azurerm-resource-api-management-subscription"
+description: |-
+  Manages a Subscription within a API Management Service.
+---
+
+# azurerm_api_management_subscription
+
+Manages a Subscription within a API Management Service.
+
+
+## Example Usage
+
+```hcl
+XXXX
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `api_management_name` - (Required) The name of the API Management Service where this Subscription should be created. Changing this forces a new resource to be created.
+
+* `display_name` - (Required) The display name of this Subscription.
+
+* `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service exists. Changing this forces a new resource to be created.
+
+* `product_id` - (Required) The ID of the Product which should be assigned to this Subscription. Changing this forces a new resource to be created.
+
+* `user_id` - (Required) The ID of the User which should be assigned to this Subscription. Changing this forces a new resource to be created.
+
+---
+
+* `state` - (Optional) The state of this Subscription. Possible values are `Active`, `Cancelled`, `Expired`, `Rejected`, `XXX`, `Submitted` and `Suspended`. Defaults to `Submitted`.
+
+* `subscription_id` - (Optional) An Identifier which should used as the ID of this Subscription. If not specified a new Subscription ID will be generated. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the API Management Subscription.
+
+## Import
+
+API Management Properties can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_subscription.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-resources/providers/Microsoft.ApiManagement/service/example-apim/properties/example-apimp
+```

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -46,7 +46,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-API Management Properties can be imported using the `resource id`, e.g.
+API Management Subscriptions can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_api_management_subscription.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-resources/providers/Microsoft.ApiManagement/service/example-apim/properties/example-apimp

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -14,7 +14,30 @@ Manages a Subscription within a API Management Service.
 ## Example Usage
 
 ```hcl
-XXXX
+data "azurerm_api_management" "test" {
+  name                = "example-apim"
+  resource_group_name = "example-resources"
+}
+
+data "azurerm_api_management_product" "test" {
+  product_id          = "00000000-0000-0000-0000-000000000000"
+  api_management_name = "${data.azurerm_api_management.test.name}"
+  resource_group_name = "${data.azurerm_api_management.test.resource_group_name}"
+}
+
+data "azurerm_api_management_user" "test" {
+  user_id             = "11111111-1111-1111-1111-111111111111"
+  api_management_name = "${data.azurerm_api_management.test.name}"
+  resource_group_name = "${data.azurerm_api_management.test.resource_group_name}"
+}
+
+resource "azurerm_api_management_subscription" "test" {
+  api_management_name = "${data.azurerm_api_management.test.name}"
+  resource_group_name = "${data.azurerm_api_management.test.resource_group_name}"
+  user_id             = "${data.azurerm_api_management_user.test.id}"
+  product_id          = "${data.azurerm_api_management_product.test.id}"
+  display_name        = "Parser API"
+}
 ```
 
 
@@ -34,7 +57,7 @@ The following arguments are supported:
 
 ---
 
-* `state` - (Optional) The state of this Subscription. Possible values are `Active`, `Cancelled`, `Expired`, `Rejected`, `XXX`, `Submitted` and `Suspended`. Defaults to `Submitted`.
+* `state` - (Optional) The state of this Subscription. Possible values are `Active`, `Cancelled`, `Expired`, `Rejected`, `Submitted` and `Suspended`. Defaults to `Submitted`.
 
 * `subscription_id` - (Optional) An Identifier which should used as the ID of this Subscription. If not specified a new Subscription ID will be generated. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This PR adds support for API Management Subscriptions, which are a part of #1177

Of particular note here is that the User ID and Product ID need to be fully qualified Resource ID's (which is what the API returns); however the API allows a short-hand too at creation time (`/products/0000`) - but there's validation to confirm the ID is a Resource ID since this is what's actually returned from the API.