### PR TITLE
New data source 'azurerm_firewall'

### DIFF
--- a/azurerm/data_source_firewall.go
+++ b/azurerm/data_source_firewall.go
@@ -1,0 +1,98 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmFirewall() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmFirewallRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAzureFirewallName,
+			},
+
+			"location": locationSchema(),
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"ip_configuration": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internal_public_ip_address_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip_address_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"tags": tagsForDataSourceSchema(),
+		},
+	}
+}
+
+func dataSourceArmFirewallRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).azureFirewallsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	read, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(read.Response) {
+			log.Printf("[DEBUG] Firewall %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making Read request on Azure Firewall %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(*read.ID)
+	d.Set("name", read.Name)
+	d.Set("resource_group_name", resourceGroup)
+
+	if location := read.Location; location != nil {
+		d.Set("location", azureRMNormalizeLocation(*location))
+	}
+
+	if props := read.AzureFirewallPropertiesFormat; props != nil {
+		ipConfigs := flattenArmFirewallIPConfigurations(props.IPConfigurations)
+		if err := d.Set("ip_configuration", ipConfigs); err != nil {
+			return fmt.Errorf("Error setting `ip_configuration`: %+v", err)
+		}
+	}
+
+	flattenAndSetTags(d, read.Tags)
+
+	return nil
+}

--- a/azurerm/data_source_firewall.go
+++ b/azurerm/data_source_firewall.go
@@ -20,9 +20,9 @@ func dataSourceArmFirewall() *schema.Resource {
 				ValidateFunc: validateAzureFirewallName,
 			},
 
-			"location": locationSchema(),
+			"location": locationForDataSourceSchema(),
 
-			"resource_group_name": resourceGroupNameSchema(),
+			"resource_group_name": resourceGroupNameForDataSourceSchema(),
 
 			"ip_configuration": {
 				Type:     schema.TypeList,

--- a/azurerm/data_source_firewall_test.go
+++ b/azurerm/data_source_firewall_test.go
@@ -1,0 +1,79 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccDataSourceAzureRMFirewall_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_firewall.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceFirewall_basic(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "ip_configuration.0.name", "configuration"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ip_configuration.0.private_ip_address"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceFirewall_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctestfirewall%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = "${azurerm_subnet.test.id}"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
+}
+
+data "azurerm_firewall" "test" {
+	name                = "acctestfirewall%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, rInt, location, rInt, rInt, rInt, rInt)
+}

--- a/azurerm/data_source_firewall_test.go
+++ b/azurerm/data_source_firewall_test.go
@@ -21,7 +21,8 @@ func TestAccDataSourceAzureRMFirewall_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceFirewall_basic(rInt, location),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "ip_configuration.#", "0"),
+					resource.TestCheckResourceAttr(dataSourceName, "ip_configuration.0.name", "configuration"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ip_configuration.0.private_ip_address"),
 				),
 			},
 		},

--- a/azurerm/data_source_firewall_test.go
+++ b/azurerm/data_source_firewall_test.go
@@ -21,8 +21,7 @@ func TestAccDataSourceAzureRMFirewall_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceFirewall_basic(rInt, location),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "ip_configuration.0.name", "configuration"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "ip_configuration.0.private_ip_address"),
+					resource.TestCheckResourceAttr(dataSourceName, "ip_configuration.#", "0"),
 				),
 			},
 		},
@@ -71,9 +70,8 @@ resource "azurerm_firewall" "test" {
 }
 
 data "azurerm_firewall" "test" {
-	name                = "acctestfirewall%d"
-  location            = "${azurerm_resource_group.test.location}"
+	name                = "${azurerm_firewall.test.name}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
-`, rInt, location, rInt, rInt, rInt, rInt)
+`, rInt, location, rInt, rInt, rInt)
 }

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -121,6 +121,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_dev_test_lab":                           dataSourceArmDevTestLab(),
 			"azurerm_dns_zone":                               dataSourceArmDnsZone(),
 			"azurerm_eventhub_namespace":                     dataSourceEventHubNamespace(),
+			"azurerm_firewall":                               dataSourceArmFirewall(),
 			"azurerm_image":                                  dataSourceArmImage(),
 			"azurerm_hdinsight_cluster":                      dataSourceArmHDInsightSparkCluster(),
 			"azurerm_key_vault_access_policy":                dataSourceArmKeyVaultAccessPolicy(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -151,6 +151,10 @@
                     <a href="/docs/providers/azurerm/d/eventhub_namespace.html">azurerm_eventhub_namespace</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-datasource-firewall") %>>
+                    <a href="/docs/providers/azurerm/d/firewall.html">azurerm_firewall</a>
+                </li>
+
                 <li<%= sidebar_current("docs-azurerm-datasource-hdinsight-cluster") %>>
                     <a href="/docs/providers/azurerm/d/hdinsight_cluster.html">azurerm_hdinsight_cluster</a>
                 </li>

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_firewall"
+sidebar_current: "docs-azurerm-datasource-firewall"
+description: |-
+  Gets information about an existing Firewall.
+
+---
+
+# Data Source: azurerm_firewall
+
+Use this data source to access information about an existing Firewall.
+
+## Example Usage
+
+```hcl
+data "azurerm_firewall" "test" {
+  name                = "firewall1"
+  resource_group_name = "firewall-RG"
+  location            = "westus"
+}
+
+output "firewall_private_ip" {
+  value = "${data.azurerm_firewall.test.ip_configuration.0.private_ip_address}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the Firewall.
+
+* `resource_group_name` - (Required) The name of the Resource Group in which the Firewall exists.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Resource ID of the Azure Firewall.
+
+* `ip_configuration` - A `ip_configuration` block as defined below.
+
+---
+
+A `ip_configuration` block exports the following:
+
+* `subnet_id` - The Resource ID of the subnet where the Azure Firewall is deployed.
+
+* `private_ip_address` - The private IP address of the Azure Firewall.
+
+* `public_ip_address_id`- The Resource ID of the public IP address of the Azure Firewall.

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -3,13 +3,13 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_firewall"
 sidebar_current: "docs-azurerm-datasource-firewall"
 description: |-
-  Gets information about an existing Firewall.
+  Gets information about an existing Azure Firewall.
 
 ---
 
 # Data Source: azurerm_firewall
 
-Use this data source to access information about an existing Firewall.
+Use this data source to access information about an existing Azure Firewall.
 
 ## Example Usage
 
@@ -17,7 +17,6 @@ Use this data source to access information about an existing Firewall.
 data "azurerm_firewall" "test" {
   name                = "firewall1"
   resource_group_name = "firewall-RG"
-  location            = "westus"
 }
 
 output "firewall_private_ip" {
@@ -27,9 +26,9 @@ output "firewall_private_ip" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Firewall.
+* `name` - (Required) The name of the Azure Firewall.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Firewall exists.
+* `resource_group_name` - (Required) The name of the Resource Group in which the Azure Firewall exists.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This introduces a new data source `azurerm_firewall`

This is mostly a cc of the corresponding resource.

- [x] New data source `azurerm_firewall`
- [x] Tests
- [x] Documentation

# Usage

```hcl
data "azurerm_firewall" "test" {
  name                = "firewall1"
  resource_group_name = "firewall-RG"
}

output "firewall_private_ip" {
  value = "${data.azurerm_firewall.test.ip_configuration.0.private_ip_address}"
}
```