### PR TITLE
Role Assignment - Treat name as case insensitive

### DIFF
--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -50,12 +50,13 @@ func resourceArmRoleAssignment() *schema.Resource {
 			},
 
 			"role_definition_name": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"role_definition_id"},
-				ValidateFunc:  validateRoleDefinitionName,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ConflictsWith:    []string{"role_definition_id"},
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     validateRoleDefinitionName,
 			},
 
 			"principal_id": {


### PR DESCRIPTION
When the wrong case is used for a role name, e.g. acrpull instead of the
correct AcrPull, azure will accept the request and return the correct
casing. This results in Terraform believing it needs to update the
resource incorrectly.

Example of incorrect behaviour:

    -/+ module.aks_simple.module.acr.azurerm_role_assignment.acr_spn_pull_role_assn (new resource required)
          role_definition_name:      "AcrPull" => "acrpull" (forces new resource)
