### PR TITLE
Error handling for 404 responses from Azure on App Services

### DIFF
--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -430,6 +430,11 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	appSettingsResp, err := client.ListApplicationSettings(ctx, resGroup, name)
 	if err != nil {
+		if utils.ResponseWasNotFound(appSettingsResp.Response) {
+			log.Printf("[DEBUG] Application Settings of App Service %q (resource group %q) were not found", name, resGroup)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on AzureRM App Service AppSettings %q: %+v", name, err)
 	}
 

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -425,6 +425,11 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 	configResp, err := client.GetConfiguration(ctx, resGroup, name)
 	if err != nil {
+		if utils.ResponseWasNotFound(configResp.Response) {
+			log.Printf("[DEBUG] Configuration of App Service %q (resource group %q) was not found", name, resGroup)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on AzureRM App Service Configuration %q: %+v", name, err)
 	}
 

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -347,6 +347,11 @@ func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) err
 
 	configResp, err := client.GetConfigurationSlot(ctx, resGroup, appServiceName, slot)
 	if err != nil {
+		if utils.ResponseWasNotFound(configResp.Response) {
+			log.Printf("[DEBUG] Configuration of App Service Slot %q/%q (resource group %q) was not found", appServiceName, slot, resGroup)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on AzureRM App Service Slot Configuration %q/%q: %+v", appServiceName, slot, err)
 	}
 

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -352,6 +352,11 @@ func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) err
 
 	appSettingsResp, err := client.ListApplicationSettingsSlot(ctx, resGroup, appServiceName, slot)
 	if err != nil {
+		if utils.ResponseWasNotFound(appSettingsResp.Response) {
+			log.Printf("[DEBUG] Application Settings of App Service Slot %q/%q (resource group %q) were not found", appServiceName, slot, resGroup)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on AzureRM App Service Slot AppSettings %q/%q: %+v", appServiceName, slot, err)
 	}
 


### PR DESCRIPTION
Similar to how the issue was solved for Azure Functions [See here](https://github.com/terraform-providers/terraform-provider-azurerm/pull/2111) the requisite error handling is missing for App Services when 404's are thrown by Azure.

Should resolve issues like:
Error refreshing state.
azurerm_app_service_slot.aps: Error making Read request on AzureRM AppService SlotConfiguration "xxxxx": web.AppsClient#GetConfigurationSlot: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.Web/sites/xxxxx" under resource group 'xxxxxxxx' was not found."

and the same for app service, for both app settings and configuration.