### PR TITLE
add zone_redundant as editable flag for mssql_elasticpool

### DIFF
--- a/azurerm/resource_arm_mssql_elasticpool.go
+++ b/azurerm/resource_arm_mssql_elasticpool.go
@@ -177,7 +177,6 @@ func resourceArmMsSqlElasticPool() *schema.Resource {
 			"zone_redundant": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 
 			"tags": tagsSchema(),
@@ -203,7 +202,6 @@ func resourceArmMsSqlElasticPoolCreateUpdate(d *schema.ResourceData, meta interf
 	elasticPoolName := d.Get("name").(string)
 	serverName := d.Get("server_name").(string)
 	resGroup := d.Get("resource_group_name").(string)
-	zoneredundant := d.Get("zone_redundant").(bool)
 
 	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, serverName, elasticPoolName)
@@ -229,8 +227,11 @@ func resourceArmMsSqlElasticPoolCreateUpdate(d *schema.ResourceData, meta interf
 		Tags:     expandTags(tags),
 		ElasticPoolProperties: &sql.ElasticPoolProperties{
 			PerDatabaseSettings: expandAzureRmMsSqlElasticPoolPerDatabaseSettings(d),
-			ZoneRedundant:       &zoneredundant,
 		},
+	}
+
+	if v, ok := d.GetOkExists("zone_redundant"); ok {
+		elasticPool.ElasticPoolProperties.ZoneRedundant = utils.Bool(v.(bool))
 	}
 
 	if d.HasChange("max_size_gb") {

--- a/azurerm/resource_arm_mssql_elasticpool.go
+++ b/azurerm/resource_arm_mssql_elasticpool.go
@@ -176,7 +176,8 @@ func resourceArmMsSqlElasticPool() *schema.Resource {
 
 			"zone_redundant": {
 				Type:     schema.TypeBool,
-				Computed: true,
+				Optional: true,
+				Default:  false,
 			},
 
 			"tags": tagsSchema(),
@@ -202,6 +203,7 @@ func resourceArmMsSqlElasticPoolCreateUpdate(d *schema.ResourceData, meta interf
 	elasticPoolName := d.Get("name").(string)
 	serverName := d.Get("server_name").(string)
 	resGroup := d.Get("resource_group_name").(string)
+	zoneredundant := d.Get("zone_redundant").(bool)
 
 	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, serverName, elasticPoolName)
@@ -227,6 +229,7 @@ func resourceArmMsSqlElasticPoolCreateUpdate(d *schema.ResourceData, meta interf
 		Tags:     expandTags(tags),
 		ElasticPoolProperties: &sql.ElasticPoolProperties{
 			PerDatabaseSettings: expandAzureRmMsSqlElasticPoolPerDatabaseSettings(d),
+			ZoneRedundant:       &zoneredundant,
 		},
 	}
 

--- a/azurerm/resource_arm_mssql_elasticpool_test.go
+++ b/azurerm/resource_arm_mssql_elasticpool_test.go
@@ -506,8 +506,8 @@ resource "azurerm_mssql_elasticpool" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
   server_name         = "${azurerm_sql_server.test.name}"
-	max_size_gb         = %.7[6]f
-	zone_redundant       = %[9]t
+  max_size_gb         = %.7[6]f
+  zone_redundant      = %[9]t
   
   sku {
     name     = "%[3]s"

--- a/azurerm/resource_arm_mssql_elasticpool_test.go
+++ b/azurerm/resource_arm_mssql_elasticpool_test.go
@@ -98,6 +98,34 @@ func TestAccAzureRMMsSqlElasticPool_standard_DTU(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMMsSqlElasticPool_premium_DTU_zone_redundant(t *testing.T) {
+	resourceName := "azurerm_mssql_elasticpool.test"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMMsSqlElasticPool_premium_DTU_zone_redundant(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMMsSqlElasticPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlElasticPoolExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sku.0.name", "PremiumPool"),
+					resource.TestCheckResourceAttr(resourceName, "zone_redundant", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"max_size_gb"},
+			},
+		},
+	})
+}
+
 func TestAccAzureRMMsSqlElasticPool_basic_vCore(t *testing.T) {
 	resourceName := "azurerm_mssql_elasticpool.test"
 	ri := tf.AccRandTimeInt()
@@ -337,11 +365,11 @@ func testCheckAzureRMMsSqlElasticPoolDisappears(resourceName string) resource.Te
 }
 
 func testAccAzureRMMsSqlElasticPool_basic_DTU(rInt int, location string) string {
-	return testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "BasicPool", "Basic", 50, 4.8828125, 0, 5)
+	return testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "BasicPool", "Basic", 50, 4.8828125, 0, 5, false)
 }
 
 func testAccAzureRMMsSqlElasticPool_requiresImport(rInt int, location string) string {
-	template := testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "BasicPool", "Basic", 50, 5242880000, 0, 5)
+	template := testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "BasicPool", "Basic", 50, 5242880000, 0, 5, false)
 	return fmt.Sprintf(`
 %s
 
@@ -357,12 +385,16 @@ resource "azurerm_mssql_elasticpool" "import" {
 `, template)
 }
 
