### PR TITLE
Fix docs issue about changing `enabled`

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `client_cert_enabled` - (Optional) Does the App Service require client certificates for incoming requests? Defaults to `false`.
 
-* `enabled` - (Optional) Is the App Service Enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the App Service Enabled?
 
 * `https_only` - (Optional) Can the App Service only be accessed via HTTPS? Defaults to `false`.
 


### PR DESCRIPTION
Changing `enabled` property value does not force to create a new resource for app_service