### PR TITLE
Fix build errors

### DIFF
--- a/azurerm/data_source_redis_cache.go
+++ b/azurerm/data_source_redis_cache.go
@@ -193,7 +193,7 @@ func dataSourceArmRedisCache() *schema.Resource {
 
 func dataSourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).redisClient
+	client := meta.(*ArmClient).redis.Client
 
 	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
@@ -244,7 +244,7 @@ func dataSourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error setting `redis_configuration`: %+v", err)
 	}
 
-	patchSchedulesClient := meta.(*ArmClient).redisPatchSchedulesClient
+	patchSchedulesClient := meta.(*ArmClient).redis.PatchSchedulesClient
 
 	schedule, err := patchSchedulesClient.Get(ctx, resourceGroup, name)
 	if err == nil {


### PR DESCRIPTION
Code tweaks to fix build errors:

```
$ make build
==> Checking that code complies with gofmt requirements...
go install
# github.com/terraform-providers/terraform-provider-azurerm/azurerm
azurerm/data_source_redis_cache.go:196:29: meta.(*ArmClient).redisClient undefined (type *ArmClient has no field or method redisClient)
azurerm/data_source_redis_cache.go:247:43: meta.(*ArmClient).redisPatchSchedulesClient undefined (type *ArmClient has no field or method redisPatchSchedulesClient)
GNUmakefile:13: recipe for target 'build' failed
make: *** [build] Error 2
```

Changes based on looking at the history [here](https://github.com/terraform-providers/terraform-provider-azurerm/commit/08396856545140527628fb2c778ea23ab39ef816)