### PR TITLE
network_security_group: Prepare "security_rule" argument for Terraform Core v0.12.0

### DIFF
--- a/azurerm/resource_arm_network_security_group.go
+++ b/azurerm/resource_arm_network_security_group.go
@@ -36,9 +36,10 @@ func resourceArmNetworkSecurityGroup() *schema.Resource {
 			"resource_group_name": resourceGroupNameSchema(),
 
 			"security_rule": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Optional:   true,
+				Computed:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -56,12 +56,12 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `security_rule` - (Optional) One or more `security_rule` blocks as defined below.
+* `security_rule` - (Optional) [List of objects](/docs/configuration/attr-as-blocks.html) representing security rules, as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 
-The `security_rule` block supports:
+Elements of `security_rule` accept the following arguments:
 
 * `name` - (Required) The name of the security rule.
 

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 
-Elements of `security_rule` accept the following arguments:
+Elements of `security_rule` support:
 
 * `name` - (Required) The name of the security rule.
 


### PR DESCRIPTION
This enables the [Attribute as Blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) processing mode for the `security_rule` argument of `azurerm_network_security_group` so that it will be treated by Terraform v0.12 as an attribute that can be explicitly set to `[]` to request deletion of any existing blocks.

Against v0.12-compatible SDK (`hashicorp/terraform@master` at the time of writing):
```
--- PASS: TestAccAzureRMNetworkSecurityGroup_update (159.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	162.834s
```

Against `v0.11` branch SDK (as vendored in this repository at the time of writing):
```
--- PASS: TestAccAzureRMNetworkSecurityGroup_update (140.30s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	145.707s
```