+func testAccAzureRMMsSqlElasticPool_premium_DTU_zone_redundant(rInt int, location string) string {
+	return testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "PremiumPool", "Premium", 125, 50, 0, 50, true)
+}
+
 func testAccAzureRMMsSqlElasticPool_standard_DTU(rInt int, location string) string {
-	return testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "StandardPool", "Standard", 50, 50, 0, 50)
+	return testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "StandardPool", "Standard", 50, 50, 0, 50, false)
 }
 
 func testAccAzureRMMsSqlElasticPool_resize_DTU(rInt int, location string) string {
-	return testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "StandardPool", "Standard", 100, 100, 50, 100)
+	return testAccAzureRMMsSqlElasticPool_DTU_Template(rInt, location, "StandardPool", "Standard", 100, 100, 50, 100, false)
 }
 
 func testAccAzureRMMsSqlElasticPool_basic_vCore(rInt int, location string) string {
@@ -453,7 +485,7 @@ resource "azurerm_mssql_elasticpool" "test" {
 `, rInt, location, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
 }
 
-func testAccAzureRMMsSqlElasticPool_DTU_Template(rInt int, location string, skuName string, skuTier string, skuCapacity int, maxSizeGB float64, databaseSettingsMin int, databaseSettingsMax int) string {
+func testAccAzureRMMsSqlElasticPool_DTU_Template(rInt int, location string, skuName string, skuTier string, skuCapacity int, maxSizeGB float64, databaseSettingsMin int, databaseSettingsMax int, zoneRedundant bool) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%[1]d"
@@ -474,7 +506,8 @@ resource "azurerm_mssql_elasticpool" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
   server_name         = "${azurerm_sql_server.test.name}"
-  max_size_gb         = %.7[6]f
+	max_size_gb         = %.7[6]f
+	zone_redundant       = %[9]t
   
   sku {
     name     = "%[3]s"
@@ -487,5 +520,5 @@ resource "azurerm_mssql_elasticpool" "test" {
     max_capacity = %[8]d
   }
 }
-`, rInt, location, skuName, skuTier, skuCapacity, maxSizeGB, databaseSettingsMin, databaseSettingsMax)
+`, rInt, location, skuName, skuTier, skuCapacity, maxSizeGB, databaseSettingsMin, databaseSettingsMax, zoneRedundant)
 }

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -92,13 +92,13 @@ The following arguments are supported:
 
 ---
 
+* `zone_redundant` - (Optional) Whether or not this elastic pool is zone redundant. `tier` needs to be `Premium` for `DTU` based  or `BusinessCritical` for `vCore` based `sku`. Defaults to `false`.
+
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The MsSQL Elastic Pool ID.
-
-* `zone_redundant` - Whether or not this elastic pool is zone redundant.
 
 ## Import
 


### PR DESCRIPTION
Hi,
we need zone_redundant elastic pools and therefore implemented the flag on the mssql_elasticpool resource.

Feel free to add any comments. 