### PR TITLE
Fixed typo issue in resource_arm_loadbalancer_rule

### DIFF
--- a/azurerm/resource_arm_loadbalancer_rule.go
+++ b/azurerm/resource_arm_loadbalancer_rule.go
@@ -135,7 +135,7 @@ func resourceArmLoadBalancerRuleCreateUpdate(d *schema.ResourceData, meta interf
 
 	newLbRule, err := expandAzureRmLoadBalancerRule(d, loadBalancer)
 	if err != nil {
-		return fmt.Errorf("Error Exanding Load Balancer Rule: %+v", err)
+		return fmt.Errorf("Error Expanding Load Balancer Rule: %+v", err)
 	}
 
 	lbRules := append(*loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules, *newLbRule)


### PR DESCRIPTION
Fixed the typo issue in place in the resource_arm_loadbalancer_rule.go "Exanding" changed to "Expanding"