### PR TITLE
IC for adding container_configuration to batch pool resource.

### DIFF
--- a/azurerm/data_source_batch_pool.go
+++ b/azurerm/data_source_batch_pool.go
@@ -112,14 +112,11 @@ func dataSourceArmBatchPool() *schema.Resource {
 			},
 			"container_configuration": {
 				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+                Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validate.NoEmptyStrings,
 						},
 					},
 				},

--- a/azurerm/data_source_batch_pool.go
+++ b/azurerm/data_source_batch_pool.go
@@ -110,6 +110,20 @@ func dataSourceArmBatchPool() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"container_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validate.NoEmptyStrings,
+						},
+					},
+				},
+			},
 			"certificate": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -271,6 +285,17 @@ func dataSourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error 
 			}
 			if err := d.Set("fixed_scale", azure.FlattenBatchPoolFixedScaleSettings(scaleSettings.FixedScale)); err != nil {
 				return fmt.Errorf("Error flattening `fixed_scale `: %+v", err)
+			}
+		}
+
+		if props.DeploymentConfiguration != nil &&
+			props.DeploymentConfiguration.VirtualMachineConfiguration != nil &&
+			props.DeploymentConfiguration.VirtualMachineConfiguration.ContainerConfiguration != nil {
+
+			containerConfiguration := props.DeploymentConfiguration.VirtualMachineConfiguration.ContainerConfiguration
+
+			if err := d.Set("container_configuration", azure.FlattenBatchPoolContainerConfiguration(containerConfiguration)); err != nil {
+				return fmt.Errorf("error setting `container_configuration`: %v", err)
 			}
 		}
 

--- a/azurerm/data_source_batch_pool_test.go
+++ b/azurerm/data_source_batch_pool_test.go
@@ -29,9 +29,9 @@ func TestAccDataSourceAzureRMBatchPool_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "account_name", fmt.Sprintf("testaccbatch%s", rs)),
 					resource.TestCheckResourceAttr(dataSourceName, "vm_size", "STANDARD_A1"),
 					resource.TestCheckResourceAttr(dataSourceName, "storage_image_reference.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "storage_image_reference.0.publisher", "Canonical"),
-					resource.TestCheckResourceAttr(dataSourceName, "storage_image_reference.0.sku", "16.04.0-LTS"),
-					resource.TestCheckResourceAttr(dataSourceName, "storage_image_reference.0.offer", "UbuntuServer"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_image_reference.0.publisher", "microsoft-azure-batch"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_image_reference.0.sku", "16-04-lts"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_image_reference.0.offer", "ubuntu-server-container"),
 					resource.TestCheckResourceAttr(dataSourceName, "fixed_scale.#", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "fixed_scale.0.target_dedicated_nodes", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "fixed_scale.0.resize_timeout", "PT15M"),
@@ -53,6 +53,7 @@ func TestAccDataSourceAzureRMBatchPool_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "certificate.0.visibility.#", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "certificate.0.visibility.3294600504", "StartTask"),
 					resource.TestCheckResourceAttr(dataSourceName, "certificate.0.visibility.4077195354", "RemoteUser"),
+					resource.TestCheckResourceAttr(dataSourceName, "container_configuration.0.type", "DockerCompatible"),
 				),
 			},
 		},
@@ -111,9 +112,9 @@ resource "azurerm_batch_pool" "test" {
   }
 
   storage_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    publisher = "microsoft-azure-batch"
+    offer     = "ubuntu-server-container"
+    sku       = "16-04-lts"
     version   = "latest"
   }
 
@@ -121,6 +122,10 @@ resource "azurerm_batch_pool" "test" {
     id             = "${azurerm_batch_certificate.test.id}"
     store_location = "CurrentUser"
     visibility     = [ "StartTask", "RemoteUser" ]
+  }
+
+  container_configuration {
+    type = "DockerCompatible"
   }
   
   start_task {

--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -204,7 +204,6 @@ func FlattenBatchPoolContainerConfiguration(armContainerConfiguration *batch.Con
 		result["type"] = *armContainerConfiguration.Type
 	}
 
-	//return []interface{}{result}
 	return []interface{}{result}
 }
 

--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -204,7 +204,8 @@ func FlattenBatchPoolContainerConfiguration(armContainerConfiguration *batch.Con
 		result["type"] = *armContainerConfiguration.Type
 	}
 
