### PR TITLE
Remove `advanced_schedule` block from the azurerm_automation_schedule documentation example

### DIFF
--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -37,7 +37,7 @@ resource "azurerm_automation_schedule" "example" {
   timezone                = "Central Europe Standard Time"
   start_time              = "2014-04-15T18:00:15+02:00"
   description             = "This is an example schedule"
-  week_days = ["Friday"]
+  week_days               = ["Friday"]
 }
 ```
 

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -37,10 +37,7 @@ resource "azurerm_automation_schedule" "example" {
   timezone                = "Central Europe Standard Time"
   start_time              = "2014-04-15T18:00:15+02:00"
   description             = "This is an example schedule"
-
-  advanced_schedule {
-    week_days = ["Friday"]
-  }
+  week_days = ["Friday"]
 }
 ```
 


### PR DESCRIPTION
The `advanced_schedule` block is not valid, and the contained `week_days` argument should not be inside it.