### PR TITLE
Support for Windows Container in Azure App Service

### DIFF
--- a/azurerm/data_source_app_service_plan.go
+++ b/azurerm/data_source_app_service_plan.go
@@ -73,6 +73,11 @@ func dataSourceAppServicePlan() *schema.Resource {
 				Computed: true,
 			},
 
+			"is_xenon": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"tags": tagsForDataSourceSchema(),
 		},
 	}
@@ -99,6 +104,7 @@ func dataSourceAppServicePlanRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)
 	d.Set("kind", resp.Kind)
+	d.Set("is_xenon", resp.IsXenon)
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azureRMNormalizeLocation(*location))

--- a/azurerm/data_source_app_service_plan_test.go
+++ b/azurerm/data_source_app_service_plan_test.go
@@ -146,26 +146,26 @@ data "azurerm_app_service_plan" "test" {
 func testAccDataSourceAppServicePlan_basicWindowsContainer(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+	name     = "acctestRG-%d"
+	location = "%s"
 }
 
 resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+	name                = "acctestASP-%d"
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
 	is_xenon            = true
 	kind                = "xenon"
 
-  sku {
-    tier = "PremiumContainer"
-    size = "PC2"
-  }
+	sku {
+		tier = "PremiumContainer"
+		size = "PC2"
+	}
 }
 
 data "azurerm_app_service_plan" "test" {
-  name                = "${azurerm_app_service_plan.test.name}"
-  resource_group_name = "${azurerm_app_service_plan.test.resource_group_name}"
+	name                = "${azurerm_app_service_plan.test.name}"
+	resource_group_name = "${azurerm_app_service_plan.test.resource_group_name}"
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/data_source_app_service_plan_test.go
+++ b/azurerm/data_source_app_service_plan_test.go
@@ -61,6 +61,29 @@ func TestAccDataSourceAzureRMAppServicePlan_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMAppServicePlan_basicWindowsContainer(t *testing.T) {
+	dataSourceName := "data.azurerm_app_service_plan.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppServicePlan_basicWindowsContainer(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "kind", "xenon"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.tier", "PremiumContainer"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku.0.size", "PC2"),
+					resource.TestCheckResourceAttr(dataSourceName, "is_xenon", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAppServicePlan_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -110,6 +133,33 @@ resource "azurerm_app_service_plan" "test" {
 
   tags = {
     environment = "Test"
+  }
+}
+
+data "azurerm_app_service_plan" "test" {
+  name                = "${azurerm_app_service_plan.test.name}"
+  resource_group_name = "${azurerm_app_service_plan.test.resource_group_name}"
+}
+`, rInt, location, rInt)
+}
+
+func testAccDataSourceAppServicePlan_basicWindowsContainer(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	is_xenon            = true
+	kind                = "xenon"
+
+  sku {
+    tier = "PremiumContainer"
+    size = "PC2"
   }
 }
 

--- a/azurerm/data_source_app_service_test.go
+++ b/azurerm/data_source_app_service_test.go
@@ -189,6 +189,26 @@ func TestAccDataSourceAzureRMAppService_minTls(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMAppService_basicWindowsContainer(t *testing.T) {
+	dataSourceName := "data.azurerm_app_service.test"
+	rInt := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppService_basicWindowsContainer(rInt, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "site_config.0.windows_fx_version", "DOCKER|mcr.microsoft.com/azure-app-service/samples/aspnethelloworld:latest"),
+					resource.TestCheckResourceAttr(dataSourceName, "app_settings.DOCKER_REGISTRY_SERVER_URL", "https://mcr.microsoft.com"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAppService_basic(rInt int, location string) string {
 	config := testAccAzureRMAppService_basic(rInt, location)
 	return fmt.Sprintf(`
@@ -287,6 +307,18 @@ data "azurerm_app_service" "test" {
 
 func testAccDataSourceAppService_minTls(rInt int, location string) string {
 	config := testAccAzureRMAppService_minTls(rInt, location, "1.1")
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_app_service" "test" {
+  name                = "${azurerm_app_service.test.name}"
+  resource_group_name = "${azurerm_app_service.test.resource_group_name}"
+}
+`, config)
+}
+
+func testAccDataSourceAppService_basicWindowsContainer(rInt int, location string) string {
+	config := testAccAzureRMAppService_basicWindowsContainer(rInt, location)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -398,7 +398,14 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 						string(web.FtpsOnly),
 					}, false),
 				},
+
 				"linux_fx_version": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+				},
+
+				"windows_fx_version": {
 					Type:     schema.TypeString,
 					Optional: true,
 					Computed: true,
@@ -560,6 +567,11 @@ func SchemaAppServiceDataSourceSiteConfig() *schema.Schema {
 				},
 
 				"linux_fx_version": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+
+				"windows_fx_version": {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
@@ -1051,6 +1063,10 @@ func ExpandAppServiceSiteConfig(input interface{}) web.SiteConfig {
 		siteConfig.LinuxFxVersion = utils.String(v.(string))
 	}
 
+	if v, ok := config["windows_fx_version"]; ok {
+		siteConfig.WindowsFxVersion = utils.String(v.(string))
+	}
+
 	if v, ok := config["http2_enabled"]; ok {
 		siteConfig.HTTP20Enabled = utils.Bool(v.(bool))
 	}
@@ -1237,6 +1253,10 @@ func FlattenAppServiceSiteConfig(input *web.SiteConfig) []interface{} {
 
 	if input.LinuxFxVersion != nil {
 		result["linux_fx_version"] = *input.LinuxFxVersion
+	}
+
+	if input.WindowsFxVersion != nil {
+		result["windows_fx_version"] = *input.WindowsFxVersion
 	}
 
 	if input.VnetName != nil {

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -144,6 +144,11 @@ func resourceArmAppServicePlan() *schema.Resource {
 				Computed: true,
 			},
 
+			"is_xenon": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -177,6 +182,13 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 
 	sku := expandAzureRmAppServicePlanSku(d)
 	properties := expandAppServicePlanProperties(d)
+
+	isXenon := d.Get("is_xenon").(bool)
+	properties.IsXenon = &isXenon
+
+	if kind == "xenon" && !isXenon {
+		return fmt.Errorf("Creating or updating App Service Plan %q (Resource Group %q): when kind is set to xenon, is_xenon property should be set to true", name, resGroup)
+	}
 
 	appServicePlan := web.AppServicePlan{
 		Location:                 &location,

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -46,11 +46,14 @@ func resourceArmAppServicePlan() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					// @tombuildsstuff: I believe `app` is the older representation of `Windows`
 					// thus we need to support it to be able to import resources without recreating them.
+					// @jcorioland: new SKU and kind 'xenon' have been added for Windows Containers support
+					// https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-windows-container-support-in-azure-app-service/
 					"App",
 					"elastic",
 					"FunctionApp",
 					"Linux",
 					"Windows",
+					"xenon",
 				}, true),
 				DiffSuppressFunc: suppress.CaseDifference,
 			},

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -272,6 +272,7 @@ func resourceArmAppServicePlanRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("location", azureRMNormalizeLocation(*location))
 	}
 	d.Set("kind", resp.Kind)
+	d.Set("is_xenon", resp.IsXenon)
 
 	if props := resp.AppServicePlanProperties; props != nil {
 		if err := d.Set("properties", flattenAppServiceProperties(props)); err != nil {

--- a/azurerm/resource_arm_app_service_plan_test.go
+++ b/azurerm/resource_arm_app_service_plan_test.go
@@ -627,21 +627,21 @@ resource "azurerm_app_service_plan" "test" {
 func testAccAzureRMAppServicePlan_basicWindowsContainer(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+	name     = "acctestRG-%d"
+	location = "%s"
 }
 
 resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+	name                = "acctestASP-%d"
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
 	kind                = "xenon"
 	is_xenon            = true
 
-  sku {
-    tier = "PremiumContainer"
-    size = "PC2"
-  }
+	sku {
+		tier = "PremiumContainer"
+		size = "PC2"
+	}
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_app_service_plan_test.go
+++ b/azurerm/resource_arm_app_service_plan_test.go
@@ -294,6 +294,34 @@ func TestAccAzureRMAppServicePlan_premiumConsumptionPlan(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServicePlan_basicWindowsContainer(t *testing.T) {
+	resourceName := "azurerm_app_service_plan.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServicePlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServicePlan_basicWindowsContainer(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServicePlanExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "kind", "xenon"),
+					resource.TestCheckResourceAttr(resourceName, "is_xenon", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sku.0.tier", "PremiumContainer"),
+					resource.TestCheckResourceAttr(resourceName, "sku.0.size", "PC2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMAppServicePlanDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*ArmClient).appServicePlansClient
 
@@ -591,6 +619,28 @@ resource "azurerm_app_service_plan" "test" {
   sku {
     tier = "ElasticPremium"
     size = "EP1"
+  }
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMAppServicePlan_basicWindowsContainer(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	kind                = "xenon"
+	is_xenon            = true
+
+  sku {
+    tier = "PremiumContainer"
+    size = "PC2"
   }
 }
 `, rInt, location, rInt)

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -3657,38 +3657,38 @@ resource "azurerm_app_service" "test" {
 func testAccAzureRMAppService_basicWindowsContainer(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+	name     = "acctestRG-%d"
+	location = "%s"
 }
 
 resource "azurerm_app_service_plan" "test" {
-  name                = "acctestASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+	name                = "acctestASP-%d"
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
 	is_xenon            = true
 	kind                = "xenon"
 
-  sku {
-    tier = "PremiumContainer"
-    size = "PC2"
-  }
+	sku {
+		tier = "PremiumContainer"
+		size = "PC2"
+	}
 }
 
 resource "azurerm_app_service" "test" {
-  name                = "acctestAS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+	name                = "acctestAS-%d"
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
 	app_service_plan_id = "${azurerm_app_service_plan.test.id}"
 	
 	site_config {
-    windows_fx_version = "DOCKER|mcr.microsoft.com/azure-app-service/samples/aspnethelloworld:latest"
+	  windows_fx_version = "DOCKER|mcr.microsoft.com/azure-app-service/samples/aspnethelloworld:latest"
 	}
 	
 	app_settings = {
-    "DOCKER_REGISTRY_SERVER_URL" = "https://mcr.microsoft.com",
-    "DOCKER_REGISTRY_SERVER_USERNAME" = "",
-    "DOCKER_REGISTRY_SERVER_PASSWORD" = "",
-  }
+		"DOCKER_REGISTRY_SERVER_URL" = "https://mcr.microsoft.com",
+		"DOCKER_REGISTRY_SERVER_USERNAME" = "",
+		"DOCKER_REGISTRY_SERVER_PASSWORD" = "",
+	}
 }
 `, rInt, location, rInt, rInt)
 }

--- a/examples/app-service/windows-container/README.md
+++ b/examples/app-service/windows-container/README.md
@@ -1,0 +1,3 @@
+## Example: App Service configured for Windows Container
+
+This example provisions an App Service inside an App Service Plan which is configured to run a Windows Container.

--- a/examples/app-service/windows-container/main.tf
+++ b/examples/app-service/windows-container/main.tf
@@ -1,0 +1,34 @@
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  kind                = "xenon"
+  is_xenon            = true
+
+  sku {
+    tier = "PremiumContainer"
+    size = "PC2"
+  }
+}
+
+resource "azurerm_app_service" "example" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.example.id}"
+
+  site_config {
+    windows_fx_version = "DOCKER|mcr.microsoft.com/azure-app-service/samples/aspnethelloworld:latest"
+  }
+
+  app_settings = {
+    "DOCKER_REGISTRY_SERVER_URL" = "https://mcr.microsoft.com",
+    "DOCKER_REGISTRY_SERVER_USERNAME" = "",
+    "DOCKER_REGISTRY_SERVER_PASSWORD" = "",
+  }
+}

--- a/examples/app-service/windows-container/outputs.tf
+++ b/examples/app-service/windows-container/outputs.tf
@@ -1,0 +1,3 @@
+output "website_url" {
+  value = "${azurerm_app_service.example.default_site_hostname}"
+}

--- a/examples/app-service/windows-container/variables.tf
+++ b/examples/app-service/windows-container/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -111,6 +111,8 @@ A `ip_restriction` block exports the following:
 
 * `linux_fx_version` - Linux App Framework and version for the AppService.
 
+* `windows_fx_version` - Windows Container Docker Image for the AppService.
+
 * `local_mysql_enabled` - Is "MySQL In App" Enabled? This runs a local MySQL instance with your app and shares resources from the App Service plan.
 
 * `managed_pipeline_mode` - The Managed Pipeline Mode used in this App Service.

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -44,6 +44,8 @@ output "app_service_plan_id" {
 
 * `maximum_number_of_workers` - The maximum number of workers supported with the App Service Plan's sku.
 
+* `is_xenon` - A flag that indicates if it's a xenon plan (support for Windows Container)
+
 ---
 
 A `sku` block supports the following:

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -139,6 +139,8 @@ A `site_config` block supports the following:
 
 * `linux_fx_version` - (Optional) Linux App Framework and version for the App Service. Possible options are a Docker container (`DOCKER|<user/image:tag>`), a base-64 encoded Docker Compose file (`COMPOSE|${filebase64("compose.yml")}`) or a base-64 encoded Kubernetes Manifest (`KUBE|${filebase64("kubernetes.yml")}`).
 
+* `windows_fx_version` - (Optional) The Windows Docker container image (`DOCKER|<user/image:tag>`)
+
 Additional examples of how to run Containers via the `azurerm_app_service` resource can be found in [the `./examples/app-service` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/app-service).
 
 * `managed_pipeline_mode` - (Optional) The Managed Pipeline Mode. Possible values are `Integrated` and `Classic`. Defaults to `Integrated`.

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -73,6 +73,28 @@ resource "azurerm_app_service_plan" "test" {
 }
 ```
 
+## Example Usage (Windows Container)
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "api-rg-pro"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "api-appserviceplan-pro"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  kind                = "xenon"
+  is_xenon            = true
+
+  sku {
+    tier = "PremiumContainer"
+    size = "PC2"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
This PR brings support for Windows Container preview feature in Azure App Service.
It fixes #2999.

- [x] support windows container in `resource_arm_app_service_plan` and `resource_arm_app_service`
- [x] support windows container in `data_source_app_service_plan` and `data_source_app_service`
- [x] tests
- [x] documentation
- [x] example