### PR TITLE
validation for identity_ids

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -102,8 +102,10 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"identity_ids": {
 							Type:     schema.TypeList,
 							Optional: true,
+							MinItems: 1,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
+								Type:         schema.TypeString,
+								ValidateFunc: validation.NoZeroValues,
 							},
 						},
 					},

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 	"golang.org/x/net/context"
 )
@@ -105,7 +106,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 							MinItems: 1,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validation.NoZeroValues,
+								ValidateFunc: validate.UUID,
 							},
 						},
 					},


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/3059

`identity_ids` is still optional,  but now if it is specified it must
1) Not be an empty array
2) Each entry must not be a UUID.

~Not sure if there is another option for this field aside from UUIDs - but if not, we can create a stronger validation checking that all entries are UUIDs.~