### PR TITLE
Fix for issue 2334 - New resource provider for azurerm_dev_test_lab_schedule

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -201,6 +201,7 @@ type ArmClient struct {
 
 	// DevTestLabs
 	devTestLabsClient            dtl.LabsClient
+	devTestLabSchedulesClient    dtl.SchedulesClient
 	devTestPoliciesClient        dtl.PoliciesClient
 	devTestVirtualMachinesClient dtl.VirtualMachinesClient
 	devTestVirtualNetworksClient dtl.VirtualNetworksClient
@@ -970,6 +971,10 @@ func (c *ArmClient) registerDevTestClients(endpoint, subscriptionId string, auth
 	devTestVirtualNetworksClient := dtl.NewVirtualNetworksClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&devTestVirtualNetworksClient.Client, auth)
 	c.devTestVirtualNetworksClient = devTestVirtualNetworksClient
+
+	devTestLabSchedulesClient := dtl.NewSchedulesClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&devTestLabSchedulesClient.Client, auth)
+	c.devTestLabSchedulesClient = devTestLabSchedulesClient
 }
 
 func (c *ArmClient) registerDevSpaceClients(endpoint, subscriptionId string, auth autorest.Authorizer) {

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -258,6 +258,7 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_databricks_workspace":                               resourceArmDatabricksWorkspace(),
 			"azurerm_ddos_protection_plan":                               resourceArmDDoSProtectionPlan(),
 			"azurerm_dev_test_lab":                                       resourceArmDevTestLab(),
+			"azurerm_dev_test_lab_schedule":                              resourceArmDevTestLabSchedules(),
 			"azurerm_dev_test_linux_virtual_machine":                     resourceArmDevTestLinuxVirtualMachine(),
 			"azurerm_dev_test_policy":                                    resourceArmDevTestPolicy(),
 			"azurerm_dev_test_virtual_network":                           resourceArmDevTestVirtualNetwork(),

--- a/azurerm/resource_arm_dev_test_lab_schedule.go
+++ b/azurerm/resource_arm_dev_test_lab_schedule.go
@@ -1,0 +1,488 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2016-05-15/dtl"
+	"github.com/Azure/azure-sdk-for-go/services/scheduler/mgmt/2016-03-01/scheduler"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmDevTestLabSchedules() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDevTestLabSchedulesCreateUpdate,
+		Read:   resourceArmDevTestLabSchedulesRead,
+		Update: resourceArmDevTestLabSchedulesCreateUpdate,
+		Delete: resourceArmDevTestLabSchedulesDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": locationSchema(),
+
+			"resource_group_name": resourceGroupNameSchema(),
+
+			"dev_test_lab_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  dtl.EnableStatusDisabled,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(dtl.EnableStatusEnabled),
+					string(dtl.EnableStatusDisabled),
+				}, true),
+			},
+
+			"task_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"weekly_recurrence": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"time": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"week_days": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(scheduler.Monday),
+									string(scheduler.Tuesday),
+									string(scheduler.Wednesday),
+									string(scheduler.Thursday),
+									string(scheduler.Friday),
+									string(scheduler.Saturday),
+									string(scheduler.Sunday),
+								}, true),
+								DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+							},
+							// Set: set.HashStringIgnoreCase,
+						},
+					},
+				},
+			},
+
+			"daily_recurrence": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"time": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"hourly_recurrence": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"minute": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"time_zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"notification_settings": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  dtl.NotificationStatusDisabled,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(dtl.NotificationStatusEnabled),
+								string(dtl.NotificationStatusDisabled),
+							}, true),
+						},
+						"time_in_minutes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"webhook_url": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+					},
+				},
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmDevTestLabSchedulesCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).devTestLabSchedulesClient
+
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	devTestLabName := d.Get("dev_test_lab_name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, devTestLabName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Schedule %q (Dev Test Lab %q / Resource Group %q): %s", name, devTestLabName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_dev_test_lab_schedule", *existing.ID)
+		}
+	}
+
+	location := azureRMNormalizeLocation(d.Get("location").(string))
+	tags := d.Get("tags").(map[string]interface{})
+
+	schedule := dtl.Schedule{
+		Location:           &location,
+		ScheduleProperties: &dtl.ScheduleProperties{},
+		Tags:               expandTags(tags),
+	}
+
+	switch status := d.Get("status"); status {
+	case string(dtl.EnableStatusEnabled):
+		schedule.ScheduleProperties.Status = dtl.EnableStatusEnabled
+	case string(dtl.EnableStatusDisabled):
+		schedule.ScheduleProperties.Status = dtl.EnableStatusDisabled
+	default:
+	}
+
+	if taskType := d.Get("task_type").(string); taskType != "" {
+		schedule.ScheduleProperties.TaskType = &taskType
+	}
+
+	if timeZoneId := d.Get("time_zone_id").(string); timeZoneId != "" {
+		schedule.ScheduleProperties.TimeZoneID = &timeZoneId
+	}
+
+	if _, ok := d.GetOk("weekly_recurrence"); ok {
+		weekRecurrence, err2 := expandArmDevTestLabScheduleRecurrenceWeekly(d)
+		if err2 != nil {
+			return err2
+		}
+
+		schedule.WeeklyRecurrence = weekRecurrence
+	}
+
+	if _, ok := d.GetOk("daily_recurrence"); ok {
+		dailyRecurrence, err2 := expandArmDevTestLabScheduleRecurrenceDaily(d)
+		if err2 != nil {
+			return err2
+		}
+
+		schedule.DailyRecurrence = dailyRecurrence
+	}
+
+	if _, ok := d.GetOk("hourly_recurrence"); ok {
+		hourlyRecurrence, err2 := expandArmDevTestLabScheduleRecurrenceHourly(d)
+		if err2 != nil {
+			return err2
+		}
+
+		schedule.HourlyRecurrence = hourlyRecurrence
+	}
+
+	if _, ok := d.GetOk("notification_settings"); ok {
+		notificationSettings, err2 := expandArmDevTestLabScheduleNotificationSettings(d)
+		if err2 != nil {
+			return err2
+		}
+		schedule.NotificationSettings = notificationSettings
+	}
+
+	_, err := client.CreateOrUpdate(ctx, resGroup, devTestLabName, name, schedule)
+	if err != nil {
+		return err
+	}
+
+	read, err := client.Get(ctx, resGroup, devTestLabName, name, "")
+	if err != nil {
+		return err
+	}
+
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read  Dev Test Lab Schedule %s (resource group %s) ID", name, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmDevTestLabSchedulesRead(d, meta)
+}
+
+func resourceArmDevTestLabSchedulesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).devTestLabSchedulesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	devTestLabName := id.Path["labs"]
+	name := id.Path["schedules"]
+
+	resp, err := client.Get(ctx, resGroup, devTestLabName, name, "")
+
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on Dev Test Lab Schedule %s: %s", name, err)
+	}
+
+	d.Set("name", resp.Name)
+	if location := resp.Location; location != nil {
+		d.Set("location", azureRMNormalizeLocation(*location))
+	}
+	d.Set("dev_test_lab_name", devTestLabName)
+	d.Set("resource_group_name", resGroup)
+
+	if props := resp.ScheduleProperties; props != nil {
+		if timeZoneId := props.TimeZoneID; *timeZoneId != "" {
+			d.Set("time_zone_id", *timeZoneId)
+		}
+
+		switch status := props.Status; status {
+		case dtl.EnableStatusEnabled:
+			d.Set("status", string(dtl.EnableStatusEnabled))
+		case dtl.EnableStatusDisabled:
+			d.Set("status", string(dtl.EnableStatusDisabled))
+		default:
+		}
+
+		if weeklyRecurrence := props.WeeklyRecurrence; weeklyRecurrence != nil {
+			if err := d.Set("weekly_recurrence", flattenAzureRmDevTestLabScheduleRecurrenceWeekly(props.WeeklyRecurrence)); err != nil {
+				return fmt.Errorf("Error setting `weeklyRecurrence`: %#v", err)
+			}
+		}
+
+		if dailyRecurrence := props.DailyRecurrence; dailyRecurrence != nil {
+			if err := d.Set("daily_recurrence", flattenAzureRmDevTestLabScheduleRecurrenceDaily(props.DailyRecurrence)); err != nil {
+				return fmt.Errorf("Error setting `dailyRecurrence`: %#v", err)
+			}
+		}
+
+		if hourlyRecurrence := props.HourlyRecurrence; hourlyRecurrence != nil {
+			if err := d.Set("hourly_recurrence", flattenAzureRmDevTestLabScheduleRecurrenceHourly(props.HourlyRecurrence)); err != nil {
+				return fmt.Errorf("Error setting `dailyRecurrence`: %#v", err)
+			}
+		}
+
+		if err := d.Set("notification_settings", flattenAzureRmDevTestLabScheduleNotificationSettings(props.NotificationSettings)); err != nil {
+			return fmt.Errorf("Error setting `notificationSettings`: %#v", err)
+		}
+	}
+
+	flattenAndSetTags(d, resp.Tags)
+
+	return nil
+}
+
+func resourceArmDevTestLabSchedulesDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).vmExtensionClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resGroup := id.ResourceGroup
+	name := id.Path["schedules"]
+	devTestLabName := id.Path["labs"]
+
+	future, err := client.Delete(ctx, resGroup, devTestLabName, name)
+	if err != nil {
+		return err
+	}
+
+	return future.WaitForCompletionRef(ctx, client.Client)
+}
+
+func expandArmDevTestLabScheduleRecurrenceDaily(d *schema.ResourceData) (*dtl.DayDetails, error) {
+	dailyRecurrenceConfigs := d.Get("daily_recurrence").(*schema.Set).List()
+	dailyRecurrenceConfig := dailyRecurrenceConfigs[0].(map[string]interface{})
+	dailyTime := dailyRecurrenceConfig["time"].(string)
+
+	return &dtl.DayDetails{
+		Time: &dailyTime,
+	}, nil
+
+}
+
+func flattenAzureRmDevTestLabScheduleRecurrenceDaily(dailyRecurrence *dtl.DayDetails) []interface{} {
+	if dailyRecurrence == nil {
+		return []interface{}{}
+	}
+
+	result := make(map[string]interface{})
+
+	if dailyRecurrence.Time != nil {
+		result["time"] = *dailyRecurrence.Time
+	}
+
+	return []interface{}{result}
+}
+
+func expandArmDevTestLabScheduleRecurrenceWeekly(d *schema.ResourceData) (*dtl.WeekDetails, error) {
+	weeklyRecurrenceConfigs := d.Get("weekly_recurrence").(*schema.Set).List()
+	weeklyRecurrenceConfig := weeklyRecurrenceConfigs[0].(map[string]interface{})
+
+	weeklyTime := weeklyRecurrenceConfig["time"].(string)
+
+	weekDays := make([]string, 0)
+	for _, dayItem := range weeklyRecurrenceConfig["week_days"].([]interface{}) {
+		weekDays = append(weekDays, dayItem.(string))
+	}
+
+	return &dtl.WeekDetails{
+		Time:     &weeklyTime,
+		Weekdays: &weekDays,
+	}, nil
+
+}
+
+func flattenAzureRmDevTestLabScheduleRecurrenceWeekly(weeklyRecurrence *dtl.WeekDetails) []interface{} {
+	if weeklyRecurrence == nil {
+		return []interface{}{}
+	}
+
+	result := make(map[string]interface{})
+
+	if weeklyRecurrence.Time != nil {
+		result["time"] = *weeklyRecurrence.Time
+	}
+
+	weekDays := make([]string, 0)
+	if w := weeklyRecurrence.Weekdays; w != nil {
+		weekDays = *w
+	}
+	result["week_days"] = weekDays
+
+	return []interface{}{result}
+}
+
+func expandArmDevTestLabScheduleRecurrenceHourly(d *schema.ResourceData) (*dtl.HourDetails, error) {
+	hourlyRecurrenceConfigs := d.Get("hourly_recurrence").(*schema.Set).List()
+	hourlyRecurrenceConfig := hourlyRecurrenceConfigs[0].(map[string]interface{})
+	hourlyMinute := int32(hourlyRecurrenceConfig["minute"].(int))
+
+	return &dtl.HourDetails{
+		Minute: &hourlyMinute,
+	}, nil
+
+}
+
+func flattenAzureRmDevTestLabScheduleRecurrenceHourly(hourlyRecurrence *dtl.HourDetails) []interface{} {
+	if hourlyRecurrence == nil {
+		return []interface{}{}
+	}
+
+	result := make(map[string]interface{})
+
+	if hourlyRecurrence.Minute != nil {
+		result["minute"] = *hourlyRecurrence.Minute
+	}
+
+	return []interface{}{result}
+}
+
+func expandArmDevTestLabScheduleNotificationSettings(d *schema.ResourceData) (*dtl.NotificationSettings, error) {
+
+	notificationSettingsConfigs := d.Get("notification_settings").(*schema.Set).List()
+	notificationSettingsConfig := notificationSettingsConfigs[0].(map[string]interface{})
+	webhookUrl := notificationSettingsConfig["webhook_url"].(string)
+	timeInMinutes := int32(notificationSettingsConfig["time_in_minutes"].(int))
+
+	var notificationStatus dtl.NotificationStatus
+	switch status := notificationSettingsConfig["status"]; status {
+	case string(dtl.NotificationStatusEnabled):
+		notificationStatus = dtl.NotificationStatusEnabled
+	case string(dtl.NotificationStatusDisabled):
+		notificationStatus = dtl.NotificationStatusDisabled
+	default:
+	}
+
+	return &dtl.NotificationSettings{
+		WebhookURL:    &webhookUrl,
+		TimeInMinutes: &timeInMinutes,
+		Status:        notificationStatus,
+	}, nil
+
+}
+
+func flattenAzureRmDevTestLabScheduleNotificationSettings(notificationSettings *dtl.NotificationSettings) []interface{} {
+	if notificationSettings == nil {
+		return []interface{}{}
+	}
+
+	result := make(map[string]interface{})
+
+	if notificationSettings.WebhookURL != nil {
+		result["webhook_url"] = *notificationSettings.WebhookURL
+	}
+
+	if notificationSettings.TimeInMinutes != nil {
+		result["time_in_minutes"] = *notificationSettings.TimeInMinutes
+	}
+
+	if string(notificationSettings.Status) != "" {
+
+		var notificationStatus string
+		switch notificationSettings.Status {
+		case dtl.NotificationStatusEnabled:
+			notificationStatus = string(dtl.NotificationStatusEnabled)
+		case dtl.NotificationStatusDisabled:
+			notificationStatus = string(dtl.NotificationStatusDisabled)
+		default:
+		}
+		result["status"] = notificationStatus
+	}
+
+	return []interface{}{result}
+}

