### PR TITLE
Show subscription_id as attribute

### DIFF
--- a/website/docs/d/subscription.html.markdown
+++ b/website/docs/d/subscription.html.markdown
@@ -26,7 +26,8 @@ output "current_subscription_display_name" {
 
 ## Attributes Reference
 
-* `id` - The ID of the Subscription.
+* `id` - The ID of the subscription.
+* `subscription_id` - The subscription GUID.
 * `display_name` - The subscription display name.
 * `state` - The subscription state. Possible values are Enabled, Warned, PastDue, Disabled, and Deleted.
 * `location_placement_id` - The subscription location placement ID.


### PR DESCRIPTION
I've checked the source code and it is in there, and it is a useful thing to have. Example usage:

```hcl
data "azurerm_subscription" "current" {}

resource "azurerm_management_group" "prod" {
  display_name    = "Prod"
  subscription_ids = [
    "${data.azurerm_subscription.current.subscription_id}"
  ]
}
```