### PR TITLE
Update virtual_machine_scale_set.html.markdown

### DIFF
--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -444,7 +444,7 @@ output "principal_id" {
 `public_ip_address_configuration` supports the following:
 
 * `name` - (Required) The name of the public ip address configuration
-* `idle_timeout` - (Required) The idle timeout in minutes. This value must be between 4 and 32.
+* `idle_timeout` - (Required) The idle timeout in minutes. This value must be between 4 and 30.
 * `domain_name_label` - (Required) The domain name label for the dns settings.
 
 `storage_profile_os_disk` supports the following:


### PR DESCRIPTION
Using a value of 32 returns the following error -- `Public IP address test_name has invalid Idle Timeout. The value must be between 4 and 30.`