### PR TITLE
resource/app_service(_slot): Set SchemaConfigModeAttr on .site_config.up_restriction

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -55,9 +55,10 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 				},
 
 				"ip_restriction": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Computed: true,
+					Type:       schema.TypeList,
+					Optional:   true,
+					Computed:   true,
+					ConfigMode: schema.SchemaConfigModeAttr,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"ip_address": {

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -171,7 +171,7 @@ A `cors` block supports the following:
 
 ---
 
-A `ip_restriction` block supports the following:
+A `ip_restriction` [block](/docs/configuration/attr-as-blocks.html) supports the following:
 
 * `ip_address` - (Required) The IP Address used for this IP Restriction.
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -123,7 +123,7 @@ A `site_config` block supports the following:
 
 * `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`.
 
-* `ip_restriction` - (Optional) One or more `ip_restriction` blocks as defined below.
+* `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.
 
 * `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7` and `1.8`.
 
@@ -171,7 +171,7 @@ A `cors` block supports the following:
 
 ---
 
-A `ip_restriction` [block](/docs/configuration/attr-as-blocks.html) supports the following:
+Elements of `ip_restriction` support:
 
 * `ip_address` - (Required) The IP Address used for this IP Restriction.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -194,7 +194,7 @@ The following arguments are supported:
 
 * `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`.
 
-* `ip_restriction` - (Optional) One or more `ip_restriction` blocks as defined below.
+* `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.
 
 * `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.
 
@@ -246,7 +246,7 @@ A `identity` block supports the following:
 
 ---
 
-A `ip_restriction` [block](/docs/configuration/attr-as-blocks.html) supports the following:
+Elements of `ip_restriction` [block](/docs/configuration/attr-as-blocks.html) support:
 
 * `ip_address` - (Required) The IP Address used for this IP Restriction.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -246,12 +246,11 @@ A `identity` block supports the following:
 
 ---
 
-A `ip_restriction` block supports the following:
+A `ip_restriction` [block](/docs/configuration/attr-as-blocks.html) supports the following:
 
 * `ip_address` - (Required) The IP Address used for this IP Restriction.
 
 * `subnet_mask` - (Optional) The Subnet mask used for this IP Restriction. Defaults to `255.255.255.255`.
-
 
 ## Attributes Reference
 


### PR DESCRIPTION

In Terraform 0.12, behaviors with configuration blocks are more explicit to allow configuration language improvements and remove ambiguities that required various undocumented workarounds in Terraform 0.11 and prior. As a consequence, configuration blocks that are marked `Optional: true` and `Computed: true` will no longer support explicitly zero-ing out the configuration without special implementation.

The `ConfigMode` schema parameter on the configuration block attribute allows the schema to override certain behaviors. In particular, setting `ConfigMode: schema.SchemaConfigModeAttr` will allow practitioners to continue setting the configuration block attribute to an empty list (in the semantic sense, e.g. `attr = []`), keeping this prior behavior in Terraform 0.12. This parameter does not have any effect with Terraform 0.11. This solution may be temporary or revisited in the future.

In Terraform 0.12, behaviors with configuration blocks are more explicit to allow configuration language improvements and remove ambiguities that required various undocumented workarounds in Terraform 0.11 and prior. As a consequence, configuration blocks that are marked Optional: true and Computed: true will no longer support explicitly zero-ing out the configuration without special implementation.

The ConfigMode schema parameter on the configuration block attribute allows the schema to override certain behaviors. In particular, setting ConfigMode: schema.SchemaConfigModeAttr will allow practitioners to continue setting the configuration block attribute to an empty list (in the semantic sense, e.g. attr = []), keeping this prior behavior in Terraform 0.12. This parameter does not have any effect with Terraform 0.11. This solution may be temporary or revisited in the future.

Test before/after:
```
0.11 SDK BEFORE
--- PASS: TestAccAzureRMAppService_zeroedIpRestriction (120.00s)

0.12 SDK BEFORE
--- FAIL: TestAccAzureRMAppService_zeroedIpRestriction (0.07s)
testing.go:568: Step 0 error: config is invalid: Unsupported argument: An argument named "ip_restriction" is not expected here. Did you mean to define a block of type "ip_restriction"?

0.12 SDK After
--- PASS: TestAccAzureRMAppService_zeroedIpRestriction (181.97s)
--- PASS: TestAccAzureRMAppServiceSlot_zeroedIpRestriction (220.55s)

0.11 SDK After
--- PASS: TestAccAzureRMAppService_zeroedIpRestriction (213.07s)
--- PASS:TestAccAzureRMAppServiceSlot_zeroedIpRestriction  (229.90s)
```
Note: both resources' blocks used the same schema for site_config (in azurerm/helpers/azure/app_service.go), which is why I don't have failing 'before' tests for app_service_slot - I'd already added the fix before noticing that it was the same underlying schema.