### PR TITLE
Update azurerm_resource_group documentation

### DIFF
--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -37,11 +37,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments above, the following attributes are exported:
 
 * `id` - The resource group ID.
-
-* `name` - The name of the resource group.
 
 ## Import
 

--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -41,6 +41,7 @@ The following attributes are exported:
 
 * `id` - The resource group ID.
 
+* `name` - The name of the resource group.
 
 ## Import
 


### PR DESCRIPTION
The  `name` attribute can be exported, but the documentation don't mention it yet.