### PR TITLE
fix error in app service plan and make pre-check

### DIFF
--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -192,7 +192,7 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	reserved, reservedExists := d.GetOkExists("reserved")
-	if kind == "Linux" {
+	if strings.EqualsFold(kind, "Linux") {
 		if !reserved.(bool) || !reservedExists {
 			return fmt.Errorf("Reserved has to be set to true when using kind Linux")
 		}

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -191,8 +191,15 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 		appServicePlan.AppServicePlanProperties.PerSiteScaling = utils.Bool(v.(bool))
 	}
 
-	if v, exists := d.GetOkExists("reserved"); exists {
-		appServicePlan.AppServicePlanProperties.Reserved = utils.Bool(v.(bool))
+	reserved, reservedExists := d.GetOkExists("reserved")
+	if kind == "Linux" {
+		if reserved.(bool) == false || !reservedExists {
+			return fmt.Errorf("Reserved has to be set to true when using kind Linux")
+		}
+	}
+
+	if reservedExists {
+		appServicePlan.AppServicePlanProperties.Reserved = utils.Bool(reserved.(bool))
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, appServicePlan)

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
@@ -192,7 +193,7 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	reserved, reservedExists := d.GetOkExists("reserved")
-	if strings.EqualsFold(kind, "Linux") {
+	if strings.EqualFold(kind, "Linux") {
 		if !reserved.(bool) || !reservedExists {
 			return fmt.Errorf("Reserved has to be set to true when using kind Linux")
 		}

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -193,7 +193,7 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 
 	reserved, reservedExists := d.GetOkExists("reserved")
 	if kind == "Linux" {
-		if reserved.(bool) == false || !reservedExists {
+		if !reserved.(bool) || !reservedExists {
 			return fmt.Errorf("Reserved has to be set to true when using kind Linux")
 		}
 	}

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -64,14 +64,11 @@ resource "azurerm_app_service_plan" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   kind                = "Linux"
+  reserved            = true
 
   sku {
     tier = "Standard"
     size = "S1"
-  }
-
-  properties {
-    reserved = true
   }
 }
 ```


### PR DESCRIPTION
There was an obsolete `properties` block which is not valid anymore. Fixed it in documentation.
The other change checks if `kind` is set to `Linux` and `reserved` is either `false` or not set. This is a proposal. If this change is not wanted feel free to skip it.

PR was created because of this issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/3379