### PR TITLE
website: Update the nav sidebar for easier browsing

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -58,7 +58,7 @@
 
             <li<%= sidebar_current("docs-azurerm-datasource") %>>
               <a href="#">Data Sources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-datasource-api-management-x") %>>
                     <a href="/docs/providers/azurerm/d/api_management.html">azurerm_api_management</a>
                 </li>
@@ -110,7 +110,7 @@
                 <li<%= sidebar_current("docs-azurerm-datasource-automation-variable-string") %>>
                     <a href="/docs/providers/azurerm/d/automation_variable_string.html">azurerm_automation_variable_string</a>
                 </li>
-                
+
                 <li<%= sidebar_current("docs-azurerm-datasource-availability-set") %>>
                     <a href="/docs/providers/azurerm/d/availability_set.html">azurerm_availability_set</a>
                 </li>
@@ -372,7 +372,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-resource") %>>
               <a href="#">Base Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-resource-group") %>>
                   <a href="/docs/providers/azurerm/r/resource_group.html">azurerm_resource_group</a>
                 </li>
@@ -381,7 +381,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-api-management") %>>
               <a href="#">API Management Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-api-management-x") %>>
                   <a href="/docs/providers/azurerm/r/api_management.html">azurerm_api_management</a>
                 </li>
@@ -405,7 +405,7 @@
                 <li<%= sidebar_current("docs-azurerm-datasource-api-management-api-schema") %>>
                   <a href="/docs/providers/azurerm/r/api_management_api_schema.html">azurerm_api_management_api_schema</a>
                 </li>
-                
+
                 <li<%= sidebar_current("docs-azurerm-resource-api-management-api-version-set") %>>
                   <a href="/docs/providers/azurerm/r/api_management_api_version_set.html">azurerm_api_management_version_set</a>
                 </li>
@@ -453,16 +453,16 @@
                 <li<%= sidebar_current("docs-azurerm-datasource-api-management-property-x") %>>
                     <a href="/docs/providers/azurerm/r/api_management_property.html">azurerm_api_management_property</a>
                 </li>
-                  
+
                 <li<%= sidebar_current("docs-azurerm-resource-api-management-user") %>>
                     <a href="/docs/providers/azurerm/r/api_management_user.html">azurerm_api_management_user</a>
-                </li>  
+                </li>
               </ul>
             </li>
 
             <li<%= sidebar_current("docs-azurerm-resource-app-service") %>>
               <a href="#">App Service (Web Apps) Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-app-service-x") %>>
                   <a href="/docs/providers/azurerm/r/app_service.html">azurerm_app_service</a>
                 </li>
@@ -491,7 +491,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-authorization") %>>
               <a href="#">Authorization Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-authorization-role-assignment") %>>
                   <a href="/docs/providers/azurerm/r/role_assignment.html">azurerm_role_assignment</a>
                 </li>
@@ -508,7 +508,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-azuread") %>>
               <a href="#">Azure Active Directory Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-azuread-application") %>>
                   <a href="/docs/providers/azurerm/r/azuread_application.html">azurerm_azuread_application</a>
                 </li>
@@ -525,7 +525,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-automation") %>>
               <a href="#">Automation Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-automation-account") %>>
                   <a href="/docs/providers/azurerm/r/automation_account.html">azurerm_automation_account</a>
                 </li>
@@ -574,7 +574,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-application-insights") %>>
               <a href="#">Application Insights Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-application-insights-x") %>>
                   <a href="/docs/providers/azurerm/r/application_insights.html">azurerm_application_insights</a>
                 </li>
@@ -591,7 +591,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-batch") %>>
               <a href="#">Batch Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-batch-account") %>>
                   <a href="/docs/providers/azurerm/r/batch_account.html">azurerm_batch_account</a>
                 </li>
@@ -608,7 +608,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-cdn") %>>
               <a href="#">CDN Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-cdn-endpoint") %>>
                   <a href="/docs/providers/azurerm/r/cdn_endpoint.html">azurerm_cdn_endpoint</a>
                 </li>
@@ -621,7 +621,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-compute") %>>
               <a href="#">Compute Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-compute-availability-set") %>>
                   <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
                 </li>
@@ -670,7 +670,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-container") %>>
               <a href="#">Container Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-container-group") %>>
                   <a href="/docs/providers/azurerm/r/container_group.html">azurerm_container_group</a>
                 </li>
@@ -691,7 +691,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-cognitive") %>>
               <a href="#">Cognitive Services Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-cognitive-account") %>>
                   <a href="/docs/providers/azurerm/r/cognitive_account.html">azurerm_cognitive_account</a>
                 </li>
@@ -700,7 +700,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-cosmosdb") %>>
               <a href="#">CosmosDB (DocumentDB) Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-cosmosdb-account") %>>
                   <a href="/docs/providers/azurerm/r/cosmosdb_account.html">azurerm_cosmosdb_account</a>
                 </li>
@@ -724,7 +724,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-database") %>>
               <a href="#">Database Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
 
                 <li<%= sidebar_current("docs-azurerm-resource-database-mariadb-database") %>>
                   <a href="/docs/providers/azurerm/r/mariadb_database.html">azurerm_mariadb_database</a>
@@ -806,7 +806,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-databricks") %>>
               <a href="#">Databricks Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-databricks-workspace") %>>
                   <a href="/docs/providers/azurerm/r/databricks_workspace.html">azurerm_databricks_workspace</a>
                 </li>
@@ -815,7 +815,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-data-factory") %>>
               <a href="#">Data Factory Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-data-factory-x") %>>
                   <a href="/docs/providers/azurerm/r/data_factory.html">azurerm_data_factory</a>
                 </li>
@@ -847,7 +847,7 @@
                 <li<%= sidebar_current("docs-azurerm-resource-data-factory-linked-service-postgresql") %>>
                   <a href="/docs/providers/azurerm/r/data_factory_linked_service_postgresql.html">azurerm_data_factory_linked_service_postgresql</a>
                 </li>
-                
+
                 <li<%= sidebar_current("docs-azurerm-resource-data-factory-linked-service-sql-server") %>>
                   <a href="/docs/providers/azurerm/r/data_factory_linked_service_sql_server.html">azurerm_data_factory_linked_service_sql_server</a>
                 </li>
