### PR TITLE
Enabled AOF data persistence on Redis Cache

### DIFF
--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -147,24 +147,46 @@ func resourceArmRedisCache() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+
 						"rdb_backup_frequency": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validateRedisBackupFrequency,
 						},
+
 						"rdb_backup_max_snapshot_count": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+
 						"rdb_storage_connection_string": {
 							Type:      schema.TypeString,
 							Optional:  true,
 							Sensitive: true,
 						},
+
 						"notify_keyspace_events": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
+						"aof_backup_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+
+						"aof_storage_connection_string_0": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+
+						"aof_storage_connection_string_1": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+						
 					},
 				},
 			},
@@ -601,7 +623,7 @@ func expandRedisConfiguration(d *schema.ResourceData) map[string]*string {
 		output["maxfragmentationmemory-reserved"] = utils.String(delta)
 	}
 
-	// Backup
+	// RDB Backup
 	if v, ok := d.GetOk("redis_configuration.0.rdb_backup_enabled"); ok {
 		delta := strconv.FormatBool(v.(bool))
 		output["rdb-backup-enabled"] = utils.String(delta)
@@ -623,6 +645,20 @@ func expandRedisConfiguration(d *schema.ResourceData) map[string]*string {
 
 	if v, ok := d.GetOk("redis_configuration.0.notify_keyspace_events"); ok {
 		output["notify-keyspace-events"] = utils.String(v.(string))
+	}
+
+	// AOF Backup
+	if v, ok := d.GetOk("redis_configuration.0.aof_backup_enabled"); ok {
+		delta := strconv.FormatBool(v.(bool))
+		output["aof-backup-enabled"] = utils.String(delta)
+	}
+
+	if v, ok := d.GetOk("redis_configuration.0.aof_storage_connection_string_0"); ok {
+		output["aof-storage-connection-string-0"] = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("redis_configuration.0.aof_storage_connection_string_1"); ok {
+		output["aof-storage-connection-string-1"] = utils.String(v.(string))
 	}
 
 	return output
@@ -719,6 +755,20 @@ func flattenRedisConfiguration(input map[string]*string) ([]interface{}, error) 
 	}
 	if v := input["notify-keyspace-events"]; v != nil {
 		outputs["notify_keyspace_events"] = *v
+	}
+
+	if v := input["aof-backup-enabled"]; v != nil {
+		b, err := strconv.ParseBool(*v)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing `aof-backup-enabled` %q: %+v", *v, err)
+		}
+		outputs["aof_backup_enabled"] = b
+	}
+	if v := input["aof-storage-connection-string-0"]; v != nil {
+		outputs["aof_storage_connection_string_0"] = *v
+	}
+	if v := input["aof-storage-connection-string-1"]; v != nil {
+		outputs["aof_storage_connection_string_1"] = *v
 	}
 
 	return []interface{}{outputs}, nil

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -186,7 +186,6 @@ func resourceArmRedisCache() *schema.Resource {
 							Optional:  true,
 							Sensitive: true,
 						},
-						
 					},
 				},
 			},

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -373,6 +373,64 @@ func TestAccAzureRMRedisCache_BackupEnabledDisabled(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMRedisCache_AOFBackupEnabled(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	config := testAccAzureRMRedisCacheAOFBackupEnabled(ri, rs, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRedisCacheExists(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"redis_configuration.0.aof_storage_connection_string_0","redis_configuration.0.aof_storage_connection_string_1"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMRedisCache_AOFBackupEnabledDisabled(t *testing.T) {
+	resourceName := "azurerm_redis_cache.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+	config := testAccAzureRMRedisCacheBackupEnabled(ri, rs, location)
+	updatedConfig := testAccAzureRMRedisCacheAOFBackupDisabled(ri, location)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRedisCacheExists(resourceName),
+				)
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRedisCacheExists(resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
 func TestAccAzureRMRedisCache_PatchSchedule(t *testing.T) {
 	resourceName := "azurerm_redis_cache.test"
 	ri := tf.AccRandTimeInt()
@@ -803,6 +861,66 @@ resource "azurerm_redis_cache" "test" {
     rdb_backup_max_snapshot_count = 1
     rdb_storage_connection_string = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key}"
   }
+}
+`, rInt, location, rString, rInt)
+}
+
+func testAccAzureRMRedisCacheAOFBackupDisabled(ri int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                = "acctestRedis-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  capacity            = 3
+  family              = "P"
+  sku_name            = "Premium"
+  enable_non_ssl_port = false
+
+  redis_configuration {
+    aof_backup_enabled = false
+  }
+}
+`, ri, location, ri)
+}
+
+func testAccAzureRMRedisCacheAOFBackupEnabled(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                = "acctestRedis-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  capacity            = 3
+  family              = "P"
+  sku_name            = "Premium"
+  enable_non_ssl_port = false
+
+  redis_configuration {
+    aof_backup_enabled            = true
+    aof_storage_connection_string_0 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key}"
+		aof_storage_connection_string_1 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key}"
+	}
 }
 `, rInt, location, rString, rInt)
 }

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -911,16 +911,16 @@ resource "azurerm_redis_cache" "test" {
   name                = "acctestRedis-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  capacity            = 3
+  capacity            = 1
   family              = "P"
   sku_name            = "Premium"
   enable_non_ssl_port = false
 
   redis_configuration {
-    aof_backup_enabled            = true
+    aof_backup_enabled              = true
     aof_storage_connection_string_0 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key}"
-		aof_storage_connection_string_1 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.secondary_access_key}"
-	}
+    aof_storage_connection_string_1 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.secondary_access_key}"
+  }
 }
 `, rInt, location, rString, rInt)
 }

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -919,7 +919,7 @@ resource "azurerm_redis_cache" "test" {
   redis_configuration {
     aof_backup_enabled            = true
     aof_storage_connection_string_0 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key}"
-		aof_storage_connection_string_1 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.primary_access_key}"
+		aof_storage_connection_string_1 = "DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.test.primary_blob_endpoint};AccountName=${azurerm_storage_account.test.name};AccountKey=${azurerm_storage_account.test.secondary_access_key}"
 	}
 }
 `, rInt, location, rString, rInt)

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -395,7 +395,7 @@ func TestAccAzureRMRedisCache_AOFBackupEnabled(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"redis_configuration.0.aof_storage_connection_string_0","redis_configuration.0.aof_storage_connection_string_1"},
+				ImportStateVerifyIgnore: []string{"redis_configuration.0.aof_storage_connection_string_0", "redis_configuration.0.aof_storage_connection_string_1"},
 			},
 		},
 	})
@@ -406,7 +406,7 @@ func TestAccAzureRMRedisCache_AOFBackupEnabledDisabled(t *testing.T) {
 	ri := tf.AccRandTimeInt()
 	rs := acctest.RandString(4)
 	location := testLocation()
-	config := testAccAzureRMRedisCacheBackupEnabled(ri, rs, location)
+	config := testAccAzureRMRedisCacheAOFBackupEnabled(ri, rs, location)
 	updatedConfig := testAccAzureRMRedisCacheAOFBackupDisabled(ri, location)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -418,7 +418,7 @@ func TestAccAzureRMRedisCache_AOFBackupEnabledDisabled(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRedisCacheExists(resourceName),
-				)
+				),
 				ExpectNonEmptyPlan: true,
 			},
 			{


### PR DESCRIPTION
Adds support for the backup fields:

- `aof_backup_enabled`
- `aof_storage_connection_string_0`
- `aof_storage_connection_string_1`


Fixes [#2690](https://github.com/terraform-providers/terraform-provider-azurerm/issues/2690)