### PR TITLE
Correct to subscription_id

### DIFF
--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -18,7 +18,7 @@ data "azurerm_subscription" "current" {}
 resource "azurerm_management_group" "example_parent" {
   display_name     = "ParentGroup"
   subscription_ids = [
-    "${data.azurerm_subscription.current.id}",
+    "${data.azurerm_subscription.current.subscription_id}"
   ]
 }
 
@@ -27,7 +27,7 @@ resource "azurerm_management_group" "example_child" {
   parent_management_group_id = "${azurerm_management_group.example_parent.id}"
   
   subscription_ids = [
-    "${data.azurerm_subscription.current.id}",
+    "${data.azurerm_subscription.current.subscription_id}",
     # other subscription IDs can go here
   ]
 }
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `parent_management_group_id` - (Optional) The ID of the Parent Management Group. Changing this forces a new resource to be created.
 
-* `subscription_ids` - (Optional) A list of Subscription ID's which should be assigned to the Management Group.
+* `subscription_ids` - (Optional) A list of Subscription GUIDs which should be assigned to the Management Group.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The example does not work as ${data.azurerm_subscription.current.id} returns the full resourceId, e.g. /subscription/2d31be49-d959-4415-bb65-8aec2c90ba62.  Instead it should be the subscription_id which is just the GUID, i.e. 2d31be49-d959-4415-bb65-8aec2c90ba62