### PR TITLE
r/api_management: support for `sign_in`, `sign_up` and `policy` blocks

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -140,6 +140,8 @@ type ArmClient struct {
 	apiManagementProductGroupsClient        apimanagement.ProductGroupClient
 	apiManagementPropertyClient             apimanagement.PropertyClient
 	apiManagementServiceClient              apimanagement.ServiceClient
+	apiManagementSignInClient               apimanagement.SignInSettingsClient
+	apiManagementSignUpClient               apimanagement.SignUpSettingsClient
 	apiManagementSubscriptionsClient        apimanagement.SubscriptionClient
 	apiManagementUsersClient                apimanagement.UserClient
 
@@ -533,6 +535,14 @@ func (c *ArmClient) registerApiManagementServiceClients(endpoint, subscriptionId
 	serviceClient := apimanagement.NewServiceClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&serviceClient.Client, auth)
 	c.apiManagementServiceClient = serviceClient
+
+	signInClient := apimanagement.NewSignInSettingsClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&signInClient.Client, auth)
+	c.apiManagementSignInClient = signInClient
+
+	signUpClient := apimanagement.NewSignUpSettingsClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&signUpClient.Client, auth)
+	c.apiManagementSignUpClient = signUpClient
 
 	openIdConnectClient := apimanagement.NewOpenIDConnectProviderClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&openIdConnectClient.Client, auth)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -135,6 +135,7 @@ type ArmClient struct {
 	apiManagementGroupUsersClient           apimanagement.GroupUserClient
 	apiManagementLoggerClient               apimanagement.LoggerClient
 	apiManagementOpenIdConnectClient        apimanagement.OpenIDConnectProviderClient
+	apiManagementPolicyClient               apimanagement.PolicyClient
 	apiManagementProductsClient             apimanagement.ProductClient
 	apiManagementProductApisClient          apimanagement.ProductAPIClient
 	apiManagementProductGroupsClient        apimanagement.ProductGroupClient
@@ -531,6 +532,10 @@ func (c *ArmClient) registerApiManagementServiceClients(endpoint, subscriptionId
 	loggerClient := apimanagement.NewLoggerClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&loggerClient.Client, auth)
 	c.apiManagementLoggerClient = loggerClient
+
+	policyClient := apimanagement.NewPolicyClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&policyClient.Client, auth)
+	c.apiManagementPolicyClient = policyClient
 
 	serviceClient := apimanagement.NewServiceClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&serviceClient.Client, auth)

--- a/azurerm/helpers/suppress/xml.go
+++ b/azurerm/helpers/suppress/xml.go
@@ -1,0 +1,47 @@
+package suppress
+
+import (
+	"encoding/xml"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func XmlDiff(_, old, new string, _ *schema.ResourceData) bool {
+	oldTokens, err := expandXmlTokensFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newTokens, err := expandXmlTokensFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldTokens, newTokens)
+}
+
+// This function will extract all XML tokens from a string, but ignoring all white-space tokens
+func expandXmlTokensFromString(input string) ([]xml.Token, error) {
+	decoder := xml.NewDecoder(strings.NewReader(input))
+	tokens := make([]xml.Token, 0)
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		if chars, ok := token.(xml.CharData); ok {
+			text := string(chars)
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+		}
+		tokens = append(tokens, xml.CopyToken(token))
+	}
+	return tokens, nil
+}

