### PR TITLE
Refactor: migrating clients into packages

### DIFF
--- a/azurerm/automation_variable.go
+++ b/azurerm/automation_variable.go
@@ -120,7 +120,7 @@ func datasourceAutomationVariableCommonSchema(attType schema.ValueType) map[stri
 }
 
 func resourceAutomationVariableCreateUpdate(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automationVariableClient
+	client := meta.(*ArmClient).automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -188,7 +188,7 @@ func resourceAutomationVariableCreateUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automationVariableClient
+	client := meta.(*ArmClient).automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -235,7 +235,7 @@ func resourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, va
 }
 
 func datasourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automationVariableClient
+	client := meta.(*ArmClient).automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -279,7 +279,7 @@ func datasourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, 
 }
 
 func resourceAutomationVariableDelete(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automationVariableClient
+	client := meta.(*ArmClient).automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/automation_variable_test.go
+++ b/azurerm/automation_variable_test.go
@@ -90,7 +90,7 @@ func testCheckAzureRMAutomationVariableExists(resourceName string, varType strin
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		accountName := rs.Primary.Attributes["automation_account_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).automationVariableClient
+		client := testAccProvider.Meta().(*ArmClient).automation.VariableClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if resp, err := client.Get(ctx, resourceGroup, accountName, name); err != nil {
@@ -105,7 +105,7 @@ func testCheckAzureRMAutomationVariableExists(resourceName string, varType strin
 }
 
 func testCheckAzureRMAutomationVariableDestroy(s *terraform.State, varType string) error {
-	client := testAccProvider.Meta().(*ArmClient).automationVariableClient
+	client := testAccProvider.Meta().(*ArmClient).automation.VariableClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	resourceName := fmt.Sprintf("azurerm_automation_variable_%s", strings.ToLower(varType))

--- a/azurerm/common_hdinsight.go
+++ b/azurerm/common_hdinsight.go
@@ -12,7 +12,7 @@ import (
 
 func hdinsightClusterUpdate(clusterKind string, readFunc schema.ReadFunc) schema.UpdateFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
-		client := meta.(*ArmClient).hdinsightClustersClient
+		client := meta.(*ArmClient).hdinsight.ClustersClient
 		ctx := meta.(*ArmClient).StopContext
 
 		id, err := parseAzureResourceID(d.Id())
@@ -60,7 +60,7 @@ func hdinsightClusterUpdate(clusterKind string, readFunc schema.ReadFunc) schema
 
 func hdinsightClusterDelete(clusterKind string) schema.DeleteFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
-		client := meta.(*ArmClient).hdinsightClustersClient
+		client := meta.(*ArmClient).hdinsight.ClustersClient
 		ctx := meta.(*ArmClient).StopContext
 
 		id, err := parseAzureResourceID(d.Id())

--- a/azurerm/common_hdinsight_test.go
+++ b/azurerm/common_hdinsight_test.go
@@ -15,7 +15,7 @@ func testCheckAzureRMHDInsightClusterDestroy(terraformResourceName string) func(
 				continue
 			}
 
-			client := testAccProvider.Meta().(*ArmClient).hdinsightClustersClient
+			client := testAccProvider.Meta().(*ArmClient).hdinsight.ClustersClient
 			ctx := testAccProvider.Meta().(*ArmClient).StopContext
 			name := rs.Primary.Attributes["name"]
 			resourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -43,7 +43,7 @@ func testCheckAzureRMHDInsightClusterExists(resourceName string) resource.TestCh
 		clusterName := rs.Primary.Attributes["name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).hdinsightClustersClient
+		client := testAccProvider.Meta().(*ArmClient).hdinsight.ClustersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, clusterName)
 		if err != nil {

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -33,7 +33,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2016-06-01/logic"
 	"github.com/Azure/azure-sdk-for-go/services/mariadb/mgmt/2018-06-01/mariadb"
-	"github.com/Azure/azure-sdk-for-go/services/mediaservices/mgmt/2018-07-01/media"
+	mediaSvc "github.com/Azure/azure-sdk-for-go/services/mediaservices/mgmt/2018-07-01/media"
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/notificationhubs/mgmt/2017-04-01/notificationhubs"
@@ -76,6 +76,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/dns"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/hdinsight"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/media"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/redis"
 
 	mainStorage "github.com/Azure/azure-sdk-for-go/storage"
@@ -110,6 +111,7 @@ type ArmClient struct {
 	dns          *dns.Client
 	hdinsight    *hdinsight.Client
 	logAnalytics *loganalytics.Client
+	media        *media.Client
 	redis        *redis.Client
 
 	// TODO: refactor
@@ -224,9 +226,6 @@ type ArmClient struct {
 	// Management Groups
 	managementGroupsClient             managementgroups.Client
 	managementGroupsSubscriptionClient managementgroups.SubscriptionsClient
-
-	// Media
-	mediaServicesClient media.MediaservicesClient
 
 	// Monitor
 	monitorActionGroupsClient               insights.ActionGroupsClient
@@ -686,9 +685,12 @@ func (c *ArmClient) registerCosmosAccountsClients(endpoint, subscriptionId strin
 }
 
 func (c *ArmClient) registerMediaServiceClients(endpoint, subscriptionId string, auth autorest.Authorizer) {
-	mediaServicesClient := media.NewMediaservicesClientWithBaseURI(endpoint, subscriptionId)
+	mediaServicesClient := mediaSvc.NewMediaservicesClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&mediaServicesClient.Client, auth)
-	c.mediaServicesClient = mediaServicesClient
+
+	c.media = &media.Client{
+		ServicesClient: mediaServicesClient,
+	}
 }
 
 func (c *ArmClient) registerComputeClients(endpoint, subscriptionId string, auth autorest.Authorizer) {

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -69,6 +69,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/streamanalytics/mgmt/2016-03-01/streamanalytics"
 	"github.com/Azure/azure-sdk-for-go/services/trafficmanager/mgmt/2018-04-01/trafficmanager"
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/devspace"
 
 	mainStorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
@@ -94,6 +95,10 @@ type ArmClient struct {
 
 	StopContext context.Context
 
+	// Services
+	devSpace *devspace.Client
+
+	// TODO: refactor
 	cosmosAccountsClient documentdb.DatabaseAccountsClient
 
 	automationAccountClient               automation.AccountClient
@@ -204,9 +209,6 @@ type ArmClient struct {
 	devTestPoliciesClient        dtl.PoliciesClient
 	devTestVirtualMachinesClient dtl.VirtualMachinesClient
 	devTestVirtualNetworksClient dtl.VirtualNetworksClient
-
-	// DevSpace
-	devSpaceControllerClient devspaces.ControllersClient
 
 	// Databases
 	mariadbDatabasesClient                   mariadb.DatabasesClient
@@ -975,7 +977,9 @@ func (c *ArmClient) registerDevTestClients(endpoint, subscriptionId string, auth
 func (c *ArmClient) registerDevSpaceClients(endpoint, subscriptionId string, auth autorest.Authorizer) {
 	controllersClient := devspaces.NewControllersClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&controllersClient.Client, auth)
-	c.devSpaceControllerClient = controllersClient
+	c.devSpace = &devspace.Client{
+		ControllersClient: controllersClient,
+	}
 }
 
 func (c *ArmClient) registerDNSClients(endpoint, subscriptionId string, auth autorest.Authorizer) {

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -69,6 +69,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/streamanalytics/mgmt/2016-03-01/streamanalytics"
 	"github.com/Azure/azure-sdk-for-go/services/trafficmanager/mgmt/2018-04-01/trafficmanager"
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/automation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/devspace"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/hdinsight"
 
@@ -97,22 +98,12 @@ type ArmClient struct {
 	StopContext context.Context
 
 	// Services
-	devSpace  *devspace.Client
-	hdinsight *hdinsight.Client
+	automation *automation.Client
+	devSpace   *devspace.Client
+	hdinsight  *hdinsight.Client
 
 	// TODO: refactor
 	cosmosAccountsClient documentdb.DatabaseAccountsClient
-
-	automationAccountClient               automationSvc.AccountClient
-	automationAgentRegistrationInfoClient automationSvc.AgentRegistrationInformationClient
-	automationCredentialClient            automationSvc.CredentialClient
-	automationDscConfigurationClient      automationSvc.DscConfigurationClient
-	automationDscNodeConfigurationClient  automationSvc.DscNodeConfigurationClient
-	automationModuleClient                automationSvc.ModuleClient
-	automationRunbookClient               automationSvc.RunbookClient
-	automationRunbookDraftClient          automationSvc.RunbookDraftClient
-	automationScheduleClient              automationSvc.ScheduleClient
-	automationVariableClient              automationSvc.VariableClient
 
 	dnsClient   dns.RecordSetsClient
 	zonesClient dns.ZonesClient
@@ -654,6 +645,19 @@ func (c *ArmClient) registerAutomationClients(endpoint, subscriptionId string, a
 
 	variableClient := automationSvc.NewVariableClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&variableClient.Client, auth)
+
+	c.automation = &automation.Client{
+		AccountClient:               accountClient,
+		AgentRegistrationInfoClient: agentRegistrationInfoClient,
+		CredentialClient:            credentialClient,
+		DscConfigurationClient:      dscConfigurationClient,
+		DscNodeConfigurationClient:  dscNodeConfigurationClient,
+		ModuleClient:                moduleClient,
+		RunbookClient:               runbookClient,
+		RunbookDraftClient:          runbookDraftClient,
+		ScheduleClient:              scheduleClient,
+		VariableClient:              variableClient,
+	}
 }
 
 func (c *ArmClient) registerAuthentication(endpoint, graphEndpoint, subscriptionId, tenantId string, auth, graphAuth autorest.Authorizer) {

--- a/azurerm/data_source_api_management.go
+++ b/azurerm/data_source_api_management.go
@@ -152,7 +152,7 @@ func dataSourceApiManagementService() *schema.Resource {
 }
 
 func dataSourceApiManagementRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementServiceClient
+	client := meta.(*ArmClient).apimgmt.ServiceClient
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_api_management_api.go
+++ b/azurerm/data_source_api_management_api.go
@@ -106,7 +106,7 @@ func dataSourceApiManagementApi() *schema.Resource {
 
 func dataSourceApiManagementApiRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).apiManagementApiClient
+	client := meta.(*ArmClient).apimgmt.ApiClient
 
 	resourceGroup := d.Get("resource_group_name").(string)
 	serviceName := d.Get("api_management_name").(string)

--- a/azurerm/data_source_api_management_group.go
+++ b/azurerm/data_source_api_management_group.go
@@ -44,7 +44,7 @@ func dataSourceApiManagementGroup() *schema.Resource {
 }
 
 func dataSourceApiManagementGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementGroupClient
+	client := meta.(*ArmClient).apimgmt.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_api_management_product.go
+++ b/azurerm/data_source_api_management_product.go
@@ -58,7 +58,7 @@ func dataSourceApiManagementProduct() *schema.Resource {
 	}
 }
 func dataSourceApiManagementProductRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductsClient
+	client := meta.(*ArmClient).apimgmt.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_api_management_user.go
+++ b/azurerm/data_source_api_management_user.go
@@ -48,7 +48,7 @@ func dataSourceArmApiManagementUser() *schema.Resource {
 }
 
 func dataSourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementUsersClient
+	client := meta.(*ArmClient).apimgmt.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_container_registry.go
+++ b/azurerm/data_source_container_registry.go
@@ -59,7 +59,7 @@ func dataSourceArmContainerRegistry() *schema.Resource {
 }
 
 func dataSourceArmContainerRegistryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).containerRegistryClient
+	client := meta.(*ArmClient).containers.RegistryClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_dns_zone.go
+++ b/azurerm/data_source_dns_zone.go
@@ -66,7 +66,7 @@ func dataSourceArmDnsZone() *schema.Resource {
 }
 
 func dataSourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).zonesClient
+	client := meta.(*ArmClient).dns.ZonesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_hdinsight_cluster.go
+++ b/azurerm/data_source_hdinsight_cluster.go
@@ -84,8 +84,8 @@ func dataSourceArmHDInsightSparkCluster() *schema.Resource {
 }
 
 func dataSourceArmHDInsightClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -341,7 +341,7 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 }
 
 func dataSourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).kubernetesClustersClient
+	client := meta.(*ArmClient).containers.KubernetesClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_kubernetes_service_version.go
+++ b/azurerm/data_source_kubernetes_service_version.go
@@ -37,7 +37,7 @@ func dataSourceArmKubernetesServiceVersions() *schema.Resource {
 }
 
 func dataSourceArmKubernetesServiceVersionsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).containerServicesClient
+	client := meta.(*ArmClient).containers.ServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	location := azureRMNormalizeLocation(d.Get("location").(string))

--- a/azurerm/data_source_log_analytics_workspace.go
+++ b/azurerm/data_source_log_analytics_workspace.go
@@ -60,7 +60,7 @@ func dataSourceLogAnalyticsWorkspace() *schema.Resource {
 }
 
 func dataSourceLogAnalyticsWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).workspacesClient
+	client := meta.(*ArmClient).logAnalytics.WorkspacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/internal/flags/features.go
+++ b/azurerm/internal/flags/features.go
@@ -1,10 +1,13 @@
-package azurerm
+package flags
 
-import "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/flags"
+import (
+	"os"
+	"strings"
+)
 
 // NOTE: we'll need to add an infobox to MySQL|PostgreSQL Configuration when this goes live
 // since these resources can't support import
 // in addition the virtual resources will need adjusting
 
 // This file contains feature flags for functionality which will prove more challenging to implement en-mass
-var requireResourcesToBeImported = flags.RequireResourcesToBeImported
+var RequireResourcesToBeImported = strings.EqualFold(os.Getenv("ARM_PROVIDER_STRICT"), "true")

--- a/azurerm/internal/services/apimgmt/client.go
+++ b/azurerm/internal/services/apimgmt/client.go
@@ -1,0 +1,29 @@
+package apimgmt
+
+import "github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimanagement"
+
+type Client struct {
+	ApiClient                  apimanagement.APIClient
+	ApiPoliciesClient          apimanagement.APIPolicyClient
+	ApiOperationsClient        apimanagement.APIOperationClient
+	ApiOperationPoliciesClient apimanagement.APIOperationPolicyClient
+	ApiSchemasClient           apimanagement.APISchemaClient
+	ApiVersionSetClient        apimanagement.APIVersionSetClient
+	AuthorizationServersClient apimanagement.AuthorizationServerClient
+	CertificatesClient         apimanagement.CertificateClient
+	GroupClient                apimanagement.GroupClient
+	GroupUsersClient           apimanagement.GroupUserClient
+	LoggerClient               apimanagement.LoggerClient
+	OpenIdConnectClient        apimanagement.OpenIDConnectProviderClient
+	PolicyClient               apimanagement.PolicyClient
+	ProductsClient             apimanagement.ProductClient
+	ProductApisClient          apimanagement.ProductAPIClient
+	ProductGroupsClient        apimanagement.ProductGroupClient
+	ProductPoliciesClient      apimanagement.ProductPolicyClient
+	PropertyClient             apimanagement.PropertyClient
+	ServiceClient              apimanagement.ServiceClient
+	SignInClient               apimanagement.SignInSettingsClient
+	SignUpClient               apimanagement.SignUpSettingsClient
+	SubscriptionsClient        apimanagement.SubscriptionClient
+	UsersClient                apimanagement.UserClient
+}

--- a/azurerm/internal/services/automation/client.go
+++ b/azurerm/internal/services/automation/client.go
@@ -1,0 +1,16 @@
+package automation
+
+import "github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
+
+type Client struct {
+	AccountClient               automation.AccountClient
+	AgentRegistrationInfoClient automation.AgentRegistrationInformationClient
+	CredentialClient            automation.CredentialClient
+	DscConfigurationClient      automation.DscConfigurationClient
+	DscNodeConfigurationClient  automation.DscNodeConfigurationClient
+	ModuleClient                automation.ModuleClient
+	RunbookClient               automation.RunbookClient
+	RunbookDraftClient          automation.RunbookDraftClient
+	ScheduleClient              automation.ScheduleClient
+	VariableClient              automation.VariableClient
+}

--- a/azurerm/internal/services/containers/client.go
+++ b/azurerm/internal/services/containers/client.go
@@ -1,0 +1,15 @@
+package containers
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/containerinstance/mgmt/2018-10-01/containerinstance"
+	"github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2017-10-01/containerregistry"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-02-01/containerservice"
+)
+
+type Client struct {
+	KubernetesClustersClient   containerservice.ManagedClustersClient
+	GroupsClient               containerinstance.ContainerGroupsClient
+	RegistryClient             containerregistry.RegistriesClient
+	RegistryReplicationsClient containerregistry.ReplicationsClient
+	ServicesClient             containerservice.ContainerServicesClient
+}

--- a/azurerm/internal/services/devspace/client.go
+++ b/azurerm/internal/services/devspace/client.go
@@ -1,0 +1,7 @@
+package devspace
+
+import "github.com/Azure/azure-sdk-for-go/services/preview/devspaces/mgmt/2018-06-01-preview/devspaces"
+
+type Client struct {
+	ControllersClient devspaces.ControllersClient
+}

--- a/azurerm/internal/services/dns/client.go
+++ b/azurerm/internal/services/dns/client.go
@@ -1,0 +1,8 @@
+package dns
+
+import "github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
+
+type Client struct {
+	RecordSetsClient dns.RecordSetsClient
+	ZonesClient      dns.ZonesClient
+}

--- a/azurerm/internal/services/hdinsight/client.go
+++ b/azurerm/internal/services/hdinsight/client.go
@@ -1,0 +1,9 @@
+package hdinsight
+
+import "github.com/Azure/azure-sdk-for-go/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight"
+
+type Client struct {
+	ApplicationsClient   hdinsight.ApplicationsClient
+	ClustersClient       hdinsight.ClustersClient
+	ConfigurationsClient hdinsight.ConfigurationsClient
+}

--- a/azurerm/internal/services/loganalytics/client.go
+++ b/azurerm/internal/services/loganalytics/client.go
@@ -1,0 +1,12 @@
+package loganalytics
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/preview/operationalinsights/mgmt/2015-11-01-preview/operationalinsights"
+	"github.com/Azure/azure-sdk-for-go/services/preview/operationsmanagement/mgmt/2015-11-01-preview/operationsmanagement"
+)
+
+type Client struct {
+	LinkedServicesClient operationalinsights.LinkedServicesClient
+	SolutionsClient      operationsmanagement.SolutionsClient
+	WorkspacesClient     operationalinsights.WorkspacesClient
+}

--- a/azurerm/internal/services/media/client.go
+++ b/azurerm/internal/services/media/client.go
@@ -1,0 +1,7 @@
+package media
+
+import "github.com/Azure/azure-sdk-for-go/services/mediaservices/mgmt/2018-07-01/media"
+
+type Client struct {
+	ServicesClient media.MediaservicesClient
+}

--- a/azurerm/internal/services/redis/client.go
+++ b/azurerm/internal/services/redis/client.go
@@ -1,0 +1,9 @@
+package redis
+
+import "github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
+
+type Client struct {
+	Client               redis.Client
+	FirewallRulesClient  redis.FirewallRulesClient
+	PatchSchedulesClient redis.PatchSchedulesClient
+}

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -364,7 +364,7 @@ func resourceArmApiManagementService() *schema.Resource {
 }
 
 func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementServiceClient
+	client := meta.(*ArmClient).apimgmt.ServiceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for API Management Service creation.")
@@ -445,19 +445,19 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 
 	signInSettingsRaw := d.Get("sign_in").([]interface{})
 	signInSettings := expandApiManagementSignInSettings(signInSettingsRaw)
-	signInClient := meta.(*ArmClient).apiManagementSignInClient
+	signInClient := meta.(*ArmClient).apimgmt.SignInClient
 	if _, err := signInClient.CreateOrUpdate(ctx, resourceGroup, name, signInSettings); err != nil {
 		return fmt.Errorf("Error setting Sign In settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	signUpSettingsRaw := d.Get("sign_up").([]interface{})
 	signUpSettings := expandApiManagementSignUpSettings(signUpSettingsRaw)
-	signUpClient := meta.(*ArmClient).apiManagementSignUpClient
+	signUpClient := meta.(*ArmClient).apimgmt.SignUpClient
 	if _, err := signUpClient.CreateOrUpdate(ctx, resourceGroup, name, signUpSettings); err != nil {
 		return fmt.Errorf("Error setting Sign Up settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	policyClient := meta.(*ArmClient).apiManagementPolicyClient
+	policyClient := meta.(*ArmClient).apimgmt.PolicyClient
 	policiesRaw := d.Get("policy").([]interface{})
 	policy, err := expandApiManagementPolicies(policiesRaw)
 	if err != nil {
@@ -484,7 +484,7 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementServiceClient
+	client := meta.(*ArmClient).apimgmt.ServiceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -506,19 +506,19 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error making Read request on API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	signInClient := meta.(*ArmClient).apiManagementSignInClient
+	signInClient := meta.(*ArmClient).apimgmt.SignInClient
 	signInSettings, err := signInClient.Get(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Sign In Settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	signUpClient := meta.(*ArmClient).apiManagementSignUpClient
+	signUpClient := meta.(*ArmClient).apimgmt.SignUpClient
 	signUpSettings, err := signUpClient.Get(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Sign Up Settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	policyClient := meta.(*ArmClient).apiManagementPolicyClient
+	policyClient := meta.(*ArmClient).apimgmt.PolicyClient
 	policy, err := policyClient.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(policy.Response) {
@@ -585,7 +585,7 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmApiManagementServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementServiceClient
+	client := meta.(*ArmClient).apimgmt.ServiceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api.go
+++ b/azurerm/resource_arm_api_management_api.go
@@ -180,7 +180,7 @@ func resourceArmApiManagementApi() *schema.Resource {
 }
 
 func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiClient
+	client := meta.(*ArmClient).apimgmt.ApiClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -285,7 +285,7 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 
 func resourceArmApiManagementApiRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).apiManagementApiClient
+	client := meta.(*ArmClient).apimgmt.ApiClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -343,7 +343,7 @@ func resourceArmApiManagementApiRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmApiManagementApiDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiClient
+	client := meta.(*ArmClient).apimgmt.ApiClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_operation.go
+++ b/azurerm/resource_arm_api_management_api_operation.go
@@ -98,7 +98,7 @@ func resourceArmApiManagementApiOperation() *schema.Resource {
 }
 
 func resourceArmApiManagementApiOperationCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiOperationsClient
+	client := meta.(*ArmClient).apimgmt.ApiOperationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -153,7 +153,7 @@ func resourceArmApiManagementApiOperationCreateUpdate(d *schema.ResourceData, me
 }
 
 func resourceArmApiManagementApiOperationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiOperationsClient
+	client := meta.(*ArmClient).apimgmt.ApiOperationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -208,7 +208,7 @@ func resourceArmApiManagementApiOperationRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementApiOperationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiOperationsClient
+	client := meta.(*ArmClient).apimgmt.ApiOperationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_operation_policy.go
+++ b/azurerm/resource_arm_api_management_api_operation_policy.go
@@ -49,7 +49,7 @@ func resourceArmApiManagementApiOperationPolicy() *schema.Resource {
 }
 
 func resourceArmApiManagementAPIOperationPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiOperationPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ApiOperationPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -110,7 +110,7 @@ func resourceArmApiManagementAPIOperationPolicyCreateUpdate(d *schema.ResourceDa
 }
 
 func resourceArmApiManagementAPIOperationPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiOperationPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ApiOperationPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -148,7 +148,7 @@ func resourceArmApiManagementAPIOperationPolicyRead(d *schema.ResourceData, meta
 }
 
 func resourceArmApiManagementAPIOperationPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiOperationPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ApiOperationPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_operation_policy_test.go
+++ b/azurerm/resource_arm_api_management_api_operation_policy_test.go
@@ -110,7 +110,7 @@ func testCheckAzureRMApiManagementAPIOperationPolicyExists(resourceName string) 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		operationID := rs.Primary.Attributes["operation_id"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementApiOperationPoliciesClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiOperationPoliciesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName, operationID)
 		if err != nil {
@@ -126,7 +126,7 @@ func testCheckAzureRMApiManagementAPIOperationPolicyExists(resourceName string) 
 }
 
 func testCheckAzureRMApiManagementAPIOperationPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementApiOperationPoliciesClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiOperationPoliciesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api_operation_policy" {

--- a/azurerm/resource_arm_api_management_api_operation_test.go
+++ b/azurerm/resource_arm_api_management_api_operation_test.go
@@ -189,7 +189,7 @@ func TestAccAzureRMApiManagementApiOperation_representations(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiOperationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementApiOperationsClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiOperationsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -230,7 +230,7 @@ func testCheckAzureRMApiManagementApiOperationExists(name string) resource.TestC
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementApiOperationsClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiOperationsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName, operationId)

--- a/azurerm/resource_arm_api_management_api_policy.go
+++ b/azurerm/resource_arm_api_management_api_policy.go
@@ -47,7 +47,7 @@ func resourceArmApiManagementApiPolicy() *schema.Resource {
 }
 
 func resourceArmApiManagementAPIPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ApiPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -107,7 +107,7 @@ func resourceArmApiManagementAPIPolicyCreateUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceArmApiManagementAPIPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ApiPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -143,7 +143,7 @@ func resourceArmApiManagementAPIPolicyRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmApiManagementAPIPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ApiPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_policy_test.go
+++ b/azurerm/resource_arm_api_management_api_policy_test.go
@@ -109,7 +109,7 @@ func testCheckAzureRMApiManagementAPIPolicyExists(resourceName string) resource.
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementApiPoliciesClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiPoliciesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName)
 		if err != nil {
@@ -117,7 +117,7 @@ func testCheckAzureRMApiManagementAPIPolicyExists(resourceName string) resource.
 				return fmt.Errorf("Bad: API Policy (API Management Service %q / API %q/  Resource Group %q) does not exist", serviceName, apiName, resourceGroup)
 			}
 
-			return fmt.Errorf("Bad: Get on apiManagementAPIPoliciesClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.ApiPoliciesClient: %+v", err)
 		}
 
 		return nil
@@ -125,7 +125,7 @@ func testCheckAzureRMApiManagementAPIPolicyExists(resourceName string) resource.
 }
 
 func testCheckAzureRMApiManagementAPIPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementApiPoliciesClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiPoliciesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api_policy" {

--- a/azurerm/resource_arm_api_management_api_schema.go
+++ b/azurerm/resource_arm_api_management_api_schema.go
@@ -47,7 +47,7 @@ func resourceArmApiManagementApiSchema() *schema.Resource {
 }
 
 func resourceArmApiManagementApiSchemaCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiSchemasClient
+	client := meta.(*ArmClient).apimgmt.ApiSchemasClient
 	ctx := meta.(*ArmClient).StopContext
 
 	schemaID := d.Get("schema_id").(string)
@@ -96,7 +96,7 @@ func resourceArmApiManagementApiSchemaCreateUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceArmApiManagementApiSchemaRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiSchemasClient
+	client := meta.(*ArmClient).apimgmt.ApiSchemasClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -135,7 +135,7 @@ func resourceArmApiManagementApiSchemaRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmApiManagementApiSchemaDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiSchemasClient
+	client := meta.(*ArmClient).apimgmt.ApiSchemasClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_schema_test.go
+++ b/azurerm/resource_arm_api_management_api_schema_test.go
@@ -65,7 +65,7 @@ func TestAccAzureRMApiManagementApiSchema_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiSchemaDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementApiSchemasClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiSchemasClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -106,7 +106,7 @@ func testCheckAzureRMApiManagementApiSchemaExists(name string) resource.TestChec
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementApiSchemasClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiSchemasClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName, schemaID)

--- a/azurerm/resource_arm_api_management_api_test.go
+++ b/azurerm/resource_arm_api_management_api_test.go
@@ -246,7 +246,7 @@ func TestAccAzureRMApiManagementApi_complete(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementApiClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api" {
@@ -288,7 +288,7 @@ func testCheckAzureRMApiManagementApiExists(name string) resource.TestCheckFunc 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		revision := rs.Primary.Attributes["revision"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementApiClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ApiClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		apiId := fmt.Sprintf("%s;rev=%s", name, revision)

--- a/azurerm/resource_arm_api_management_api_version_set.go
+++ b/azurerm/resource_arm_api_management_api_version_set.go
@@ -71,7 +71,7 @@ func resourceArmApiManagementApiVersionSet() *schema.Resource {
 }
 
 func resourceArmApiManagementApiVersionSetCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiVersionSetClient
+	client := meta.(*ArmClient).apimgmt.ApiVersionSetClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -153,7 +153,7 @@ func resourceArmApiManagementApiVersionSetCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmApiManagementApiVersionSetRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiVersionSetClient
+	client := meta.(*ArmClient).apimgmt.ApiVersionSetClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -191,7 +191,7 @@ func resourceArmApiManagementApiVersionSetRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmApiManagementApiVersionSetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementApiVersionSetClient
+	client := meta.(*ArmClient).apimgmt.ApiVersionSetClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_version_set_test.go
+++ b/azurerm/resource_arm_api_management_api_version_set_test.go
@@ -150,7 +150,7 @@ func TestAccAzureRMApiManagementApiVersionSet_update(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiVersionSetDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementApiVersionSetClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.ApiVersionSetClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api_version_set" {
 			continue
@@ -185,7 +185,7 @@ func testCheckAzureRMApiManagementApiVersionSetExists(resourceName string) resou
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementApiVersionSetClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.ApiVersionSetClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_authorization_server.go
+++ b/azurerm/resource_arm_api_management_authorization_server.go
@@ -175,7 +175,7 @@ func resourceArmApiManagementAuthorizationServer() *schema.Resource {
 }
 
 func resourceArmApiManagementAuthorizationServerCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementAuthorizationServersClient
+	client := meta.(*ArmClient).apimgmt.AuthorizationServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -269,7 +269,7 @@ func resourceArmApiManagementAuthorizationServerCreateUpdate(d *schema.ResourceD
 
 func resourceArmApiManagementAuthorizationServerRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).apiManagementAuthorizationServersClient
+	client := meta.(*ArmClient).apimgmt.AuthorizationServersClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -333,7 +333,7 @@ func resourceArmApiManagementAuthorizationServerRead(d *schema.ResourceData, met
 }
 
 func resourceArmApiManagementAuthorizationServerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementAuthorizationServersClient
+	client := meta.(*ArmClient).apimgmt.AuthorizationServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_authorization_server_test.go
+++ b/azurerm/resource_arm_api_management_authorization_server_test.go
@@ -90,7 +90,7 @@ func TestAccAzureRMAPIManagementAuthorizationServer_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementAuthorizationServerDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementAuthorizationServersClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.AuthorizationServersClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_authorization_server" {
 			continue
@@ -125,7 +125,7 @@ func testCheckAzureRMAPIManagementAuthorizationServerExists(resourceName string)
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementAuthorizationServersClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.AuthorizationServersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_certificate.go
+++ b/azurerm/resource_arm_api_management_certificate.go
@@ -62,7 +62,7 @@ func resourceArmApiManagementCertificate() *schema.Resource {
 }
 
 func resourceArmApiManagementCertificateCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementCertificatesClient
+	client := meta.(*ArmClient).apimgmt.CertificatesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -108,7 +108,7 @@ func resourceArmApiManagementCertificateCreateUpdate(d *schema.ResourceData, met
 }
 
 func resourceArmApiManagementCertificateRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementCertificatesClient
+	client := meta.(*ArmClient).apimgmt.CertificatesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -149,7 +149,7 @@ func resourceArmApiManagementCertificateRead(d *schema.ResourceData, meta interf
 }
 
 func resourceArmApiManagementCertificateDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementCertificatesClient
+	client := meta.(*ArmClient).apimgmt.CertificatesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_certificate_test.go
+++ b/azurerm/resource_arm_api_management_certificate_test.go
@@ -73,7 +73,7 @@ func TestAccAzureRMAPIManagementCertificate_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementCertificateDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementCertificatesClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.CertificatesClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_certificate" {
 			continue
@@ -108,7 +108,7 @@ func testCheckAzureRMAPIManagementCertificateExists(resourceName string) resourc
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementCertificatesClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.CertificatesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_group.go
+++ b/azurerm/resource_arm_api_management_group.go
@@ -62,7 +62,7 @@ func resourceArmApiManagementGroup() *schema.Resource {
 }
 
 func resourceArmApiManagementGroupCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementGroupClient
+	client := meta.(*ArmClient).apimgmt.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -113,7 +113,7 @@ func resourceArmApiManagementGroupCreateUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceArmApiManagementGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementGroupClient
+	client := meta.(*ArmClient).apimgmt.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -150,7 +150,7 @@ func resourceArmApiManagementGroupRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmApiManagementGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementGroupClient
+	client := meta.(*ArmClient).apimgmt.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_group_test.go
+++ b/azurerm/resource_arm_api_management_group_test.go
@@ -139,7 +139,7 @@ func TestAccAzureRMAPIManagementGroup_descriptionDisplayNameUpdate(t *testing.T)
 }
 
 func testCheckAzureRMAPIManagementGroupDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementGroupClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.GroupClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_group" {
 			continue
@@ -174,14 +174,14 @@ func testCheckAzureRMAPIManagementGroupExists(resourceName string) resource.Test
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementGroupClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.GroupClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: API Management Group %q (Resource Group %q / API Management Service %q) does not exist", name, resourceGroup, serviceName)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementGroupClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.GroupClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_api_management_group_user.go
+++ b/azurerm/resource_arm_api_management_group_user.go
@@ -32,7 +32,7 @@ func resourceArmApiManagementGroupUser() *schema.Resource {
 }
 
 func resourceArmApiManagementGroupUserCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementGroupUsersClient
+	client := meta.(*ArmClient).apimgmt.GroupUsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -67,7 +67,7 @@ func resourceArmApiManagementGroupUserCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmApiManagementGroupUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementGroupUsersClient
+	client := meta.(*ArmClient).apimgmt.GroupUsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -99,7 +99,7 @@ func resourceArmApiManagementGroupUserRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmApiManagementGroupUserDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementGroupUsersClient
+	client := meta.(*ArmClient).apimgmt.GroupUsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_group_user_test.go
+++ b/azurerm/resource_arm_api_management_group_user_test.go
@@ -65,7 +65,7 @@ func TestAccAzureRMAPIManagementGroupUser_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementGroupUserDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementGroupUsersClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.GroupUsersClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_group_user" {
 			continue
@@ -101,14 +101,14 @@ func testCheckAzureRMAPIManagementGroupUserExists(resourceName string) resource.
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementGroupUsersClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.GroupUsersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.CheckEntityExists(ctx, resourceGroup, serviceName, groupName, userId)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp) {
 				return fmt.Errorf("Bad: User %q / Group %q (API Management Service %q / Resource Group %q) does not exist", userId, groupName, serviceName, resourceGroup)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementGroupUsersClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.GroupUsersClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_api_management_logger.go
+++ b/azurerm/resource_arm_api_management_logger.go
@@ -87,7 +87,7 @@ func resourceArmApiManagementLogger() *schema.Resource {
 }
 
 func resourceArmApiManagementLoggerCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementLoggerClient
+	client := meta.(*ArmClient).apimgmt.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -146,7 +146,7 @@ func resourceArmApiManagementLoggerCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmApiManagementLoggerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementLoggerClient
+	client := meta.(*ArmClient).apimgmt.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -183,7 +183,7 @@ func resourceArmApiManagementLoggerRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmApiManagementLoggerUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementLoggerClient
+	client := meta.(*ArmClient).apimgmt.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -216,7 +216,7 @@ func resourceArmApiManagementLoggerUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmApiManagementLoggerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementLoggerClient
+	client := meta.(*ArmClient).apimgmt.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_logger_test.go
+++ b/azurerm/resource_arm_api_management_logger_test.go
@@ -225,14 +225,14 @@ func testCheckAzureRMApiManagementLoggerExists(resourceName string) resource.Tes
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementLoggerClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.LoggerClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if resp, err := client.Get(ctx, resourceGroup, serviceName, name); err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: Logger %q (Resource Group %q / API Management Service %q) does not exist", name, resourceGroup, serviceName)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementLoggerClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.LoggerClient: %+v", err)
 		}
 
 		return nil
@@ -240,7 +240,7 @@ func testCheckAzureRMApiManagementLoggerExists(resourceName string) resource.Tes
 }
 
 func testCheckAzureRMApiManagementLoggerDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementLoggerClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.LoggerClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -254,7 +254,7 @@ func testCheckAzureRMApiManagementLoggerDestroy(s *terraform.State) error {
 
 		if resp, err := client.Get(ctx, resourceGroup, serviceName, name); err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Get on apiManagementLoggerClient: %+v", err)
+				return fmt.Errorf("Bad: Get on apimgmt.LoggerClient: %+v", err)
 			}
 		}
 

--- a/azurerm/resource_arm_api_management_openid_connect_provider.go
+++ b/azurerm/resource_arm_api_management_openid_connect_provider.go
@@ -65,7 +65,7 @@ func resourceArmApiManagementOpenIDConnectProvider() *schema.Resource {
 }
 
 func resourceArmApiManagementOpenIDConnectProviderCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementOpenIdConnectClient
+	client := meta.(*ArmClient).apimgmt.OpenIdConnectClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -112,7 +112,7 @@ func resourceArmApiManagementOpenIDConnectProviderCreateUpdate(d *schema.Resourc
 }
 
 func resourceArmApiManagementOpenIDConnectProviderRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementOpenIdConnectClient
+	client := meta.(*ArmClient).apimgmt.OpenIdConnectClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -149,7 +149,7 @@ func resourceArmApiManagementOpenIDConnectProviderRead(d *schema.ResourceData, m
 }
 
 func resourceArmApiManagementOpenIDConnectProviderDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementOpenIdConnectClient
+	client := meta.(*ArmClient).apimgmt.OpenIdConnectClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_openid_connect_provider_test.go
+++ b/azurerm/resource_arm_api_management_openid_connect_provider_test.go
@@ -106,14 +106,14 @@ func testCheckAzureRMApiManagementOpenIDConnectProviderExists(resourceName strin
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementOpenIdConnectClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.OpenIdConnectClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if resp, err := client.Get(ctx, resourceGroup, serviceName, name); err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: OpenID Connect Provider %q (Resource Group %q / API Management Service %q) does not exist", name, resourceGroup, serviceName)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementOpenIdConnectClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.OpenIdConnectClient: %+v", err)
 		}
 
 		return nil
@@ -121,7 +121,7 @@ func testCheckAzureRMApiManagementOpenIDConnectProviderExists(resourceName strin
 }
 
 func testCheckAzureRMApiManagementOpenIDConnectProviderDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementOpenIdConnectClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.OpenIdConnectClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -135,7 +135,7 @@ func testCheckAzureRMApiManagementOpenIDConnectProviderDestroy(s *terraform.Stat
 
 		if resp, err := client.Get(ctx, resourceGroup, serviceName, name); err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Get on apiManagementOpenIdConnectClient: %+v", err)
+				return fmt.Errorf("Bad: Get on apimgmt.OpenIdConnectClient: %+v", err)
 			}
 		}
 

--- a/azurerm/resource_arm_api_management_product.go
+++ b/azurerm/resource_arm_api_management_product.go
@@ -69,7 +69,7 @@ func resourceArmApiManagementProduct() *schema.Resource {
 }
 
 func resourceArmApiManagementProductCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductsClient
+	client := meta.(*ArmClient).apimgmt.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for API Management Product creation.")
@@ -139,7 +139,7 @@ func resourceArmApiManagementProductCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmApiManagementProductRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductsClient
+	client := meta.(*ArmClient).apimgmt.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -180,7 +180,7 @@ func resourceArmApiManagementProductRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmApiManagementProductDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductsClient
+	client := meta.(*ArmClient).apimgmt.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_api.go
+++ b/azurerm/resource_arm_api_management_product_api.go
@@ -32,7 +32,7 @@ func resourceArmApiManagementProductApi() *schema.Resource {
 }
 
 func resourceArmApiManagementProductApiCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductApisClient
+	client := meta.(*ArmClient).apimgmt.ProductApisClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -67,7 +67,7 @@ func resourceArmApiManagementProductApiCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementProductApiRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductApisClient
+	client := meta.(*ArmClient).apimgmt.ProductApisClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -99,7 +99,7 @@ func resourceArmApiManagementProductApiRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmApiManagementProductApiDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductApisClient
+	client := meta.(*ArmClient).apimgmt.ProductApisClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_api_test.go
+++ b/azurerm/resource_arm_api_management_product_api_test.go
@@ -65,7 +65,7 @@ func TestAccAzureRMAPIManagementProductApi_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementProductApiDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementProductApisClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.ProductApisClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product_api" {
 			continue
@@ -101,14 +101,14 @@ func testCheckAzureRMAPIManagementProductApiExists(resourceName string) resource
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementProductApisClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.ProductApisClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.CheckEntityExists(ctx, resourceGroup, serviceName, productId, apiName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp) {
 				return fmt.Errorf("Bad: API %q / Product %q (API Management Service %q / Resource Group %q) does not exist", apiName, productId, serviceName, resourceGroup)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementProductApisClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.ProductApisClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_api_management_product_group.go
+++ b/azurerm/resource_arm_api_management_product_group.go
@@ -32,7 +32,7 @@ func resourceArmApiManagementProductGroup() *schema.Resource {
 }
 
 func resourceArmApiManagementProductGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductGroupsClient
+	client := meta.(*ArmClient).apimgmt.ProductGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -67,7 +67,7 @@ func resourceArmApiManagementProductGroupCreate(d *schema.ResourceData, meta int
 }
 
 func resourceArmApiManagementProductGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductGroupsClient
+	client := meta.(*ArmClient).apimgmt.ProductGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -99,7 +99,7 @@ func resourceArmApiManagementProductGroupRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementProductGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductGroupsClient
+	client := meta.(*ArmClient).apimgmt.ProductGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_group_test.go
+++ b/azurerm/resource_arm_api_management_product_group_test.go
@@ -65,7 +65,7 @@ func TestAccAzureRMAPIManagementProductGroup_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementProductGroupDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementProductGroupsClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.ProductGroupsClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product_group" {
 			continue
@@ -101,14 +101,14 @@ func testCheckAzureRMAPIManagementProductGroupExists(resourceName string) resour
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementProductGroupsClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.ProductGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.CheckEntityExists(ctx, resourceGroup, serviceName, productId, groupName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp) {
 				return fmt.Errorf("Bad: Product %q / Group %q (API Management Service %q / Resource Group %q) does not exist", productId, groupName, serviceName, resourceGroup)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementProductGroupsClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.ProductGroupsClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_api_management_product_policy.go
+++ b/azurerm/resource_arm_api_management_product_policy.go
@@ -47,7 +47,7 @@ func resourceArmApiManagementProductPolicy() *schema.Resource {
 }
 
 func resourceArmApiManagementProductPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ProductPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -107,7 +107,7 @@ func resourceArmApiManagementProductPolicyCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmApiManagementProductPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ProductPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -143,7 +143,7 @@ func resourceArmApiManagementProductPolicyRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmApiManagementProductPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementProductPoliciesClient
+	client := meta.(*ArmClient).apimgmt.ProductPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_policy_test.go
+++ b/azurerm/resource_arm_api_management_product_policy_test.go
@@ -109,7 +109,7 @@ func testCheckAzureRMApiManagementProductPolicyExists(resourceName string) resou
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementProductPoliciesClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ProductPoliciesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, productID)
 		if err != nil {
@@ -117,7 +117,7 @@ func testCheckAzureRMApiManagementProductPolicyExists(resourceName string) resou
 				return fmt.Errorf("Bad: Product Policy (API Management Service %q / Product %q/  Resource Group %q) does not exist", serviceName, productID, resourceGroup)
 			}
 
-			return fmt.Errorf("Bad: Get on apiManagementProductPoliciesClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.ProductPoliciesClient: %+v", err)
 		}
 
 		return nil
@@ -125,7 +125,7 @@ func testCheckAzureRMApiManagementProductPolicyExists(resourceName string) resou
 }
 
 func testCheckAzureRMApiManagementProductPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementProductPoliciesClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ProductPoliciesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product_policy" {

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -72,7 +72,7 @@ func TestAccAzureRMApiManagementProduct_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementProductDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementProductsClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ProductsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product" {
@@ -233,7 +233,7 @@ func testCheckAzureRMApiManagementProductExists(resourceName string) resource.Te
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementProductsClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ProductsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, productId)
 		if err != nil {
@@ -241,7 +241,7 @@ func testCheckAzureRMApiManagementProductExists(resourceName string) resource.Te
 				return fmt.Errorf("Bad: Product %q (API Management Service %q / Resource Group %q) does not exist", productId, serviceName, resourceGroup)
 			}
 
-			return fmt.Errorf("Bad: Get on apiManagementProductsClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.ProductsClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_api_management_property.go
+++ b/azurerm/resource_arm_api_management_property.go
@@ -59,7 +59,7 @@ func resourceArmApiManagementProperty() *schema.Resource {
 }
 
 func resourceArmApiManagementPropertyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementPropertyClient
+	client := meta.(*ArmClient).apimgmt.PropertyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -108,7 +108,7 @@ func resourceArmApiManagementPropertyCreateUpdate(d *schema.ResourceData, meta i
 }
 
 func resourceArmApiManagementPropertyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementPropertyClient
+	client := meta.(*ArmClient).apimgmt.PropertyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -145,7 +145,7 @@ func resourceArmApiManagementPropertyRead(d *schema.ResourceData, meta interface
 }
 
 func resourceArmApiManagementPropertyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementPropertyClient
+	client := meta.(*ArmClient).apimgmt.PropertyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_property_test.go
+++ b/azurerm/resource_arm_api_management_property_test.go
@@ -81,7 +81,7 @@ func TestAccAzureRMAPIManagementProperty_update(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementPropertyDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementPropertyClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.PropertyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_property" {
 			continue
@@ -116,14 +116,14 @@ func testCheckAzureRMAPIManagementPropertyExists(resourceName string) resource.T
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementPropertyClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.PropertyClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: API Management Property %q (Resource Group %q / API Management Service %q) does not exist", name, resourceGroup, serviceName)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementPropertyClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.PropertyClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_api_management_subscription.go
+++ b/azurerm/resource_arm_api_management_subscription.go
@@ -79,7 +79,7 @@ func resourceArmApiManagementSubscription() *schema.Resource {
 }
 
 func resourceArmApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementSubscriptionsClient
+	client := meta.(*ArmClient).apimgmt.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -141,7 +141,7 @@ func resourceArmApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, me
 }
 
 func resourceArmApiManagementSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementSubscriptionsClient
+	client := meta.(*ArmClient).apimgmt.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -180,7 +180,7 @@ func resourceArmApiManagementSubscriptionRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementSubscriptionsClient
+	client := meta.(*ArmClient).apimgmt.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_subscription_test.go
+++ b/azurerm/resource_arm_api_management_subscription_test.go
@@ -145,7 +145,7 @@ func TestAccAzureRMAPIManagementSubscription_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementSubscriptionDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagementSubscriptionsClient
+	client := testAccProvider.Meta().(*ArmClient).apimgmt.SubscriptionsClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_subscription" {
 			continue
@@ -178,14 +178,14 @@ func testCheckAzureRMAPIManagementSubscriptionExists(resourceName string) resour
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagementSubscriptionsClient
+		client := testAccProvider.Meta().(*ArmClient).apimgmt.SubscriptionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: Subscription %q (API Management Service %q / Resource Group %q) does not exist", subscriptionId, serviceName, resourceGroup)
 			}
-			return fmt.Errorf("Bad: Get on apiManagementSubscriptionsClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.SubscriptionsClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -199,7 +199,7 @@ func TestAccAzureRMApiManagement_policy(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementServiceClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.ServiceClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management" {
@@ -239,7 +239,7 @@ func testCheckAzureRMApiManagementExists(resourceName string) resource.TestCheck
 			return fmt.Errorf("Bad: no resource group found in state for Api Management: %s", apiMangementName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementServiceClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.ServiceClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, apiMangementName)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_user.go
+++ b/azurerm/resource_arm_api_management_user.go
@@ -84,7 +84,7 @@ func resourceArmApiManagementUser() *schema.Resource {
 }
 
 func resourceArmApiManagementUserCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementUsersClient
+	client := meta.(*ArmClient).apimgmt.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for API Management User creation.")
@@ -154,7 +154,7 @@ func resourceArmApiManagementUserCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementUsersClient
+	client := meta.(*ArmClient).apimgmt.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -193,7 +193,7 @@ func resourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmApiManagementUserDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagementUsersClient
+	client := meta.(*ArmClient).apimgmt.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_user_test.go
+++ b/azurerm/resource_arm_api_management_user_test.go
@@ -226,7 +226,7 @@ func TestAccAzureRMApiManagementUser_complete(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementUserDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagementUsersClient
+	conn := testAccProvider.Meta().(*ArmClient).apimgmt.UsersClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_user" {
@@ -264,7 +264,7 @@ func testCheckAzureRMApiManagementUserExists(resourceName string) resource.TestC
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagementUsersClient
+		conn := testAccProvider.Meta().(*ArmClient).apimgmt.UsersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, userId)
 		if err != nil {
@@ -272,7 +272,7 @@ func testCheckAzureRMApiManagementUserExists(resourceName string) resource.TestC
 				return fmt.Errorf("Bad: User %q (API Management Service %q / Resource Group %q) does not exist", userId, serviceName, resourceGroup)
 			}
 
-			return fmt.Errorf("Bad: Get on apiManagementUsersClient: %+v", err)
+			return fmt.Errorf("Bad: Get on apimgmt.UsersClient: %+v", err)
 		}
 
 		return nil

--- a/azurerm/resource_arm_automation_account.go
+++ b/azurerm/resource_arm_automation_account.go
@@ -78,7 +78,7 @@ func resourceArmAutomationAccount() *schema.Resource {
 }
 
 func resourceArmAutomationAccountCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationAccountClient
+	client := meta.(*ArmClient).automation.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Automation Account create/update.")
@@ -130,8 +130,8 @@ func resourceArmAutomationAccountCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmAutomationAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationAccountClient
-	registrationClient := meta.(*ArmClient).automationAgentRegistrationInfoClient
+	client := meta.(*ArmClient).automation.AccountClient
+	registrationClient := meta.(*ArmClient).automation.AgentRegistrationInfoClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -187,7 +187,7 @@ func resourceArmAutomationAccountRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmAutomationAccountDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationAccountClient
+	client := meta.(*ArmClient).automation.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_account_test.go
+++ b/azurerm/resource_arm_automation_account_test.go
@@ -94,7 +94,7 @@ func TestAccAzureRMAutomationAccount_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationAccountDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automationAccountClient
+	conn := testAccProvider.Meta().(*ArmClient).automation.AccountClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -136,7 +136,7 @@ func testCheckAzureRMAutomationAccountExists(resourceName string) resource.TestC
 			return fmt.Errorf("Bad: no resource group found in state for Automation Account: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automationAccountClient
+		conn := testAccProvider.Meta().(*ArmClient).automation.AccountClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -56,7 +56,7 @@ func resourceArmAutomationCredential() *schema.Resource {
 }
 
 func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationCredentialClient
+	client := meta.(*ArmClient).automation.CredentialClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Credential creation.")
@@ -110,7 +110,7 @@ func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmAutomationCredentialRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationCredentialClient
+	client := meta.(*ArmClient).automation.CredentialClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -143,7 +143,7 @@ func resourceArmAutomationCredentialRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmAutomationCredentialDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationCredentialClient
+	client := meta.(*ArmClient).automation.CredentialClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_credential_test.go
+++ b/azurerm/resource_arm_automation_credential_test.go
@@ -93,7 +93,7 @@ func TestAccAzureRMAutomationCredential_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationCredentialDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automationCredentialClient
+	conn := testAccProvider.Meta().(*ArmClient).automation.CredentialClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -143,7 +143,7 @@ func testCheckAzureRMAutomationCredentialExists(resourceName string) resource.Te
 			return fmt.Errorf("Bad: no resource group found in state for Automation Credential: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automationCredentialClient
+		conn := testAccProvider.Meta().(*ArmClient).automation.CredentialClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_dsc_configuration.go
+++ b/azurerm/resource_arm_automation_dsc_configuration.go
@@ -73,7 +73,7 @@ func resourceArmAutomationDscConfiguration() *schema.Resource {
 }
 
 func resourceArmAutomationDscConfigurationCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationDscConfigurationClient
+	client := meta.(*ArmClient).automation.DscConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Dsc Configuration creation.")
@@ -131,7 +131,7 @@ func resourceArmAutomationDscConfigurationCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmAutomationDscConfigurationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationDscConfigurationClient
+	client := meta.(*ArmClient).automation.DscConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -183,7 +183,7 @@ func resourceArmAutomationDscConfigurationRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmAutomationDscConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationDscConfigurationClient
+	client := meta.(*ArmClient).automation.DscConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_dsc_configuration_test.go
+++ b/azurerm/resource_arm_automation_dsc_configuration_test.go
@@ -69,7 +69,7 @@ func TestAccAzureRMAutomationDscConfiguration_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationDscConfigurationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automationDscConfigurationClient
+	conn := testAccProvider.Meta().(*ArmClient).automation.DscConfigurationClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -119,7 +119,7 @@ func testCheckAzureRMAutomationDscConfigurationExists(resourceName string) resou
 			return fmt.Errorf("Bad: no resource group found in state for Automation Dsc Configuration: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automationDscConfigurationClient
+		conn := testAccProvider.Meta().(*ArmClient).automation.DscConfigurationClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
@@ -55,7 +55,7 @@ func resourceArmAutomationDscNodeConfiguration() *schema.Resource {
 }
 
 func resourceArmAutomationDscNodeConfigurationCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationDscNodeConfigurationClient
+	client := meta.(*ArmClient).automation.DscNodeConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Dsc Node Configuration creation.")
@@ -114,7 +114,7 @@ func resourceArmAutomationDscNodeConfigurationCreateUpdate(d *schema.ResourceDat
 }
 
 func resourceArmAutomationDscNodeConfigurationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationDscNodeConfigurationClient
+	client := meta.(*ArmClient).automation.DscNodeConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -146,7 +146,7 @@ func resourceArmAutomationDscNodeConfigurationRead(d *schema.ResourceData, meta 
 }
 
 func resourceArmAutomationDscNodeConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationDscNodeConfigurationClient
+	client := meta.(*ArmClient).automation.DscNodeConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
@@ -67,7 +67,7 @@ func TestAccAzureRMAutomationDscNodeConfiguration_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationDscNodeConfigurationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automationDscNodeConfigurationClient
+	conn := testAccProvider.Meta().(*ArmClient).automation.DscNodeConfigurationClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -117,7 +117,7 @@ func testCheckAzureRMAutomationDscNodeConfigurationExists(resourceName string) r
 			return fmt.Errorf("Bad: no resource group found in state for Automation Dsc Node Configuration: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automationDscNodeConfigurationClient
+		conn := testAccProvider.Meta().(*ArmClient).automation.DscNodeConfigurationClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_module.go
+++ b/azurerm/resource_arm_automation_module.go
@@ -77,7 +77,7 @@ func resourceArmAutomationModule() *schema.Resource {
 }
 
 func resourceArmAutomationModuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationModuleClient
+	client := meta.(*ArmClient).automation.ModuleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Module creation.")
@@ -168,7 +168,7 @@ func resourceArmAutomationModuleCreateUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmAutomationModuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationModuleClient
+	client := meta.(*ArmClient).automation.ModuleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -197,7 +197,7 @@ func resourceArmAutomationModuleRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmAutomationModuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationModuleClient
+	client := meta.(*ArmClient).automation.ModuleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_module_test.go
+++ b/azurerm/resource_arm_automation_module_test.go
@@ -93,7 +93,7 @@ func TestAccAzureRMAutomationModule_multipleModules(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationModuleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automationModuleClient
+	conn := testAccProvider.Meta().(*ArmClient).automation.ModuleClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -143,7 +143,7 @@ func testCheckAzureRMAutomationModuleExists(resourceName string) resource.TestCh
 			return fmt.Errorf("Bad: no resource group found in state for Automation Module: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automationModuleClient
+		conn := testAccProvider.Meta().(*ArmClient).automation.ModuleClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -120,7 +120,7 @@ func resourceArmAutomationRunbook() *schema.Resource {
 }
 
 func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationRunbookClient
+	client := meta.(*ArmClient).automation.RunbookClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Runbook creation.")
@@ -172,7 +172,7 @@ func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta inter
 	if v, ok := d.GetOk("content"); ok {
 		content := v.(string)
 		reader := ioutil.NopCloser(bytes.NewBufferString(content))
-		draftClient := meta.(*ArmClient).automationRunbookDraftClient
+		draftClient := meta.(*ArmClient).automation.RunbookDraftClient
 
 		if _, err := draftClient.ReplaceContent(ctx, resGroup, accName, name, reader); err != nil {
 			return fmt.Errorf("Error setting the draft Automation Runbook %q (Account %q / Resource Group %q): %+v", name, accName, resGroup, err)
@@ -198,7 +198,7 @@ func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmAutomationRunbookRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationRunbookClient
+	client := meta.(*ArmClient).automation.RunbookClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -257,7 +257,7 @@ func resourceArmAutomationRunbookRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmAutomationRunbookDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationRunbookClient
+	client := meta.(*ArmClient).automation.RunbookClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_runbook_test.go
+++ b/azurerm/resource_arm_automation_runbook_test.go
@@ -119,7 +119,7 @@ func TestAccAzureRMAutomationRunbook_PSWithContent(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationRunbookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automationRunbookClient
+	conn := testAccProvider.Meta().(*ArmClient).automation.RunbookClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -168,7 +168,7 @@ func testCheckAzureRMAutomationRunbookExists(resourceName string) resource.TestC
 			return fmt.Errorf("Bad: no resource group found in state for Automation Runbook: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automationRunbookClient
+		conn := testAccProvider.Meta().(*ArmClient).automation.RunbookClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_schedule.go
+++ b/azurerm/resource_arm_automation_schedule.go
@@ -216,7 +216,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 }
 
 func resourceArmAutomationScheduleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationScheduleClient
+	client := meta.(*ArmClient).automation.ScheduleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Schedule creation.")
@@ -309,7 +309,7 @@ func resourceArmAutomationScheduleCreateUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceArmAutomationScheduleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationScheduleClient
+	client := meta.(*ArmClient).automation.ScheduleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -369,7 +369,7 @@ func resourceArmAutomationScheduleRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmAutomationScheduleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automationScheduleClient
+	client := meta.(*ArmClient).automation.ScheduleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_schedule_test.go
+++ b/azurerm/resource_arm_automation_schedule_test.go
@@ -268,7 +268,7 @@ func TestAccAzureRMAutomationSchedule_monthly_advanced_by_week_day(t *testing.T)
 }
 
 func testCheckAzureRMAutomationScheduleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automationScheduleClient
+	conn := testAccProvider.Meta().(*ArmClient).automation.ScheduleClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -302,7 +302,7 @@ func testCheckAzureRMAutomationScheduleDestroy(s *terraform.State) error {
 
 func testCheckAzureRMAutomationScheduleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*ArmClient).automationScheduleClient
+		conn := testAccProvider.Meta().(*ArmClient).automation.ScheduleClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		// Ensure we have enough information in state to look up in API

--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -419,7 +419,7 @@ func resourceArmContainerGroup() *schema.Resource {
 }
 
 func resourceArmContainerGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).containerGroupsClient
+	client := meta.(*ArmClient).containers.GroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resGroup := d.Get("resource_group_name").(string)
@@ -496,7 +496,7 @@ func resourceArmContainerGroupCreate(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmContainerGroupRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).containerGroupsClient
+	client := meta.(*ArmClient).containers.GroupsClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -559,7 +559,7 @@ func resourceArmContainerGroupRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceArmContainerGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).containerGroupsClient
+	client := meta.(*ArmClient).containers.GroupsClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -1043,7 +1043,7 @@ func testCheckAzureRMContainerGroupExists(resourceName string) resource.TestChec
 			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).containerGroupsClient
+		conn := testAccProvider.Meta().(*ArmClient).containers.GroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)
@@ -1058,7 +1058,7 @@ func testCheckAzureRMContainerGroupExists(resourceName string) resource.TestChec
 }
 
 func testCheckAzureRMContainerGroupDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).containerGroupsClient
+	conn := testAccProvider.Meta().(*ArmClient).containers.GroupsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_container_registry.go
+++ b/azurerm/resource_arm_container_registry.go
@@ -129,7 +129,7 @@ func resourceArmContainerRegistry() *schema.Resource {
 }
 
 func resourceArmContainerRegistryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).containerRegistryClient
+	client := meta.(*ArmClient).containers.RegistryClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for AzureRM Container Registry creation.")
 
@@ -215,7 +215,7 @@ func resourceArmContainerRegistryCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmContainerRegistryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).containerRegistryClient
+	client := meta.(*ArmClient).containers.RegistryClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for AzureRM Container Registry update.")
 
@@ -300,7 +300,7 @@ func resourceArmContainerRegistryUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func applyGeoReplicationLocations(meta interface{}, resourceGroup string, name string, oldGeoReplicationLocations []interface{}, newGeoReplicationLocations []interface{}) error {
-	replicationClient := meta.(*ArmClient).containerRegistryReplicationsClient
+	replicationClient := meta.(*ArmClient).containers.RegistryReplicationsClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing to apply geo-replications for AzureRM Container Registry.")
 
@@ -369,8 +369,8 @@ func applyGeoReplicationLocations(meta interface{}, resourceGroup string, name s
 }
 
 func resourceArmContainerRegistryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).containerRegistryClient
-	replicationClient := meta.(*ArmClient).containerRegistryReplicationsClient
+	client := meta.(*ArmClient).containers.RegistryClient
+	replicationClient := meta.(*ArmClient).containers.RegistryReplicationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -454,7 +454,7 @@ func resourceArmContainerRegistryRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmContainerRegistryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).containerRegistryClient
+	client := meta.(*ArmClient).containers.RegistryClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_container_registry_test.go
+++ b/azurerm/resource_arm_container_registry_test.go
@@ -335,7 +335,7 @@ func TestAccAzureRMContainerRegistry_geoReplication(t *testing.T) {
 }
 
 func testCheckAzureRMContainerRegistryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).containerRegistryClient
