### PR TITLE
Fix validation in resource azurerm_virtual_network_gateway for zone-redundant VPN gateways

### DIFF
--- a/azurerm/resource_arm_virtual_network_gateway.go
+++ b/azurerm/resource_arm_virtual_network_gateway.go
@@ -80,21 +80,15 @@ func resourceArmVirtualNetworkGateway() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				DiffSuppressFunc: suppress.CaseDifference,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(network.VirtualNetworkGatewaySkuTierBasic),
-					string(network.VirtualNetworkGatewaySkuTierStandard),
-					string(network.VirtualNetworkGatewaySkuTierHighPerformance),
-					string(network.VirtualNetworkGatewaySkuTierUltraPerformance),
-					string(network.VirtualNetworkGatewaySkuNameVpnGw1),
-					string(network.VirtualNetworkGatewaySkuNameVpnGw2),
-					string(network.VirtualNetworkGatewaySkuNameVpnGw3),
-					string(network.VirtualNetworkGatewaySkuNameErGw1AZ),
-					string(network.VirtualNetworkGatewaySkuNameErGw2AZ),
-					string(network.VirtualNetworkGatewaySkuNameErGw3AZ),
-					string(network.VirtualNetworkGatewaySkuNameVpnGw1AZ),
-					string(network.VirtualNetworkGatewaySkuNameVpnGw2AZ),
-					string(network.VirtualNetworkGatewaySkuNameVpnGw3AZ),
-				}, true),
+				// This validator checks for all possible values for the SKU regardless of the attributes vpn_type and
+				// type. For a validation which depends on the attributes vpn_type and type, refer to the special case
+				// validators validateArmVirtualNetworkGatewayPolicyBasedVpnSku, validateArmVirtualNetworkGatewayRouteBasedVpnSku
+				// and validateArmVirtualNetworkGatewayExpressRouteSku.
+				ValidateFunc: validation.Any(
+					validateArmVirtualNetworkGatewayPolicyBasedVpnSku(),
+					validateArmVirtualNetworkGatewayRouteBasedVpnSku(),
+					validateArmVirtualNetworkGatewayExpressRouteSku(),
+				),
 			},
 
 			"ip_configuration": {
@@ -773,6 +767,9 @@ func validateArmVirtualNetworkGatewayRouteBasedVpnSku() schema.SchemaValidateFun
 		string(network.VirtualNetworkGatewaySkuNameVpnGw1),
 		string(network.VirtualNetworkGatewaySkuNameVpnGw2),
 		string(network.VirtualNetworkGatewaySkuNameVpnGw3),
+		string(network.VirtualNetworkGatewaySkuNameVpnGw1AZ),
+		string(network.VirtualNetworkGatewaySkuNameVpnGw2AZ),
+		string(network.VirtualNetworkGatewaySkuNameVpnGw3AZ),
 	}, true)
 }
 


### PR DESCRIPTION
### Description

This pull request fixes an issue with the `azurerm_virtual_network_gateway` in which the validation prevents from creating zone-redundant VPN virtual network gateways.

* In https://github.com/terraform-providers/terraform-provider-azurerm/pull/3171, zone-redundant gateway types have been added effectively for ExpressRoute gateway but not yet for VPN gateways.
* I have cleaned up the validation for the `sku` attribute to rely on the "sub validators" to avoid ambiguity.

### New or Affected Resource(s)

* `azurerm_virtual_network_gateway`

### References

* Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/3314
* https://github.com/terraform-providers/terraform-provider-azurerm/pull/3171