### PR TITLE
[docs] azurerm_app_service: Adds missing auth_settings to the Argument Reference section

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 * `app_settings` - (Optional) A key-value pair of App Settings.
 
+* `auth_settings` - (Optional) A `auth_settings` block as defined below.
+
 * `connection_string` - (Optional) One or more `connection_string` blocks as defined below.
 
 * `client_affinity_enabled` - (Optional) Should the App Service send session affinity cookies, which route client requests in the same session to the same instance?


### PR DESCRIPTION
This PR fixes #3526 and adds `auth_settings` to the `Argument Reference` section in the docs