### PR TITLE
Updated import statement

### DIFF
--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -85,5 +85,5 @@ The following attributes are exported:
 Shared Image Versions can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_shared_image_version.version1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/galleries/gallery1/images/image1/versions/1.2.3
+terraform import azurerm_shared_image_version.version /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/galleries/gallery1/images/image1/versions/1.2.3
 ```


### PR DESCRIPTION
Import statement had a extract character `1`

Was:
`terraform import azurerm_shared_image_version.version1`

Should be:
`terraform import azurerm_shared_image_version.version`