### PR TITLE
Fix TestAccAzureRMContainerGroup_windows

### DIFF
--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -778,7 +778,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "windowsservercore"
-    image  = "microsoft/windowsservercore:latest"
+    image  = "microsoft/iis:windowsservercore"
     cpu    = "2.0"
     memory = "3.5"
     ports {
@@ -836,7 +836,7 @@ resource "azurerm_container_group" "test" {
 
   container {
     name   = "windowsservercore"
-    image  = "microsoft/windowsservercore:latest"
+    image  = "microsoft/iis:windowsservercore"
     cpu    = "2.0"
     memory = "3.5"
     ports {


### PR DESCRIPTION
Before:

```
TestAccAzureRMContainerGroup_windowsBasic
--- FAIL: TestAccAzureRMContainerGroup_windowsComplete (92.76s)
--- FAIL: TestAccAzureRMContainerGroup_windowsBasic (64.87s)
```

After:
```
--- PASS: TestAccAzureRMContainerGroup_windowsBasic (570.42s)
--- PASS: TestAccAzureRMContainerGroup_windowsComplete (1072.86s)
```