### PR TITLE
[Redis] Add min tls redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.24.0 (Unreleased)
 
+UPGRADE NOTES:
+
+* `azurerm_kubernetes_cluster` - `ssh_key` is now limited to a single element to reflect what the API expects [GH-3099]
+
 FEATURES:
 
 * **New Data Source:** `azurerm_api_management_api` [GH-3010]
@@ -29,7 +33,6 @@ IMPROVEMENTS:
 * `azurerm_virtual_machine_scale_set` - support for managed disks up to 32TB [GH-3062]
 
 BUG FIXES:
-Application Gateway: fixing the permanent AGW tf update problem (fqdns) #3085
 * `azurerm_application_gateway` - correctly populating backend addresses from both new and deprecated properties `fqdns`/`fqdn_list` [GH-3085]
 * `azurerm_key_vault_certificate` - making `contents` and `password` within the `certificate` block sensitive [GH-3064]
 * `monitor_metric_alert` - support for setting `aggregation` to `count`  [GH-3047]

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -266,7 +266,7 @@ func resourceArmRedisCacheCreate(d *schema.ResourceData, meta interface{}) error
 				Family:   family,
 				Name:     sku,
 			},
-			MinimumTLSVersion:  expandMinimumTlsVersion(d.Get("minimum_tls_version").(string)),
+			MinimumTLSVersion:  redis.TLSVersion(d.Get("minimum_tls_version").(string)),
 			RedisConfiguration: expandRedisConfiguration(d),
 		},
 		Tags: expandedTags,
@@ -572,15 +572,6 @@ func redisStateRefreshFunc(ctx context.Context, client redis.Client, resourceGro
 
 		return res, string(res.ProvisioningState), nil
 	}
-}
-
-func expandMinimumTlsVersion(tlsVersion string) redis.TLSVersion {
-	if tlsVersion == "1.2" {
-		return redis.OneFullStopTwo
-	} else if tlsVersion == "1.1" {
-		return redis.OneFullStopOne
-	}
-	return redis.OneFullStopZero
 }
 
 func expandRedisConfiguration(d *schema.ResourceData) map[string]*string {

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -360,7 +360,7 @@ func resourceArmRedisCacheUpdate(d *schema.ResourceData, meta interface{}) error
 
 	parameters := redis.UpdateParameters{
 		UpdateProperties: &redis.UpdateProperties{
-			MinimumTLSVersion: expandMinimumTlsVersion(d.Get("minimum_tls_version").(string)),
+			MinimumTLSVersion: redis.TLSVersion(d.Get("minimum_tls_version").(string)),
 			EnableNonSslPort:  utils.Bool(enableNonSSLPort),
 			Sku: &redis.Sku{
 				Capacity: utils.Int32(capacity),

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -117,6 +117,7 @@ func TestAccAzureRMRedisCache_basic(t *testing.T) {
 				Config: testAccAzureRMRedisCache_basic(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRedisCacheExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "minimum_tls_version"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -595,8 +595,8 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Basic"
-	enable_non_ssl_port = false
-	minimum_tls_version = "1.2"
+  enable_non_ssl_port = false
+  minimum_tls_version = "1.2"
 
   redis_configuration {}
 }

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -595,7 +595,8 @@ resource "azurerm_redis_cache" "test" {
   capacity            = 1
   family              = "C"
   sku_name            = "Basic"
-  enable_non_ssl_port = false
+	enable_non_ssl_port = false
+	minimum_tls_version = "1.2"
 
   redis_configuration {}
 }

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -48,6 +48,7 @@ resource "azurerm_redis_cache" "test" {
   family              = "C"
   sku_name            = "Standard"
   enable_non_ssl_port = false
+  minimum_tls_version = "1.2"
 }
 ```
 
@@ -134,6 +135,8 @@ The pricing group for the Redis Family - either "C" or "P" at present.
 * `sku_name` - (Required) The SKU of Redis to use - can be either Basic, Standard or Premium.
 
 * `enable_non_ssl_port` - (Optional) Enable the non-SSL port (6789) - disabled by default.
+
+* `minimum_tls_version` - (Optional) The minimum TLS version.  Defaults to `1.0`.
 
 * `patch_schedule` - (Optional) A list of `patch_schedule` blocks as defined below - only available for Premium SKU's.
 


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/2839 by adding MinimumTLSVersion as a configurable property to the `azurerm_redis_cache` resource.