### PR TITLE
arm_search_service - changing tags should not force new resource

### DIFF
--- a/azurerm/resource_arm_search_service.go
+++ b/azurerm/resource_arm_search_service.go
@@ -17,6 +17,7 @@ func resourceArmSearchService() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmSearchServiceCreateUpdate,
 		Read:   resourceArmSearchServiceRead,
+		Update: resourceArmSearchServiceCreateUpdate,
 		Delete: resourceArmSearchServiceDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/azurerm/resource_arm_search_service.go
+++ b/azurerm/resource_arm_search_service.go
@@ -70,7 +70,7 @@ func resourceArmSearchService() *schema.Resource {
 				Computed: true,
 			},
 
-			"tags": tagsForceNewSchema(),
+			"tags": tagsSchema(),
 		},
 	}
 }

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -92,6 +92,35 @@ func TestAccAzureRMSearchService_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSearchService_tagUpdate(t *testing.T) {
+	resourceName := "azurerm_search_service.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSearchService_withCustomTagValue(ri, testLocation(), "staging"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
+				),
+			},
+			{
+				Config: testAccAzureRMSearchService_withCustomTagValue(ri, testLocation(), "production"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSearchServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMSearchServiceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -146,7 +175,7 @@ func testCheckAzureRMSearchServiceDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMSearchService_basic(rInt int, location string) string {
+func testAccAzureRMSearchService_withCustomTagValue(rInt int, location string, tagValue string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -160,10 +189,14 @@ resource "azurerm_search_service" "test" {
   sku                 = "standard"
 
   tags = {
-    environment = "staging"
+    environment = "%s"
   }
 }
-`, rInt, location, rInt)
+`, rInt, location, rInt, tagValue)
+}
+
+func testAccAzureRMSearchService_basic(rInt int, location string) string {
+	return testAccAzureRMSearchService_withCustomTagValue(rInt, location, "staging")
 }
 
 func testAccAzureRMSearchService_requiresImport(rInt int, location string) string {

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `partition_count` - (Optional) Default is 1. Valid values include 1, 2, 3, 4, 6, or 12. Valid only when `sku` is `standard`. Changing this forces a new resource to be created.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changing tags should not force creating new search service.

However, the new test fails with the error:
```
=== RUN   TestAccAzureRMSearchService_tagUpdate
=== PAUSE TestAccAzureRMSearchService_tagUpdate
=== CONT  TestAccAzureRMSearchService_tagUpdate
--- FAIL: TestAccAzureRMSearchService_tagUpdate (99.17s)
    testing.go:568: Step 2 error: errors during apply:

        Error: doesn't support update

          on C:\Users\11024186\AppData\Local\Temp\tf-test975401293\main.tf line 7:
          (source code not available)


FAIL
FAIL    github.com/terraform-providers/terraform-provider-azurerm/azurerm       102.504s
```

Not sure what is the problem, as the raw REST calls work without any issue. Please see #3641 for more information