### PR TITLE
Test Fix: `azurerm_eventhub_namespace`

### DIFF
--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -217,7 +217,7 @@ func TestAccAzureRMEventHubNamespace_BasicWithTagsUpdate(t *testing.T) {
 func TestAccAzureRMEventHubNamespace_BasicWithCapacity(t *testing.T) {
 	resourceName := "azurerm_eventhub_namespace.test"
 	ri := tf.AccRandTimeInt()
-	config := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 100)
+	config := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 20)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -238,7 +238,7 @@ func TestAccAzureRMEventHubNamespace_BasicWithCapacity(t *testing.T) {
 func TestAccAzureRMEventHubNamespace_BasicWithCapacityUpdate(t *testing.T) {
 	resourceName := "azurerm_eventhub_namespace.test"
 	ri := tf.AccRandTimeInt()
-	preConfig := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 100)
+	preConfig := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 20)
 	postConfig := testAccAzureRMEventHubNamespace_capacity(ri, testLocation(), 2)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -494,7 +494,7 @@ resource "azurerm_eventhub_namespace" "test" {
   sku                      = "Standard"
   capacity                 = "2"
   auto_inflate_enabled     = true
-  maximum_throughput_units = 100
+  maximum_throughput_units = 20
 }
 `, rInt, location, rInt)
 }


### PR DESCRIPTION
```
--- FAIL: TestAccAzureRMEventHubNamespace_BasicWithCapacity (0.11s)
--- FAIL: TestAccAzureRMEventHubNamespace_BasicWithCapacityUpdate (0.09s)
--- FAIL: TestAccAzureRMEventHubNamespace_maximumThroughputUnits (0.10s)
--- FAIL: TestAccAzureRMEventHubNamespace_maximumThroughputUnitsUpdate (0.10s)
```

to 

```
--- PASS: TestAccAzureRMEventHubNamespace_maximumThroughputUnits (172.36s)
--- PASS: TestAccAzureRMEventHubNamespace_maximumThroughputUnitsUpdate (259.96s)
--- PASS: TestAccAzureRMEventHubNamespace_BasicWithCapacity (161.78s)
--- PASS: TestAccAzureRMEventHubNamespace_BasicWithCapacityUpdate (246.92s)
```