### PR TITLE
provider/azurerm: Add maximum_elastic_worker_count to app_service_plan

### DIFF
--- a/azurerm/data_source_app_service_plan.go
+++ b/azurerm/data_source_app_service_plan.go
@@ -74,6 +74,11 @@ func dataSourceAppServicePlan() *schema.Resource {
 				Computed: true,
 			},
 
+			"maximum_elastic_worker_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
 			"is_xenon": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -118,6 +123,10 @@ func dataSourceAppServicePlanRead(d *schema.ResourceData, meta interface{}) erro
 
 		if props.MaximumNumberOfWorkers != nil {
 			d.Set("maximum_number_of_workers", int(*props.MaximumNumberOfWorkers))
+		}
+
+		if props.MaximumElasticWorkerCount != nil {
+			d.Set("maximum_elastic_worker_count", int(*props.MaximumElasticWorkerCount))
 		}
 	}
 

--- a/azurerm/data_source_app_service_plan_test.go
+++ b/azurerm/data_source_app_service_plan_test.go
@@ -61,6 +61,29 @@ func TestAccDataSourceAzureRMAppServicePlan_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMAppServicePlan_premiumSKU(t *testing.T) {
+	dataSourceName := "data.azurerm_app_service_plan.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppServicePlan_premiumSKU(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "kind", "elastic"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.tier", "ElasticPremium"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.size", "EP1"),
+					resource.TestCheckResourceAttr(dataSourceName, "maximum_elastic_worker_count", "20"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAzureRMAppServicePlan_basicWindowsContainer(t *testing.T) {
 	dataSourceName := "data.azurerm_app_service_plan.test"
 	rInt := tf.AccRandTimeInt()
@@ -125,6 +148,41 @@ resource "azurerm_app_service_plan" "test" {
   sku {
     tier = "Standard"
     size = "S1"
+  }
+
+  properties {
+    per_site_scaling = true
+  }
+
+  tags = {
+    environment = "Test"
+  }
+}
+
+data "azurerm_app_service_plan" "test" {
+  name                = "${azurerm_app_service_plan.test.name}"
+  resource_group_name = "${azurerm_app_service_plan.test.resource_group_name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceAppServicePlan_premiumSKU(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                         = "acctestASP-%d"
+  location                     = "${azurerm_resource_group.test.location}"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  kind                         = "elastic"
+  maximum_elastic_worker_count = 20
+
+  sku {
+    tier = "ElasticPremium"
+    size = "EP1"
   }
 
   properties {

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -118,6 +118,7 @@ func resourceArmAppServicePlan() *schema.Resource {
 				},
 			},
 
+			/// AppServicePlanProperties
 			"app_service_environment_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -138,6 +139,13 @@ func resourceArmAppServicePlan() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ConflictsWith: []string{"properties.0.reserved"},
+			},
+
+			"maximum_elastic_worker_count": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 
 			"maximum_number_of_workers": {
@@ -216,6 +224,10 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
+	if v, exists := d.GetOkExists("maximum_elastic_worker_count"); exists {
+		appServicePlan.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(v.(int)))
+	}
+
 	if reservedExists {
 		appServicePlan.AppServicePlanProperties.Reserved = utils.Bool(reserved.(bool))
 	}
@@ -286,6 +298,10 @@ func resourceArmAppServicePlanRead(d *schema.ResourceData, meta interface{}) err
 
 		if props.MaximumNumberOfWorkers != nil {
 			d.Set("maximum_number_of_workers", int(*props.MaximumNumberOfWorkers))
+		}
+
+		if props.MaximumElasticWorkerCount != nil {
+			d.Set("maximum_elastic_worker_count", int(*props.MaximumElasticWorkerCount))
 		}
 
 		d.Set("per_site_scaling", props.PerSiteScaling)

--- a/azurerm/resource_arm_app_service_plan_test.go
+++ b/azurerm/resource_arm_app_service_plan_test.go
@@ -288,6 +288,7 @@ func TestAccAzureRMAppServicePlan_premiumConsumptionPlan(t *testing.T) {
 					testCheckAzureRMAppServicePlanExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "sku.0.tier", "ElasticPremium"),
 					resource.TestCheckResourceAttr(resourceName, "sku.0.size", "EP1"),
+					resource.TestCheckResourceAttr(resourceName, "maximum_elastic_worker_count", "20"),
 				),
 			},
 		},
@@ -615,6 +616,8 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
   kind                = "elastic"
+
+  maximum_elastic_worker_count = 20
 
   sku {
     tier = "ElasticPremium"

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -42,10 +42,11 @@ output "app_service_plan_id" {
 
 * `tags` - A mapping of tags assigned to the resource.
 
-* `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.
+* `maximum_elastic_worker_count` - The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan.
 
 * `is_xenon` - A flag that indicates if it's a xenon plan (support for Windows Container)
 
+* `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.
 ---
 
 A `sku` block supports the following:

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -47,6 +47,7 @@ output "app_service_plan_id" {
 * `is_xenon` - A flag that indicates if it's a xenon plan (support for Windows Container)
 
 * `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.
+
 ---
 
 A `sku` block supports the following:

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -107,6 +107,8 @@ The following arguments are supported:
 
 * `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows` (also available as `App`), `Linux`, `elastic` (for Premium Consumption) and `FunctionApp` (for a Consumption Plan). Defaults to `Windows`. Changing this forces a new resource to be created.
 
+* `maximum_elastic_worker_count` - The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan.
+
 ~> **NOTE:** When creating a `Linux` App Service Plan, the `reserved` field must be set to `true`.
 
 * `sku` - (Required) A `sku` block as documented below.
@@ -128,7 +130,6 @@ The following arguments are supported:
 * `size` - (Required) Specifies the plan's instance size.
 
 * `capacity` - (Optional) Specifies the number of workers associated with this App Service Plan.
-
 
 
 ## Attributes Reference


### PR DESCRIPTION
@tombuildsstuff so I didn't add this to the `deprecated` properties block and went with the new way of `maximum_number_of_workers`

Fixes: #3445

```
▶ acctests azurerm TestAccDataSourceAzureRMAppServicePlan_premiumSKU
=== RUN   TestAccDataSourceAzureRMAppServicePlan_premiumSKU
=== PAUSE TestAccDataSourceAzureRMAppServicePlan_premiumSKU
=== CONT  TestAccDataSourceAzureRMAppServicePlan_premiumSKU
--- PASS: TestAccDataSourceAzureRMAppServicePlan_premiumSKU (87.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	87.978s


▶ acctests azurerm TestAccAzureRMAppServicePlan_premiumConsumptionPlan
=== RUN   TestAccAzureRMAppServicePlan_premiumConsumptionPlan
=== PAUSE TestAccAzureRMAppServicePlan_premiumConsumptionPlan
=== CONT  TestAccAzureRMAppServicePlan_premiumConsumptionPlan
--- PASS: TestAccAzureRMAppServicePlan_premiumConsumptionPlan (83.97s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	84.024s
```