### PR TITLE
resource/app_service(_slot): Set SchemaConfigModeAttr on .site_config.ip_restriction

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -55,9 +55,10 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 				},
 
 				"ip_restriction": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Computed: true,
+					Type:       schema.TypeList,
+					Optional:   true,
+					Computed:   true,
+					ConfigMode: schema.SchemaConfigModeAttr,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"ip_address": {

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -177,6 +177,8 @@ A `ip_restriction` block supports the following:
 
 * `subnet_mask` - (Optional) The Subnet mask used for this IP Restriction. Defaults to `255.255.255.255`.
 
+This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -252,6 +252,7 @@ A `ip_restriction` block supports the following:
 
 * `subnet_mask` - (Optional) The Subnet mask used for this IP Restriction. Defaults to `255.255.255.255`.
 
+This argument is processed in [attribute-as-blocks mode](/docs/configuration/attr-as-blocks.html).
 
 ## Attributes Reference
 


### PR DESCRIPTION
In Terraform 0.12, behaviors with configuration blocks are more explicit to allow configuration language improvements and remove ambiguities that required various undocumented workarounds in Terraform 0.11 and prior. As a consequence, configuration blocks that are marked `Optional: true` and `Computed: true` will no longer support explicitly zero-ing out the configuration without special implementation.

The `ConfigMode` schema parameter on the configuration block attribute allows the schema to override certain behaviors. In particular, setting `ConfigMode: schema.SchemaConfigModeAttr` will allow practitioners to continue setting the configuration block attribute to an empty list (in the semantic sense, e.g. `attr = []`), keeping this prior behavior in Terraform 0.12. This parameter does not have any effect with Terraform 0.11. This solution may be temporary or revisited in the future.

Test before/after:

0.11 SDK BEFORE
--- PASS: TestAccAzureRMAppService_zeroedIpRestriction (120.00s)

0.12 SDK BEFORE
--- FAIL: TestAccAzureRMAppService_zeroedIpRestriction (0.07s)
    testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "ip_restriction" is not expected here. Did you mean to define a block of type "ip_restriction"?

0.12 SDK After
--- PASS: TestAccAzureRMAppService_zeroedIpRestriction (116.49s)
--- PASS: TestAccAzureRMAppServiceSlot_zeroedIpRestriction (146.22s)

0.11 SDK After
--- PASS: TestAccAzureRMAppService_zeroedIpRestriction (122.05s)
--- PASS: TestAccAzureRMAppServiceSlot_zeroedIpRestriction (154.21s)

Note: both resources' blocks used the same schema for `site_config` (in azurerm/helpers/azure/app_service.go), which is why I don't have failing 'before' tests for app_service_slot - I'd already added the fix before noticing that it was the same underlying schema.