+	conn := testAccProvider.Meta().(*ArmClient).containers.RegistryClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -373,7 +373,7 @@ func testCheckAzureRMContainerRegistryExists(resourceName string) resource.TestC
 			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).containerRegistryClient
+		conn := testAccProvider.Meta().(*ArmClient).containers.RegistryClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)
@@ -403,7 +403,7 @@ func testCheckAzureRMContainerRegistryGeoreplications(resourceName string, sku s
 			return fmt.Errorf("Bad: no resource group found in state for Container Registry: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).containerRegistryReplicationsClient
+		conn := testAccProvider.Meta().(*ArmClient).containers.RegistryReplicationsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.List(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_container_service.go
+++ b/azurerm/resource_arm_container_service.go
@@ -194,7 +194,7 @@ More information can be found here: https://azure.microsoft.com/en-us/updates/az
 func resourceArmContainerServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	ctx := meta.(*ArmClient).StopContext
-	containerServiceClient := client.containerServicesClient
+	containerServiceClient := client.containers.ServicesClient
 
 	log.Printf("[INFO] preparing arguments for Azure ARM Container Service creation.")
 
@@ -276,7 +276,7 @@ func resourceArmContainerServiceCreateUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmContainerServiceRead(d *schema.ResourceData, meta interface{}) error {
-	containerServiceClient := meta.(*ArmClient).containerServicesClient
+	containerServiceClient := meta.(*ArmClient).containers.ServicesClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -330,7 +330,7 @@ func resourceArmContainerServiceRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmContainerServiceDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
-	containerServiceClient := client.containerServicesClient
+	containerServiceClient := client.containers.ServicesClient
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -548,7 +548,7 @@ func expandAzureRmContainerServiceAgentProfiles(d *schema.ResourceData) []contai
 func containerServiceStateRefreshFunc(client *ArmClient, resourceGroupName string, containerServiceName string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		ctx := client.StopContext
-		res, err := client.containerServicesClient.Get(ctx, resourceGroupName, containerServiceName)
+		res, err := client.containers.ServicesClient.Get(ctx, resourceGroupName, containerServiceName)
 		if err != nil {
 			return nil, "", fmt.Errorf("Error issuing read request in containerServiceStateRefreshFunc to Azure ARM for Container Service '%s' (RG: '%s'): %s", containerServiceName, resourceGroupName, err)
 		}

--- a/azurerm/resource_arm_container_service_test.go
+++ b/azurerm/resource_arm_container_service_test.go
@@ -410,7 +410,7 @@ func testCheckAzureRMContainerServiceExists(resourceName string) resource.TestCh
 			return fmt.Errorf("Bad: no resource group found in state for Container Service Instance: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).containerServicesClient
+		conn := testAccProvider.Meta().(*ArmClient).containers.ServicesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)
@@ -427,7 +427,7 @@ func testCheckAzureRMContainerServiceExists(resourceName string) resource.TestCh
 }
 
 func testCheckAzureRMContainerServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).containerServicesClient
+	conn := testAccProvider.Meta().(*ArmClient).containers.ServicesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_container_service" {

--- a/azurerm/resource_arm_devspace_controller.go
+++ b/azurerm/resource_arm_devspace_controller.go
@@ -95,7 +95,7 @@ func resourceArmDevSpaceController() *schema.Resource {
 }
 
 func resourceArmDevSpaceControllerCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).devSpaceControllerClient
+	client := meta.(*ArmClient).devSpace.ControllersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for DevSpace Controller creation")
@@ -159,7 +159,7 @@ func resourceArmDevSpaceControllerCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmDevSpaceControllerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).devSpaceControllerClient
+	client := meta.(*ArmClient).devSpace.ControllersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -202,7 +202,7 @@ func resourceArmDevSpaceControllerRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmDevSpaceControllerUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).devSpaceControllerClient
+	client := meta.(*ArmClient).devSpace.ControllersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for DevSpace Controller updating")
@@ -229,7 +229,7 @@ func resourceArmDevSpaceControllerUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmDevSpaceControllerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).devSpaceControllerClient
+	client := meta.(*ArmClient).devSpace.ControllersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_devspace_controller_test.go
+++ b/azurerm/resource_arm_devspace_controller_test.go
@@ -81,7 +81,7 @@ func testCheckAzureRMDevSpaceControllerExists(resourceName string) resource.Test
 			return fmt.Errorf("Bad: no resource group found in state for DevSpace Controller: %s", ctrlName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).devSpaceControllerClient