--- a/azurerm/resource_arm_dev_test_lab_schedule_test.go
+++ b/azurerm/resource_arm_dev_test_lab_schedule_test.go
@@ -1,0 +1,561 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccAzureRMDevTestLabSchedule_autoShutdownPropertyRulesCheck(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	missingRecurrenceConfig := testAccAzureRMDevTestLabSchedule_autoShutdownMissingRecurrence(ri, location)
+	missingDailyRecurrenceConfig := testAccAzureRMDevTestLabSchedule_autoShutdownMissingDailyRecurrence(ri, location)
+	incorrectTaskNameConfig := testAccAzureRMDevTestLabSchedule_autoShutdownIncorrectTaskName(ri, location)
+	taskNameTaskTypeMismatchConfig := testAccAzureRMDevTestLabSchedule_autoShutdowntaskNameTaskTypeMismatch(ri, location)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDevTestLabScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      missingRecurrenceConfig,
+				ExpectError: regexp.MustCompile("MissingRequiredProperties"),
+			},
+			{
+				Config:      missingDailyRecurrenceConfig,
+				ExpectError: regexp.MustCompile("MissingRequiredProperty"),
+			},
+			{
+				Config:      incorrectTaskNameConfig,
+				ExpectError: regexp.MustCompile("IncorrectResourceName"),
+			},
+			{
+				Config:      taskNameTaskTypeMismatchConfig,
+				ExpectError: regexp.MustCompile("IncorrectResourceName"),
+			},
+		},
+	})
+
+}
+
+func TestAccAzureRMDevTestLabSchedule_autoShutdownBasic(t *testing.T) {
+	resourceName := "azurerm_dev_test_lab_schedule.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	preConfig := testAccAzureRMDevTestLabSchedule_autoShutdownBasic(ri, location)
+	postConfig := testAccAzureRMDevTestLabSchedule_autoShutdownBasicUpdate(ri, location)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDevTestLabScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDevTestLabScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Disabled"),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.2350700632.status", "Disabled"),
+					resource.TestCheckResourceAttr(resourceName, "daily_recurrence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "daily_recurrence.2029622669.time", "0100"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"task_type"},
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDevTestLabScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.941185200.status", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.941185200.time_in_minutes", "30"),
+					resource.TestCheckResourceAttr(resourceName, "notification_settings.941185200.webhook_url", "https://www.bing.com/2/4"),
+					resource.TestCheckResourceAttr(resourceName, "daily_recurrence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "daily_recurrence.3175988578.time", "0900"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMDevTestLabSchedule_autoStartupBasic(t *testing.T) {
+	resourceName := "azurerm_dev_test_lab_schedule.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	preConfig := testAccAzureRMDevTestLabSchedule_autoStartupBasic(ri, location)
+	postConfig := testAccAzureRMDevTestLabSchedule_autoStartupBasicUpdate(ri, location)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDevTestLabScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDevTestLabScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Disabled"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.504166703.time", "1100"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.504166703.week_days.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.504166703.week_days.1", "Tuesday"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"task_type"},
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDevTestLabScheduleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "status", "Enabled"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.4041497624.time", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.4041497624.week_days.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "weekly_recurrence.4041497624.week_days.1", "Thursday"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMDevTestLabSchedule_concurrent(t *testing.T) {
+	firstResourceName := "azurerm_dev_test_lab_schedule.test"
+	secondResourceName := "azurerm_dev_test_lab_schedule.test2"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMDevTestLabSchedule_concurrent(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDevTestLabScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDevTestLabScheduleExists(firstResourceName),
+					testCheckAzureRMDevTestLabScheduleExists(secondResourceName),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMDevTestLabScheduleExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		devTestLabName := rs.Primary.Attributes["dev_test_lab_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		client := testAccProvider.Meta().(*ArmClient).devTestLabSchedulesClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := client.Get(ctx, resourceGroup, devTestLabName, name, "")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on devTestLabSchedulesClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Dev Test Lab Schedule %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMDevTestLabScheduleDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ArmClient).devTestLabSchedulesClient
+	ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_dev_test_lab_schedule" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		devTestLabName := rs.Primary.Attributes["azurerm_dev_test_lab"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := client.Get(ctx, resourceGroup, devTestLabName, name, "")
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Dev Test Lab Schedule still exists:\n%#v", resp.ScheduleProperties)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureRMDevTestLabSchedule_autoShutdowntaskNameTaskTypeMismatch(rInt int, location string) string {
+	return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name     = "acctestrg-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_dev_test_lab" "test" {
+    name                = "acctdtl-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    
+  }
+  
+  resource "azurerm_dev_test_lab_schedule" "test" {
+    name = "LabVmsShutdown"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+    daily_recurrence  {
+        time = "0100"
+    }
+    time_zone_id = "India Standard Time"
+    task_type = "LabVmsStartupTask"
+    notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+  }
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_autoShutdownIncorrectTaskName(rInt int, location string) string {
+	return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name     = "acctestrg-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_dev_test_lab" "test" {
+    name                = "acctdtl-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    
+  }
+  
+  resource "azurerm_dev_test_lab_schedule" "test" {
+    name = "NotLabVmsShutdown"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+    daily_recurrence  {
+        time = "0100"
+    }
+    time_zone_id = "India Standard Time"
+    task_type = "LabVmsShutdownTask"
+    notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+  }
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_autoShutdownMissingRecurrence(rInt int, location string) string {
+	return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name     = "acctestrg-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_dev_test_lab" "test" {
+    name                = "acctdtl-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    
+  }
+  
+  resource "azurerm_dev_test_lab_schedule" "test" {
+    name = "LabVmsShutdown"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+  
+    time_zone_id = "India Standard Time"
+    task_type = "LabVmsShutdownTask"
+    notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+  }
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_autoShutdownMissingDailyRecurrence(rInt int, location string) string {
+	return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name     = "acctestrg-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_dev_test_lab" "test" {
+    name                = "acctdtl-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    
+  }
+  
+  resource "azurerm_dev_test_lab_schedule" "test" {
+    name = "LabVmsShutdown"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+  
+    time_zone_id = "India Standard Time"
+		task_type = "LabVmsShutdownTask"
+		
+		weekly_recurrence {
+			time = "1100"
+			week_days = ["Monday", "Tuesday"]
+	}
+
+    notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+  }
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_autoShutdownBasic(rInt int, location string) string {
+	return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name     = "acctestrg-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_dev_test_lab" "test" {
+    name                = "acctdtl-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    
+  }
+  
+  resource "azurerm_dev_test_lab_schedule" "test" {
+    name = "LabVmsShutdown"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+    daily_recurrence  {
+        time = "0100"
+    }
+    time_zone_id = "India Standard Time"
+    task_type = "LabVmsShutdownTask"
+    notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+  }
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_autoShutdownBasicUpdate(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_dev_test_lab" "test" {
+  name                = "acctdtl-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  
+}
+
+resource "azurerm_dev_test_lab_schedule" "test" {
+  name = "LabVmsShutdown"
+  status = "Enabled"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+  daily_recurrence  {
+      time = "0900"
+  }
+  time_zone_id = "India Standard Time"
+  task_type = "LabVmsShutdownTask"
+  notification_settings {
+    time_in_minutes = 30
+    webhook_url = "https://www.bing.com/2/4"
+    status = "Enabled"
+  }
+tags = {
+    environment = "Production"
+  }
+}
+
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_autoStartupBasic(rInt int, location string) string {
+	return fmt.Sprintf(`
+  resource "azurerm_resource_group" "test" {
+    name     = "acctestrg-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_dev_test_lab" "test" {
+    name                = "acctdtl-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    
+  }
+  
+  resource "azurerm_dev_test_lab_schedule" "test" {
+    name = "LabVmAutoStart"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+		weekly_recurrence {
+			time = "1100"
+			week_days = ["Monday", "Tuesday"]
+		}
+
+    time_zone_id = "India Standard Time"
+    task_type = "LabVmsStartupTask"
+		
+		notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+  }
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_autoStartupBasicUpdate(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_dev_test_lab" "test" {
+  name                = "acctdtl-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  
+}
+
+resource "azurerm_dev_test_lab_schedule" "test" {
+  name = "LabVmAutoStart"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+		dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+		weekly_recurrence {
+			time = "1000"
+			week_days = ["Wednesday", "Thursday", "Friday"]
+		}
+
+    time_zone_id = "India Standard Time"
+		task_type = "LabVmsStartupTask"
+		
+    notification_settings {
+ 
+		}
+
+		status = "Enabled"
+		
+    tags = {
+      environment = "Production"
+    }
+}
+
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMDevTestLabSchedule_concurrent(rInt int, location string) string {
+	return fmt.Sprintf(`
+	resource "azurerm_resource_group" "test" {
+    name     = "acctestrg-%d"
+    location = "%s"
+  }
+  
+  resource "azurerm_dev_test_lab" "test" {
+    name                = "acctdtl-%d"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    
+  }
+  
+  resource "azurerm_dev_test_lab_schedule" "test" {
+    name = "LabVmAutoStart"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+		weekly_recurrence {
+			time = "1100"
+			week_days = ["Monday", "Tuesday"]
+		}
+
+    time_zone_id = "India Standard Time"
+    task_type = "LabVmsStartupTask"
+		
+		notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+	}
+	
+	resource "azurerm_dev_test_lab_schedule" "test2" {
+    name = "LabVmsShutdown"
+    location            = "${azurerm_resource_group.test.location}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+    daily_recurrence  {
+        time = "0100"
+    }
+    time_zone_id = "India Standard Time"
+    task_type = "LabVmsShutdownTask"
+    notification_settings {
+
+    }
+
+    tags = {
+      environment = "Production"
+    }
+  }
+`, rInt, location, rInt)
+}

--- a/website/docs/r/dev_test_lab_schedule.html.markdown
+++ b/website/docs/r/dev_test_lab_schedule.html.markdown
@@ -1,0 +1,120 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dev_test_lab_schedule"
+sidebar_current: "docs-azurerm-dev-test-lab-schedule"
+description: |-
+    Manages automated startup and shutdown schedules for Azure Dev Test Lab.
+---
+
+# azurerm_dev_test_lab_schedule
+
+Manages automated startup and shutdown schedules for Azure Dev Test Lab.
+
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG"
+  location = "West US"
+}
+
+resource "azurerm_dev_test_lab" "test" {
+  name                = "acctestDTL"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+}
+
+resource "azurerm_dev_test_lab_schedule" "test" {
+  name = "LabVmAutoStart"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dev_test_lab_name = "${azurerm_dev_test_lab.test.name}"
+  
+  weekly_recurrence {
+    time      = "1100"
+    week_days = ["Monday", "Tuesday"]
+  }
+
+  time_zone_id = "Pacific Standard Time"
+  task_type = "LabVmsStartupTask"
+
+  notification_settings {
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the dev test lab schedule. Valid value for name
+    depends on the `task_type`. For instance for task_type `LabVmsStartupTask`
+    the name needs to be `LabVmAutoStart`
+
+* `location` - (Required) The location where the schedule is created. Changing
+    this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the dev test lab schedule. Changing this forces a new resource to be
+    created.
+
+* `dev_test_lab_name` - (Required) The name of the dev test lab. Changing
+    this forces a new resource to be created.
+
+* `status` - The status of this schedule. Possible values are `Enabled`
+    and `Disabled`. Defaults to `Disabled`.
+
+* `task_type` - (Required) The task type of the schedule. Possible values include
+    `LabVmsShutdownTask` and `LabVmAutoStart`.
+
+* `time_zone_id` - (Required) The time zone ID (e.g. Pacific Standard time)
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `weekly_recurrence` - block supports the following:
+
+* `time` - The time when the schedule takes effect.
+
+* `week_days` -  A list of days that this schedule takes effect . Possible values
+    include `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
+
+---
+
+A `daily_recurrence` - block supports the following:
+
+* `time` - The time each day when the schedule takes effect.
+
+---
+
+A `notification_settings` - (Required)  - block supports the following:
+
+* `status` - The status of the notification. Possible values are `Enabled`
+    and `Disabled`. Defaults to `Disabled`
+
+* `time_in_minutes` - Time in minutes before event at which notification
+    will be sent.
+
+* `webhook_url` - The webhook URL to which the notification will be sent.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Dev Test Lab Schedule ID.
+
+## Import
+
+Dev Test Lab Schedule can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_dev_test_lab_schedule.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.DevTestLab/labs/myDevTestLab/schedules/labvmautostart
+```


### PR DESCRIPTION
This pull request is to fix issue #2334, It has changes to add new resource provider **azurerm_dev_test_lab_schedule**.

**Additional Points**
* Resource provider has been created based on [microsoft.devtestlab/2016-05-15/schedules](https://docs.microsoft.com/en-us/azure/templates/microsoft.devtestlab/2016-05-15/schedules)