### PR TITLE
Add support for creation_option "Restore" on managed disks (issue #3421)

### DIFF
--- a/azurerm/resource_arm_managed_disk.go
+++ b/azurerm/resource_arm_managed_disk.go
@@ -60,6 +60,7 @@ func resourceArmManagedDisk() *schema.Resource {
 					string(compute.Empty),
 					string(compute.FromImage),
 					string(compute.Import),
+					string(compute.Restore),
 				}, true),
 			},
 
@@ -183,7 +184,7 @@ func resourceArmManagedDiskCreateUpdate(d *schema.ResourceData, meta interface{}
 		} else {
 			return fmt.Errorf("[ERROR] source_uri must be specified when create_option is `%s`", compute.Import)
 		}
-	} else if strings.EqualFold(createOption, string(compute.Copy)) {
+	} else if strings.EqualFold(createOption, string(compute.Copy)) || strings.EqualFold(createOption, string(compute.Restore)) {
 		if sourceResourceId := d.Get("source_resource_id").(string); sourceResourceId != "" {
 			createDisk.CreationData.SourceResourceID = &sourceResourceId
 		} else {

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -89,10 +89,12 @@ The following arguments are supported:
  * `Empty` - Create an empty managed disk.
  * `Copy` - Copy an existing managed disk or snapshot (specified with `source_resource_id`).
  * `FromImage` - Copy a Platform Image (specified with `image_reference_id`)
+ * `Restore` - Set by Azure Backup or Site Recovery on a restored disk (specified with `source_resource_id`).
 
 * `source_uri` - (Optional) URI to a valid VHD file to be used when `create_option` is `Import`.
 
-* `source_resource_id` - (Optional) ID of an existing managed disk to copy when `create_option` is `Copy`.
+* `source_resource_id` - (Optional) ID of an existing managed disk to copy `create_option` is `Copy`
+    or the recovery point to restore when `create_option` is `Restore`
 
 * `image_reference_id` - (Optional) ID of an existing platform/marketplace disk image to copy when `create_option` is `FromImage`.
 


### PR DESCRIPTION
First time contributing and go rookie so I'm open to feedback and let me know if I'm violating any guidelines.

Took a stab at issue #3421. The documentation doesn't really document the Restore option other than that it is a valid value for createOption. Based on this issue and my own experience in our Azure environment, however, this gets set when a disk is restored from backup or created during failover in Azure Site Recovery. Along with it, the sourceResourceId gets set.

For reference, below is some sanitized output from the Azure CLI of a disk created during Site Recovery failover (Azure to Azure):

```
az disk show -g rg -n disk --query creationData
{
  "createOption": "Restore",
  "imageReference": null,
  "sourceResourceId": "/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-ASRReplica/bookmark/16db43c8-f886-48df-934a-3437e5f4f75c",
  "sourceUri": null,
  "storageAccountId": null
}
```

Acceptance tests are difficult for this one. I'm not sure if it is actually possible to create a disk using the "Restore" option using the normal disk API since I cannot find IDs in that format anywhere within Azure and it is not documented in the API docs (https://docs.microsoft.com/de-de/azure/templates/microsoft.compute/2018-09-30/disks#creationdata-object).

Fixes #3421 