+		client := testAccProvider.Meta().(*ArmClient).devSpace.ControllersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		result, err := client.Get(ctx, resGroupName, ctrlName)
 
@@ -98,7 +98,7 @@ func testCheckAzureRMDevSpaceControllerExists(resourceName string) resource.Test
 }
 
 func testCheckAzureRMDevSpaceControllerDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).devSpaceControllerClient
+	client := testAccProvider.Meta().(*ArmClient).devSpace.ControllersClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_a_record.go
+++ b/azurerm/resource_arm_dns_a_record.go
@@ -52,7 +52,7 @@ func resourceArmDnsARecord() *schema.Resource {
 }
 
 func resourceArmDnsARecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -105,7 +105,7 @@ func resourceArmDnsARecordCreateUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -140,7 +140,7 @@ func resourceArmDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArmDnsARecordDelete(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_a_record_test.go
+++ b/azurerm/resource_arm_dns_a_record_test.go
@@ -145,7 +145,7 @@ func testCheckAzureRMDnsARecordExists(resourceName string) resource.TestCheckFun
 			return fmt.Errorf("Bad: no resource group found in state for DNS A record: %s", aName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, aName, dns.A)
 		if err != nil {
@@ -161,7 +161,7 @@ func testCheckAzureRMDnsARecordExists(resourceName string) resource.TestCheckFun
 }
 
 func testCheckAzureRMDnsARecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_aaaa_record.go
+++ b/azurerm/resource_arm_dns_aaaa_record.go
@@ -52,7 +52,7 @@ func resourceArmDnsAAAARecord() *schema.Resource {
 }
 
 func resourceArmDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -105,7 +105,7 @@ func resourceArmDnsAaaaRecordCreateUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmDnsAaaaRecordRead(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -140,7 +140,7 @@ func resourceArmDnsAaaaRecordRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmDnsAaaaRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_aaaa_record_test.go
+++ b/azurerm/resource_arm_dns_aaaa_record_test.go
@@ -145,7 +145,7 @@ func testCheckAzureRMDnsAaaaRecordExists(resourceName string) resource.TestCheck
 			return fmt.Errorf("Bad: no resource group found in state for DNS AAAA record: %s", aaaaName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, aaaaName, dns.AAAA)
 		if err != nil {
@@ -161,7 +161,7 @@ func testCheckAzureRMDnsAaaaRecordExists(resourceName string) resource.TestCheck
 }
 
 func testCheckAzureRMDnsAaaaRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_caa_record.go
+++ b/azurerm/resource_arm_dns_caa_record.go
@@ -78,7 +78,7 @@ func resourceArmDnsCaaRecord() *schema.Resource {
 }
 
 func resourceArmDnsCaaRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -131,7 +131,7 @@ func resourceArmDnsCaaRecordCreateUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmDnsCaaRecordRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -166,7 +166,7 @@ func resourceArmDnsCaaRecordRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmDnsCaaRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_caa_record_test.go
+++ b/azurerm/resource_arm_dns_caa_record_test.go
@@ -145,7 +145,7 @@ func testCheckAzureRMDnsCaaRecordExists(resourceName string) resource.TestCheckF
 			return fmt.Errorf("Bad: no resource group found in state for DNS CAA record: %s", caaName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, caaName, dns.CAA)
 		if err != nil {
@@ -161,7 +161,7 @@ func testCheckAzureRMDnsCaaRecordExists(resourceName string) resource.TestCheckF
 }
 
 func testCheckAzureRMDnsCaaRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_cname_record.go
+++ b/azurerm/resource_arm_dns_cname_record.go
@@ -58,7 +58,7 @@ func resourceArmDnsCNameRecord() *schema.Resource {
 }
 
 func resourceArmDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -114,7 +114,7 @@ func resourceArmDnsCNameRecordCreateUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmDnsCNameRecordRead(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -152,7 +152,7 @@ func resourceArmDnsCNameRecordRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmDnsCNameRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_cname_record_test.go
+++ b/azurerm/resource_arm_dns_cname_record_test.go
@@ -169,7 +169,7 @@ func testCheckAzureRMDnsCNameRecordExists(resourceName string) resource.TestChec
 			return fmt.Errorf("Bad: no resource group found in state for DNS CNAME record: %s", cnameName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, cnameName, dns.CNAME)
 		if err != nil {
@@ -185,7 +185,7 @@ func testCheckAzureRMDnsCNameRecordExists(resourceName string) resource.TestChec
 }
 
 func testCheckAzureRMDnsCNameRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_mx_record.go
+++ b/azurerm/resource_arm_dns_mx_record.go
@@ -68,7 +68,7 @@ func resourceArmDnsMxRecord() *schema.Resource {
 }
 
 func resourceArmDnsMxRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -121,7 +121,7 @@ func resourceArmDnsMxRecordCreateUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmDnsMxRecordRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -156,7 +156,7 @@ func resourceArmDnsMxRecordRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceArmDnsMxRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_mx_record_test.go
+++ b/azurerm/resource_arm_dns_mx_record_test.go
@@ -145,7 +145,7 @@ func testCheckAzureRMDnsMxRecordExists(resourceName string) resource.TestCheckFu
 			return fmt.Errorf("Bad: no resource group found in state for DNS MX record: %s", mxName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, mxName, dns.MX)
 		if err != nil {
@@ -161,7 +161,7 @@ func testCheckAzureRMDnsMxRecordExists(resourceName string) resource.TestCheckFu
 }
 
 func testCheckAzureRMDnsMxRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_ns_record.go
+++ b/azurerm/resource_arm_dns_ns_record.go
@@ -70,7 +70,7 @@ func resourceArmDnsNsRecord() *schema.Resource {
 }
 
 func resourceArmDnsNsRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -123,7 +123,7 @@ func resourceArmDnsNsRecordCreateUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmDnsNsRecordRead(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -164,7 +164,7 @@ func resourceArmDnsNsRecordRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceArmDnsNsRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	dnsClient := meta.(*ArmClient).dnsClient
+	dnsClient := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_ns_record_test.go
+++ b/azurerm/resource_arm_dns_ns_record_test.go
@@ -259,7 +259,7 @@ func testCheckAzureRMDnsNsRecordExists(resourceName string) resource.TestCheckFu
 			return fmt.Errorf("Bad: no resource group found in state for DNS NS record: %s", nsName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, nsName, dns.NS)
 		if err != nil {
@@ -275,7 +275,7 @@ func testCheckAzureRMDnsNsRecordExists(resourceName string) resource.TestCheckFu
 }
 
 func testCheckAzureRMDnsNsRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_ptr_record.go
+++ b/azurerm/resource_arm_dns_ptr_record.go
@@ -52,7 +52,7 @@ func resourceArmDnsPtrRecord() *schema.Resource {
 }
 
 func resourceArmDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -105,7 +105,7 @@ func resourceArmDnsPtrRecordCreateUpdate(d *schema.ResourceData, meta interface{
 
 func resourceArmDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
-	dnsClient := client.dnsClient
+	dnsClient := client.dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -142,7 +142,7 @@ func resourceArmDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceArmDnsPtrRecordDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
-	dnsClient := client.dnsClient
+	dnsClient := client.dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_ptr_record_test.go
+++ b/azurerm/resource_arm_dns_ptr_record_test.go
@@ -146,7 +146,7 @@ func testCheckAzureRMDnsPtrRecordExists(resourceName string) resource.TestCheckF
 			return fmt.Errorf("Bad: no resource group found in state for DNS PTR record: %s", ptrName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, ptrName, dns.PTR)
 		if err != nil {
@@ -162,7 +162,7 @@ func testCheckAzureRMDnsPtrRecordExists(resourceName string) resource.TestCheckF
 }
 
 func testCheckAzureRMDnsPtrRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_srv_record.go
+++ b/azurerm/resource_arm_dns_srv_record.go
@@ -76,7 +76,7 @@ func resourceArmDnsSrvRecord() *schema.Resource {
 }
 
 func resourceArmDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -129,7 +129,7 @@ func resourceArmDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmDnsSrvRecordRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -164,7 +164,7 @@ func resourceArmDnsSrvRecordRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmDnsSrvRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_srv_record_test.go
+++ b/azurerm/resource_arm_dns_srv_record_test.go
@@ -145,7 +145,7 @@ func testCheckAzureRMDnsSrvRecordExists(resourceName string) resource.TestCheckF
 			return fmt.Errorf("Bad: no resource group found in state for DNS SRV record: %s", srvName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, srvName, dns.SRV)
 		if err != nil {
@@ -161,7 +161,7 @@ func testCheckAzureRMDnsSrvRecordExists(resourceName string) resource.TestCheckF
 }
 
 func testCheckAzureRMDnsSrvRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_txt_record.go
+++ b/azurerm/resource_arm_dns_txt_record.go
@@ -58,7 +58,7 @@ func resourceArmDnsTxtRecord() *schema.Resource {
 }
 
 func resourceArmDnsTxtRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -111,7 +111,7 @@ func resourceArmDnsTxtRecordCreateUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -146,7 +146,7 @@ func resourceArmDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmDnsTxtRecordDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).dnsClient
+	client := meta.(*ArmClient).dns.RecordSetsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_txt_record_test.go
+++ b/azurerm/resource_arm_dns_txt_record_test.go
@@ -143,7 +143,7 @@ func testCheckAzureRMDnsTxtRecordExists(resourceName string) resource.TestCheckF
 			return fmt.Errorf("Bad: no resource group found in state for DNS TXT record: %s", txtName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).dnsClient
+		conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, zoneName, txtName, dns.TXT)
 		if err != nil {
@@ -159,7 +159,7 @@ func testCheckAzureRMDnsTxtRecordExists(resourceName string) resource.TestCheckF
 }
 
 func testCheckAzureRMDnsTxtRecordDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).dnsClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.RecordSetsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_dns_zone.go
+++ b/azurerm/resource_arm_dns_zone.go
@@ -75,7 +75,7 @@ func resourceArmDnsZone() *schema.Resource {
 }
 
 func resourceArmDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).zonesClient
+	client := meta.(*ArmClient).dns.ZonesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -133,7 +133,7 @@ func resourceArmDnsZoneCreateUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
-	zonesClient := meta.(*ArmClient).zonesClient
+	zonesClient := meta.(*ArmClient).dns.ZonesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -183,7 +183,7 @@ func resourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArmDnsZoneDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).zonesClient
+	client := meta.(*ArmClient).dns.ZonesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_dns_zone_test.go
+++ b/azurerm/resource_arm_dns_zone_test.go
@@ -138,7 +138,7 @@ func testCheckAzureRMDnsZoneExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("Bad: no resource group found in state for DNS zone: %s", zoneName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).zonesClient
+		client := testAccProvider.Meta().(*ArmClient).dns.ZonesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, zoneName)
 		if err != nil {
@@ -154,7 +154,7 @@ func testCheckAzureRMDnsZoneExists(resourceName string) resource.TestCheckFunc {
 }
 
 func testCheckAzureRMDnsZoneDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).zonesClient