-	return result
+	//return []interface{}{result}
+	return []interface{}{result}
 }
 
 // ExpandBatchPoolImageReference expands Batch pool image reference

--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -197,7 +197,7 @@ func FlattenBatchPoolContainerConfiguration(armContainerConfiguration *batch.Con
 	result := make(map[string]interface{})
 
 	if armContainerConfiguration == nil {
-		return result
+		return nil
 	}
 
 	if armContainerConfiguration.Type != nil {

--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -233,7 +233,7 @@ func ExpandBatchPoolImageReference(list []interface{}) (*batch.ImageReference, e
 // ExpandBatchPoolContainerConfiguration expands the Batch pool container configuration
 func ExpandBatchPoolContainerConfiguration(list []interface{}) (*batch.ContainerConfiguration, error) {
 	if len(list) == 0 {
-		return nil, fmt.Errorf("Error: container configuration should be defined")
+		return nil, nil
 	}
 
 	containerConfiguration := list[0].(map[string]interface{})

--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -191,6 +191,22 @@ func FlattenBatchPoolCertificateReferences(armCertificates *[]batch.CertificateR
 	return output
 }
 
+// FlattenBatchPoolContainerConfiguration flattens a Batch pool container configuration
+func FlattenBatchPoolContainerConfiguration(armContainerConfiguration *batch.ContainerConfiguration) interface{} {
+
+	result := make(map[string]interface{})
+
+	if armContainerConfiguration == nil {
+		return result
+	}
+
+	if armContainerConfiguration.Type != nil {
+		result["type"] = *armContainerConfiguration.Type
+	}
+
+	return result
+}
+
 // ExpandBatchPoolImageReference expands Batch pool image reference
 func ExpandBatchPoolImageReference(list []interface{}) (*batch.ImageReference, error) {
 	if len(list) == 0 {
@@ -212,6 +228,22 @@ func ExpandBatchPoolImageReference(list []interface{}) (*batch.ImageReference, e
 	}
 
 	return imageRef, nil
+}
+
+// ExpandBatchPoolContainerConfiguration expands the Batch pool container configuration
+func ExpandBatchPoolContainerConfiguration(list []interface{}) (*batch.ContainerConfiguration, error) {
+	if len(list) == 0 {
+		return nil, fmt.Errorf("Error: container configuration should be defined")
+	}
+
+	containerConfiguration := list[0].(map[string]interface{})
+	containerType := containerConfiguration["type"].(string)
+
+	containerConf := &batch.ContainerConfiguration{
+		Type: &containerType,
+	}
+
+	return containerConf, nil
 }
 
 // ExpandBatchPoolCertificateReferences expands Batch pool certificate references

--- a/azurerm/resource_arm_batch_pool.go
+++ b/azurerm/resource_arm_batch_pool.go
@@ -588,13 +588,10 @@ func resourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 			d.Set("node_agent_sku_id", props.DeploymentConfiguration.VirtualMachineConfiguration.NodeAgentSkuID)
 		}
 
-		if props.DeploymentConfiguration != nil &&
-			props.DeploymentConfiguration.VirtualMachineConfiguration != nil &&
-			props.DeploymentConfiguration.VirtualMachineConfiguration.ContainerConfiguration != nil {
-
-			containerConfiguration := props.DeploymentConfiguration.VirtualMachineConfiguration.ContainerConfiguration
-
-			d.Set("container_configuration", azure.FlattenBatchPoolContainerConfiguration(containerConfiguration))
+		if dcfg := props.DeploymentConfiguration; dcfg != nil {
+			if vmcfg := dcfg.VirtualMachineConfiguration; vmcfg != nil {
+				d.Set("container_configuration", azure.FlattenBatchPoolContainerConfiguration(vmcfg.ContainerConfiguration))
+			}
 		}
 
 		if err := d.Set("certificate", azure.FlattenBatchPoolCertificateReferences(props.Certificates)); err != nil {

--- a/azurerm/resource_arm_batch_pool.go
+++ b/azurerm/resource_arm_batch_pool.go
@@ -113,6 +113,20 @@ func resourceArmBatchPool() *schema.Resource {
 					},
 				},
 			},
+			"container_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validate.NoEmptyStrings,
+						},
+					},
+				},
+			},
 			"storage_image_reference": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -385,10 +399,17 @@ func resourceArmBatchPoolCreate(d *schema.ResourceData, meta interface{}) error 
 		parameters.PoolProperties.StartTask = startTask
 	}
 
