### PR TITLE
Update api_management.go

### DIFF
--- a/azurerm/helpers/validate/api_management.go
+++ b/azurerm/helpers/validate/api_management.go
@@ -71,8 +71,8 @@ func ApiManagementApiName(v interface{}, k string) (ws []string, es []error) {
 func ApiManagementApiPath(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^[\w][\w-/.]+[\w-]$`).Match([]byte(value)); !matched {
-		es = append(es, fmt.Errorf("%q may only be up to 256 characters in length, not start or end with `/` and only contain valid url characters", k))
+	if matched := regexp.MustCompile(`^(?:|[\w][\w-/.]{0,398}[\w-])$`).Match([]byte(value)); !matched {
+		es = append(es, fmt.Errorf("%q may only be up to 400 characters in length, not start or end with `/` and only contain valid url characters", k))
 	}
 	return ws, es
 }

--- a/azurerm/helpers/validate/api_management_test.go
+++ b/azurerm/helpers/validate/api_management_test.go
@@ -1,8 +1,8 @@
 package validate
 
 import (
-	"testing"
 	s "strings"
+	"testing"
 )
 
 func TestAzureRMApiManagementServiceName_validation(t *testing.T) {

--- a/azurerm/helpers/validate/api_management_test.go
+++ b/azurerm/helpers/validate/api_management_test.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"testing"
+	s "strings"
 )
 
 func TestAzureRMApiManagementServiceName_validation(t *testing.T) {
@@ -103,7 +104,7 @@ func TestAzureRMApiManagementApiPath_validation(t *testing.T) {
 	}{
 		{
 			Value:    "",
-			ErrCount: 1,
+			ErrCount: 0,
 		},
 		{
 			Value:    "/",
@@ -124,6 +125,10 @@ func TestAzureRMApiManagementApiPath_validation(t *testing.T) {
 		{
 			Value:    "api1/sub",
 			ErrCount: 0,
+		},
+		{
+			Value:    s.Repeat("x", 401),
+			ErrCount: 1,
 		},
 	}
 


### PR DESCRIPTION
The api management api resource has a required property for path. This property can be left blank, according to the Azure docs (& how we're using it). The validation expression however requires it to be at least 3 characters long.

I've adjusted the regex to allow an empty path and to also enforce the maximum length as specified in Azure API spec (https://github.com/Azure/azure-rest-api-specs/blob/8578473fb7799590c01a7ce243a53121ababdb76/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-01-01/definitions.json#L129).