--- a/azurerm/helpers/suppress/xml_test.go
+++ b/azurerm/helpers/suppress/xml_test.go
@@ -1,0 +1,81 @@
+package suppress
+
+import "testing"
+
+func TestXmlDiff(t *testing.T) {
+	cases := []struct {
+		Name     string
+		XmlA     string
+		XmlB     string
+		Suppress bool
+	}{
+		{
+			Name:     "empty",
+			XmlA:     "",
+			XmlB:     "",
+			Suppress: true,
+		},
+		{
+			Name:     "neither are xml",
+			XmlA:     "this is not an xml",
+			XmlB:     "neither is this",
+			Suppress: false,
+		},
+		{
+			Name:     "identical texts",
+			XmlA:     "this is not an xml",
+			XmlB:     "this is not an xml",
+			Suppress: true,
+		},
+		{
+			Name:     "xml vs text",
+			XmlA:     "<r></r>",
+			XmlB:     "this is not an xml",
+			Suppress: false,
+		},
+		{
+			Name:     "text vs xml",
+			XmlA:     "this is not an xml",
+			XmlB:     "<r></r>",
+			Suppress: false,
+		},
+		{
+			Name:     "identical xml",
+			XmlA:     "<r><c></c></r>",
+			XmlB:     "<r><c></c></r>",
+			Suppress: true,
+		},
+		{
+			Name:     "xml with different line endings",
+			XmlA:     "<r>\n<c>\n</c>\n</r>",
+			XmlB:     "<r>\r\n<c>\r\n</c>\r\n</r>",
+			Suppress: true,
+		},
+		{
+			Name:     "xml with different indentations",
+			XmlA:     "<r>\n  <c>\n  </c>\n</r>",
+			XmlB:     "<r>\r\n\t<c>\r\n\t</c>\r\n</r>",
+			Suppress: true,
+		},
+		{
+			Name:     "xml with different quotation marks",
+			XmlA:     "<r><c attr=\"test\"></c></r>",
+			XmlB:     "<r>\r\n\t<c attr='test'>\r\n\t</c>\r\n</r>",
+			Suppress: true,
+		},
+		{
+			Name:     "xml with different spaces",
+			XmlA:     "<r><c   attr = 'test'></c></r>",
+			XmlB:     "<r>\r\n\t<c attr='test'>\r\n\t</c>\r\n</r>",
+			Suppress: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if XmlDiff("test", tc.XmlA, tc.XmlB, nil) != tc.Suppress {
+				t.Fatalf("Expected XmlDiff to return %t for '%q' == '%q'", tc.Suppress, tc.XmlA, tc.XmlB)
+			}
+		})
+	}
+}

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -255,6 +255,58 @@ func resourceArmApiManagementService() *schema.Resource {
 				},
 			},
 