@@ -856,7 +856,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-data-lake") %>>
               <a href="#">Data Lake Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-data-lake-analytics-account") %>>
                   <a href="/docs/providers/azurerm/r/data_lake_analytics_account.html">azurerm_data_lake_analytics_account</a>
                 </li>
@@ -877,7 +877,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-devspace") %>>
               <a href="#">DevSpace Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-devspace-controller") %>>
                   <a href="/docs/providers/azurerm/r/devspace_controller.html">azurerm_devspace_controller</a>
                 </li>
@@ -886,7 +886,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-dev-test") %>>
               <a href="#">Dev Test Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-dev-test-lab") %>>
                   <a href="/docs/providers/azurerm/r/dev_test_lab.html">azurerm_dev_test_lab</a>
                 </li>
@@ -911,7 +911,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-dns") %>>
                 <a href="#">DNS Resources</a>
-                <ul class="nav nav-visible">
+                <ul class="nav">
                   <li<%= sidebar_current("docs-azurerm-resource-dns-a-record") %>>
                     <a href="/docs/providers/azurerm/r/dns_a_record.html">azurerm_dns_a_record</a>
                   </li>
@@ -956,7 +956,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-hdinsight") %>>
               <a href="#">HDInsight Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-hdinsight-hadoop-cluster") %>>
                   <a href="/docs/providers/azurerm/r/hdinsight_hadoop_cluster.html">azurerm_hdinsight_hadoop_cluster</a>
                 </li>
@@ -986,7 +986,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-key-vault") %>>
               <a href="#">Key Vault Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-key-vault-x") %>>
                   <a href="/docs/providers/azurerm/r/key_vault.html">azurerm_key_vault</a>
                 </li>
@@ -1011,7 +1011,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-loadbalancer") %>>
               <a href="#">Load Balancer Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                   <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-x") %>>
                     <a href="/docs/providers/azurerm/r/loadbalancer.html">azurerm_lb</a>
                   </li>
@@ -1044,7 +1044,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-logic") %>>
               <a href="#">Logic App Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-logic-app-action-custom") %>>
                   <a href="/docs/providers/azurerm/r/logic_app_action_custom.html">azurerm_logic_app_action_custom</a>
                 </li>
@@ -1073,7 +1073,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-management") %>>
               <a href="#">Management Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-management-lock") %>>
                   <a href="/docs/providers/azurerm/r/management_lock.html">azurerm_management_lock</a>
                 </li>
@@ -1082,7 +1082,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-messaging") %>>
               <a href="#">Messaging Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-messaging-eventgrid-domain") %>>
                   <a href="/docs/providers/azurerm/r/eventgrid_domain.html">azurerm_eventgrid_domain</a>
                 </li>
@@ -1184,7 +1184,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-monitor") %>>
               <a href="#">Monitor Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-autoscale-setting") %>>
                   <a href="/docs/providers/azurerm/r/autoscale_setting.html">azurerm_autoscale_setting</a>
                 </li>
@@ -1224,7 +1224,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-network") %>>
               <a href="#">Network Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
 
                 <li<%= sidebar_current("docs-azurerm-resource-network-application-gateway") %>>
                   <a href="/docs/providers/azurerm/r/application_gateway.html">azurerm_application_gateway</a>
@@ -1382,7 +1382,7 @@
 
             <li<%= sidebar_current("docs-azurerm-management-group") %>>
               <a href="#">Management Group Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-management-group") %>>
                   <a href="/docs/providers/azurerm/r/management_group.html">azurerm_management_group</a>
                 </li>
@@ -1391,7 +1391,7 @@
 
             <li<%= sidebar_current("docs-azurerm-log-analytics") %>>
               <a href="#">Log Analytics Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-log-analytics-linked-service") %>>
                   <a href="/docs/providers/azurerm/r/log_analytics_linked_service.html">azurerm_log_analytics_linked_service</a>
                 </li>
@@ -1412,7 +1412,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-policy") %>>
               <a href="#">Policy Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-policy-assignment") %>>
                   <a href="/docs/providers/azurerm/r/policy_assignment.html">azurerm_policy_assignment</a>
                 </li>
@@ -1429,7 +1429,7 @@
 
             <li<%= sidebar_current("docs-azurerm-recovery-services") %>>
               <a href="#">Recovery Services</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-recovery-services-protection-policy-vm") %>>
                   <a href="/docs/providers/azurerm/r/recovery_services_protection_policy_vm.html">azurerm_recovery_services_protection_policy_vm</a>
                 </li>
@@ -1446,7 +1446,7 @@
 
             <li<%= sidebar_current("docs-azurerm-redis") %>>
               <a href="#">Redis Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-redis-cache") %>>
                   <a href="/docs/providers/azurerm/r/redis_cache.html">azurerm_redis_cache</a>
                 </li>
@@ -1459,7 +1459,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-search") %>>
               <a href="#">Search Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-search-service") %>>
                   <a href="/docs/providers/azurerm/r/search_service.html">azurerm_search_service</a>
                 </li>
@@ -1468,7 +1468,7 @@
 
             <li<%= sidebar_current("docs-azurerm-security-center") %>>
               <a href="#">Security Center Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-security-center-contact") %>>
                   <a href="/docs/providers/azurerm/r/security_center_contact.html">azurerm_security_center_contact</a>
                 </li>
@@ -1485,7 +1485,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-scheduler") %>>
               <a href="#">Scheduler Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-scheduler-job-collection") %>>
                   <a href="/docs/providers/azurerm/r/scheduler_job_collection.html">azurerm_scheduler_job_collection</a>
                 </li>
@@ -1498,7 +1498,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-service-fabric") %>>
               <a href="#">Service Fabric Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-service-fabric-cluster") %>>
                   <a href="/docs/providers/azurerm/r/service_fabric_cluster.html">azurerm_service_fabric_cluster</a>
                 </li>
@@ -1507,7 +1507,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-stream-analytics") %>>
               <a href="#">Stream Analytics Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-job") %>>
                   <a href="/docs/providers/azurerm/r/stream_analytics_job.html">azurerm_stream_analytics_job</a>
                 </li>
