### PR TITLE
Adding UltraSSD to list of sku names when creating a managed disk

### DIFF
--- a/azurerm/resource_arm_managed_disk.go
+++ b/azurerm/resource_arm_managed_disk.go
@@ -149,6 +149,8 @@ func resourceArmManagedDiskCreateUpdate(d *schema.ResourceData, meta interface{}
 		skuName = compute.StandardLRS
 	} else if strings.EqualFold(storageAccountType, string(compute.StandardSSDLRS)) {
 		skuName = compute.StandardSSDLRS
+	} else if strings.EqualFold(storageAccountType, string(compute.UltraSSDLRS)) {
+		skuName = compute.UltraSSDLRS
 	}
 
 	createDisk := compute.Disk{


### PR DESCRIPTION
Though UltraSSD was added back in 1.18.0 (#2118), it appears that it is not properly passing the SKU name. This properly sets the SKU name when creating the disk.

Fixes #3306 