### PR TITLE
azurerm_kubernetes_cluster: Add support for virtual machine scale set node pool

### DIFF
--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -76,6 +76,11 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 							Computed: true,
 						},
 
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"count": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -550,6 +555,10 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 
 	for _, profile := range *input {
 		agentPoolProfile := make(map[string]interface{})
+
+		if profile.Type != "" {
+			agentPoolProfile["type"] = string(profile.Type)
+		}
 
 		if profile.Count != nil {
 			agentPoolProfile["count"] = int(*profile.Count)

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -109,8 +109,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								string(containerservice.AvailabilitySet),
 								string(containerservice.VirtualMachineScaleSets),
-							}, true),
-							DiffSuppressFunc: suppress.CaseDifference,
+							}, false),
 						},
 
 						"count": {

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -80,7 +80,7 @@ A `addon_profile` block exports the following:
 
 A `agent_pool_profile` block exports the following:
 
-* `type` - The type of the Pool.
+* `type` - The type of the Agent Pool.
 
 * `count` - The number of Agents (VM's) in the Pool.
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -80,6 +80,8 @@ A `addon_profile` block exports the following:
 
 A `agent_pool_profile` block exports the following:
 
+* `type` - The type of the Pool.
+
 * `count` - The number of Agents (VM's) in the Pool.
 
 * `max_pods` - The maximum number of pods that can run on each agent.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -109,6 +109,7 @@ A `agent_pool_profile` block supports the following:
 * `count` - (Required) Number of Agents (VMs) in the Pool. Possible values must be in the range of 1 to 100 (inclusive). Defaults to `1`.
 * `vm_size` - (Required) The size of each VM in the Agent Pool (e.g. `Standard_F1`). Changing this forces a new resource to be created.
 
+* `type` - (Optional) Type of the Agent Pool. Possible values are `AvailabilitySet` and `VirtualMachineScaleSets`. Changing this forces a new resource to be created. Defaults to `AvailabilitySet`.
 * `max_pods` - (Optional) The maximum number of pods that can run on each agent.
 * `os_disk_size_gb` - (Optional) The Agent Operating System disk size in GB. Changing this forces a new resource to be created.
 * `os_type` - (Optional) The Operating System used for the Agents. Possible values are `Linux` and `Windows`.  Changing this forces a new resource to be created. Defaults to `Linux`.


### PR DESCRIPTION
This pull request adds support for virtual machine scale set node pools in the resource and data source `azurerm_kubernetes_cluster`.

* The relevant test `TestAccAzureRMKubernetesCluster_virtualMachineScaleSets` requires the resource provider features `MultiAgentpoolPreview` and `VMSSPreview`. I assume these features are registered before the test is executed. Refer to https://docs.microsoft.com/en-us/azure/aks/use-multiple-node-pools.

### Tests

```
=== RUN   TestAccAzureRMKubernetesCluster_virtualMachineScaleSets
=== PAUSE TestAccAzureRMKubernetesCluster_virtualMachineScaleSets
=== CONT  TestAccAzureRMKubernetesCluster_virtualMachineScaleSets
--- PASS: TestAccAzureRMKubernetesCluster_virtualMachineScaleSets (896.94s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       896.981s
```

### New or Affected Resource(s)

* `azurerm_kubernetes_cluster`

### References

* https://github.com/terraform-providers/terraform-provider-azurerm/issues/2900
