### PR TITLE
New resource: azurerm_stream_analytics_reference_input_blob

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -474,6 +474,7 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_stream_analytics_output_eventhub":                                       resourceArmStreamAnalyticsOutputEventHub(),
 		"azurerm_stream_analytics_output_servicebus_queue":                               resourceArmStreamAnalyticsOutputServiceBusQueue(),
 		"azurerm_stream_analytics_output_servicebus_topic":                               resourceArmStreamAnalyticsOutputServiceBusTopic(),
+		"azurerm_stream_analytics_reference_input_blob":                                  resourceArmStreamAnalyticsReferenceInputBlob(),
 		"azurerm_stream_analytics_stream_input_blob":                                     resourceArmStreamAnalyticsStreamInputBlob(),
 		"azurerm_stream_analytics_stream_input_eventhub":                                 resourceArmStreamAnalyticsStreamInputEventHub(),
 		"azurerm_stream_analytics_stream_input_iothub":                                   resourceArmStreamAnalyticsStreamInputIoTHub(),

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob.go
@@ -97,12 +97,12 @@ func resourceArmStreamAnalyticsReferenceInputBlobCreateUpdate(d *schema.Resource
 		existing, err := client.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Stream Analytics Stream Input %q (Job %q / Resource Group %q): %s", name, jobName, resourceGroup, err)
+				return fmt.Errorf("Error checking for presence of existing Stream Analytics Reference Input %q (Job %q / Resource Group %q): %s", name, jobName, resourceGroup, err)
 			}
 		}
 
 		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_stream_analytics_stream_input_blob", *existing.ID)
+			return tf.ImportAsExistsError("azurerm_stream_analytics_reference_input_blob", *existing.ID)
 		}
 	}
 

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob.go
@@ -26,6 +26,13 @@ func resourceArmStreamAnalyticsReferenceInputBlob() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -127,7 +134,8 @@ func getBlobReferenceInputProps(ctx context.Context, d *schema.ResourceData) str
 
 func resourceArmStreamAnalyticsReferenceInputBlobCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).StreamAnalytics.InputsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Reference Input Blob creation.")
 	name := d.Get("name").(string)
@@ -168,7 +176,8 @@ func resourceArmStreamAnalyticsReferenceInputBlobCreate(d *schema.ResourceData, 
 
 func resourceArmStreamAnalyticsReferenceInputBlobUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).StreamAnalytics.InputsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Reference Input Blob creation.")
 	name := d.Get("name").(string)
@@ -186,7 +195,8 @@ func resourceArmStreamAnalyticsReferenceInputBlobUpdate(d *schema.ResourceData, 
 
 func resourceArmStreamAnalyticsReferenceInputBlobRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).StreamAnalytics.InputsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {
@@ -242,7 +252,8 @@ func resourceArmStreamAnalyticsReferenceInputBlobRead(d *schema.ResourceData, me
 
 func resourceArmStreamAnalyticsReferenceInputBlobDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).StreamAnalytics.InputsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := parseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob.go
@@ -85,7 +85,7 @@ func resourceArmStreamAnalyticsReferenceInputBlob() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsReferenceInputBlobCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamAnalyticsInputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Reference Input Blob creation.")
@@ -166,7 +166,7 @@ func resourceArmStreamAnalyticsReferenceInputBlobCreateUpdate(d *schema.Resource
 }
 
 func resourceArmStreamAnalyticsReferenceInputBlobRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamAnalyticsInputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())
@@ -222,7 +222,7 @@ func resourceArmStreamAnalyticsReferenceInputBlobRead(d *schema.ResourceData, me
 }
 
 func resourceArmStreamAnalyticsReferenceInputBlobDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamAnalyticsInputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob.go
