### PR TITLE
route_table: Prepare "route" argument for Terraform Core v0.12.0

### DIFF
--- a/azurerm/resource_arm_route_table.go
+++ b/azurerm/resource_arm_route_table.go
@@ -41,9 +41,10 @@ func resourceArmRouteTable() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"route": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeList,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Optional:   true,
+				Computed:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/azurerm/resource_arm_route_table_test.go
+++ b/azurerm/resource_arm_route_table_test.go
@@ -159,7 +159,8 @@ func TestAccAzureRMRouteTable_removeRoute(t *testing.T) {
 	resourceName := "azurerm_route_table.test"
 	ri := tf.AccRandTimeInt()
 	config := testAccAzureRMRouteTable_singleRoute(ri, testLocation())
-	updatedConfig := testAccAzureRMRouteTable_singleRouteRemoved(ri, testLocation())
+	noBlocksConfig := testAccAzureRMRouteTable_noRouteBlocks(ri, testLocation())
+	blocksEmptyConfig := testAccAzureRMRouteTable_singleRouteRemoved(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -167,6 +168,7 @@ func TestAccAzureRMRouteTable_removeRoute(t *testing.T) {
 		CheckDestroy: testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
+				// This configuration includes a single explicit route block
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteTableExists(resourceName),
@@ -174,9 +176,23 @@ func TestAccAzureRMRouteTable_removeRoute(t *testing.T) {
 				),
 			},
 			{
-				Config: updatedConfig,
+				// This configuration has no route blocks at all.
+				Config: noBlocksConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRouteTableExists(resourceName),
+					// The route from the first step is preserved because no
+					// blocks at all means "ignore existing blocks".
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+				),
+			},
+			{
+				// This configuration sets route to [] explicitly using the
+				// attribute syntax.
+				Config: blocksEmptyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRouteTableExists(resourceName),
+					// The route from the first step is now removed, leaving us
+					// with no routes at all.
 					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
 				),
 			},
@@ -488,6 +504,21 @@ resource "azurerm_route_table" "test" {
     address_prefix = "10.1.0.0/16"
     next_hop_type  = "vnetlocal"
   }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMRouteTable_noRouteBlocks(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "acctestrt%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 `, rInt, location, rInt)
 }

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -47,13 +47,13 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `route` - (Optional) Can be specified multiple times to define multiple routes. Each `route` block supports fields documented below.
+* `route` - (Optional) [List of objects](/docs/configuration/attr-as-blocks.html) representing routes. Each object accepts the arguments documented below.
 
 * `disable_bgp_route_propagation` - (Optional) Boolean flag which controls propagation of routes learned by BGP on that route table. True means disable.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-The `route` block supports:
+Elements of `route` accept the following arguments:
 
 * `name` - (Required) The name of the route.
 
@@ -62,7 +62,6 @@ The `route` block supports:
 * `next_hop_type` - (Required) The type of Azure hop the packet should be sent to. Possible values are `VirtualNetworkGateway`, `VnetLocal`, `Internet`, `VirtualAppliance` and `None`.
 
 * `next_hop_in_ip_address` - (Optional) Contains the IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is `VirtualAppliance`.
-
 
 ## Attributes Reference
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-Elements of `route` accept the following arguments:
+Elements of `route` support:
 
 * `name` - (Required) The name of the route.
 


### PR DESCRIPTION
This enables the [Attribute as Blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) processing mode for the `route` argument of `azurerm_route_table` so that it will be treated by Terraform v0.12 as an attribute that can be explicitly set to `[]` to request deletion of any existing blocks.

Against v0.12-compatible SDK:
```
=== RUN   TestAccAzureRMRouteTable_update
=== PAUSE TestAccAzureRMRouteTable_update
=== CONT  TestAccAzureRMRouteTable_update
--- PASS: TestAccAzureRMRouteTable_update (134.38s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	135.052s
```

Against `v0.11` branch SDK:
```
=== RUN   TestAccAzureRMRouteTable_update
=== PAUSE TestAccAzureRMRouteTable_update
=== CONT  TestAccAzureRMRouteTable_update
--- PASS: TestAccAzureRMRouteTable_update (121.72s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	122.356s
```