@@ -1544,7 +1544,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-storage") %>>
               <a href="#">Storage Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
 
                 <li<%= sidebar_current("docs-azurerm-resource-storage-account") %>>
                   <a href="/docs/providers/azurerm/r/storage_account.html">azurerm_storage_account</a>
@@ -1575,7 +1575,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-template") %>>
               <a href="#">Template Resources</a>
-              <ul class="nav nav-visible">
+              <ul class="nav">
                 <li<%= sidebar_current("docs-azurerm-resource-template-deployment") %>>
                   <a href="/docs/providers/azurerm/r/template_deployment.html">azurerm_template_deployment</a>
                 </li>
@@ -1584,7 +1584,7 @@
 
             <li<%= sidebar_current("docs-azurerm-resource-media") %>>
             <a href="#">Media Resources</a>
-            <ul class="nav nav-visible">
+            <ul class="nav">
               <li<%= sidebar_current("docs-azurerm-resource-media-media-services-account") %>>
                 <a href="/docs/providers/azurerm/r/media_services_account.html">azurerm_media_services_account</a>
               </li>

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -3,1589 +3,1589 @@
     <% content_for :sidebar do %>
         <div class="docs-sidebar hidden-print affix-top" role="complementary">
           <ul class="nav docs-sidenav">
-            <li<%= sidebar_current("docs-home") %>>
+            <li>
               <a href="/docs/providers/index.html">All Providers</a>
             </li>
 
             <li>
               <a href="#">Azure Providers</a>
               <ul class="nav nav-visible">
-                <li<%= sidebar_current("docs-azuread-index") %>>
+                <li>
                    <a href="/docs/providers/azuread/index.html">Azure Active Directory</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-index") %>>
+                <li>
                    <a href="/docs/providers/azurerm/index.html">Azure</a>
                 </li>
-                <li<%= sidebar_current("docs-azurestack-index") %>>
+                <li>
                    <a href="/docs/providers/azurestack/index.html">Azure Stack</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-guide") %>>
+            <li>
               <a href="#">Guides</a>
               <ul class="nav nav-visible">
-                <li<%= sidebar_current("docs-azurerm-guide-2.0-upgrade") %>>
+                <li>
                    <a href="/docs/providers/azurerm/guides/2.0-upgrade-guide.html">Azure Provider 2.0 Upgrade Guide</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-guide-authentication-azure-cli") %>>
+                <li>
                     <a href="/docs/providers/azurerm/auth/azure_cli.html">Authenticating using the Azure CLI</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-guide-authentication-managed-service-identity") %>>
+                <li>
                     <a href="/docs/providers/azurerm/auth/managed_service_identity.html">Authenticating using Managed Service Identity</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-guide-authentication-service-principal-client-certificate") %>>
+                <li>
                     <a href="/docs/providers/azurerm/auth/service_principal_client_certificate.html">Authenticating using a Service Principal with a Client Certificate</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-guide-authentication-service-principal-client-secret") %>>
+                <li>
                     <a href="/docs/providers/azurerm/auth/service_principal_client_secret.html">Authenticating using a Service Principal with a Client Secret</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-community-events") %>>
+            <li>
               <a href="#">Upcoming Community Events</a>
               <ul class="nav nav-visible">
-                <li<%= sidebar_current("docs-azurerm-community-events-gardening-fall-2018") %>>
+                <li>
                   <a href="/docs/extend/community/events/2018/fall-gardening.html">Community Gardening - Fall 2018</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-datasource") %>>
+            <li>
               <a href="#">Data Sources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/api_management.html">azurerm_api_management</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-api-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/api_management_api.html">azurerm_api_management_api</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-group") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/api_management_group.html">azurerm_api_management_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-product") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/api_management_product.html">azurerm_api_management_product</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-user") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/api_management_user.html">azurerm_api_management_user</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-network-application-security-group") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/application_security_group.html">azurerm_application_security_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-app-service-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/app_service.html">azurerm_app_service</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-app-service-plan") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-application-insights") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/application_insights.html">azurerm_application_insights</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-automation-variable-bool") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/automation_variable_bool.html">azurerm_automation_variable_bool</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-automation-variable-datetime") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/automation_variable_datetime.html">azurerm_automation_variable_datetime</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-automation-variable-int") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/automation_variable_int.html">azurerm_automation_variable_int</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-automation-variable-string") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/automation_variable_string.html">azurerm_automation_variable_string</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-availability-set") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/availability_set.html">azurerm_availability_set</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-azuread-application") %>>
+                <li>
                   <a href="/docs/providers/azurerm/d/azuread_application.html">azurerm_azuread_application</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-azuread-service-principal") %>>
+                <li>
                   <a href="/docs/providers/azurerm/d/azuread_service_principal.html">azurerm_azuread_service_principal</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-batch-account") %>>
+                <li>
                   <a href="/docs/providers/azurerm/d/batch_account.html">azurerm_batch_account</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-batch-certificate") %>>
+                <li>
                   <a href="/docs/providers/azurerm/d/batch_certificate.html">azurerm_batch_certificate</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-batch-pool") %>>
+                <li>
                   <a href="/docs/providers/azurerm/d/batch_pool.html">azurerm_batch_pool</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-builtin-role-definition") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/builtin_role_definition.html">azurerm_builtin_role_definition</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-cdn-profile") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/cdn_profile.html">azurerm_cdn_profile</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-client-config") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/client_config.html">azurerm_client_config</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-container-registry") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/container_registry.html">azurerm_container_registry</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-cosmosdb-account") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/cosmosdb_account.html">azurerm_cosmosdb_account</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-dns-zone") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/dns_zone.html">azurerm_dns_zone</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-data-lake-store") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/data_lake_store.html">azurerm_data_lake_store</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-dev-test-lab") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/dev_test_lab.html">azurerm_dev_test_lab</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-eventhub-namespace") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/eventhub_namespace.html">azurerm_eventhub_namespace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-express-route-circuit") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/express_route_circuit.html">azurerm_express_route_circuit</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-firewall") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/firewall.html">azurerm_firewall</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-hdinsight-cluster") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/hdinsight_cluster.html">azurerm_hdinsight_cluster</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-image") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/image.html">azurerm_image</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-key-vault-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/key_vault.html">azurerm_key_vault</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-key-vault-access-policy") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/key_vault_access_policy.html">azurerm_key_vault_access_policy</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-key-vault-key") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/key_vault_key.html">azurerm_key_vault_key</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-key-vault-secret") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/key_vault_secret.html">azurerm_key_vault_secret</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-data-source-kubernetes-cluster") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/kubernetes_cluster.html">azurerm_kubernetes_cluster</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-kubernetes-service-versions") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/kubernetes_service_versions.html">azurerm_kubernetes_service_versions</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-load-balancer-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/loadbalancer.html">azurerm_lb</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-load-balancer-backend-address-pool") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/loadbalancer_backend_address_pool.html">azurerm_lb_backend_address_pool</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-oms-log-analytics-workspace") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/log_analytics_workspace.html">azurerm_log_analytics_workspace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-data-source-logic-app-workflow") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/logic_app_workflow.html">azurerm_logic_app_workflow</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-managed-disk") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/managed_disk.html">azurerm_managed_disk</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-management-group") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/management_group.html">azurerm_management_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-monitor-action-group") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/monitor_action_group.html">azurerm_monitor_action_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-monitor-diagnostic-categories") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/monitor_diagnostic_categories.html">azurerm_monitor_diagnostic_categories</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-monitor-log-profile") %>>