@@ -50,8 +50,9 @@ func resourceArmStreamAnalyticsReferenceInputBlob() *schema.Resource {
 			},
 
 			"path_pattern": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 
 			"storage_account_key": {

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob.go
@@ -1,0 +1,243 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+
+	"github.com/Azure/azure-sdk-for-go/services/streamanalytics/mgmt/2016-03-01/streamanalytics"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmStreamAnalyticsReferenceInputBlob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmStreamAnalyticsReferenceInputBlobCreateUpdate,
+		Read:   resourceArmStreamAnalyticsReferenceInputBlobRead,
+		Update: resourceArmStreamAnalyticsReferenceInputBlobCreateUpdate,
+		Delete: resourceArmStreamAnalyticsReferenceInputBlobDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"stream_analytics_job_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"date_format": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"path_pattern": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"storage_account_key": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"storage_account_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"storage_container_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"time_format": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"serialization": azure.SchemaStreamAnalyticsStreamInputSerialization(),
+		},
+	}
+}
+
+func resourceArmStreamAnalyticsReferenceInputBlobCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).streamAnalyticsInputsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Reference Input Blob creation.")
+	name := d.Get("name").(string)
+	jobName := d.Get("stream_analytics_job_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	if requireResourcesToBeImported && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, jobName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Stream Analytics Stream Input %q (Job %q / Resource Group %q): %s", name, jobName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_stream_analytics_stream_input_blob", *existing.ID)
+		}
+	}
+
+	containerName := d.Get("storage_container_name").(string)
+	dateFormat := d.Get("date_format").(string)
+	pathPattern := d.Get("path_pattern").(string)
+	storageAccountKey := d.Get("storage_account_key").(string)
+	storageAccountName := d.Get("storage_account_name").(string)
+	timeFormat := d.Get("time_format").(string)
+
+	serializationRaw := d.Get("serialization").([]interface{})
+	serialization, err := azure.ExpandStreamAnalyticsStreamInputSerialization(serializationRaw)
+	if err != nil {
+		return fmt.Errorf("Error expanding `serialization`: %+v", err)
+	}
+
+	props := streamanalytics.Input{
+		Name: utils.String(name),
+		Properties: &streamanalytics.ReferenceInputProperties{
+			Type: streamanalytics.TypeReference,
+			Datasource: &streamanalytics.BlobReferenceInputDataSource{
+				Type: streamanalytics.TypeBasicReferenceInputDataSourceTypeMicrosoftStorageBlob,
+				BlobReferenceInputDataSourceProperties: &streamanalytics.BlobReferenceInputDataSourceProperties{
+					Container:   utils.String(containerName),
+					DateFormat:  utils.String(dateFormat),
+					PathPattern: utils.String(pathPattern),
+					TimeFormat:  utils.String(timeFormat),
+					StorageAccounts: &[]streamanalytics.StorageAccount{
+						{
+							AccountName: utils.String(storageAccountName),
+							AccountKey:  utils.String(storageAccountKey),
+						},
+					},
+				},
+			},
+			Serialization: serialization,
+		},
+	}
+
+	if d.IsNewResource() {
+		if _, err := client.CreateOrReplace(ctx, props, resourceGroup, jobName, name, "", ""); err != nil {
+			return fmt.Errorf("Error Creating Stream Analytics Reference Input Blob %q (Job %q / Resource Group %q): %+v", name, jobName, resourceGroup, err)
+		}
+
+		read, err := client.Get(ctx, resourceGroup, jobName, name)
+		if err != nil {
+			return fmt.Errorf("Error retrieving Stream Analytics Reference Input Blob %q (Job %q / Resource Group %q): %+v", name, jobName, resourceGroup, err)
+		}
+		if read.ID == nil {
+			return fmt.Errorf("Cannot read ID of Stream Analytics Reference Input Blob %q (Job %q / Resource Group %q)", name, jobName, resourceGroup)
+		}
+
+		d.SetId(*read.ID)
+	} else {
+		if _, err := client.Update(ctx, props, resourceGroup, jobName, name, ""); err != nil {
+			return fmt.Errorf("Error Updating Stream Analytics Reference Input Blob %q (Job %q / Resource Group %q): %+v", name, jobName, resourceGroup, err)
+		}
+	}
+
+	return resourceArmStreamAnalyticsReferenceInputBlobRead(d, meta)
+}
+
+func resourceArmStreamAnalyticsReferenceInputBlobRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).streamAnalyticsInputsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	jobName := id.Path["streamingjobs"]
+	name := id.Path["inputs"]
+
+	resp, err := client.Get(ctx, resourceGroup, jobName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Reference Input Blob %q was not found in Stream Analytics Job %q / Resource Group %q - removing from state!", name, jobName, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Reference Input Blob %q (Stream Analytics Job %q / Resource Group %q): %+v", name, jobName, resourceGroup, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("stream_analytics_job_name", jobName)
+
+	if props := resp.Properties; props != nil {
+		v, ok := props.AsReferenceInputProperties()
+		if !ok {
+			return fmt.Errorf("Error converting Reference Input Blob to a Reference Input: %+v", err)
+		}
+
+		blobInputDataSource, ok := v.Datasource.AsBlobReferenceInputDataSource()
+		if !ok {
+			return fmt.Errorf("Error converting Reference Input Blob to an Blob Stream Input: %+v", err)
+		}
+
+		d.Set("date_format", blobInputDataSource.DateFormat)
+		d.Set("path_pattern", blobInputDataSource.PathPattern)
+		d.Set("storage_container_name", blobInputDataSource.Container)
+		d.Set("time_format", blobInputDataSource.TimeFormat)
+
+		if accounts := blobInputDataSource.StorageAccounts; accounts != nil && len(*accounts) > 0 {
+			account := (*accounts)[0]
+			d.Set("storage_account_name", account.AccountName)
+		}
+
+		if err := d.Set("serialization", azure.FlattenStreamAnalyticsStreamInputSerialization(v.Serialization)); err != nil {
+			return fmt.Errorf("Error setting `serialization`: %+v", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceArmStreamAnalyticsReferenceInputBlobDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).streamAnalyticsInputsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	jobName := id.Path["streamingjobs"]
+	name := id.Path["inputs"]
+
+	if resp, err := client.Delete(ctx, resourceGroup, jobName, name); err != nil {
+		if !response.WasNotFound(resp.Response) {
+			return fmt.Errorf("Error deleting Reference Input Blob %q (Stream Analytics Job %q / Resource Group %q) %+v", name, jobName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
@@ -180,7 +180,7 @@ func testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName string
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamAnalyticsInputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -196,10 +196,10 @@ func testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName string
 }
 
 func testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamAnalyticsInputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "azurerm_stream_analytics_reference_input_eventhub" {
+		if rs.Type != "azurerm_stream_analytics_reference_input_blob" {
 			continue
 		}
 
@@ -213,7 +213,7 @@ func testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy(s *terraform.State
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("Stream Analytics Stream Input EventHub still exists:\n%#v", resp.Properties)
+			return fmt.Errorf("Stream Analytics Stream Input Blob still exists:\n%#v", resp.Properties)
 		}
 	}
 

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
@@ -1,0 +1,394 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccAzureRMStreamAnalyticsReferenceInputBlob_avro(t *testing.T) {
+	resourceName := "azurerm_stream_analytics_reference_input_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStreamAnalyticsReferenceInputBlob_avro(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// not returned from the API
+					"storage_account_key",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStreamAnalyticsReferenceInputBlob_csv(t *testing.T) {
+	resourceName := "azurerm_stream_analytics_reference_input_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStreamAnalyticsReferenceInputBlob_csv(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// not returned from the API
+					"storage_account_key",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStreamAnalyticsReferenceInputBlob_json(t *testing.T) {
+	resourceName := "azurerm_stream_analytics_reference_input_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStreamAnalyticsReferenceInputBlob_json(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// not returned from the API
+					"storage_account_key",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStreamAnalyticsReferenceInputBlob_update(t *testing.T) {
+	resourceName := "azurerm_stream_analytics_reference_input_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStreamAnalyticsReferenceInputBlob_json(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName),
+				),
+			},
+			{
+				Config: testAccAzureRMStreamAnalyticsReferenceInputBlob_updated(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// not returned from the API
+					"storage_account_key",
+				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStreamAnalyticsReferenceInputBlob_requiresImport(t *testing.T) {
+	if !requireResourcesToBeImported {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_stream_analytics_reference_input_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStreamAnalyticsReferenceInputBlob_json(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMStreamAnalyticsReferenceInputBlob_requiresImport(ri, rs, location),
+				ExpectError: testRequiresImportError("azurerm_stream_analytics_stream_input_blob"),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMStreamAnalyticsReferenceInputBlobExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		conn := testAccProvider.Meta().(*ArmClient).streamAnalyticsInputsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
+		if err != nil {
+			return fmt.Errorf("Bad: Get on streamAnalyticsInputsClient: %+v", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Stream Input %q (Stream Analytics Job %q / Resource Group %q) does not exist", name, jobName, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).streamAnalyticsInputsClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_stream_analytics_stream_input_eventhub" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Stream Analytics Stream Input EventHub still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureRMStreamAnalyticsReferenceInputBlob_avro(rInt int, rString string, location string) string {
+	template := testAccAzureRMStreamAnalyticsReferenceInputBlob_template(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_stream_input_blob" "test" {
+  name                         = "acctestinput-%d"
+  stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
+  resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
+  storage_account_name         = "${azurerm_storage_account.test.name}"
+  storage_account_key          = "${azurerm_storage_account.test.primary_access_key}"
+  storage_container_name       = "${azurerm_storage_container.test.name}"
+  path_pattern                 = "some-random-pattern"
+  date_format                  = "yyyy/MM/dd"
+  time_format                  = "HH"
+
+  serialization {
+    type = "Avro"
+  }
+}
+`, template, rInt)
+}
+
+func testAccAzureRMStreamAnalyticsReferenceInputBlob_csv(rInt int, rString string, location string) string {
+	template := testAccAzureRMStreamAnalyticsReferenceInputBlob_template(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_stream_input_blob" "test" {
+  name                         = "acctestinput-%d"
+  stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
+  resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
+  storage_account_name         = "${azurerm_storage_account.test.name}"
+  storage_account_key          = "${azurerm_storage_account.test.primary_access_key}"
+  storage_container_name       = "${azurerm_storage_container.test.name}"
+  path_pattern                 = "some-random-pattern"
+  date_format                  = "yyyy/MM/dd"
+  time_format                  = "HH"
+
+  serialization {
+    type            = "Csv"
+    encoding        = "UTF8"
+    field_delimiter = ","
+  }
+}
+`, template, rInt)
+}
+
+func testAccAzureRMStreamAnalyticsReferenceInputBlob_json(rInt int, rString string, location string) string {
+	template := testAccAzureRMStreamAnalyticsReferenceInputBlob_template(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_stream_input_blob" "test" {
+  name                         = "acctestinput-%d"
+  stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
+  resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
+  storage_account_name         = "${azurerm_storage_account.test.name}"
+  storage_account_key          = "${azurerm_storage_account.test.primary_access_key}"
+  storage_container_name       = "${azurerm_storage_container.test.name}"
+  path_pattern                 = "some-random-pattern"
+  date_format                  = "yyyy/MM/dd"
+  time_format                  = "HH"
+
+  serialization {
+    type     = "Json"
+    encoding = "UTF8"
+  }
+}
+`, template, rInt)
+}
+
+func testAccAzureRMStreamAnalyticsReferenceInputBlob_updated(rInt int, rString string, location string) string {
+	template := testAccAzureRMStreamAnalyticsReferenceInputBlob_template(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "updated" {
+  name                     = "acctestsa2%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "updated" {
+  name                  = "example2"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_stream_analytics_stream_input_blob" "test" {
+  name                         = "acctestinput-%d"
+  stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
+  resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
+  storage_account_name         = "${azurerm_storage_account.updated.name}"
+  storage_account_key          = "${azurerm_storage_account.updated.primary_access_key}"
+  storage_container_name       = "${azurerm_storage_container.updated.name}"
+  path_pattern                 = "some-other-pattern"
+  date_format                  = "yyyy-MM-dd"
+  time_format                  = "HH"
+
+  serialization {
+    type = "Avro"
+  }
+}
+`, template, rString, rInt)
+}
+
+func testAccAzureRMStreamAnalyticsReferenceInputBlob_requiresImport(rInt int, rString string, location string) string {
+	template := testAccAzureRMStreamAnalyticsReferenceInputBlob_json(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_stream_input_blob" "import" {
+  name                      = "${azurerm_stream_analytics_reference_input_blob.test.name}"
+  stream_analytics_job_name = "${azurerm_stream_analytics_reference_input_blob.test.stream_analytics_job_name}"
+  resource_group_name       = "${azurerm_stream_analytics_reference_input_blob.test.resource_group_name}"
+  storage_account_name      = "${azurerm_stream_analytics_reference_input_blob.test.storage_account_name}"
+  storage_account_key       = "${azurerm_stream_analytics_reference_input_blob.test.storage_account_key}"
+  storage_container_name    = "${azurerm_stream_analytics_reference_input_blob.test.storage_container_name}"
+  path_pattern              = "${azurerm_stream_analytics_reference_input_blob.test.path_pattern}"
+  date_format               = "${azurerm_stream_analytics_reference_input_blob.test.date_format}"
+  time_format               = "${azurerm_stream_analytics_reference_input_blob.test.time_format}"
+  serialization             = "${azurerm_stream_analytics_reference_input_blob.test.serialization}"
+}
+`, template)
+}
+
+func testAccAzureRMStreamAnalyticsReferenceInputBlob_template(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "example"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_stream_analytics_job" "test" {
+  name                                     = "acctestjob-%d"
+  resource_group_name                      = "${azurerm_resource_group.test.name}"
+  location                                 = "${azurerm_resource_group.test.location}"
+  compatibility_level                      = "1.0"
+  data_locale                              = "en-GB"
+  events_late_arrival_max_delay_in_seconds = 60
+  events_out_of_order_max_delay_in_seconds = 50
+  events_out_of_order_policy               = "Adjust"
+  output_error_policy                      = "Drop"
+  streaming_units                          = 3
+
+  transformation_query = <<QUERY
+    SELECT *
+    INTO [YourOutputAlias]
+    FROM [YourInputAlias]
+QUERY
+}
+`, rInt, location, rString, rInt)
+}

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 
-	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
 func TestAccAzureRMStreamAnalyticsReferenceInputBlob_avro(t *testing.T) {
@@ -139,7 +140,7 @@ func TestAccAzureRMStreamAnalyticsReferenceInputBlob_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsReferenceInputBlob_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_reference_input_blob_test.go
@@ -162,7 +162,7 @@ func TestAccAzureRMStreamAnalyticsReferenceInputBlob_requiresImport(t *testing.T
 			},
 			{
 				Config:      testAccAzureRMStreamAnalyticsReferenceInputBlob_requiresImport(ri, rs, location),
-				ExpectError: testRequiresImportError("azurerm_stream_analytics_stream_input_blob"),
+				ExpectError: testRequiresImportError("azurerm_stream_analytics_reference_input_blob"),
 			},
 		},
 	})
@@ -199,7 +199,7 @@ func testCheckAzureRMStreamAnalyticsReferenceInputBlobDestroy(s *terraform.State
 	conn := testAccProvider.Meta().(*ArmClient).streamAnalyticsInputsClient
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "azurerm_stream_analytics_stream_input_eventhub" {
+		if rs.Type != "azurerm_stream_analytics_reference_input_eventhub" {
 			continue
 		}
 
@@ -225,7 +225,7 @@ func testAccAzureRMStreamAnalyticsReferenceInputBlob_avro(rInt int, rString stri
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_stream_analytics_stream_input_blob" "test" {
+resource "azurerm_stream_analytics_reference_input_blob" "test" {
   name                         = "acctestinput-%d"
   stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
   resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
@@ -248,7 +248,7 @@ func testAccAzureRMStreamAnalyticsReferenceInputBlob_csv(rInt int, rString strin
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_stream_analytics_stream_input_blob" "test" {
+resource "azurerm_stream_analytics_reference_input_blob" "test" {
   name                         = "acctestinput-%d"
   stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
   resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
@@ -273,7 +273,7 @@ func testAccAzureRMStreamAnalyticsReferenceInputBlob_json(rInt int, rString stri
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_stream_analytics_stream_input_blob" "test" {
+resource "azurerm_stream_analytics_reference_input_blob" "test" {
   name                         = "acctestinput-%d"
   stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
   resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
@@ -312,7 +312,7 @@ resource "azurerm_storage_container" "updated" {
   container_access_type = "private"
 }
 
-resource "azurerm_stream_analytics_stream_input_blob" "test" {
+resource "azurerm_stream_analytics_reference_input_blob" "test" {
   name                         = "acctestinput-%d"
   stream_analytics_job_name    = "${azurerm_stream_analytics_job.test.name}"
   resource_group_name          = "${azurerm_stream_analytics_job.test.resource_group_name}"
@@ -335,7 +335,7 @@ func testAccAzureRMStreamAnalyticsReferenceInputBlob_requiresImport(rInt int, rS
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_stream_analytics_stream_input_blob" "import" {
+resource "azurerm_stream_analytics_reference_input_blob" "import" {
   name                      = "${azurerm_stream_analytics_reference_input_blob.test.name}"
   stream_analytics_job_name = "${azurerm_stream_analytics_reference_input_blob.test.stream_analytics_job_name}"
   resource_group_name       = "${azurerm_stream_analytics_reference_input_blob.test.resource_group_name}"

--- a/examples/stream-analytics/README.md
+++ b/examples/stream-analytics/README.md
@@ -1,3 +1,3 @@
 ## Example: Azure Stream Analytics
 
-This example provisions an Azure Storage Account and a Stream Analytics job that uses it as a reference input.
+This example provisions an Azure Storage Account and a Stream Analytics job, that uses it as a reference input.

--- a/examples/stream-analytics/README.md
+++ b/examples/stream-analytics/README.md
@@ -1,0 +1,3 @@
+## Example: Azure Stream Analytics
+
+This example provisions an Azure Storage Account and a Stream Analytics job that uses it as a reference input.

--- a/examples/stream-analytics/main.tf
+++ b/examples/stream-analytics/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_storage_account" "example" {
 }
 
 resource "azurerm_storage_container" "example" {
-  name                  = "example"
+  name                  = "${var.prefix}example"
   resource_group_name   = "${azurerm_resource_group.example.name}"
   storage_account_name  = "${azurerm_storage_account.example.name}"
   container_access_type = "private"
@@ -44,7 +44,7 @@ QUERY
 }
 
 resource "azurerm_stream_analytics_reference_input_blob" "test" {
-  name                         = "blob-reference-input"
+  name                         = "${var.prefix}-blob-reference-input"
   stream_analytics_job_name    = "${azurerm_stream_analytics_job.example.name}"
   resource_group_name          = "${azurerm_stream_analytics_job.example.resource_group_name}"
   storage_account_name         = "${azurerm_storage_account.example.name}"

--- a/examples/stream-analytics/main.tf
+++ b/examples/stream-analytics/main.tf
@@ -1,0 +1,61 @@
+provider "azurerm" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-example-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "${var.prefix}-examplestoracc"
+  resource_group_name      = "${azurerm_resource_group.example.name}"
+  location                 = "${azurerm_resource_group.example.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "example" {
+  name                  = "example"
+  resource_group_name   = "${azurerm_resource_group.example.name}"
+  storage_account_name  = "${azurerm_storage_account.example.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_stream_analytics_job" "example" {
+  name                                     = "${var.prefix}-example-job"
+  resource_group_name                      = "${azurerm_resource_group.example.name}"
+  location                                 = "${azurerm_resource_group.example.location}"
+  compatibility_level                      = "1.1"
+  data_locale                              = "en-US"
+  events_late_arrival_max_delay_in_seconds = 60
+  events_out_of_order_max_delay_in_seconds = 50
+  events_out_of_order_policy               = "Adjust"
+  output_error_policy                      = "Drop"
+  streaming_units                          = 3
+
+  tags = {
+    environment = "Example"
+  }
+
+  transformation_query = <<QUERY
+    SELECT *
+    INTO [YourOutputAlias]
+    FROM [YourInputAlias]
+QUERY
+}
+
+resource "azurerm_stream_analytics_reference_input_blob" "test" {
+  name                         = "blob-reference-input"
+  stream_analytics_job_name    = "${azurerm_stream_analytics_job.example.name}"
+  resource_group_name          = "${azurerm_stream_analytics_job.example.resource_group_name}"
+  storage_account_name         = "${azurerm_storage_account.example.name}"
+  storage_account_key          = "${azurerm_storage_account.example.primary_access_key}"
+  storage_container_name       = "${azurerm_storage_container.example.name}"
+  path_pattern                 = "some-random-pattern"
+  date_format                  = "yyyy/MM/dd"
+  time_format                  = "HH"
+
+  serialization {
+    type     = "Json"
+    encoding = "UTF8"
+  }
+}

--- a/examples/stream-analytics/variables.tf
+++ b/examples/stream-analytics/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix which should be used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created."
+}

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -1,15 +1,14 @@
 ---
-subcategory: "Stream Analytics"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_stream_analytics_stream_input_blob"
-sidebar_current: "docs-azurerm-resource-stream-analytics-stream-input-blob"
+page_title: "Azure Resource Manager: azurerm_stream_analytics_reference_input_blob"
+sidebar_current: "docs-azurerm-resource-stream-analytics-reference-input-blob"
 description: |-
-  Manages a Stream Analytics Stream Input Blob.
+  Manages a Stream Analytics Reference Input Blob.
 ---
 
-# azurerm_stream_analytics_stream_input_blob
+# azurerm_stream_analytics_reference_input_blob
 
-Manages a Stream Analytics Stream Input Blob.
+Manages a Stream Analytics Reference Input Blob. Reference data (also known as a lookup table) is a finite data set that is static or slowly changing in nature, used to perform a lookup or to correlate with your data stream. Learn more [here](https://docs.microsoft.com/en-us/azure/stream-analytics/stream-analytics-use-reference-data#azure-blob-storage).
 
 ## Example Usage
 
@@ -38,8 +37,8 @@ resource "azurerm_storage_container" "example" {
   container_access_type = "private"
 }
 
-resource "azurerm_stream_analytics_stream_input_blob" "test" {
-  name                         = "blob-stream-input"
+resource "azurerm_stream_analytics_reference_input_blob" "test" {
+  name                         = "blob-reference-input"
   stream_analytics_job_name    = "${data.azurerm_stream_analytics_job.example.name}"
   resource_group_name          = "${data.azurerm_stream_analytics_job.example.resource_group_name}"
   storage_account_name         = "${azurerm_storage_account.example.name}"
@@ -60,7 +59,7 @@ resource "azurerm_stream_analytics_stream_input_blob" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Stream Input Blob. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Reference Input Blob. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Stream Analytics Job exists. Changing this forces a new resource to be created.
 
@@ -84,7 +83,7 @@ The following arguments are supported:
 
 A `serialization` block supports the following:
 
-* `type` - (Required) The serialization format used for incoming data streams. Possible values are `Avro`, `Csv` and `Json`.
+* `type` - (Required) The serialization format used for the reference data. Possible values are `Avro`, `Csv` and `Json`.
 
 * `encoding` - (Optional) The encoding of the incoming data in the case of input and the encoding of outgoing data in the case of output. It currently can only be set to `UTF8`.
 
@@ -98,12 +97,12 @@ A `serialization` block supports the following:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The ID of the Stream Analytics Stream Input Blob.
+* `id` - The ID of the Stream Analytics Reference Input Blob.
 
 ## Import
 
-Stream Analytics Stream Input Blob's can be imported using the `resource id`, e.g.
+Stream Analytics Reference Input Blob's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_stream_input_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_stream_input_blob.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -89,7 +89,7 @@ A `serialization` block supports the following:
 
 -> **NOTE:** This is required when `type` is set to `Csv` or `Json`.
 
-* `field_delimiter` - (Optional) The delimiter that will be used to separate comma-separated value (CSV) records. Possible values are ` ` (space), `,` (comma), `   ` (tab), `|` (pipe) and `;`.
+* `field_delimiter` - (Optional) The delimiter that will be used to separate comma-separated value (CSV) records. Possible values are ` ` (space), `,` (comma), `	` (tab), `|` (pipe) and `;`.
 
 -> **NOTE:** This is required when `type` is set to `Csv`.
 

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `path_pattern` - (Required) The blob path pattern. Not a regular expression. It represents a pattern against which blob names will be matched to determine whether or not they should be included as input or output to the job.
 
-* `storage_account_name` - (Required) The name of the Storage Account.
+* `storage_account_name` - (Required) The name of the Storage Account that has the blob container with reference data.
 
 * `storage_account_key` - (Required) The Access Key which should be used to connect to this Storage Account.
 
@@ -104,5 +104,5 @@ The following attributes are exported in addition to the arguments listed above:
 Stream Analytics Reference Input Blob's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_stream_input_blob.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_reference_input_blob.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -105,5 +105,5 @@ The following attributes are exported in addition to the arguments listed above:
 Stream Analytics Reference Input Blob's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_reference_input_blob.test /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_reference_input_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_reference_input_blob"
 sidebar_current: "docs-azurerm-resource-stream-analytics-reference-input-blob"

--- a/website/docs/r/stream_analytics_stream_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_blob.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_storage_container" "example" {
   container_access_type = "private"
 }
 
-resource "azurerm_stream_analytics_stream_input_blob" "test" {
+resource "azurerm_stream_analytics_stream_input_blob" "example" {
   name                         = "blob-stream-input"
   stream_analytics_job_name    = "${data.azurerm_stream_analytics_job.example.name}"
   resource_group_name          = "${data.azurerm_stream_analytics_job.example.resource_group_name}"


### PR DESCRIPTION
I noticed that it was not possible to create inputs for a stream analytics job of type [reference](https://docs.microsoft.com/en-us/azure/stream-analytics/stream-analytics-use-reference-data#azure-blob-storage). The code to represent such a resource already existed, but just wasn't exposed as a resource to be able to use it.

I also added an example, that I tested using my own subscription. Here's a screenshot of how the "reference" input looks.

![Screenshot_2019-06-10 Microsoft Azure](https://user-images.githubusercontent.com/1466314/59235384-c6a3d080-8ba5-11e9-90bb-f63c5c7354eb.png)
