### PR TITLE
Fix documentation for storage_account network rules

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -132,6 +132,8 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 * `ip_rules` - (Optional) List of public IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed. Private IP address ranges (as defined in [RFC 1918](https://tools.ietf.org/html/rfc1918#section-3)) are not allowed.
 * `virtual_network_subnet_ids` - (Optional) A list of resource ids for subnets.
 
+~> **Note:** If specifying `network_rules`, one of either `ip_rules` or `virtual_network_subnet_ids` must be specified.
+
 ~> **Note:** [More information on Validation is available here](https://docs.microsoft.com/en-gb/azure/storage/blobs/storage-custom-domain-name)
 
 ---


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/2198

This looks to be happening because the read fails to set the network rules if [both the `ip_rules` and `virtual_network_subnet_ids` are empty arrays](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/resource_arm_storage_account.go#L965).

I think it makes sense to have to specify one or the other, otherwise I am not sure what the bypass is actually bypassing.  I have updated the documentation to include a note stating that one or the other is required.