+                <li>
                   <a href="/docs/providers/azurerm/d/monitor_log_profile.html">azurerm_monitor_log_profile</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-network-interface") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/network_interface.html">azurerm_network_interface</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-network-security-group") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/network_security_group.html">azurerm_network_security_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-network-watcher") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/network_watcher.html">azurerm_network_watcher</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-notification-hub-namespace") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/notification_hub_namespace.html">azurerm_notification_hub_namespace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-platform-image") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/platform_image.html">azurerm_platform_image</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-policy-definition") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/policy_definition.html">azurerm_policy_definition</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-public-ip-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/public_ip.html">azurerm_public_ip</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-public-ips") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/public_ips.html">azurerm_public_ips</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-recovery-services-vault") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/recovery_services_vault.html">azurerm_recovery_services_vault</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-recovery-services-protection-policy-vm") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/recovery_services_protection_policy_vm.html">azurerm_recovery_services_protection_policy_vm</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-resource-group") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/resource_group.html">azurerm_resource_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-role-definition") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/role_definition.html">azurerm_role_definition</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-data-source-route-table") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/route_table.html">azurerm_route_table</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-scheduler-job-collection") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/scheduler_job_collection.html">azurerm_scheduler_job_collection</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-servicebus-namespace") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/servicebus_namespace.html">azurerm_servicebus_namespace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-shared-image-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/shared_image.html">azurerm_shared_image</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-shared-image-gallery") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/shared_image_gallery.html">azurerm_shared_image_gallery</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-shared-image-version") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/shared_image_version.html">azurerm_shared_image_version</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-sql-server") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/sql_server.html">azurerm_sql_server</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-stream-analytics-job") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/stream_analytics_job.html">azurerm_stream_analytics_job</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-storage-account-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/storage_account.html">azurerm_storage_account</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-storage-account-sas") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/storage_account_sas.html">azurerm_storage_account_sas</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-subnet") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/subnet.html">azurerm_subnet</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-subscription-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/subscription.html">azurerm_subscription</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-subscriptions") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/subscriptions.html">azurerm_subscriptions</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-traffic-manager-geographical-location") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/traffic_manager_geographical_location.html">azurerm_traffic_manager_geographical_location</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-user-assigned-identity") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/user_assigned_identity.html">azurerm_user_assigned_identity</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-virtual-machine") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/virtual_machine.html">azurerm_virtual_machine</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-virtual-network-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/virtual_network.html">azurerm_virtual_network</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-virtual-network-gateway") %>>
+                <li>
                     <a href="/docs/providers/azurerm/d/virtual_network_gateway.html">azurerm_virtual_network_gateway</a>
                 </li>
 
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-resource") %>>
+            <li>
               <a href="#">Base Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-resource-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/resource_group.html">azurerm_resource_group</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-api-management") %>>
+            <li>
               <a href="#">API Management Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management.html">azurerm_api_management</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-api-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_api.html">azurerm_api_management_api</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-api-operation") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_api_operation.html">azurerm_api_management_api_operation</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-api-operation-policy") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_api_operation_policy.html">azurerm_api_management_api_operation_policy</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-api-policy") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_api_policy.html">azurerm_api_management_api_policy</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-api-schema") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_api_schema.html">azurerm_api_management_api_schema</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-api-version-set") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_api_version_set.html">azurerm_api_management_version_set</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-authorization-server") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_authorization_server.html">azurerm_api_management_authorization_server</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-certificate") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_certificate.html">azurerm_api_management_certificate</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-group-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_group.html">azurerm_api_management_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-group-user") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_group_user.html">azurerm_api_management_group_user</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-logger") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_logger.html">azurerm_api_management_logger</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-openid-connect-provider") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_openid_connect_provider.html">azurerm_api_management_openid_connect_provider</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-product-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_product.html">azurerm_api_management_product</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-product-api") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_product_api.html">azurerm_api_management_product_api</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-product-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_product_group.html">azurerm_api_management_product_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-product-policy") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_product_policy.html">azurerm_api_management_product_policy</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-datasource-api-management-property-x") %>>
+                <li>
                     <a href="/docs/providers/azurerm/r/api_management_property.html">azurerm_api_management_property</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-api-management-user") %>>
+                <li>
                     <a href="/docs/providers/azurerm/r/api_management_user.html">azurerm_api_management_user</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-app-service") %>>
+            <li>
               <a href="#">App Service (Web Apps) Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-app-service-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service.html">azurerm_app_service</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-app-service-active-slot") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service_active_slot.html">azurerm_app_service_active_slot</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-app-service-custom-hostname-binding") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service_custom_hostname_binding.html">azurerm_app_service_custom_hostname_binding</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-app-service-plan") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service_plan.html">azurerm_app_service_plan</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-app-service-slot") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service_slot.html">azurerm_app_service_slot</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-app-service-function-app") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/function_app.html">azurerm_function_app</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-authorization") %>>