+	conn := testAccProvider.Meta().(*ArmClient).dns.ZonesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_hdinsight_hadoop_cluster.go
+++ b/azurerm/resource_arm_hdinsight_hadoop_cluster.go
@@ -109,7 +109,7 @@ func resourceArmHDInsightHadoopCluster() *schema.Resource {
 }
 
 func resourceArmHDInsightHadoopClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -199,8 +199,8 @@ func resourceArmHDInsightHadoopClusterCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmHDInsightHadoopClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_hdinsight_hbase_cluster.go
+++ b/azurerm/resource_arm_hdinsight_hbase_cluster.go
@@ -107,7 +107,7 @@ func resourceArmHDInsightHBaseCluster() *schema.Resource {
 }
 
 func resourceArmHDInsightHBaseClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -197,8 +197,8 @@ func resourceArmHDInsightHBaseClusterCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmHDInsightHBaseClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_hdinsight_interactive_query_cluster.go
+++ b/azurerm/resource_arm_hdinsight_interactive_query_cluster.go
@@ -107,7 +107,7 @@ func resourceArmHDInsightInteractiveQueryCluster() *schema.Resource {
 }
 
 func resourceArmHDInsightInteractiveQueryClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -197,8 +197,8 @@ func resourceArmHDInsightInteractiveQueryClusterCreate(d *schema.ResourceData, m
 }
 
 func resourceArmHDInsightInteractiveQueryClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_hdinsight_kafka_cluster.go
