### PR TITLE
Fixing deadlock in subnet resources

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -144,8 +144,8 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 
 	addressPrefix := d.Get("address_prefix").(string)
 
-	azureRMLockByName(vnetName, virtualNetworkResourceName)
-	defer azureRMUnlockByName(vnetName, virtualNetworkResourceName)
+	azureRMLockByName(name, subnetResourceName)
+	defer azureRMUnlockByName(name, subnetResourceName)
 
 	properties := network.SubnetPropertiesFormat{
 		AddressPrefix: &addressPrefix,
@@ -156,14 +156,6 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 		properties.NetworkSecurityGroup = &network.SecurityGroup{
 			ID: &nsgId,
 		}
-
-		networkSecurityGroupName, err := parseNetworkSecurityGroupName(nsgId)
-		if err != nil {
-			return err
-		}
-
-		azureRMLockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
-		defer azureRMUnlockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
 	} else {
 		properties.NetworkSecurityGroup = nil
 	}
@@ -173,14 +165,6 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 		properties.RouteTable = &network.RouteTable{
 			ID: &rtId,
 		}
-
-		routeTableName, err := parseRouteTableName(rtId)
-		if err != nil {
-			return err
-		}
-
-		azureRMLockByName(routeTableName, routeTableResourceName)
-		defer azureRMUnlockByName(routeTableName, routeTableResourceName)
 	} else {
 		properties.RouteTable = nil
 	}
@@ -289,31 +273,6 @@ func resourceArmSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 	resGroup := id.ResourceGroup
 	name := id.Path["subnets"]
 	vnetName := id.Path["virtualNetworks"]
-
-	if v, ok := d.GetOk("network_security_group_id"); ok {
-		networkSecurityGroupId := v.(string)
-		networkSecurityGroupName, err2 := parseNetworkSecurityGroupName(networkSecurityGroupId)
-		if err2 != nil {
-			return err2
-		}
-
-		azureRMLockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
-		defer azureRMUnlockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
-	}
-
-	if v, ok := d.GetOk("route_table_id"); ok {
-		rtId := v.(string)
-		routeTableName, err2 := parseRouteTableName(rtId)
-		if err2 != nil {
-			return err2
-		}
-
-		azureRMLockByName(routeTableName, routeTableResourceName)
-		defer azureRMUnlockByName(routeTableName, routeTableResourceName)
-	}
-
-	azureRMLockByName(vnetName, virtualNetworkResourceName)
-	defer azureRMUnlockByName(vnetName, virtualNetworkResourceName)
 
 	azureRMLockByName(name, subnetResourceName)
 	defer azureRMUnlockByName(name, subnetResourceName)