+            <li>
               <a href="#">Authorization Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-authorization-role-assignment") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/role_assignment.html">azurerm_role_assignment</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-authorization-role-definition") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/role_definition.html">azurerm_role_definition</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-authorization-user-assigned-identity") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/user_assigned_identity.html">azurerm_user_assigned_identity</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-azuread") %>>
+            <li>
               <a href="#">Azure Active Directory Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-azuread-application") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/azuread_application.html">azurerm_azuread_application</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-azuread-service-principal-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/azuread_service_principal.html">azurerm_azuread_service_principal</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-azuread-service-principal-password") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/azuread_service_principal_password.html">azurerm_azuread_service_principal_password</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-automation") %>>
+            <li>
               <a href="#">Automation Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-automation-account") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_account.html">azurerm_automation_account</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-credential") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_credential.html">azurerm_automation_credential</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-dsc-configuration") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_dsc_configuration.html">azurerm_automation_dsc_configuration</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-dsc-nodeconfiguration") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_dsc_nodeconfiguration.html">azurerm_automation_dsc_nodeconfiguration</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-module") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_module.html">azurerm_automation_module</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-runbook") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_runbook.html">azurerm_automation_runbook</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-schedule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_schedule.html">azurerm_automation_schedule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-variable-bool") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_variable_bool.html">azurerm_automation_variable_bool</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-variable-datetime") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_variable_datetime.html">azurerm_automation_variable_datetime</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-variable-int") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_variable_int.html">azurerm_automation_variable_bool</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-automation-variable-string") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/automation_variable_string.html">azurerm_automation_variable_string</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-application-insights") %>>
+            <li>
               <a href="#">Application Insights Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-application-insights-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/application_insights.html">azurerm_application_insights</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-application-insights-api-key") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/application_insights_api_key.html">azurerm_application_insights_api_key</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-application-insights-webtests") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/application_insights_webtests.html">azurerm_application_insights_webtests</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-batch") %>>
+            <li>
               <a href="#">Batch Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-batch-account") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/batch_account.html">azurerm_batch_account</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-batch-certificate") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/batch_certificate.html">azurerm_batch_certificate</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-batch-pool") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/batch_pool.html">azurerm_batch_pool</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-cdn") %>>
+            <li>
               <a href="#">CDN Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-cdn-endpoint") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cdn_endpoint.html">azurerm_cdn_endpoint</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-cdn-profile") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cdn_profile.html">azurerm_cdn_profile</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-compute") %>>
+            <li>
               <a href="#">Compute Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-compute-availability-set") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-image") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/image.html">azurerm_image</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-managed-disk") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/managed_disk.html">azurerm_managed_disk</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-snapshot") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/snapshot.html">azurerm_snapshot</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-shared-image-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/shared_image.html">azurerm_shared_image</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-shared-image-gallery") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/shared_image_gallery.html">azurerm_shared_image_gallery</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-shared-image-version") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/shared_image_version.html">azurerm_shared_image_version</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-virtual-machine-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_machine.html">azurerm_virtual_machine</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-virtual-machine-data-disk-attachment") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_machine_data_disk_attachment.html">azurerm_virtual_machine_data_disk_attachment</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-virtualmachine-extension") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_machine_extension.html">azurerm_virtual_machine_extension</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-compute-virtualmachine-scale-set") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_machine_scale_set.html">azurerm_virtual_machine_scale_set</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-container") %>>
+            <li>
               <a href="#">Container Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-container-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/container_group.html">azurerm_container_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-container-registry") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/container_registry.html">azurerm_container_registry</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-container-service") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/container_service.html">azurerm_container_service</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-container-kubernetes-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/kubernetes_cluster.html">azurerm_kubernetes_cluster</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-cognitive") %>>
+            <li>
               <a href="#">Cognitive Services Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-cognitive-account") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cognitive_account.html">azurerm_cognitive_account</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-cosmosdb") %>>
+            <li>
               <a href="#">CosmosDB (DocumentDB) Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-cosmosdb-account") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cosmosdb_account.html">azurerm_cosmosdb_account</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-cosmosdb-cassandra-keyspace") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cosmosdb_cassandra_keyspace.html">azurerm_cosmosdb_cassandra_keyspace</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-cosmosdb-mongo-collection") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cosmosdb_mongo_collection.html">azurerm_cosmosdb_mongo_collection</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-cosmosdb-mongo-database") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cosmosdb_mongo_database.html">azurerm_cosmosdb_mongo_database</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-cosmosdb-sql-database") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cosmosdb_sql_database.html">azurerm_cosmosdb_sql_database</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-cosmosdb-table") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/cosmosdb_table.html">azurerm_cosmosdb_table</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-database") %>>
+            <li>
               <a href="#">Database Resources</a>
               <ul class="nav">
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mariadb-database") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mariadb_database.html">azurerm_mariadb_database</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mariadb-server") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mariadb_server.html">azurerm_mariadb_server</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mysql-configuration") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mysql_configuration.html">azurerm_mysql_configuration</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mysql-database") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mysql_database.html">azurerm_mysql_database</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mysql-firewall-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mysql_firewall_rule.html">azurerm_mysql_firewall_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mysql-server") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mysql_server.html">azurerm_mysql_server</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mysql-virtual-network-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mysql_virtual_network_rule.html">azurerm_mysql_virtual_network_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-postgresql-configuration") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/postgresql_configuration.html">azurerm_postgresql_configuration</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-postgresql-database") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/postgresql_database.html">azurerm_postgresql_database</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-postgresql-firewall-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/postgresql_firewall_rule.html">azurerm_postgresql_firewall_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-postgresql-server") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/postgresql_server.html">azurerm_postgresql_server</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-postgresql-virtual-network-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/postgresql_virtual_network_rule.html">azurerm_postgresql_virtual_network_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-sql-database") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/sql_database.html">azurerm_sql_database</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-sql-administrator") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/sql_active_directory_administrator.html">azurerm_sql_active_directory_administrator</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-sql-elasticpool") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/sql_elasticpool.html">azurerm_sql_elasticpool</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-mssql-elasticpool") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/mssql_elasticpool.html">azurerm_mssql_elasticpool</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-sql-firewall-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/sql_firewall_rule.html">azurerm_sql_firewall_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-sql-server") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/sql_server.html">azurerm_sql_server</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-database-sql-virtual-network-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/sql_virtual_network_rule.html">azurerm_sql_virtual_network_rule</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-databricks") %>>
+            <li>
               <a href="#">Databricks Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-databricks-workspace") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/databricks_workspace.html">azurerm_databricks_workspace</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-data-factory") %>>
