### PR TITLE
remove minItem for zone in VMSS

### DIFF
--- a/azurerm/helpers/azure/zones.go
+++ b/azurerm/helpers/azure/zones.go
@@ -7,7 +7,6 @@ func SchemaZones() *schema.Schema {
 		Type:     schema.TypeList,
 		Optional: true,
 		ForceNew: true,
-		MinItems: 1,
 		Elem: &schema.Schema{
 			Type: schema.TypeString,
 		},

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -1335,6 +1335,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   upgrade_policy_mode = "Manual"
+  zones               = []
 
   sku {
     name     = "Standard_D1_v2"


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/1787

A search of the repo found that only VMSS was using this helper.  I also noticed that `expandZones` - the helper for the zones, returns nil if the length is 0, so an empty array will work out of the box.  I added the empty array to the basic VMSS test.  Not sure I am running the `make testacc` incorrectly but trying to regex *just* the basic test ended up firing all tests which began with `TestAccAzureRMVirtualMachineScaleSet_basic` in the name which caused throttling limits.  I thought this flag could take a regex like `TestAccAzureRMVirtualMachineScaleSet_basic$`?