### PR TITLE
Fix the crash point for APIM client registration

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -503,7 +503,6 @@ func (c *ArmClient) registerAPIManagementClients(endpoint, subscriptionId string
 
 	loggerClient := apimanagement.NewLoggerClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&loggerClient.Client, auth)
-	c.apimgmt.LoggerClient = loggerClient
 
 	policyClient := apimanagement.NewPolicyClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&policyClient.Client, auth)
@@ -552,6 +551,7 @@ func (c *ArmClient) registerAPIManagementClients(endpoint, subscriptionId string
 		CertificatesClient:         certificatesClient,
 		GroupClient:                groupsClient,
 		GroupUsersClient:           groupUsersClient,
+		LoggerClient:               loggerClient,
 		PolicyClient:               policyClient,
 		ServiceClient:              serviceClient,
 		SignInClient:               signInClient,


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3325780]

goroutine 12 [running]:
github.com/terraform-providers/terraform-provider-azurerm/azurerm.(*ArmClient).registerAPIManagementClients(0xc000736000, 0x432e83d, 0x1d, 0xc000048054, 0x24, 0x4ae49a0, 0xc000179e80)

```