+	containerConfigurationSet := d.Get("container_configuration").([]interface{})
+	containerConfiguration, err := azure.ExpandBatchPoolContainerConfiguration(containerConfigurationSet)
+	if err != nil {
+		return fmt.Errorf("Error creating Batch pool %q (Resource Group %q): %+v", poolName, resourceGroup, err)
+	}
+
 	parameters.PoolProperties.DeploymentConfiguration = &batch.DeploymentConfiguration{
 		VirtualMachineConfiguration: &batch.VirtualMachineConfiguration{
-			NodeAgentSkuID: &nodeAgentSkuID,
-			ImageReference: imageReference,
+			NodeAgentSkuID:         &nodeAgentSkuID,
+			ImageReference:         imageReference,
+			ContainerConfiguration: containerConfiguration,
 		},
 	}
 
@@ -565,6 +586,15 @@ func resourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 			d.Set("storage_image_reference", azure.FlattenBatchPoolImageReference(imageReference))
 			d.Set("node_agent_sku_id", props.DeploymentConfiguration.VirtualMachineConfiguration.NodeAgentSkuID)
+		}
+
+		if props.DeploymentConfiguration != nil &&
+			props.DeploymentConfiguration.VirtualMachineConfiguration != nil &&
+			props.DeploymentConfiguration.VirtualMachineConfiguration.ContainerConfiguration != nil {
+
+			containerConfiguration := props.DeploymentConfiguration.VirtualMachineConfiguration.ContainerConfiguration
+
+			d.Set("container_configuration", azure.FlattenBatchPoolContainerConfiguration(containerConfiguration))
 		}
 
 		if err := d.Set("certificate", azure.FlattenBatchPoolCertificateReferences(props.Certificates)); err != nil {

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -47,6 +47,8 @@ The following attributes are exported:
 
 * `certificate` - One or more `certificate` blocks that describe the certificates installed on each compute node in the pool.
 
+* `container_configuration` - The container configuration used in the pool's VMs.
+
 ---
 
 A `fixed_scale` block exports the following:
@@ -128,3 +130,9 @@ A `resource_file` block exports the following:
 * `http_url` - The URL of the file to download. If the URL is Azure Blob Storage, it must be readable using anonymous access.
 
 * `storage_container_url` - The URL of the blob container within Azure Blob Storage.
+
+---
+
+A `container_configuration` block exports the following:
+
+* `type` - The type of container configuration.

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -206,6 +206,12 @@ A `certificate` block supports the following:
 
 ---
 
+A `container_configuration` block supports the following:
+
+* `type` - (Optional) The type of container configuration. Possible value is `DockerCompatible`.
+
+---
+
 A `resource_file` block supports the following:
 
 * `auto_storage_container_name` - (Optional) The storage container name in the auto storage account.

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -68,10 +68,14 @@ EOF
   }
 
   storage_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04.0-LTS"
+    publisher = "microsoft-azure-batch"
+    offer     = "ubuntu-server-container"
+    sku       = "16-04-lts"
     version   = "latest"
+  }
+
+  container_configuration {
+    type = "DockerCompatible"
   }
 
   start_task {

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -132,6 +132,8 @@ The following arguments are supported:
 
 * `certificate` - (Optional) One or more `certificate` blocks that describe the certificates to be installed on each compute node in the pool.
 
+* `container_configuration` - (Optional) The container configuration used in the pool's VMs.
+
 -> **NOTE:** For Windows compute nodes, the Batch service installs the certificates to the specified certificate store and location. For Linux compute nodes, the certificates are stored in a directory inside the task working directory and an environment variable `AZ_BATCH_CERTIFICATES_DIR` is supplied to the task to query for this location. For certificates with visibility of `remoteUser`, a `certs` directory is created in the user's home directory (e.g., `/home/{user-name}/certs`) and certificates are placed in that directory.
 
 ~> **Please Note:** `fixed_scale` and `auto_scale` blocks cannot be used both at the same time.


### PR DESCRIPTION
Hi -- this PR adds the `container_configuration` block to the batch pool resource.

This setting is necessary for the Pool to support containerized workloads. There are more settings not included in this PR, e.g. setting a default registry. I'd like to add that at some point, but this seemed like a good intermediate step since this is my first PR and if the docker is enabled then the Tasks can still set the registry or other items.