--- a/azurerm/resource_arm_subnet_network_security_group_association.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association.go
@@ -64,8 +64,8 @@ func resourceArmSubnetNetworkSecurityGroupAssociationCreate(d *schema.ResourceDa
 	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
 	resourceGroup := parsedSubnetId.ResourceGroup
 
-	azureRMLockByName(virtualNetworkName, virtualNetworkResourceName)
-	defer azureRMUnlockByName(virtualNetworkName, virtualNetworkResourceName)
+	azureRMLockByName(subnetName, subnetResourceName)
+	defer azureRMUnlockByName(subnetName, subnetResourceName)
 
 	subnet, err := client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
@@ -192,9 +192,6 @@ func resourceArmSubnetNetworkSecurityGroupAssociationDelete(d *schema.ResourceDa
 
 	azureRMLockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
 	defer azureRMUnlockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
-
-	azureRMLockByName(virtualNetworkName, virtualNetworkResourceName)
-	defer azureRMUnlockByName(virtualNetworkName, virtualNetworkResourceName)
 
 	azureRMLockByName(subnetName, subnetResourceName)
 	defer azureRMUnlockByName(subnetName, subnetResourceName)

--- a/azurerm/resource_arm_subnet_network_security_group_association.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association.go
@@ -52,14 +52,6 @@ func resourceArmSubnetNetworkSecurityGroupAssociationCreate(d *schema.ResourceDa
 		return err
 	}
 
-	networkSecurityGroupName, err := parseNetworkSecurityGroupName(networkSecurityGroupId)
-	if err != nil {
-		return err
-	}
-
-	azureRMLockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
-	defer azureRMUnlockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
-
 	subnetName := parsedSubnetId.Path["subnets"]
 	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
 	resourceGroup := parsedSubnetId.ResourceGroup
@@ -183,15 +175,6 @@ func resourceArmSubnetNetworkSecurityGroupAssociationDelete(d *schema.ResourceDa
 		log.Printf("[DEBUG] Subnet %q (Virtual Network %q / Resource Group %q) has no Network Security Group - removing from state!", subnetName, virtualNetworkName, resourceGroup)
 		return nil
 	}
-
-	// once we have the network security group id to lock on, lock on that
-	networkSecurityGroupName, err := parseNetworkSecurityGroupName(*props.NetworkSecurityGroup.ID)
-	if err != nil {
-		return err
-	}
-
-	azureRMLockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
-	defer azureRMUnlockByName(networkSecurityGroupName, networkSecurityGroupResourceName)
 
 	azureRMLockByName(subnetName, subnetResourceName)
 	defer azureRMUnlockByName(subnetName, subnetResourceName)

--- a/azurerm/resource_arm_subnet_route_table_association.go
+++ b/azurerm/resource_arm_subnet_route_table_association.go
@@ -52,14 +52,6 @@ func resourceArmSubnetRouteTableAssociationCreate(d *schema.ResourceData, meta i
 		return err
 	}
 
-	routeTableName, err := parseRouteTableName(routeTableId)
-	if err != nil {
-		return err
-	}
-
-	azureRMLockByName(routeTableName, routeTableResourceName)
-	defer azureRMUnlockByName(routeTableName, routeTableResourceName)
-
 	subnetName := parsedSubnetId.Path["subnets"]
 	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
 	resourceGroup := parsedSubnetId.ResourceGroup
@@ -183,15 +175,6 @@ func resourceArmSubnetRouteTableAssociationDelete(d *schema.ResourceData, meta i
 		log.Printf("[DEBUG] Subnet %q (Virtual Network %q / Resource Group %q) has no Route Table - removing from state!", subnetName, virtualNetworkName, resourceGroup)
 		return nil
 	}
-
-	// once we have the route table id to lock on, lock on that
-	routeTableName, err := parseRouteTableName(*props.RouteTable.ID)
-	if err != nil {
-		return err
-	}
-
-	azureRMLockByName(routeTableName, routeTableResourceName)
-	defer azureRMUnlockByName(routeTableName, routeTableResourceName)
 
 	azureRMLockByName(subnetName, subnetResourceName)
 	defer azureRMUnlockByName(subnetName, subnetResourceName)

--- a/azurerm/resource_arm_subnet_route_table_association.go
+++ b/azurerm/resource_arm_subnet_route_table_association.go
@@ -64,8 +64,8 @@ func resourceArmSubnetRouteTableAssociationCreate(d *schema.ResourceData, meta i
 	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
 	resourceGroup := parsedSubnetId.ResourceGroup
 
-	azureRMLockByName(virtualNetworkName, virtualNetworkResourceName)
-	defer azureRMUnlockByName(virtualNetworkName, virtualNetworkResourceName)
+	azureRMLockByName(subnetName, subnetResourceName)
+	defer azureRMUnlockByName(subnetName, subnetResourceName)
 
 	subnet, err := client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
@@ -192,9 +192,6 @@ func resourceArmSubnetRouteTableAssociationDelete(d *schema.ResourceData, meta i
 
 	azureRMLockByName(routeTableName, routeTableResourceName)
 	defer azureRMUnlockByName(routeTableName, routeTableResourceName)
-
-	azureRMLockByName(virtualNetworkName, virtualNetworkResourceName)
-	defer azureRMUnlockByName(virtualNetworkName, virtualNetworkResourceName)
 
 	azureRMLockByName(subnetName, subnetResourceName)
 	defer azureRMUnlockByName(subnetName, subnetResourceName)

--- a/azurerm/resourceid.go
+++ b/azurerm/resourceid.go
@@ -46,12 +46,3 @@ func parseNetworkSecurityGroupName(networkSecurityGroupId string) (string, error
 
 	return id.Path["networkSecurityGroups"], nil
 }
-
-func parseRouteTableName(routeTableId string) (string, error) {
-	id, err := parseAzureResourceID(routeTableId)
-	if err != nil {
-		return "", fmt.Errorf("[ERROR] Unable to parse Route Table ID '%s': %+v", routeTableId, err)
-	}
-
-	return id.Path["routeTables"], nil
-}


### PR DESCRIPTION
The assumption I'm making here is that the purpose of all these locks is to prevent the same resource being modified by multiple threads at the same time.  None of these resources actually modify the route table, network security group, or vnet itself, so removing locks on those should be safe.  I replaced the vnet locks with subnet locks which *is* modified by the route table association and nsg association.

If I'm wrong about why we have all these locks in here, please let me know.  This is to fix #2489 and I've confirmed that it works on my local config that was previously triggering this problem.