### PR TITLE
key_vault: Prepare "access_policy" argument for Terraform Core v0.12.0

### DIFF
--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -81,10 +81,11 @@ func resourceArmKeyVault() *schema.Resource {
 			},
 
 			"access_policy": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1024,
+				Type:       schema.TypeList,
+				ConfigMode: schema.SchemaConfigModeAttr,
+				Optional:   true,
+				Computed:   true,
+				MaxItems:   1024,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"tenant_id": {

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 ---
 
-Elements of `access_policy` accept the following arguments:
+Elements of `access_policy` support:
 
 * `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. Must match the `tenant_id` used above.
 

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -73,8 +73,8 @@ The following arguments are supported:
 
 * `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault.
 
-* `access_policy` - (Optional) An access policy block as described below. A maximum of 16 may be declared.
-    
+* `access_policy` - (Optional) [A list](/docs/configuration/attr-as-blocks.html) of up to 16 objects describing access policies, as described below.
+
 ~> **NOTE:** It's possible to define Key Vault Access Policies both within [the `azurerm_key_vault` resource](key_vault.html) via the `access_policy` block and by using [the `azurerm_key_vault_access_policy` resource](key_vault_access_policy.html). However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
 
 * `enabled_for_deployment` - (Optional) Boolean flag to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault. Defaults to `false`.
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 ---
 
-A `access_policy` block supports the following:
+Elements of `access_policy` accept the following arguments:
 
 * `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. Must match the `tenant_id` used above.
 


### PR DESCRIPTION
This enables the [Attribute as Blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html) processing mode for the `access_policy` argument of `azurerm_key_vault` so that it will be treated by Terraform v0.12 as an attribute that can be explicitly set to `[]` to request deletion of any existing blocks.

With the v0.11-only SDK that is vendored at the time of testing:

```
--- PASS: TestAccAzureRMKeyVault_update (254.50s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	255.139s
```

With the v0.12-compatible SDK from the `master` branch at the time of testing:

```
--- PASS: TestAccAzureRMKeyVault_update (257.78s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	258.454s
```
