### PR TITLE
Changed casing of field "SubnetName" for the virtual kubelet/aci addon in AKS

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -825,7 +825,7 @@ func expandKubernetesClusterAddonProfiles(d *schema.ResourceData) map[string]*co
 		enabled := value["enabled"].(bool)
 
 		if subnetName, ok := value["subnet_name"]; ok {
-			config["subnetName"] = utils.String(subnetName.(string))
+			config["SubnetName"] = utils.String(subnetName.(string))
 		}
 
 		addonProfiles["aciConnectorLinux"] = &containerservice.ManagedClusterAddonProfile{
@@ -888,7 +888,7 @@ func flattenKubernetesClusterAddonProfiles(profile map[string]*containerservice.
 		}
 
 		subnetName := ""
-		if v := aciConnector.Config["subnetName"]; v != nil {
+		if v := aciConnector.Config["SubnetName"]; v != nil {
 			subnetName = *v
 		}
 


### PR DESCRIPTION
This fixes he incorrect casing in REST api for AKS. They'll make it backwards compatible as they replied in https://github.com/Azure/AKS/issues/783

So this enables the ACI module working in AKS through terraform. 