+++ b/azurerm/resource_arm_hdinsight_kafka_cluster.go
@@ -108,7 +108,7 @@ func resourceArmHDInsightKafkaCluster() *schema.Resource {
 }
 
 func resourceArmHDInsightKafkaClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -198,8 +198,8 @@ func resourceArmHDInsightKafkaClusterCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmHDInsightKafkaClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_hdinsight_ml_services_cluster.go
+++ b/azurerm/resource_arm_hdinsight_ml_services_cluster.go
@@ -126,7 +126,7 @@ func expandHDInsightsMLServicesConfigurations(gateway []interface{}, rStudio boo
 }
 
 func resourceArmHDInsightMLServicesClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -214,8 +214,8 @@ func resourceArmHDInsightMLServicesClusterCreate(d *schema.ResourceData, meta in
 }
 
 func resourceArmHDInsightMLServicesClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_hdinsight_rserver_cluster.go
+++ b/azurerm/resource_arm_hdinsight_rserver_cluster.go
@@ -126,7 +126,7 @@ func expandHDInsightsRServerConfigurations(gateway []interface{}, rStudio bool) 
 }
 
 func resourceArmHDInsightRServerClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -214,8 +214,8 @@ func resourceArmHDInsightRServerClusterCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmHDInsightRServerClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_hdinsight_spark_cluster.go
