### PR TITLE
alter identity_id check to be non-empty

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 	"golang.org/x/net/context"
 )
@@ -106,7 +105,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 							MinItems: 1,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
-								ValidateFunc: validate.UUID,
+								ValidateFunc: validation.NoZeroValues,
 							},
 						},
 					},


### PR DESCRIPTION
Fixes a bug I introduced in https://github.com/terraform-providers/terraform-provider-azurerm/pull/3183.  Big thanks for the catch by @adamday2 - I have fixed the validation to just check for non-zero values.  I did not see an existing check for an exact resource ID regex - something to consider at a later date I suppose.