### PR TITLE
Fix for #3563

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -501,10 +501,6 @@ func (c *ArmClient) registerAPIManagementClients(endpoint, subscriptionId string
 	groupUsersClient := apimanagement.NewGroupUserClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&groupUsersClient.Client, auth)
 
-	loggerClient := apimanagement.NewLoggerClientWithBaseURI(endpoint, subscriptionId)
-	c.configureClient(&loggerClient.Client, auth)
-	c.apimgmt.LoggerClient = loggerClient
-
 	policyClient := apimanagement.NewPolicyClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&policyClient.Client, auth)
 
@@ -565,6 +561,10 @@ func (c *ArmClient) registerAPIManagementClients(endpoint, subscriptionId string
 		SubscriptionsClient:        subscriptionsClient,
 		UsersClient:                usersClient,
 	}
+
+	loggerClient := apimanagement.NewLoggerClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&loggerClient.Client, auth)
+	c.apimgmt.LoggerClient = loggerClient
 }
 
 func (c *ArmClient) registerAppInsightsClients(endpoint, subscriptionId string, auth autorest.Authorizer) {


### PR DESCRIPTION
This PR fixes #3563 by moving logger assignation after the api management configuration.