+++ b/azurerm/resource_arm_hdinsight_spark_cluster.go
@@ -107,7 +107,7 @@ func resourceArmHDInsightSparkCluster() *schema.Resource {
 }
 
 func resourceArmHDInsightSparkClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -197,8 +197,8 @@ func resourceArmHDInsightSparkClusterCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmHDInsightSparkClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_hdinsight_storm_cluster.go
+++ b/azurerm/resource_arm_hdinsight_storm_cluster.go
@@ -108,7 +108,7 @@ func resourceArmHDInsightStormCluster() *schema.Resource {
 }
 
 func resourceArmHDInsightStormClusterCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).hdinsightClustersClient
+	client := meta.(*ArmClient).hdinsight.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -198,8 +198,8 @@ func resourceArmHDInsightStormClusterCreate(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmHDInsightStormClusterRead(d *schema.ResourceData, meta interface{}) error {
-	clustersClient := meta.(*ArmClient).hdinsightClustersClient
-	configurationsClient := meta.(*ArmClient).hdinsightConfigurationsClient
+	clustersClient := meta.(*ArmClient).hdinsight.ClustersClient
+	configurationsClient := meta.(*ArmClient).hdinsight.ConfigurationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -536,7 +536,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 }
 
 func resourceArmKubernetesClusterCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).kubernetesClustersClient
