### PR TITLE
Switch to use xargs instead of backquote

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,7 +33,7 @@ debugacc: fmtcheck
 fmt:
 	@echo "==> Fixing source code with gofmt..."
 	# This logic should match the search logic in scripts/gofmtcheck.sh
-	gofmt -s -w `find . -name '*.go' | grep -v vendor`
+	find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
 
 # Currently required by tf-deploy compile
 fmtcheck:

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -4,7 +4,7 @@
 echo "==> Checking that code complies with gofmt requirements..."
 
 # This filter should match the search filter in ../GNUMakefile
-gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
+gofmt_files=$(find . -name '*.go' | grep -v vendor | xargs gofmt -l)
 if [ -n "${gofmt_files}" ]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"


### PR DESCRIPTION
Under Git Bash on Windows, while running `make` or `make fmt`, you will see below error:
```
terraform-providers/terraform-provider-azurerm/scripts/gofmtcheck.sh: line 7:
gofmt: Argument list too long
```

This is because `backquote` could fail if the command line gets too long. In above case, its limit is `32, 000`, while the length of expanded part is `34,617`. You can run  `getconf ARG_MAX` to get this limitation and `find . -name '*.go' | grep -v vendor | wc -c` to get length for expanded part.

That's where this PR comes from. By switching `backquote` to `xargs`, we can get rid of this limitation on any platform.