### PR TITLE
Fix: Ignore case difference in Resource Group Name for Data Factory resources

### DIFF
--- a/azurerm/resource_arm_data_factory.go
+++ b/azurerm/resource_arm_data_factory.go
@@ -36,7 +36,9 @@ func resourceArmDataFactory() *schema.Resource {
 
 			"location": locationSchema(),
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"identity": {
 				Type:     schema.TypeList,

--- a/azurerm/resource_arm_data_factory_dataset_mysql.go
+++ b/azurerm/resource_arm_data_factory_dataset_mysql.go
@@ -42,7 +42,9 @@ func resourceArmDataFactoryDatasetMySQL() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"linked_service_name": {
 				Type:         schema.TypeString,

--- a/azurerm/resource_arm_data_factory_dataset_postgresql.go
+++ b/azurerm/resource_arm_data_factory_dataset_postgresql.go
@@ -42,7 +42,9 @@ func resourceArmDataFactoryDatasetPostgreSQL() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"linked_service_name": {
 				Type:         schema.TypeString,

--- a/azurerm/resource_arm_data_factory_dataset_sql_server_table.go
+++ b/azurerm/resource_arm_data_factory_dataset_sql_server_table.go
@@ -42,7 +42,9 @@ func resourceArmDataFactoryDatasetSQLServerTable() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"linked_service_name": {
 				Type:         schema.TypeString,

--- a/azurerm/resource_arm_data_factory_linked_service_mysql.go
+++ b/azurerm/resource_arm_data_factory_linked_service_mysql.go
@@ -41,7 +41,9 @@ func resourceArmDataFactoryLinkedServiceMySQL() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"connection_string": {
 				Type:             schema.TypeString,

--- a/azurerm/resource_arm_data_factory_linked_service_postgresql.go
+++ b/azurerm/resource_arm_data_factory_linked_service_postgresql.go
@@ -41,7 +41,9 @@ func resourceArmDataFactoryLinkedServicePostgreSQL() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"connection_string": {
 				Type:             schema.TypeString,

--- a/azurerm/resource_arm_data_factory_linked_service_sql_server.go
+++ b/azurerm/resource_arm_data_factory_linked_service_sql_server.go
@@ -42,7 +42,9 @@ func resourceArmDataFactoryLinkedServiceSQLServer() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"connection_string": {
 				Type:             schema.TypeString,

--- a/azurerm/resource_arm_data_factory_pipeline.go
+++ b/azurerm/resource_arm_data_factory_pipeline.go
@@ -40,7 +40,9 @@ func resourceArmDataFactoryPipeline() *schema.Resource {
 				),
 			},
 
-			"resource_group_name": resourceGroupNameSchema(),
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": resourceGroupNameDiffSuppressSchema(),
 
 			"parameters": {
 				Type:     schema.TypeMap,


### PR DESCRIPTION
This PR addresses is a band aid to a bug in the api that returns lower case resource group names. 

That issue can be followed at https://github.com/Azure/azure-rest-api-specs/issues/5788