+            <li>
               <a href="#">Data Factory Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory.html">azurerm_data_factory</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-dataset-mysql") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_dataset_mysql.html">azurerm_data_factory_dataset_mysql</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-dataset-postgresql") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_dataset_postgresql.html">azurerm_data_factory_dataset_postgresql</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-dataset-sql-server-table") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_dataset_sql_server_table.html">azurerm_data_factory_dataset_sql_server_table</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-pipeline") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_pipeline.html">azurerm_data_factory_pipeline</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-linked-service-data-lake-storage-gen2") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_linked_service_data_lake_storage_gen2.html">azurerm_data_factory_linked_service_data_lake_storage_gen2</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-linked-service-mysql") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_linked_service_mysql.html">azurerm_data_factory_linked_service_mysql</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-linked-service-postgresql") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_linked_service_postgresql.html">azurerm_data_factory_linked_service_postgresql</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-factory-linked-service-sql-server") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_linked_service_sql_server.html">azurerm_data_factory_linked_service_sql_server</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-data-lake") %>>
+            <li>
               <a href="#">Data Lake Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-data-lake-analytics-account") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_lake_analytics_account.html">azurerm_data_lake_analytics_account</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-lake-analytics-firewall-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_lake_analytics_firewall_rule.html">azurerm_data_lake_analytics_firewall_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-lake-store-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_lake_store.html">azurerm_data_lake_store</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-data-lake-store-firewall-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/data_lake_store_firewall_rule.html">azurerm_data_lake_store_firewall_rule</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-devspace") %>>
+            <li>
               <a href="#">DevSpace Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-devspace-controller") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/devspace_controller.html">azurerm_devspace_controller</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-dev-test") %>>
+            <li>
               <a href="#">Dev Test Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-dev-test-lab") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/dev_test_lab.html">azurerm_dev_test_lab</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-dev-test-linux-virtual-machine") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/dev_test_linux_virtual_machine.html">azurerm_dev_test_linux_virtual_machine</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-dev-test-policy") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/dev_test_policy.html">azurerm_dev_test_policy</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-dev-test-virtual-network") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/dev_test_virtual_network.html">azurerm_dev_test_virtual_network</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-dev-test-windows-virtual-machine") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/dev_test_windows_virtual_machine.html">azurerm_dev_test_windows_virtual_machine</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-dns") %>>
+            <li>
                 <a href="#">DNS Resources</a>
                 <ul class="nav">
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-a-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_a_record.html">azurerm_dns_a_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-aaaa-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_aaaa_record.html">azurerm_dns_aaaa_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-caa-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_caa_record.html">azurerm_dns_caa_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-cname-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_cname_record.html">azurerm_dns_cname_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-mx-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_mx_record.html">azurerm_dns_mx_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-ns-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_ns_record.html">azurerm_dns_ns_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-ptr-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_ptr_record.html">azurerm_dns_ptr_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-srv-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_srv_record.html">azurerm_dns_srv_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-txt-record") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/dns_txt_record.html">azurerm_dns_txt_record</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-dns-zone") %>>
+                  <li>
                       <a href="/docs/providers/azurerm/r/dns_zone.html">azurerm_dns_zone</a>
                   </li>
                 </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-hdinsight") %>>
+            <li>
               <a href="#">HDInsight Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-hadoop-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_hadoop_cluster.html">azurerm_hdinsight_hadoop_cluster</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-hbase-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_hbase_cluster.html">azurerm_hdinsight_hbase_cluster</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-kafka-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_kafka_cluster.html">azurerm_hdinsight_kafka_cluster</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-interactive-query-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_interactive_query_cluster.html">azurerm_hdinsight_interactive_query_cluster</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-ml-services-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_ml_services_cluster.html">azurerm_hdinsight_ml_services_cluster</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-rserver-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_rserver_cluster.html">azurerm_hdinsight_rserver_cluster</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-spark-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_spark_cluster.html">azurerm_hdinsight_spark_cluster</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-hdinsight-storm-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/hdinsight_storm_cluster.html">azurerm_hdinsight_storm_cluster</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-key-vault") %>>
+            <li>
               <a href="#">Key Vault Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-key-vault-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/key_vault.html">azurerm_key_vault</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-key-vault-access-policy") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/key_vault_access_policy.html">azurerm_key_vault_access_policy</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-key-vault-certificate") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/key_vault_certificate.html">azurerm_key_vault_certificate</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-key-vault-key") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/key_vault_key.html">azurerm_key_vault_key</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-key-vault-secret") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/key_vault_secret.html">azurerm_key_vault_secret</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-loadbalancer") %>>
+            <li>
               <a href="#">Load Balancer Resources</a>
               <ul class="nav">
-                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-x") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/loadbalancer.html">azurerm_lb</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-backend-address-pool") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html">azurerm_lb_backend_address_pool</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-rule") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/loadbalancer_rule.html">azurerm_lb_rule</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-outbound-rule") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/loadbalancer_outbound_rule.html">azurerm_lb_outbound_rule</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-nat-rule") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/loadbalancer_nat_rule.html">azurerm_lb_nat_rule</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-nat-pool") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/loadbalancer_nat_pool.html">azurerm_lb_nat_pool</a>
                   </li>
 
-                  <li<%= sidebar_current("docs-azurerm-resource-loadbalancer-probe") %>>
+                  <li>
                     <a href="/docs/providers/azurerm/r/loadbalancer_probe.html">azurerm_lb_probe</a>
                   </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-logic") %>>
+            <li>
               <a href="#">Logic App Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-logic-app-action-custom") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/logic_app_action_custom.html">azurerm_logic_app_action_custom</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-logic-app-action-http") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/logic_app_action_http.html">azurerm_logic_app_action_http</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-logic-app-trigger-custom") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/logic_app_trigger_custom.html">azurerm_logic_app_trigger_custom</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-logic-app-trigger-http-request") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/logic_app_trigger_http_request.html">azurerm_logic_app_trigger_http_request</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-logic-app-trigger-recurrence") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/logic_app_trigger_recurrence.html">azurerm_logic_app_trigger_recurrence</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-logic-app-workflow") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/logic_app_workflow.html">azurerm_logic_app_workflow</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-management") %>>
