### PR TITLE
Application gateway: disabled rule groups

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -2721,7 +2721,7 @@ func flattenApplicationGatewayDisabledRuleGroups(input *[]network.ApplicationGat
 	for _, v := range *input {
 		output := map[string]interface{}{}
 
-		output["rule_group_name"] = string(*v.RuleGroupName)
+		output["rule_group_name"] = *v.RuleGroupName
 
 		if v.Rules != nil {
 			rulesOutput := make([]interface{}, 0)
@@ -2735,7 +2735,7 @@ func flattenApplicationGatewayDisabledRuleGroups(input *[]network.ApplicationGat
 		result = append(result, output)
 	}
 
-	return []interface{}{result}
+	return result
 }
 
 func expandApplicationGatewayCustomErrorConfigurations(vs []interface{}) *[]network.ApplicationGatewayCustomError {

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -2724,13 +2724,12 @@ func flattenApplicationGatewayDisabledRuleGroups(input *[]network.ApplicationGat
 		output["rule_group_name"] = string(*v.RuleGroupName)
 
 		if v.Rules != nil {
+			rulesOutput := make([]interface{}, 0)
 			for _, r := range *v.Rules {
-				rulesOutput := map[string]interface{}{}
-
-				rulesOutput["rules"] = r
-
-				result = append(result, rulesOutput)
+				rulesOutput = append(rulesOutput, r)
 			}
+
+			output["rules"] = rulesOutput
 		}
 
 		result = append(result, output)

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -494,6 +494,38 @@ func TestAccAzureRMApplicationGateway_webApplicationFirewall(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApplicationGateway_webApplicationFirewallDisabledRuleGroups(t *testing.T) {
+	resourceName := "azurerm_application_gateway.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApplicationGateway_webApplicationFirewallDisabledRuleGroups(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationGatewayExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "sku.0.name", "WAF_v2"),
+					resource.TestCheckResourceAttr(resourceName, "sku.0.tier", "WAF_v2"),
+					resource.TestCheckResourceAttr(resourceName, "sku.0.capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.firewall_mode", "Detection"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.rule_set_type", "OWASP"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.rule_set_version", "3.0"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.file_upload_limit_mb", "100"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.request_body_check", "true"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.max_request_body_size_kb", "100"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.disabled_rule_group.0.rule_group_name", "REQUEST-913-SCANNER-DETECTION"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.disabled_rule_group.0.rules.0", "913100"),
+					resource.TestCheckResourceAttr(resourceName, "waf_configuration.0.disabled_rule_group.1.rule_group_name", "REQUEST-920-PROTOCOL-ENFORCEMENT"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMApplicationGateway_connectionDraining(t *testing.T) {
 	resourceName := "azurerm_application_gateway.test"
 	ri := tf.AccRandTimeInt()
@@ -1996,6 +2028,104 @@ resource "azurerm_application_gateway" "test" {
   }
 }
 `, template, rInt)
+}
+
+func testAccAzureRMApplicationGateway_webApplicationFirewallDisabledRuleGroups(rInt int, location string) string {
+	template := testAccAzureRMApplicationGateway_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-%d-standard"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 1
+  }
+
+  waf_configuration {
+    enabled          = true
+    firewall_mode    = "Detection"
+    rule_set_type    = "OWASP"
+    rule_set_version = "3.0"
+    file_upload_limit_mb = 100
+    request_body_check = true
+    max_request_body_size_kb = 100
+
+	disabled_rule_group {
+		rule_group_name = "REQUEST-913-SCANNER-DETECTION"
+		rules = [ 913100 ]
+    }
+
+	disabled_rule_group {
+		rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
+    }
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  frontend_port {
+    name = "${local.frontend_port_name}"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "${local.frontend_ip_configuration_name}"
+    public_ip_address_id = "${azurerm_public_ip.test_standard.id}"
+  }
+
+  backend_address_pool {
+    name = "${local.backend_address_pool_name}"
+  }
+
+  backend_http_settings {
+    name                  = "${local.http_setting_name}"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = "${local.listener_name}"
+    frontend_ip_configuration_name = "${local.frontend_ip_configuration_name}"
+    frontend_port_name             = "${local.frontend_port_name}"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "${local.request_routing_rule_name}"
+    rule_type                  = "Basic"
+    http_listener_name         = "${local.listener_name}"
+    backend_address_pool_name  = "${local.backend_address_pool_name}"
+    backend_http_settings_name = "${local.http_setting_name}"
+  }
+}
+`, template, rInt, rInt)
 }
 
 func testAccAzureRMApplicationGateway_connectionDraining(rInt int, location string) string {

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -397,6 +397,16 @@ A `waf_configuration` block supports the following:
 
 * `max_request_body_size_kb` - (Optional) The Maximum Request Body Size in KB.  Accepted values are in the range `1`KB to `128`KB.  Defaults to `128`KB.
 
+* `disabled_rule_group` - (Optional) a disabled rule block
+
+---
+
+A `disabled_rule_group` block supports the following:
+
+* `rule_group_name` - (Required) The rule group name to disable, e.g. `REQUEST-913-SCANNER-DETECTION`.
+
+* `rules` - (Optional) A list of rules to disabled, e.g.  `[ 913100 ]`. Disables all rules in the group if `rules` is not specified.
+
 ---
 
 A `custom_error_configuration` block supports the following:


### PR DESCRIPTION
Currently WIP

Having issues with the flatten, although the creation works fine

```
--- FAIL: TestAccAzureRMApplicationGateway_webApplicationFirewallDisabledRuleGroups (264.94s)
    testing.go:568: Step 0 error: errors during apply:

        Error: Error setting `waf_configuration`: waf_configuration.0.disabled_rule_group.0: '' expected a map, got 'slice'

          on /var/folders/6r/vwg96jz13pn1dlb6tk2_x6rm0000gn/T/tf-test386488536/main.tf line 48:
          (source code not available)


    testing.go:629: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.

        Error: errors during refresh: Error setting `waf_configuration`: waf_configuration.0.disabled_rule_group.0: '' expected a map, got 'slice'

        State: <nil>
FAIL
```

Opening for comment on the design and any general feedback

```
  waf_configuration {
    enabled          = true
    firewall_mode    = "Detection"
    rule_set_type    = "OWASP"
    rule_set_version = "3.0"
    file_upload_limit_mb = 100
    request_body_check = true
    max_request_body_size_kb = 100

	disabled_rule_group {
		rule_group_name = "REQUEST-913-SCANNER-DETECTION"
		rules = [ 913100 ]
    }

	disabled_rule_group {
		rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
    }
  }
```