+	client := meta.(*ArmClient).containers.KubernetesClustersClient
 	ctx := meta.(*ArmClient).StopContext
 	tenantId := meta.(*ArmClient).tenantId
 
@@ -630,7 +630,7 @@ func resourceArmKubernetesClusterCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).kubernetesClustersClient
+	client := meta.(*ArmClient).containers.KubernetesClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -733,7 +733,7 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmKubernetesClusterDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).kubernetesClustersClient
+	client := meta.(*ArmClient).containers.KubernetesClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -666,7 +666,7 @@ func testCheckAzureRMKubernetesClusterExists(resourceName string) resource.TestC
 			return fmt.Errorf("Bad: no resource group found in state for Managed Kubernetes Cluster: %s", name)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).kubernetesClustersClient
+		client := testAccProvider.Meta().(*ArmClient).containers.KubernetesClustersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		aks, err := client.Get(ctx, resourceGroup, name)
@@ -683,7 +683,7 @@ func testCheckAzureRMKubernetesClusterExists(resourceName string) resource.TestC
 }
 
 func testCheckAzureRMKubernetesClusterDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).kubernetesClustersClient
+	conn := testAccProvider.Meta().(*ArmClient).containers.KubernetesClustersClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_kubernetes_cluster" {

--- a/azurerm/resource_arm_log_analytics_linked_service.go
+++ b/azurerm/resource_arm_log_analytics_linked_service.go
@@ -83,7 +83,7 @@ func resourceArmLogAnalyticsLinkedService() *schema.Resource {
 }
 
 func resourceArmLogAnalyticsLinkedServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).linkedServicesClient
