### PR TITLE
Blob metadata

### DIFF
--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -580,7 +580,7 @@ func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("metadata") {
-		blob.Metadata = expandBlobMetadata(d)
+		blob.Metadata = expandStorageAccountBlobMetadata(d)
 
 		opts := &storage.SetBlobMetadataOptions{}
 		if err := blob.SetMetadata(opts); err != nil {

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -114,6 +114,14 @@ func resourceArmStorageBlob() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.IntAtLeast(1),
 			},
+
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -199,6 +207,13 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 				}
 			}
 		}
+	}
+
+	blob.Metadata = expandBlobMetadata(d)
+
+	opts := &storage.SetBlobMetadataOptions{}
+	if err := blob.SetMetadata(opts); err != nil {
+		return fmt.Errorf("Error setting metadata for storage blob on Azure: %s", err)
 	}
 
 	d.SetId(id)
@@ -564,6 +579,15 @@ func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error setting properties of blob %s (container %s, storage account %s): %+v", id.blobName, id.containerName, id.storageAccountName, err)
 	}
 
+	if d.HasChange("metadata") {
+		blob.Metadata = expandBlobMetadata(d)
+
+		opts := &storage.SetBlobMetadataOptions{}
+		if err := blob.SetMetadata(opts); err != nil {
+			return fmt.Errorf("Error setting metadata for storage blob on Azure: %s", err)
+		}
+	}
+
 	return nil
 }
 
@@ -615,6 +639,12 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error getting properties of blob %s (container %s, storage account %s): %+v", id.blobName, id.containerName, id.storageAccountName, err)
 	}
 
+	metadataOptions := &storage.GetBlobMetadataOptions{}
+	blob.GetMetadata(metadataOptions)
+	if err != nil {
+		return fmt.Errorf("Error getting metadata of blob %s (container %s, storage account %s): %+v", id.blobName, id.containerName, id.storageAccountName, err)
+	}
+
 	d.Set("name", id.blobName)
 	d.Set("storage_container_name", id.containerName)
 	d.Set("storage_account_name", id.storageAccountName)
@@ -632,6 +662,7 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 		log.Printf("[INFO] URL for %q is empty", id.blobName)
 	}
 	d.Set("url", u)
+	d.Set("metadata", flattenBlobMetadata(blob.Metadata))
 
 	return nil
 }
@@ -729,4 +760,24 @@ func determineResourceGroupForStorageAccount(accountName string, client *ArmClie
 	}
 
 	return nil, nil
+}
+
+func expandBlobMetadata(d *schema.ResourceData) storage.BlobMetadata {
+	blobMetadata := make(map[string]string)
+
+	blobMetadataRaw := d.Get("metadata").(map[string]interface{})
+	for key, value := range blobMetadataRaw {
+		blobMetadata[key] = value.(string)
+	}
+	return storage.BlobMetadata(blobMetadata)
+}
+
+func flattenBlobMetadata(in storage.BlobMetadata) map[string]interface{} {
+	blobMetadata := make(map[string]interface{})
+
+	for key, value := range in {
+		blobMetadata[key] = value
+	}
+
+	return blobMetadata
 }

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -640,7 +640,7 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	metadataOptions := &storage.GetBlobMetadataOptions{}
-	blob.GetMetadata(metadataOptions)
+	err = blob.GetMetadata(metadataOptions)
 	if err != nil {
 		return fmt.Errorf("Error getting metadata of blob %s (container %s, storage account %s): %+v", id.blobName, id.containerName, id.storageAccountName, err)
 	}

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -209,7 +209,7 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	blob.Metadata = expandBlobMetadata(d)
+	blob.Metadata = expandStorageAccountBlobMetadata(d)
 
 	opts := &storage.SetBlobMetadataOptions{}
 	if err := blob.SetMetadata(opts); err != nil {

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -119,7 +119,8 @@ func resourceArmStorageBlob() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validate.NoEmptyStrings,
 				},
 			},
 		},
@@ -762,7 +763,7 @@ func determineResourceGroupForStorageAccount(accountName string, client *ArmClie
 	return nil, nil
 }
 
-func expandBlobMetadata(d *schema.ResourceData) storage.BlobMetadata {
+func expandStorageAccountBlobMetadata(d *schema.ResourceData) storage.BlobMetadata {
 	blobMetadata := make(map[string]string)
 
 	blobMetadataRaw := d.Get("metadata").(map[string]interface{})
@@ -772,7 +773,7 @@ func expandBlobMetadata(d *schema.ResourceData) storage.BlobMetadata {
 	return storage.BlobMetadata(blobMetadata)
 }
 
-func flattenBlobMetadata(in storage.BlobMetadata) map[string]interface{} {
+func flattenStorageAccountBlobMetadata(in storage.BlobMetadata) map[string]interface{} {
 	blobMetadata := make(map[string]interface{})
 
 	for key, value := range in {

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -663,7 +663,7 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 		log.Printf("[INFO] URL for %q is empty", id.blobName)
 	}
 	d.Set("url", u)
-	d.Set("metadata", flattenBlobMetadata(blob.Metadata))
+	d.Set("metadata", flattenStorageAccountBlobMetadata(blob.Metadata))
 
 	return nil
 }

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -495,10 +495,10 @@ resource "azurerm_storage_blob" "test" {
   type = "page"
 	size = 5120
 	
-	metadata {
-		test = "value1"
-		test2 = "value2"
-	}
+  metadata {
+    test = "value1"
+    test2 = "value2"
+  }
 }
 `, rInt, location, rString)
 }

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -31,6 +31,9 @@ func TestAccAzureRMStorageBlob_basic(t *testing.T) {
 				Config: testAccAzureRMStorageBlob_basic(ri, rs, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "metadata.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.test", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.test2", "value2"),
 				),
 			},
 			{
@@ -490,7 +493,12 @@ resource "azurerm_storage_blob" "test" {
   storage_container_name = "${azurerm_storage_container.test.name}"
 
   type = "page"
-  size = 5120
+	size = 5120
+	
+	metadata {
+		test = "value1"
+		test2 = "value2"
+	}
 }
 `, rInt, location, rString)
 }

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -493,8 +493,8 @@ resource "azurerm_storage_blob" "test" {
   storage_container_name = "${azurerm_storage_container.test.name}"
 
   type = "page"
-	size = 5120
-	
+  size = 5120
+  
   metadata {
     test = "value1"
     test2 = "value2"

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -75,6 +75,8 @@ The following arguments are supported:
 
 * `attempts` - (Optional) The number of attempts to make per page or block when uploading. Defaults to `1`.
 
+* `metadata` - (Optional) A map of custom blob metadata.
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/1400

- Added support for `metadata` property for storage blobs
- Updated markdown by adding property
- Added metadata to basic test (if desired, I can split this into a *separate* test for metadata, but seeing as metadata is like a tag it looks like we normally just include those in basic tests) 