+			"sign_in": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"sign_up": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+
+						"terms_of_service": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"consent_required": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+									"text": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"tags": tagsSchema(),
 
 			"gateway_url": {
@@ -365,6 +417,20 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 
 	d.SetId(*read.ID)
 
+	signInSettingsRaw := d.Get("sign_in").([]interface{})
+	signInSettings := expandApiManagementSignInSettings(signInSettingsRaw)
+	signInClient := meta.(*ArmClient).apiManagementSignInClient
+	if _, err := signInClient.CreateOrUpdate(ctx, resourceGroup, name, signInSettings); err != nil {
+		return fmt.Errorf("Error setting Sign In settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	signUpSettingsRaw := d.Get("sign_up").([]interface{})
+	signUpSettings := expandApiManagementSignUpSettings(signUpSettingsRaw)
+	signUpClient := meta.(*ArmClient).apiManagementSignUpClient
+	if _, err := signUpClient.CreateOrUpdate(ctx, resourceGroup, name, signUpSettings); err != nil {
+		return fmt.Errorf("Error setting Sign Up settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
 	return resourceArmApiManagementServiceRead(d, meta)
 }
 
@@ -389,6 +455,18 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 		}
 
 		return fmt.Errorf("Error making Read request on API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	signInClient := meta.(*ArmClient).apiManagementSignInClient
+	signInSettings, err := signInClient.Get(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Sign In Settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	signUpClient := meta.(*ArmClient).apiManagementSignUpClient
+	signUpSettings, err := signUpClient.Get(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Sign Up Settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	d.Set("name", name)
@@ -430,6 +508,14 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 
 	if err := d.Set("sku", flattenApiManagementServiceSku(resp.Sku)); err != nil {
 		return fmt.Errorf("Error setting `sku`: %+v", err)
+	}
+
+	if err := d.Set("sign_in", flattenApiManagementSignInSettings(signInSettings)); err != nil {
+		return fmt.Errorf("Error setting `sign_in`: %+v", err)
+	}
+
+	if err := d.Set("sign_up", flattenApiManagementSignUpSettings(signUpSettings)); err != nil {
+		return fmt.Errorf("Error setting `sign_up`: %+v", err)
 	}
 
 	flattenAndSetTags(d, resp.Tags)
@@ -856,4 +942,106 @@ func parseApiManagementNilableDictionary(input map[string]*string, key string) b
 	}
 
 	return val
+}
+
+func expandApiManagementSignInSettings(input []interface{}) apimanagement.PortalSigninSettings {
+	enabled := false
+
+	if len(input) > 0 {
+		vs := input[0].(map[string]interface{})
+		enabled = vs["enabled"].(bool)
+	}
+
+	return apimanagement.PortalSigninSettings{
+		PortalSigninSettingProperties: &apimanagement.PortalSigninSettingProperties{
+			Enabled: utils.Bool(enabled),
+		},
+	}
+}
+
+func flattenApiManagementSignInSettings(input apimanagement.PortalSigninSettings) []interface{} {
+	enabled := false
+
+	if props := input.PortalSigninSettingProperties; props != nil {
+		if props.Enabled != nil {
+			enabled = *props.Enabled
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enabled": enabled,
+		},
+	}
+}
+
+func expandApiManagementSignUpSettings(input []interface{}) apimanagement.PortalSignupSettings {
+	if len(input) == 0 {
+		return apimanagement.PortalSignupSettings{
+			PortalSignupSettingsProperties: &apimanagement.PortalSignupSettingsProperties{
+				Enabled: utils.Bool(false),
+				TermsOfService: &apimanagement.TermsOfServiceProperties{
+					ConsentRequired: utils.Bool(false),
+					Enabled:         utils.Bool(false),
+					Text:            utils.String(""),
+				},
+			},
+		}
+	}
+
+	vs := input[0].(map[string]interface{})
+
+	props := apimanagement.PortalSignupSettingsProperties{
+		Enabled: utils.Bool(vs["enabled"].(bool)),
+	}
+
+	termsOfServiceRaw := vs["terms_of_service"].([]interface{})
+	if len(termsOfServiceRaw) > 0 {
+		termsOfServiceVs := termsOfServiceRaw[0].(map[string]interface{})
+		props.TermsOfService = &apimanagement.TermsOfServiceProperties{
+			Enabled:         utils.Bool(termsOfServiceVs["enabled"].(bool)),
+			ConsentRequired: utils.Bool(termsOfServiceVs["consent_required"].(bool)),
+			Text:            utils.String(termsOfServiceVs["text"].(string)),
+		}
+	}
+
+	return apimanagement.PortalSignupSettings{
+		PortalSignupSettingsProperties: &props,
+	}
+}
+
+func flattenApiManagementSignUpSettings(input apimanagement.PortalSignupSettings) []interface{} {
+	enabled := false
+	termsOfService := make([]interface{}, 0)
+
+	if props := input.PortalSignupSettingsProperties; props != nil {
+		if props.Enabled != nil {
+			enabled = *props.Enabled
+		}
+
+		if tos := props.TermsOfService; tos != nil {
+			output := make(map[string]interface{})
+
+			if tos.Enabled != nil {
+				output["enabled"] = *tos.Enabled
+			}
+
+			if tos.ConsentRequired != nil {
+				output["consent_required"] = *tos.ConsentRequired
+			}
+
+			if tos.Text != nil {
+				output["text"] = *tos.Text
+			}
+
+			termsOfService = append(termsOfService, output)
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"enabled":          enabled,
+			"terms_of_service": termsOfService,
+		},
+	}
 }

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -259,6 +259,7 @@ func resourceArmApiManagementService() *schema.Resource {
 			"policy": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -184,7 +184,7 @@ func TestAccAzureRMApiManagement_policy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"policy.0.xml_link"},
 			},
 			{
-				Config: testAccAzureRMApiManagement_basic(ri, location),
+				Config: testAccAzureRMApiManagement_policyRemoved(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementExists(resourceName),
 				),
@@ -330,6 +330,30 @@ resource "azurerm_api_management" "test" {
   policy {
     xml_link = "https://gist.githubusercontent.com/tombuildsstuff/4f58581599d2c9f64b236f505a361a67/raw/0d29dcb0167af1e5afe4bd52a6d7f69ba1e05e1f/example.xml"
   }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMApiManagement_policyRemoved(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+
+  policy = []
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -125,6 +125,31 @@ func TestAccAzureRMApiManagement_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApiManagement_signInSignUpSettings(t *testing.T) {
+	resourceName := "azurerm_api_management.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagement_signInSignUpSettings(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMApiManagementDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).apiManagementServiceClient
 
@@ -245,6 +270,42 @@ resource "azurerm_api_management" "test" {
   security {
     disable_frontend_tls10     = true
     disable_triple_des_chipers = true
+  }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMApiManagement_signInSignUpSettings(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+
+  sku {
+    name     = "Developer"
+    capacity = 1
+  }
+
+  sign_in {
+    enabled = true
+  }
+
+  sign_up {
+    enabled          = true
+
+    terms_of_service {
+      enabled          = true
+      consent_required = false
+      text             = "Lorem Ipsum Dolor Morty"
+    }
   }
 }
 `, rInt, location, rInt)

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -62,6 +62,10 @@ The following arguments are supported:
 
 * `security` - (Optional) A `security` block as defined below.
 
+* `sign_in` - (Optional) A `sign_in` block as defined below.
+
+* `sign_up` - (Optional) A `sign_up` block as defined below.
+
 * `tags` - (Optional) A mapping of tags assigned to the resource.
 
 ---
@@ -80,11 +84,63 @@ A `certificate` block supports the following:
 
 * `store_name` - (Required) The name of the Certificate Store where this certificate should be stored. Possible values are `CertificateAuthority` and `Root`.
 
+
+---
+
+A `hostname_configuration` block supports the following:
+
+* `management` - (Optional) One or more `management` blocks as documented below.
+
+* `portal` - (Optional) One or more `portal` blocks as documented below.
+
+* `proxy` - (Optional) One or more `proxy` blocks as documented below.
+
+* `scm` - (Optional) One or more `scm` blocks as documented below.
+
 ---
 
 A `identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this API Management Service. At this time the only supported value is`SystemAssigned`.
+
+---
+
+A `management`, `portal` and `scm` block supports the following:
+
+* `host_name` - (Required) The Hostname to use for the Management API.
+
+* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type `application/x-pkcs12`.
+
+-> **NOTE:** Setting this field requires the `identity` block to be specified, since this identity is used for to retrieve the Key Vault Certificate. Auto-updating the Certificate from the Key Vault requires the Secret version isn't specified.
+
+* `certificate` - (Optional) The Base64 Encoded Certificate.
+
+* `certificate_password` - (Optional) The password associated with the certificate provided above.
+
+-> **NOTE:** Either `key_vault_id` or `certificate` and `certificate_password` must be specified.
+
+* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to `false`.
+
+---
+
+A `proxy` block supports the following:
+
+* `default_ssl_binding` - (Optional) Is the certificate associated with this Hostname the Default SSL Certificate? This is used when an SNI header isn't specified by a client. Defaults to `false`.
+
+* `host_name` - (Required) The Hostname to use for the Management API.
+
+* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type `application/x-pkcs12`.
+
+-> **NOTE:** Setting this field requires the `identity` block to be specified, since this identity is used for to retrieve the Key Vault Certificate. Auto-updating the Certificate from the Key Vault requires the Secret version isn't specified.
+
+* `certificate` - (Optional) The Base64 Encoded Certificate.
+
+* `certificate_password` - (Optional) The password associated with the certificate provided above.
+
+-> **NOTE:** Either `key_vault_id` or `certificate` and `certificate_password` must be specified.
+
+* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to `false`.
+
 
 ---
 
@@ -128,54 +184,27 @@ A `sku` block supports the following:
 
 ---
 
-A `hostname_configuration` block supports the following:
+A `sign_in` block supports the following:
 
-* `management` - (Optional) One or more `management` blocks as documented below.
-
-* `portal` - (Optional) One or more `portal` blocks as documented below.
-
-* `proxy` - (Optional) One or more `proxy` blocks as documented below.
-
-* `scm` - (Optional) One or more `scm` blocks as documented below.
+* `enabled` - (Required) Should anonymous users be redirected to the sign in page?
 
 ---
 
-A `management`, `portal` and `scm` block supports the following:
+A `sign_up` block supports the following:
 
-* `host_name` - (Required) The Hostname to use for the Management API.
+* `enabled` - (Required) Can users sign up on the development portal?
 
-* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type `application/x-pkcs12`.
-
--> **NOTE:** Setting this field requires the `identity` block to be specified, since this identity is used for to retrieve the Key Vault Certificate. Auto-updating the Certificate from the Key Vault requires the Secret version isn't specified.
-
-* `certificate` - (Optional) The Base64 Encoded Certificate.
-
-* `certificate_password` - (Optional) The password associated with the certificate provided above.
-
--> **NOTE:** Either `key_vault_id` or `certificate` and `certificate_password` must be specified.
-
-* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to `false`.
+* `terms_of_service` - (Optional) A `terms_of_service` block as defined below.
 
 ---
 
-A `proxy` block supports the following:
+A `terms_of_service` block supports the following:
 
-* `default_ssl_binding` - (Optional) Is the certificate associated with this Hostname the Default SSL Certificate? This is used when an SNI header isn't specified by a client. Defaults to `false`.
+* `consent_required` - (Required) Should the user be asked for consent during sign up?
 
-* `host_name` - (Required) The Hostname to use for the Management API.
+* `enabled` - (Required) Should Terms of Service be displayed during sign up?.
 
-* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type `application/x-pkcs12`.
-
--> **NOTE:** Setting this field requires the `identity` block to be specified, since this identity is used for to retrieve the Key Vault Certificate. Auto-updating the Certificate from the Key Vault requires the Secret version isn't specified.
-
-* `certificate` - (Optional) The Base64 Encoded Certificate.
-
-* `certificate_password` - (Optional) The password associated with the certificate provided above.
-
--> **NOTE:** Either `key_vault_id` or `certificate` and `certificate_password` must be specified.
-
-* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to `false`.
-
+* `text` - (Required) The Terms of Service which users are required to agree to in order to sign up.
 
 
 ## Attributes Reference

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `notification_sender_email` - (Optional) Email address from which the notification will be sent.
 
+* `policy` - (Optional) A `policy` block as defined below.
+
 * `security` - (Optional) A `security` block as defined below.
 
 * `sign_in` - (Optional) A `sign_in` block as defined below.
@@ -123,6 +125,14 @@ A `management`, `portal` and `scm` block supports the following:
 
 ---
 
+A `policy` block supports the following:
+
+* `xml_content` - (Optional) The XML Content for this Policy.
+
+* `xml_link` - (Optional) A link to an API Management Policy XML Document, which must be publicly available.
+
+---
+
 A `proxy` block supports the following:
 
 * `default_ssl_binding` - (Optional) Is the certificate associated with this Hostname the Default SSL Certificate? This is used when an SNI header isn't specified by a client. Defaults to `false`.
@@ -140,7 +150,6 @@ A `proxy` block supports the following:
 -> **NOTE:** Either `key_vault_id` or `certificate` and `certificate_password` must be specified.
 
 * `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to `false`.
-
 
 ---
 
@@ -213,9 +222,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The ID of the API Management Service.
 
+* `additional_location` - One or more `additional_location` blocks as documented below.
+
 * `gateway_url` - The URL of the Gateway for the API Management Service.
 
 * `gateway_regional_url` - The Region URL for the Gateway of the API Management Service.
+
+* `identity` - An `identity` block as defined below.
 
 * `management_api_url` - The URL for the Management API associated with this API Management service.
 
@@ -225,9 +238,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `scm_url` - The URL for the SCM (Source Code Management) Endpoint associated with this API Management service.
 
-* `identity` - An `identity` block as defined below.
+---
 
-* `additional_location` - One or more `additional_location` blocks as documented below.
+An `additional_location` block exports the following:
+
+* `gateway_regional_url` - The URL of the Regional Gateway for the API Management Service in the specified region.
+
+* `public_ip_addresses` - Public Static Load Balanced IP addresses of the API Management service in the additional location. Available only for Basic, Standard and Premium SKU.
 
 ---
 
@@ -236,14 +253,6 @@ An `identity` block exports the following:
 * `principal_id` - The Principal ID associated with this Managed Service Identity.
 
 * `tenant_id` - The Tenant ID associated with this Managed Service Identity.
-
----
-
-An `additional_location` block exports the following:
-
-* `gateway_regional_url` - The URL of the Regional Gateway for the API Management Service in the specified region.
-
-* `public_ip_addresses` - Public Static Load Balanced IP addresses of the API Management service in the additional location. Available only for Basic, Standard and Premium SKU.
 
 ## Import
 


### PR DESCRIPTION
This PR adds support for the `sign_in` and `sign_up` settings blocks - and also adds support for the `policy` block, which was previously added as a separate resource by @JunyiYi in #3145 (I've rolled this up into this PR since it's only possible to have one per API, thus it makes more sense within this resource).

This is the last PR from our list covered in #1177 - as such this fixed #1177