+            <li>
               <a href="#">Management Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-management-lock") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/management_lock.html">azurerm_management_lock</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-messaging") %>>
+            <li>
               <a href="#">Messaging Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventgrid-domain") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventgrid_domain.html">azurerm_eventgrid_domain</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventgrid-event-subscription") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventgrid_event_subscription.html">azurerm_eventgrid_event_subscription</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventgrid-topic") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventgrid_topic.html">azurerm_eventgrid_topic</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventhub-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventhub.html">azurerm_eventhub</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventhub-authorization-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventhub_authorization_rule.html">azurerm_eventhub_authorization_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventhub-consumer-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventhub_consumer_group.html">azurerm_eventhub_consumer_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventhub-namespace-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventhub_namespace.html">azurerm_eventhub_namespace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-eventhub-namespace-authorization-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/eventhub_namespace_authorization_rule.html">azurerm_eventhub_namespace_authorization_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-iothub-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/iothub.html">azurerm_iothub</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-iothub-consumer-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/iothub_consumer_group.html">azurerm_iothub_consumer_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-iothub-shared-access-policy-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/iothub_shared_access_policy.html">azurerm_iothub_shared_access_policy</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-notification-hub-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/notification_hub.html">azurerm_notification_hub</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-notification-hub-authorization-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/notification_hub_authorization_rule.html">azurerm_notification_hub_authorization_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-notification-hub-namespace") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/notification_hub_namespace.html">azurerm_notification_hub_namespace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-relay-namespace") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/relay_namespace.html">azurerm_relay_namespace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-namespace-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_namespace.html">azurerm_servicebus_namespace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-namespace-authorization-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_namespace_authorization_rule.html">azurerm_servicebus_namespace_authorization_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-queue-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_queue.html">azurerm_servicebus_queue</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-queue-authorization-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_queue_authorization_rule.html">azurerm_servicebus_queue_authorization_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-subscription-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_subscription.html">azurerm_servicebus_subscription</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-subscription-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_subscription_rule.html">azurerm_servicebus_subscription_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-topic-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_topic.html">azurerm_servicebus_topic</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-servicebus-topic-authorization-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_topic_authorization_rule.html">azurerm_servicebus_topic_authorization_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-messaging-signalr-service") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/signalr_service.html">azurerm_signalr_service</a>
                 </li>
               </ul>
             </li>
 
 
-            <li<%= sidebar_current("docs-azurerm-resource-monitor") %>>
+            <li>
               <a href="#">Monitor Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-autoscale-setting") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/autoscale_setting.html">azurerm_autoscale_setting</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-monitor-action-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/monitor_action_group.html">azurerm_monitor_action_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-monitor-activity-log-alert") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/monitor_activity_log_alert.html">azurerm_monitor_activity_log_alert</a>
                 </li>
-                <li<%= sidebar_current("docs-azurerm-resource-monitor-autoscale-setting") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/monitor_autoscale_setting.html">azurerm_monitor_autoscale_setting</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-monitor-diagnostic-setting") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/monitor_diagnostic_setting.html">azurerm_monitor_diagnostic_setting</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-monitor-log-profile") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/monitor_log_profile.html">azurerm_monitor_log_profile</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-monitor-metric-alert-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/monitor_metric_alert.html">azurerm_monitor_metric_alert</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-monitor-metric-alertrule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/monitor_metric_alertrule.html">azurerm_monitor_metric_alertrule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-metric-alertrule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/metric_alertrule.html">azurerm_metric_alertrule</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-network") %>>
+            <li>
               <a href="#">Network Resources</a>
               <ul class="nav">
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-application-gateway") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/application_gateway.html">azurerm_application_gateway</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-application-security-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/application_security_group.html">azurerm_application_security_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-connection-monitor") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/connection_monitor.html">azurerm_connection_monitor</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-connection-monitor") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_connection_monitor.html">azurerm_network_connection_monitor</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-ddos-protection-plan") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/ddos_protection_plan.html">azurerm_ddos_protection_plan</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-ddos-protection-plan") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_ddos_protection_plan.html">azurerm_network_ddos_protection_plan</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-express-route-circuit-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/express_route_circuit.html">azurerm_express_route_circuit</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-express-route-circuit-authorization") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/express_route_circuit_authorization.html">azurerm_express_route_circuit_authorization</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-express-route-circuit-peering") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/express_route_circuit_peering.html">azurerm_express_route_circuit_peering</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-firewall-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/firewall.html">azurerm_firewall</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-firewall-application-rule-collection") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/firewall_application_rule_collection.html">azurerm_firewall_application_rule_collection</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-firewall-nat-rule-collection") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/firewall_nat_rule_collection.html">azurerm_firewall_nat_rule_collection</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-firewall-network-rule-collection") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/firewall_network_rule_collection.html">azurerm_firewall_network_rule_collection</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-local-network-gateway") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/local_network_gateway.html">azurerm_local_network_gateway</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-interface-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_interface.html">azurerm_network_interface</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-interface-application-gateway-backend-address-pool-association") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_interface_application_gateway_backend_address_pool_association.html">azurerm_network_interface_application_gateway_backend_address_pool_association</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-interface-application-security-group-association") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_interface_application_security_group_association.html">azurerm_network_interface_application_security_group_association</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-interface-backend-address-pool-association") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_interface_backend_address_pool_association.html">azurerm_network_interface_backend_address_pool_association</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-interface-nat-rule-association") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_interface_nat_rule_association.html">azurerm_network_interface_nat_rule_association</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-profile") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_profile.html">azurerm_network_profile</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-security-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_security_group.html">azurerm_network_security_group</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-security-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_security_rule.html">azurerm_network_security_rule</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-watcher") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_watcher.html">azurerm_network_watcher</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-packet-capture") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/packet_capture.html">azurerm_packet_capture</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-packet-capture") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/network_packet_capture.html">azurerm_network_packet_capture</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-public-ip") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/public_ip.html">azurerm_public_ip</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-public-ip-prefix") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/public_ip_prefix.html">azurerm_public_ip_prefix</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-route-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/route.html">azurerm_route</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-route-table") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/route_table.html">azurerm_route_table</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-subnet-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/subnet.html">azurerm_subnet</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-subnet-network-security-group-association") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/subnet_network_security_group_association.html">azurerm_subnet_network_security_group_association</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-subnet-route-table-association") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/subnet_route_table_association.html">azurerm_subnet_route_table_association</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-traffic-manager-endpoint") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/traffic_manager_endpoint.html">azurerm_traffic_manager_endpoint</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-traffic-manager-profile") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/traffic_manager_profile.html">azurerm_traffic_manager_profile</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_network.html">azurerm_virtual_network</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network-gateway-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_network_gateway.html">azurerm_virtual_network_gateway</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network-gateway-connection") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_network_gateway_connection.html">azurerm_virtual_network_gateway_connection</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-network-peering") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/virtual_network_peering.html">azurerm_virtual_network_peering</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-management-group") %>>
+            <li>
               <a href="#">Management Group Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-management-group") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/management_group.html">azurerm_management_group</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-log-analytics") %>>
