### PR TITLE
Bug Fix: `azurerm_express_route_circuit`

### DIFF
--- a/azurerm/resource_arm_express_route_circuit.go
+++ b/azurerm/resource_arm_express_route_circuit.go
@@ -138,7 +138,7 @@ func resourceArmExpressRouteCircuitCreateUpdate(d *schema.ResourceData, meta int
 	tags := d.Get("tags").(map[string]interface{})
 	expandedTags := expandTags(tags)
 
-	// There is the potential for the express to get out of sync when the service provider updates
+	// There is the potential for the express route circuit to become out of sync when the service provider updates
 	// the express route circuit. We'll get and update the resource in place as per https://aka.ms/erRefresh
 	// We also want to keep track of the resource obtained from the api and pass down any attributes not
 	// managed by Terraform.

--- a/azurerm/resource_arm_express_route_circuit.go
+++ b/azurerm/resource_arm_express_route_circuit.go
@@ -113,6 +113,9 @@ func resourceArmExpressRouteCircuitCreateUpdate(d *schema.ResourceData, meta int
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 
+	azureRMLockByName(name, expressRouteCircuitResourceName)
+	defer azureRMUnlockByName(name, expressRouteCircuitResourceName)
+
 	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name)
 		if err != nil {
@@ -135,23 +138,52 @@ func resourceArmExpressRouteCircuitCreateUpdate(d *schema.ResourceData, meta int
 	tags := d.Get("tags").(map[string]interface{})
 	expandedTags := expandTags(tags)
 
-	erc := network.ExpressRouteCircuit{
-		Name:     &name,
-		Location: &location,
-		Sku:      sku,
-		ExpressRouteCircuitPropertiesFormat: &network.ExpressRouteCircuitPropertiesFormat{
+	// There is the potential for the express to get out of sync when the service provider updates
+	// the express route circuit. We'll get and update the resource in place as per https://aka.ms/erRefresh
+	// We also want to keep track of the resource obtained from the api and pass down any attributes not
+	// managed by Terraform.
+	erc := network.ExpressRouteCircuit{}
+	if !d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(erc.Response) {
+				return fmt.Errorf("Error checking for presence of existing ExpressRoute Circuit %q (Resource Group %q): %s", name, resGroup, err)
+			}
+		}
+
+		future, err := client.CreateOrUpdate(ctx, resGroup, name, existing)
+		if err != nil {
+			return fmt.Errorf("Error Creating/Updating ExpressRouteCircuit %q (Resource Group %q): %+v", name, resGroup, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error Creating/Updating ExpressRouteCircuit %q (Resource Group %q): %+v", name, resGroup, err)
+		}
+		erc = existing
+	}
+
+	erc.Name = &name
+	erc.Location = &location
+	erc.Sku = sku
+	erc.Tags = expandedTags
+
+	if erc.ExpressRouteCircuitPropertiesFormat != nil {
+		erc.ExpressRouteCircuitPropertiesFormat.AllowClassicOperations = &allowRdfeOps
+		if erc.ExpressRouteCircuitPropertiesFormat.ServiceProviderProperties != nil {
+			erc.ExpressRouteCircuitPropertiesFormat.ServiceProviderProperties.ServiceProviderName = &serviceProviderName
+			erc.ExpressRouteCircuitPropertiesFormat.ServiceProviderProperties.PeeringLocation = &peeringLocation
+			erc.ExpressRouteCircuitPropertiesFormat.ServiceProviderProperties.BandwidthInMbps = &bandwidthInMbps
+		}
+	} else {
+		erc.ExpressRouteCircuitPropertiesFormat = &network.ExpressRouteCircuitPropertiesFormat{
 			AllowClassicOperations: &allowRdfeOps,
 			ServiceProviderProperties: &network.ExpressRouteCircuitServiceProviderProperties{
 				ServiceProviderName: &serviceProviderName,
 				PeeringLocation:     &peeringLocation,
 				BandwidthInMbps:     &bandwidthInMbps,
 			},
-		},
-		Tags: expandedTags,
+		}
 	}
-
-	azureRMLockByName(name, expressRouteCircuitResourceName)
-	defer azureRMUnlockByName(name, expressRouteCircuitResourceName)
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, erc)
 	if err != nil {

--- a/azurerm/resource_arm_express_route_circuit_authorization.go
+++ b/azurerm/resource_arm_express_route_circuit_authorization.go
@@ -56,6 +56,9 @@ func resourceArmExpressRouteCircuitAuthorizationCreate(d *schema.ResourceData, m
 	resourceGroup := d.Get("resource_group_name").(string)
 	circuitName := d.Get("express_route_circuit_name").(string)
 
+	azureRMLockByName(circuitName, expressRouteCircuitResourceName)
+	defer azureRMUnlockByName(circuitName, expressRouteCircuitResourceName)
+
 	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, circuitName, name)
 		if err != nil {
@@ -72,9 +75,6 @@ func resourceArmExpressRouteCircuitAuthorizationCreate(d *schema.ResourceData, m
 	properties := network.ExpressRouteCircuitAuthorization{
 		AuthorizationPropertiesFormat: &network.AuthorizationPropertiesFormat{},
 	}
-
-	azureRMLockByName(circuitName, expressRouteCircuitResourceName)
-	defer azureRMUnlockByName(circuitName, expressRouteCircuitResourceName)
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, circuitName, name, properties)
 	if err != nil {

--- a/azurerm/resource_arm_express_route_circuit_peering.go
+++ b/azurerm/resource_arm_express_route_circuit_peering.go
@@ -114,6 +114,9 @@ func resourceArmExpressRouteCircuitPeeringCreateUpdate(d *schema.ResourceData, m
 	circuitName := d.Get("express_route_circuit_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
+	azureRMLockByName(circuitName, expressRouteCircuitResourceName)
+	defer azureRMUnlockByName(circuitName, expressRouteCircuitResourceName)
+
 	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, circuitName, peeringType)
 		if err != nil {
@@ -155,9 +158,6 @@ func resourceArmExpressRouteCircuitPeeringCreateUpdate(d *schema.ResourceData, m
 		peeringConfig := expandExpressRouteCircuitPeeringMicrosoftConfig(peerings)
 		parameters.ExpressRouteCircuitPeeringPropertiesFormat.MicrosoftPeeringConfig = peeringConfig
 	}
-
-	azureRMLockByName(circuitName, expressRouteCircuitResourceName)
-	defer azureRMUnlockByName(circuitName, expressRouteCircuitResourceName)
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, circuitName, peeringType, parameters)
 	if err != nil {

--- a/azurerm/resource_arm_express_route_circuit_test.go
+++ b/azurerm/resource_arm_express_route_circuit_test.go
@@ -28,8 +28,9 @@ func TestAccAzureRMExpressRouteCircuit(t *testing.T) {
 			"data_basic":                   testAccDataSourceAzureRMExpressRoute_basicMetered,
 		},
 		"PrivatePeering": {
-			"azurePrivatePeering": testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering,
-			"requiresImport":      testAccAzureRMExpressRouteCircuitPeering_requiresImport,
+			"azurePrivatePeering":           testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering,
+			"azurePrivatePeeringWithUpdate": testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeeringWithCircuitUpdate,
+			"requiresImport":                testAccAzureRMExpressRouteCircuitPeering_requiresImport,
 		},
 		"MicrosoftPeering": {
 			"microsoftPeering": testAccAzureRMExpressRouteCircuitPeering_microsoftPeering,


### PR DESCRIPTION
The Express Route Circuit resource would overwrite any sub resources (ie. peering and authorization) associated it when updating. This PR changes that by passing in the resource obtained from the api with only the circuit attributes managed by Terraform being changed. 

This resource may also become out of sync after the service provider updates the express route circuit outside of Azure. We can get around this by updating the resource prior to updating any values.

Addresses #2250


This test is prior to the changes below:
```
--- FAIL: TestAccAzureRMExpressRouteCircuitPeering_azurePrivatePeeringWithCircuitUpdate (214.88s)
```

After:
```
--- PASS: TestAccAzureRMExpressRouteCircuit (1942.40s)
    --- PASS: TestAccAzureRMExpressRouteCircuit/basic (1002.60s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/update (168.30s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/allowClassicOperationsUpdate (166.48s)
        --- SKIP: TestAccAzureRMExpressRouteCircuit/basic/requiresImport (0.00s)
            resource_arm_express_route_circuit_test.go:84: Skipping since resources aren't required to be imported
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/metered (118.72s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/unlimited (128.62s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/premiumUnlimited (128.01s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/tierUpdate (165.50s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/premiumMetered (126.97s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/basic/data_basic (133.05s)
    --- PASS: TestAccAzureRMExpressRouteCircuit/PrivatePeering (387.35s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/PrivatePeering/azurePrivatePeering (387.35s)
        --- SKIP: TestAccAzureRMExpressRouteCircuit/PrivatePeering/requiresImport (0.00s)
            resource_arm_express_route_circuit_peering_test.go:44: Skipping since resources aren't required to be imported
    --- PASS: TestAccAzureRMExpressRouteCircuit/MicrosoftPeering (246.58s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/MicrosoftPeering/microsoftPeering (246.58s)
    --- PASS: TestAccAzureRMExpressRouteCircuit/authorization (0.00s)
        --- SKIP: TestAccAzureRMExpressRouteCircuit/authorization/requiresImport (0.00s)
            resource_arm_express_route_circuit_authorization_test.go:41: Skipping since resources aren't required to be imported
        --- PASS: TestAccAzureRMExpressRouteCircuit/authorization/basic (151.11s)
        --- PASS: TestAccAzureRMExpressRouteCircuit/authorization/multiple (172.81s)
PASS
```