### PR TITLE
azurerm_app_service_slot: Add site_credential attribute export

### DIFF
--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -260,6 +260,15 @@ The following attributes are exported:
 
 * `default_site_hostname` - The Default Hostname associated with the App Service Slot - such as `mysite.azurewebsites.net`
 
+* `site_credential` - A `site_credential` block as defined below, which contains the site-level credentials used to publish to this App Service.
+
+---
+
+`site_credential` exports the following:
+
+* `username` - The username which can be used to publish to this App Service
+* `password` - The password associated with the username, which can be used to publish to this App Service.
+
 ## Import
 
 App Service Slots can be imported using the `resource id`, e.g.


### PR DESCRIPTION
A feature we're missing. Also requested in for example #1439.

Tested and working. However I added no automated tests since it's just a new export (and other exports are not tested). Tell me if you want me to add a test, and if so, if you want me to add a new test step or if I should simply add it to an existing test (e.g. TestAccAzureRMAppServiceSlot_basic).