### PR TITLE
Update virtual_machine_scale_set.html.markdown

### DIFF
--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -65,7 +65,6 @@ resource "azurerm_lb_backend_address_pool" "bpepool" {
 }
 
 resource "azurerm_lb_nat_pool" "lbnatpool" {
-  count                          = 3
   resource_group_name            = "${azurerm_resource_group.test.name}"
   name                           = "ssh"
   loadbalancer_id                = "${azurerm_lb.test.id}"


### PR DESCRIPTION
Count is not needed in azurerm_lb_nat_pool.lbnatpool for a VM scale set. 
The NAT rules will be created dynamically between frontend_port_start and frontend_port_end even if there's only one resource deployed.