### PR TITLE
Fix mismatched API management hostname configurations

### DIFF
--- a/azurerm/data_source_api_management.go
+++ b/azurerm/data_source_api_management.go
@@ -255,8 +255,8 @@ func flattenDataSourceApiManagementHostnameConfigurations(input *[]apimanagement
 	return []interface{}{
 		map[string]interface{}{
 			"management": managementResults,
-			"portal":     proxyResults,
-			"proxy":      portalResults,
+			"portal":     portalResults,
+			"proxy":      proxyResults,
 			"scm":        scmResults,
 		},
 	}


### PR DESCRIPTION
Validated locally that this resolves the issue described in #3072.