### PR TITLE
Add storage permission to KV access policy resource

### DIFF
--- a/azurerm/resource_arm_key_vault_access_policy.go
+++ b/azurerm/resource_arm_key_vault_access_policy.go
@@ -100,6 +100,8 @@ func resourceArmKeyVaultAccessPolicy() *schema.Resource {
 			"key_permissions": azure.SchemaKeyVaultKeyPermissions(),
 
 			"secret_permissions": azure.SchemaKeyVaultSecretPermissions(),
+
+			"storage_permissions": azure.SchemaKeyVaultStoragePermissions(),
 		},
 	}
 }
@@ -208,6 +210,9 @@ func resourceArmKeyVaultAccessPolicyCreateOrDelete(d *schema.ResourceData, meta 
 	secretPermissionsRaw := d.Get("secret_permissions").([]interface{})
 	secretPermissions := azure.ExpandSecretPermissions(secretPermissionsRaw)
 
+	storagePermissionsRaw := d.Get("storage_permissions").([]interface{})
+	storagePermissions := azure.ExpandStoragePermissions(storagePermissionsRaw)
+
 	accessPolicy := keyvault.AccessPolicyEntry{
 		ObjectID: utils.String(objectId),
 		TenantID: &tenantId,
@@ -215,6 +220,7 @@ func resourceArmKeyVaultAccessPolicyCreateOrDelete(d *schema.ResourceData, meta 
 			Certificates: certPermissions,
 			Keys:         keyPermissions,
 			Secrets:      secretPermissions,
+			Storage:      storagePermissions,
 		},
 	}
 
@@ -331,6 +337,11 @@ func resourceArmKeyVaultAccessPolicyRead(d *schema.ResourceData, meta interface{
 		secretPermissions := azure.FlattenSecretPermissions(permissions.Secrets)
 		if err := d.Set("secret_permissions", secretPermissions); err != nil {
 			return fmt.Errorf("Error setting `secret_permissions`: %+v", err)
+		}
+
+		storagePermissions := azure.FlattenStoragePermissions(permissions.Storage)
+		if err := d.Set("storage_permissions", storagePermissions); err != nil {
+			return fmt.Errorf("Error setting `storage_permissions`: %+v", err)
 		}
 	}
 

--- a/azurerm/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/resource_arm_key_vault_access_policy_test.go
@@ -352,6 +352,23 @@ resource "azurerm_key_vault_access_policy" "test_no_application_id" {
     "delete",
   ]
 
+  storage_permissions = [
+    "backup",
+    "delete",
+    "deletesas",
+    "get",
+    "getsas",
+    "list",
+    "listsas",
+    "purge",
+    "recover",
+    "regeneratekey",
+    "restore",
+    "set",
+    "setsas",
+    "update",
+  ]
+
   tenant_id = "${data.azurerm_client_config.current.tenant_id}"
   object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
 }

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -89,6 +89,8 @@ The following arguments are supported:
 * `secret_permissions` - (Required) List of secret permissions, must be one or more
     from the following: `backup`, `delete`, `get`, `list`, `purge`, `recover`, `restore` and `set`.
 
+* `storage_permissions` - (Optional) List of storage permissions, must be one or more from the following: `backup`, `delete`, `deletesas`, `get`, `getsas`, `list`, `listsas`, `purge`, `recover`, `regeneratekey`, `restore`, `set`, `setsas` and `update`.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Firstly, this is my first ever pull request, for any project, so please be gentle! And hopefully this is useful. :-)

I ran into issue #2405 so I'm very grateful to @Lucretius for submitting PR #3081. However, after cloning and building the provider after that had been merged, I was still getting the following error when trying to deploy access policy resources with storage permissions:

```
PS C:\Users\rlewis> terraform validate -var-file="test.tfvars"

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_SP: : invalid or unknown key: storage_permissions

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_users[0]: : invalid or unknown key: storage_permissions

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_users[1]: : invalid or unknown key: storage_permissions

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_users[2]: : invalid or unknown key: storage_permissions


PS C:\Users\rlewis> terraform plan -var-file="test.tfvars"

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_SP: : invalid or unknown key: storage_permissions

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_users[0]: : invalid or unknown key: storage_permissions

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_users[1]: : invalid or unknown key: storage_permissions

Error: azurerm_key_vault_access_policy.devopsmetaKVaccesspolicy_users[2]: : invalid or unknown key: storage_permissions
```

So I just searched through the code looking for "secret_permissions" to check that an equivalent existed for "storage_permissions" and discovered that there _was not_ one in the ```azurerm/resource_arm_key_vault_access_policy.go``` file. So I made the changes in this PR, rebuilt the provider and it worked. I've successfully run 'terraform apply' and can confirm that my Key Vault is deployed with the storage permissions set in the access policy.

I suspect that I ran into this problem despite @Lucretius's changes because I was using the standalone access policy resource rather than including them within the parent key vault resource? But I'm not sure. All I know is that the changes below made it work for me. :-)

I should add that I'm by no means a Go developer, indeed I'm not a developer at all, I'm #JustAnOpsGuy, so apologies if the changes are incomplete or lacking in quality.

If there's any other info I can give you or anything else I should have done to this PR then please just shout.

Thanks
Rich.