### PR TITLE
Travis enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ services:
 - docker
 language: go
 go:
-- "1.11.x"
+- "1.12.x"
+
+env:
+  matrix:
+  - MODE=unit-tests
+  - MODE=linters
+  - MODE=website
 
 install:
 # This script is used by the Travis build to install a cookie for
@@ -15,9 +21,9 @@ install:
 - make tools
 
 script:
-- make test
-- GOGC=30 make lint
-- make website-test
+  - if [[ $MODE == 'unit-tests' ]]; then make test; fi
+  - if [[ $MODE == 'linters' ]]; then GOGC=30 make lint; fi
+  - if [[ $MODE == 'website' ]]; then make website-test; fi
 
 branches:
   only:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -14,10 +14,10 @@ build: fmtcheck
 
 build-docker:
 	mkdir -p bin
-	docker run --rm -v $$(pwd)/bin:/go/bin -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm -e GOOS golang:1.11 make build
+	docker run --rm -v $$(pwd)/bin:/go/bin -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm -e GOOS golang:1.12 make build
 
 test-docker:
-	docker run --rm -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm golang:1.11 make test
+	docker run --rm -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm golang:1.12 make test
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1


### PR DESCRIPTION
This PR updates Travis to run multiple builds in parallel, which should highlight /what/ failed in a build without having to dig through the entire build log