### PR TITLE
Add support multiple agent pool profiles

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the Resource Group where the Managed Kubernetes Cluster should exist. Changing this forces a new resource to be created.
 
-* `agent_pool_profile` - (Required) An `agent_pool_profile` block.  Currently only one agent pool can exist.
+* `agent_pool_profile` - (Required) One or more `agent_pool_profile` blocks as defined below.
 
 * `dns_prefix` - (Required) DNS prefix specified when creating the managed cluster. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -36,6 +36,14 @@ resource "azurerm_kubernetes_cluster" "test" {
     os_disk_size_gb = 30
   }
 
+  agent_pool_profile {
+    name            = "pool2"
+    count           = 1
+    vm_size         = "Standard_D2_v2"
+    os_type         = "Linux"
+    os_disk_size_gb = 30
+  }
+
   service_principal {
     client_id     = "00000000-0000-0000-0000-000000000000"
     client_secret = "00000000000000000000000000000000"


### PR DESCRIPTION
Hello,

This small patch, enable multi agent pool profiles. It lets users put multiple `agent_pool_profile` blocks
```
resource "azurerm_kubernetes_cluster" "aks" {
  ...
  agent_pool_profile {
     name  = "Linux"
      ...
  }
  agent_pool_profile {
     name  = "Windows"
      ...
  }
  ...
}
```