### PR TITLE
Bugfix: panic when importing azure_app_service_plan

### DIFF
--- a/azurerm/data_source_app_service_plan.go
+++ b/azurerm/data_source_app_service_plan.go
@@ -110,7 +110,6 @@ func dataSourceAppServicePlanRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)
 	d.Set("kind", resp.Kind)
-	d.Set("is_xenon", resp.IsXenon)
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
@@ -128,6 +127,8 @@ func dataSourceAppServicePlanRead(d *schema.ResourceData, meta interface{}) erro
 		if props.MaximumElasticWorkerCount != nil {
 			d.Set("maximum_elastic_worker_count", int(*props.MaximumElasticWorkerCount))
 		}
+
+		d.Set("is_xenon", props.IsXenon)
 	}
 
 	if err := d.Set("sku", flattenAppServicePlanSku(resp.Sku)); err != nil {

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -285,7 +285,6 @@ func resourceArmAppServicePlanRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 	d.Set("kind", resp.Kind)
-	d.Set("is_xenon", resp.IsXenon)
 
 	if props := resp.AppServicePlanProperties; props != nil {
 		if err := d.Set("properties", flattenAppServiceProperties(props)); err != nil {
@@ -306,6 +305,7 @@ func resourceArmAppServicePlanRead(d *schema.ResourceData, meta interface{}) err
 
 		d.Set("per_site_scaling", props.PerSiteScaling)
 		d.Set("reserved", props.Reserved)
+		d.Set("is_xenon", props.IsXenon)
 	}
 
 	if err := d.Set("sku", flattenAppServicePlanSku(resp.Sku)); err != nil {


### PR DESCRIPTION
When importing an `azurerm_app_service_plan` resource, I got an error:
```
Error: rpc error: code = Unavailable desc = transport is closing
```

The TRACE logs showed a panic:
```
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: panic: runtime error: invalid memory address or nil pointer dereference
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: [signal 0xc0000005 code=0x0 addr=0x78 pc=0x26b04a5]
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: goroutine 15 [running]:
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: github.com/terraform-providers/terraform-provider-azurerm/azurerm.resourceArmAppServicePlanRead(0xc0003cd260, 0x30546c0, 0xc00094c000, 0xc0003cd260, 0x0)
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_app_service_plan.go:288 +0x735
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000517e80, 0xc00016b900, 0x30546c0, 0xc00094c000, 0xc00078d5f0, 0xc00016b900, 0x0)
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:447 +0x123
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/plugin.(*GRPCProviderServer).ReadResource(0xc00014e458, 0x355a020, 0xc00078c600, 0xc000636280, 0xc00014e458, 0xc00078c570, 0x2d3a820)
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provider.go:496 +0x312
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/internal/tfplugin5._Provider_ReadResource_Handler(0x2fce620, 0xc00014e458, 0x355a020, 0xc00078c600, 0xc00016b770, 0x0, 0x0, 0x0, 0xc000864480, 0x162)
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/internal/tfplugin5/tfplugin5.pb.go:2983 +0x245
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc00016d800, 0x3576460, 0xc0004a0600, 0xc000703e00, 0xc00058f110, 0x5f08e50, 0x0, 0x0, 0x0)
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:966 +0x4a9
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).handleStream(0xc00016d800, 0x3576460, 0xc0004a0600, 0xc000703e00, 0x0)
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:1245 +0xd68
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000240090, 0xc00016d800, 0x3576460, 0xc0004a0600, 0xc000703e00)
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:685 +0xa6
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: created by github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
2019-06-14T09:00:14.700+0200 [DEBUG] plugin.terraform-provider-azurerm_v1.30.1_x4.exe: 	/opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:683 +0xa8
2019/06/14 09:00:14 [ERROR] module.web_apps: eval: *terraform.EvalRefresh, err: rpc error: code = Unavailable desc = transport is closing
```

After some investigation I discovered that the `web.AppServicePlan` type does not have a `IsXenon` property, which is in fact present on `web.AppServicePlanProperties`. After populating `is_xenon` property from a correct place, the panic no longer occurs. 

This leaves me wondering, how does the original code even compile, with a reference to a non-existent property?