### PR TITLE
AutoRest: ensuring the same senders are used for auth & client requests

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -455,24 +455,25 @@ func getArmClient(c *authentication.Config, skipProviderRegistration bool, partn
 		return nil, fmt.Errorf("Unable to configure OAuthConfig for tenant %s", c.TenantID)
 	}
 
+	sender := azure.BuildSender()
+
 	// Resource Manager endpoints
 	endpoint := env.ResourceManagerEndpoint
-	auth, err := c.GetAuthorizationToken(oauthConfig, env.TokenAudience)
+	auth, err := c.GetAuthorizationToken(sender, oauthConfig, env.TokenAudience)
 	if err != nil {
 		return nil, err
 	}
 
 	// Graph Endpoints
 	graphEndpoint := env.GraphEndpoint
-	graphAuth, err := c.GetAuthorizationToken(oauthConfig, graphEndpoint)
+	graphAuth, err := c.GetAuthorizationToken(sender, oauthConfig, graphEndpoint)
 	if err != nil {
 		return nil, err
 	}
 
 	// Key Vault Endpoints
-	sender := azure.BuildSender()
 	keyVaultAuth := autorest.NewBearerAuthorizerCallback(sender, func(tenantID, resource string) (*autorest.BearerAuthorizer, error) {
-		keyVaultSpt, err := c.GetAuthorizationToken(oauthConfig, resource)
+		keyVaultSpt, err := c.GetAuthorizationToken(sender, oauthConfig, resource)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/google/uuid v0.0.0-20170814143639-7e072fc3a7be
 	github.com/grpc-ecosystem/grpc-gateway v1.6.3 // indirect
-	github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363
+	github.com/hashicorp/go-azure-helpers v0.4.0
 	github.com/hashicorp/go-getter v0.0.0-20180327010114-90bb99a48d86
 	github.com/hashicorp/go-hclog v0.0.0-20170903163258-8105cc0a3736 // indirect
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363 h1:9d0jVlMpgfMTdL/QSsRDQsLenOQZIHp5cEBiWSYc8w4=
 github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363/go.mod h1:Y5ejHZY3jQby82dOASJzyQ2xZw37zs+D5x6AaOC6O5E=
+github.com/hashicorp/go-azure-helpers v0.4.0 h1:iAJWTrKSD002iu5g33TgKeHK1NNqmafQftPC+yx+Hgk=
+github.com/hashicorp/go-azure-helpers v0.4.0/go.mod h1:lu62V//auUow6k0IykxLK2DCNW8qTmpm8KqhYVWattA=
 github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de h1:XDCSythtg8aWSRSO29uwhgh7b127fWr+m5SemqjSUL8=
 github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de/go.mod h1:xIwEieBHERyEvaeKF/TcHh1Hu+lxPM+n2vT1+g9I4m4=
 github.com/hashicorp/go-cleanhttp v0.0.0-20170211013415-3573b8b52aa7 h1:67fHcS+inUoiIqWCKIqeDuq2AlPHNHPiTqp97LdQ+bc=

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method.go
@@ -10,7 +10,7 @@ type authMethod interface {
 
 	isApplicable(b Builder) bool
 
-	getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error)
+	getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error)
 
 	name() string
 

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_token.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_token.go
@@ -55,7 +55,7 @@ func (a azureCliTokenAuth) isApplicable(b Builder) bool {
 	return b.SupportsAzureCliToken
 }
 
-func (a azureCliTokenAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a azureCliTokenAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	// the Azure CLI appears to cache these, so to maintain compatibility with the interface this method is intentionally not on the pointer
 	token, err := obtainAuthorizationToken(endpoint, a.profile.subscriptionId)
 	if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_client_cert.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_client_cert.go
@@ -41,7 +41,7 @@ func (a servicePrincipalClientCertificateAuth) name() string {
 	return "Service Principal / Client Certificate"
 }
 
-func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	certificateData, err := ioutil.ReadFile(a.clientCertPath)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading Client Certificate %q: %v", a.clientCertPath, err)
@@ -57,6 +57,8 @@ func (a servicePrincipalClientCertificateAuth) getAuthorizationToken(oauthConfig
 	if err != nil {
 		return nil, err
 	}
+
+	spt.SetSender(sender)
 
 	err = spt.Refresh()
 	if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_client_secret.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_client_secret.go
@@ -33,11 +33,12 @@ func (a servicePrincipalClientSecretAuth) name() string {
 	return "Service Principal / Client Secret"
 }
 
-func (a servicePrincipalClientSecretAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a servicePrincipalClientSecretAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	spt, err := adal.NewServicePrincipalToken(*oauthConfig, a.clientId, a.clientSecret, endpoint)
 	if err != nil {
 		return nil, err
 	}
+	spt.SetSender(sender)
 
 	auth := autorest.NewBearerAuthorizer(spt)
 	return auth, nil

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_msi.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_msi.go
@@ -39,11 +39,14 @@ func (a managedServiceIdentityAuth) name() string {
 	return "Managed Service Identity"
 }
 
-func (a managedServiceIdentityAuth) getAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+func (a managedServiceIdentityAuth) getAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
 	spt, err := adal.NewServicePrincipalTokenFromMSI(a.endpoint, endpoint)
 	if err != nil {
 		return nil, err
 	}
+
+	spt.SetSender(sender)
+
 	auth := autorest.NewBearerAuthorizer(spt)
 	return auth, nil
 }

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/config.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/config.go
@@ -22,8 +22,8 @@ type Config struct {
 }
 
 // GetAuthorizationToken returns an authorization token for the authentication method defined in the Config
-func (c Config) GetAuthorizationToken(oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
-	return c.authMethod.getAuthorizationToken(oauthConfig, endpoint)
+func (c Config) GetAuthorizationToken(sender autorest.Sender, oauthConfig *adal.OAuthConfig, endpoint string) (*autorest.BearerAuthorizer, error) {
+	return c.authMethod.getAuthorizationToken(sender, oauthConfig, endpoint)
 }
 
 func (c Config) validate() (*Config, error) {

--- a/vendor/github.com/hashicorp/go-azure-helpers/resourceproviders/registration.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/resourceproviders/registration.go
@@ -39,7 +39,7 @@ func RegisterForSubscription(ctx context.Context, client resources.ProvidersClie
 		go func(p string) {
 			defer wg.Done()
 			log.Printf("[DEBUG] Registering Resource Provider %q with namespace", p)
-			if innerErr := registerWithSubscription(ctx, p, client); err != nil {
+			if innerErr := registerWithSubscription(ctx, p, client); innerErr != nil {
 				err = innerErr
 			}
 		}(providerName)
@@ -51,8 +51,7 @@ func RegisterForSubscription(ctx context.Context, client resources.ProvidersClie
 }
 
 func registerWithSubscription(ctx context.Context, providerName string, client resources.ProvidersClient) error {
-	_, err := client.Register(ctx, providerName)
-	if err != nil {
+	if _, err := client.Register(ctx, providerName); err != nil {
 		return fmt.Errorf("Cannot register provider %s with Azure Resource Manager: %s.", providerName, err)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/golang/protobuf/ptypes/duration
 github.com/google/uuid
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.0.0-20181211121309-38db96513363
+# github.com/hashicorp/go-azure-helpers v0.4.0
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/storage


### PR DESCRIPTION
Passing the same Sender to the Auth and Client calls

Fixes #3271