+	client := meta.(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Linked Services creation.")
@@ -140,7 +140,7 @@ func resourceArmLogAnalyticsLinkedServiceCreateUpdate(d *schema.ResourceData, me
 }
 
 func resourceArmLogAnalyticsLinkedServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).linkedServicesClient
+	client := meta.(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -180,7 +180,7 @@ func resourceArmLogAnalyticsLinkedServiceRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmLogAnalyticsLinkedServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).linkedServicesClient
+	client := meta.(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_log_analytics_linked_service_test.go
+++ b/azurerm/resource_arm_log_analytics_linked_service_test.go
@@ -95,7 +95,7 @@ func TestAccAzureRMLogAnalyticsLinkedService_complete(t *testing.T) {
 }
 
 func testCheckAzureRMLogAnalyticsLinkedServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).linkedServicesClient
+	conn := testAccProvider.Meta().(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -140,7 +140,7 @@ func testCheckAzureRMLogAnalyticsLinkedServiceExists(resourceName string) resour
 			return fmt.Errorf("Bad: no resource group found in state for Log Analytics Linked Service: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).linkedServicesClient
+		conn := testAccProvider.Meta().(*ArmClient).logAnalytics.LinkedServicesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, workspaceName, lsName)

--- a/azurerm/resource_arm_log_analytics_solution.go
+++ b/azurerm/resource_arm_log_analytics_solution.go
@@ -84,7 +84,7 @@ func resourceArmLogAnalyticsSolution() *schema.Resource {
 }
 
 func resourceArmLogAnalyticsSolutionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).solutionsClient
+	client := meta.(*ArmClient).logAnalytics.SolutionsClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for Log Analytics Solution creation.")
 
@@ -146,7 +146,7 @@ func resourceArmLogAnalyticsSolutionCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmLogAnalyticsSolutionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).solutionsClient
+	client := meta.(*ArmClient).logAnalytics.SolutionsClient
 	ctx := meta.(*ArmClient).StopContext
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -200,7 +200,7 @@ func resourceArmLogAnalyticsSolutionRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmLogAnalyticsSolutionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).solutionsClient
+	client := meta.(*ArmClient).logAnalytics.SolutionsClient
 	ctx := meta.(*ArmClient).StopContext
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_log_analytics_solution_test.go
+++ b/azurerm/resource_arm_log_analytics_solution_test.go
@@ -87,7 +87,7 @@ func TestAccAzureRMLogAnalyticsSolution_basicSecurity(t *testing.T) {
 }
 
 func testCheckAzureRMLogAnalyticsSolutionDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).solutionsClient
+	conn := testAccProvider.Meta().(*ArmClient).logAnalytics.SolutionsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -126,7 +126,7 @@ func testCheckAzureRMLogAnalyticsSolutionExists(resourceName string) resource.Te
 			return fmt.Errorf("Bad: no resource group found in state for Log Analytics Workspace: %q", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).solutionsClient
+		conn := testAccProvider.Meta().(*ArmClient).logAnalytics.SolutionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_log_analytics_workspace.go
+++ b/azurerm/resource_arm_log_analytics_workspace.go
@@ -86,7 +86,7 @@ func resourceArmLogAnalyticsWorkspace() *schema.Resource {
 }
 
 func resourceArmLogAnalyticsWorkspaceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).workspacesClient
+	client := meta.(*ArmClient).logAnalytics.WorkspacesClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Workspace creation.")
 
@@ -151,7 +151,7 @@ func resourceArmLogAnalyticsWorkspaceCreateUpdate(d *schema.ResourceData, meta i
 }
 
 func resourceArmLogAnalyticsWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).workspacesClient
+	client := meta.(*ArmClient).logAnalytics.WorkspacesClient
 	ctx := meta.(*ArmClient).StopContext
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -195,7 +195,7 @@ func resourceArmLogAnalyticsWorkspaceRead(d *schema.ResourceData, meta interface
 }
 
 func resourceArmLogAnalyticsWorkspaceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).workspacesClient
+	client := meta.(*ArmClient).logAnalytics.WorkspacesClient
 	ctx := meta.(*ArmClient).StopContext
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_log_analytics_workspace_linked_service.go
+++ b/azurerm/resource_arm_log_analytics_workspace_linked_service.go
@@ -90,7 +90,7 @@ As such the existing 'azurerm_log_analytics_workspace_linked_service' resource i
 }
 
 func resourceArmLogAnalyticsWorkspaceLinkedServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).linkedServicesClient
+	client := meta.(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Log Analytics Linked Services creation.")
@@ -147,7 +147,7 @@ func resourceArmLogAnalyticsWorkspaceLinkedServiceCreateUpdate(d *schema.Resourc
 }
 
 func resourceArmLogAnalyticsWorkspaceLinkedServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).linkedServicesClient
+	client := meta.(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -187,7 +187,7 @@ func resourceArmLogAnalyticsWorkspaceLinkedServiceRead(d *schema.ResourceData, m
 }
 
 func resourceArmLogAnalyticsWorkspaceLinkedServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).linkedServicesClient
+	client := meta.(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
+++ b/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
@@ -95,7 +95,7 @@ func TestAccAzureRMLogAnalyticsWorkspaceLinkedService_complete(t *testing.T) {
 }
 
 func testCheckAzureRMLogAnalyticsWorkspaceLinkedServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).linkedServicesClient
+	conn := testAccProvider.Meta().(*ArmClient).logAnalytics.LinkedServicesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -140,7 +140,7 @@ func testCheckAzureRMLogAnalyticsWorkspaceLinkedServiceExists(resourceName strin
 			return fmt.Errorf("Bad: no resource group found in state for Log Analytics Linked Service: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).linkedServicesClient
+		conn := testAccProvider.Meta().(*ArmClient).logAnalytics.LinkedServicesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, workspaceName, lsName)

--- a/azurerm/resource_arm_log_analytics_workspace_test.go
+++ b/azurerm/resource_arm_log_analytics_workspace_test.go
@@ -130,7 +130,7 @@ func TestAccAzureRMLogAnalyticsWorkspace_complete(t *testing.T) {
 }
 
 func testCheckAzureRMLogAnalyticsWorkspaceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).workspacesClient
+	conn := testAccProvider.Meta().(*ArmClient).logAnalytics.WorkspacesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -169,7 +169,7 @@ func testCheckAzureRMLogAnalyticsWorkspaceExists(resourceName string) resource.T
 			return fmt.Errorf("Bad: no resource group found in state for Log Analytics Workspace: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).workspacesClient
+		conn := testAccProvider.Meta().(*ArmClient).logAnalytics.WorkspacesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_media_services_account.go
+++ b/azurerm/resource_arm_media_services_account.go
@@ -66,7 +66,7 @@ func resourceArmMediaServicesAccount() *schema.Resource {
 }
 
 func resourceArmMediaServicesAccountCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).mediaServicesClient
+	client := meta.(*ArmClient).media.ServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	accountName := d.Get("name").(string)
@@ -100,7 +100,7 @@ func resourceArmMediaServicesAccountCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmMediaServicesAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).mediaServicesClient
+	client := meta.(*ArmClient).media.ServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -141,7 +141,7 @@ func resourceArmMediaServicesAccountRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmMediaServicesAccountDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).mediaServicesClient
+	client := meta.(*ArmClient).media.ServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_media_services_account_test.go
+++ b/azurerm/resource_arm_media_services_account_test.go
@@ -99,7 +99,7 @@ func testCheckAzureRMMediaServicesAccountExists(resourceName string) resource.Te
 			return fmt.Errorf("Bad: no resource group found in state for Media Services Account: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).mediaServicesClient
+		conn := testAccProvider.Meta().(*ArmClient).media.ServicesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)
@@ -116,7 +116,7 @@ func testCheckAzureRMMediaServicesAccountExists(resourceName string) resource.Te
 }
 
 func testCheckAzureRMMediaServicesAccountDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).mediaServicesClient
+	conn := testAccProvider.Meta().(*ArmClient).media.ServicesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -577,12 +577,12 @@ func testCheckAzureRMRedisCacheExists(resourceName string) resource.TestCheckFun
 			return fmt.Errorf("Bad: no resource group found in state for Redis Instance: %s", redisName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).redisClient
+		conn := testAccProvider.Meta().(*ArmClient).redis.Client
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, redisName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on redisClient: %+v", err)
+			return fmt.Errorf("Bad: Get on redis.Client: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
@@ -594,7 +594,7 @@ func testCheckAzureRMRedisCacheExists(resourceName string) resource.TestCheckFun
 }
 
 func testCheckAzureRMRedisCacheDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).redisClient
+	conn := testAccProvider.Meta().(*ArmClient).redis.Client
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_redis_firewall_rule.go
+++ b/azurerm/resource_arm_redis_firewall_rule.go
@@ -53,7 +53,7 @@ func resourceArmRedisFirewallRule() *schema.Resource {
 }
 
 func resourceArmRedisFirewallRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).redisFirewallClient
+	client := meta.(*ArmClient).redis.FirewallRulesClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for AzureRM Redis Firewall Rule creation.")
 
@@ -101,7 +101,7 @@ func resourceArmRedisFirewallRuleCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmRedisFirewallRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).redisFirewallClient
+	client := meta.(*ArmClient).redis.FirewallRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -136,7 +136,7 @@ func resourceArmRedisFirewallRuleRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmRedisFirewallRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).redisFirewallClient
+	client := meta.(*ArmClient).redis.FirewallRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_redis_firewall_rule_test.go
+++ b/azurerm/resource_arm_redis_firewall_rule_test.go
@@ -142,14 +142,14 @@ func testCheckAzureRMRedisFirewallRuleExists(resourceName string) resource.TestC
 		cacheName := rs.Primary.Attributes["redis_cache_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).redisFirewallClient
+		client := testAccProvider.Meta().(*ArmClient).redis.FirewallRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, cacheName, name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: Firewall Rule %q (cache %q resource group: %q) does not exist", name, cacheName, resourceGroup)
 			}
-			return fmt.Errorf("Bad: Get on redisFirewallClient: %+v", err)
+			return fmt.Errorf("Bad: Get on redis.FirewallRulesClient: %+v", err)
 		}
 
 		return nil


### PR DESCRIPTION
This is the first in a series of PR's to refactor the resources into packages.

This first PR migrates some of the API Clients into a new `services` folder so that we can later move the associated code out into packages.

The clients are intentionally pointers because if they're unassigned the Provider should panic (as this'll be caught in the tests)