### PR TITLE
[WIP] Adding Computed to subnet for route table id

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -52,6 +52,7 @@ func resourceArmSubnet() *schema.Resource {
 			"route_table_id": {
 				Type:       schema.TypeString,
 				Optional:   true,
+				Computed:   true,
 				Deprecated: "Use the `azurerm_subnet_route_table_association` resource instead.",
 			},
 


### PR DESCRIPTION
Our tests aren't catching that a route table is associated with a subnet when using `azurerm_subnet_route_table_association`. 


Before this addition:
```
- route_table_id       = "/subscriptions/1010010101010101010101010/resourceGroups/101010101/providers/Microsoft.Network/routeTables/1001010101" -> null
```

->

After this addition:
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

Addressing #3471.