### PR TITLE
r/batch_account & r/batch_pool: temporarily treating the resource group name as case insensitive

### DIFF
--- a/azurerm/resource_arm_batch_account.go
+++ b/azurerm/resource_arm_batch_account.go
@@ -31,8 +31,12 @@ func resourceArmBatchAccount() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateAzureRMBatchAccountName,
 			},
-			"resource_group_name": resourceGroupNameSchema(),
-			"location":            locationSchema(),
+
+			// TODO: make this case sensitive once this API bug has been fixed:
+			// https://github.com/Azure/azure-rest-api-specs/issues/5574
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
+
+			"location": locationSchema(),
 			"storage_account_id": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/azurerm/resource_arm_batch_pool.go
+++ b/azurerm/resource_arm_batch_pool.go
@@ -37,7 +37,11 @@ func resourceArmBatchPool() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: azure.ValidateAzureRMBatchPoolName,
 			},
-			"resource_group_name": resourceGroupNameSchema(),
+
+			// TODO: make this case sensitive once this API bug has been fixed:
+			// https://github.com/Azure/azure-rest-api-specs/issues/5574
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
+
 			"account_name": {
 				Type:         schema.TypeString,
 				Required:     true,

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Batch account. Changing this forces a new resource to be created.
 
+~> **NOTE:** To work around [a bug in the Azure API](https://github.com/Azure/azure-rest-api-specs/issues/5574) this property is currently treated as case-insensitive. A future version of Terraform will require that the casing is correct.
+
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
 * `pool_allocation_mode` - (Optional) Specifies the mode to use for pool allocation. Possible values are `BatchService` or `UserSubscription`. Defaults to `BatchService`.

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -106,6 +106,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Batch pool. Changing this forces a new resource to be created.
 
+~> **NOTE:** To work around [a bug in the Azure API](https://github.com/Azure/azure-rest-api-specs/issues/5574) this property is currently treated as case-insensitive. A future version of Terraform will require that the casing is correct.
+
 * `account_name` - (Required) Specifies the name of the Batch account in which the pool will be created. Changing this forces a new resource to be created.
 
 * `node_agent_sku_id` - (Required) Specifies the Sku of the node agents that will be created in the Batch pool.


### PR DESCRIPTION
Whilst some Azure API's treat Resource ID's as case insensitive, others (particularly where they take Resource ID's from other resources) don't - as such Terraform intentionally treats Resource ID's as case sensitive.

Unfortunately the Batch API returns [Resource ID's in the incorrect case](https://github.com/Azure/azure-rest-api-specs/issues/5574) which means we're forced to treat the Resource Group Name as case insensitive until this API bug is resolved.