### PR TITLE
Fix Application Insights application_type documentation

### DIFF
--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `Java`, `iOS`, `MobileCenter`, `Other`, `Phone`, `Store`, `Web` and `Node.JS`.
+* `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `ios` for _iOS_, `java` for _Java web_, `MobileCenter` for _App Center_, `Node.JS` for _Node.js_, `other` for _General_, `phone` for _Windows Phone_, `store` for _Windows Store_ and `web` for _ASP.NET_. Please note these values are case sensitive; unmatched values are treated as _ASP.NET_ by Azure. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/application_insights_api_key.html.markdown
+++ b/website/docs/r/application_insights_api_key.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_application_insights" "test" {
   name                = "tf-test-appinsights"
   location            = "West Europe"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  application_type    = "Web"
+  application_type    = "web"
 }
 
 resource "azurerm_application_insights_api_key" "read_telemetry" {


### PR DESCRIPTION
## Problem

Application Insights application_type is case sensitive in Azure API, so I think we should document it with the correct casing.

Using invalid values or values with incorrect casing results in application type set as _ASP.NET_.

As to the azurerm provider API, we're matching application_type case-insensitively, changing that would be a breaking change, and is tracked by https://github.com/terraform-providers/terraform-provider-azurerm/issues/1871#issuecomment-433435080.

## Proposed changes

I've made the change so that 
* application_type uses the correct case recognized by Azure API;
* list the type as shown in Azure Portal in addition to what's used in API, since that may not be obvious;
* sort values alphabetically.

As to the change of application_type from `Web` to `web`, `web` is what we use in [API](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/resource_arm_application_insights.go#L44). This is also what az CLI returns for Application Insights created from Azure Portal with application type set to _ASP.NET_.

## Test configuration

Here is a test terraform configuration for this:

```
provider "azurerm" {}

resource "azurerm_resource_group" "test" {
  name     = "appinsights-test"
  location = "West Europe"
}

// Valid
// ---------------------------------------------------------------------
resource "azurerm_application_insights" "web" {
  name                = "appinsights-test-web"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "web"
}

resource "azurerm_application_insights" "other" {
  name                = "appinsights-test-other"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "other"
}

resource "azurerm_application_insights" "java" {
  name                = "appinsights-test-java"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "java"
}

resource "azurerm_application_insights" "MobileCenter" {
  name                = "appinsights-test-MobileCenter"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "MobileCenter"
}

resource "azurerm_application_insights" "phone" {
  name                = "appinsights-test-phone"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "phone"
}

resource "azurerm_application_insights" "store" {
  name                = "appinsights-test-store"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "store"
}

resource "azurerm_application_insights" "ios" {
  name                = "appinsights-test-ios"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "ios"
}

resource "azurerm_application_insights" "NodeJS" {
  name                = "appinsights-test-Node.JS"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "Node.JS"
}

// Invalid
// ---------------------------------------------------------------------
resource "azurerm_application_insights" "Web-invalid" {
  name                = "appinsights-test-Web-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "Web"
}

resource "azurerm_application_insights" "Other-invalid" {
  name                = "appinsights-test-Other-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "Other"
}

resource "azurerm_application_insights" "Java-invalid" {
  name                = "appinsights-test-Java-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "Java"
}

resource "azurerm_application_insights" "mobilecenter-invalid" {
  name                = "appinsights-test-mobilecenter-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "mobilecenter"
}

resource "azurerm_application_insights" "Phone-invalid" {
  name                = "appinsights-test-Phone-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "Phone"
}

resource "azurerm_application_insights" "Store-invalid" {
  name                = "appinsights-test-Store-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "Store"
}

resource "azurerm_application_insights" "iOS-invalid" {
  name                = "appinsights-test-iOS-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "iOS"
}

resource "azurerm_application_insights" "Nodejs-invalid" {
  name                = "appinsights-test-Node.js-invalid"
  location            = "${azurerm_resource_group.test.location}"
  resource_group_name = "${azurerm_resource_group.test.name}"

  application_type = "Node.js"
}
```