### PR TITLE
r/automation_module: polling until the module's finished provisioning

### DIFF
--- a/azurerm/resource_arm_automation_module_test.go
+++ b/azurerm/resource_arm_automation_module_test.go
@@ -65,6 +65,33 @@ func TestAccAzureRMAutomationModule_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAutomationModule_multipleModules(t *testing.T) {
+	resourceName := "azurerm_automation_module.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAutomationModuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAutomationModule_multipleModules(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAutomationModuleExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Module link is not returned by api in Get operation
+				ImportStateVerifyIgnore: []string{"module_link"},
+			},
+		},
+	})
+}
+
 func testCheckAzureRMAutomationModuleDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).automationModuleClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -158,6 +185,47 @@ resource "azurerm_automation_module" "test" {
   module_link {
     uri = "https://devopsgallerystorage.blob.core.windows.net/packages/xactivedirectory.2.19.0.nupkg"
   }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMAutomationModule_multipleModules(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_automation_account" "test" {
+  name                = "acctest-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    name = "Basic"
+  }
+}
+
+resource "azurerm_automation_module" "test" {
+  name                    = "AzureRM.Profile"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  automation_account_name = "${azurerm_automation_account.test.name}"
+
+  module_link {
+    uri = "https://psg-prod-eastus.azureedge.net/packages/azurerm.profile.5.8.2.nupkg"
+  }
+}
+
+resource "azurerm_automation_module" "second" {
+  name                    = "AzureRM.OperationalInsights"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  automation_account_name = "${azurerm_automation_account.test.name}"
+
+  module_link {
+    uri = "https://psg-prod-eastus.azureedge.net/packages/azurerm.operationalinsights.5.0.6.nupkg"
+  }
+
+  depends_on = ["azurerm_automation_module.test"]
 }
 `, rInt, location, rInt)
 }


### PR DESCRIPTION
Tests pass:

```
 $ acctests azurerm TestAccAzureRMAutomationModule_
=== RUN   TestAccAzureRMAutomationModule_basic
=== PAUSE TestAccAzureRMAutomationModule_basic
=== RUN   TestAccAzureRMAutomationModule_requiresImport
--- SKIP: TestAccAzureRMAutomationModule_requiresImport (0.00s)
    resource_arm_automation_module_test.go:41: Skipping since resources aren't required to be imported
=== RUN   TestAccAzureRMAutomationModule_multipleModules
=== PAUSE TestAccAzureRMAutomationModule_multipleModules
=== CONT  TestAccAzureRMAutomationModule_basic
--- PASS: TestAccAzureRMAutomationModule_basic (183.77s)
=== CONT  TestAccAzureRMAutomationModule_multipleModules
--- PASS: TestAccAzureRMAutomationModule_multipleModules (271.98s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	458.164s
```

Fixes #2600