### PR TITLE
remove "Computed" from schema

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -182,7 +182,6 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 				"use_32_bit_worker_process": {
 					Type:     schema.TypeBool,
 					Optional: true,
-					Computed: true,
 				},
 
 				"websockets_enabled": {


### PR DESCRIPTION
Resolves https://github.com/terraform-providers/terraform-provider-azurerm/issues/3146

From the discussion I had in the issue, it looks like this feature can be updated after the resource is spun up.  I believe that since it is `Computed` in the schema, updates to the existing resource are ignored.  This helper function is used by both the `app_service` and `app_service_slot` resources.  The default will be `false`.  If the app service requires a 32 bit resource the effect will be that this needs to be specified.