+            <li>
               <a href="#">Log Analytics Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-log-analytics-linked-service") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/log_analytics_linked_service.html">azurerm_log_analytics_linked_service</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-log-analytics-solution") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/log_analytics_solution.html">azurerm_log_analytics_solution</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-log-analytics-workspace-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/log_analytics_workspace.html">azurerm_log_analytics_workspace</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-log-analytics-workspace-linked-service") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/log_analytics_workspace_linked_service.html">azurerm_log_analytics_workspace_linked_service</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-policy") %>>
+            <li>
               <a href="#">Policy Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-policy-assignment") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/policy_assignment.html">azurerm_policy_assignment</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-policy-definition") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/policy_definition.html">azurerm_policy_definition</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-policy-set-definition") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/policy_set_definition.html">azurerm_policy_set_definition</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-recovery-services") %>>
+            <li>
               <a href="#">Recovery Services</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-recovery-services-protection-policy-vm") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/recovery_services_protection_policy_vm.html">azurerm_recovery_services_protection_policy_vm</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-recovery-services-protected-vm") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/recovery_services_protected_vm.html">azurerm_recovery_services_protected_vm</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-recovery-services-vault") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/recovery_services_vault.html">azurerm_recovery_services_vault</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-redis") %>>
+            <li>
               <a href="#">Redis Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-redis-cache") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/redis_cache.html">azurerm_redis_cache</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-redis-firewall-rule") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/redis_firewall_rule.html">azurerm_redis_firewall_rule</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-search") %>>
+            <li>
               <a href="#">Search Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-search-service") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/search_service.html">azurerm_search_service</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-security-center") %>>
+            <li>
               <a href="#">Security Center Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-security-center-contact") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/security_center_contact.html">azurerm_security_center_contact</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-security-center-subscription-pricing") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/security_center_subscription_pricing.html">azurerm_security_center_subscription_pricing</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-security-center-workspace") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/security_center_workspace.html">azurerm_security_center_workspace</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-scheduler") %>>
+            <li>
               <a href="#">Scheduler Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-scheduler-job-collection") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/scheduler_job_collection.html">azurerm_scheduler_job_collection</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-scheduler-job-x") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/scheduler_job.html">azurerm_scheduler_job</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-service-fabric") %>>
+            <li>
               <a href="#">Service Fabric Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-service-fabric-cluster") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/service_fabric_cluster.html">azurerm_service_fabric_cluster</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-stream-analytics") %>>
+            <li>
               <a href="#">Stream Analytics Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-job") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_job.html">azurerm_stream_analytics_job</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-function-javascript-udf") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_function_javascript_udf.html">azurerm_stream_analytics_function_javascript_udf</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-output-blob") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_output_blob.html">azurerm_stream_analytics_output_blob</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-output-eventhub") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_output_eventhub.html">azurerm_stream_analytics_output_eventhub</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-output-servicebus-queue") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_output_servicebus_queue.html">azurerm_stream_analytics_output_servicebus_queue</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-stream-input-blob") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_stream_input_blob.html">azurerm_stream_analytics_stream_input_blob</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-stream-input-eventhub") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_stream_input_eventhub.html">azurerm_stream_analytics_stream_input_eventhub</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-stream-analytics-stream-input-iothub") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/stream_analytics_stream_input_iothub.html">azurerm_stream_analytics_stream_input_iothub</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-storage") %>>
+            <li>
               <a href="#">Storage Resources</a>
               <ul class="nav">
 
-                <li<%= sidebar_current("docs-azurerm-resource-storage-account") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/storage_account.html">azurerm_storage_account</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-storage-blob") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/storage_blob.html">azurerm_storage_blob</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-storage-container") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/storage_container.html">azurerm_storage_container</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-storage-queue") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/storage_queue.html">azurerm_storage_queue</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-storage-share") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/storage_share.html">azurerm_storage_share</a>
                 </li>
 
-                <li<%= sidebar_current("docs-azurerm-resource-storage-table") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/storage_table.html">azurerm_storage_table</a>
                 </li>
 
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-template") %>>
+            <li>
               <a href="#">Template Resources</a>
               <ul class="nav">
-                <li<%= sidebar_current("docs-azurerm-resource-template-deployment") %>>
+                <li>
                   <a href="/docs/providers/azurerm/r/template_deployment.html">azurerm_template_deployment</a>
                 </li>
               </ul>
             </li>
 
-            <li<%= sidebar_current("docs-azurerm-resource-media") %>>
+            <li>
             <a href="#">Media Resources</a>
             <ul class="nav">
-              <li<%= sidebar_current("docs-azurerm-resource-media-media-services-account") %>>
+              <li>
                 <a href="/docs/providers/azurerm/r/media_services_account.html">azurerm_media_services_account</a>
               </li>
             </ul>


### PR DESCRIPTION
This makes the azurerm provider's docs sidebar act like the AWS one — the resource/data sections default to closed, and can be either revealed individually, filtered with the filter box, or mass-opened with the expand-all button. 

I left the guides, other Azure stuff, and events sections defaulting to open.