### PR TITLE
resource/function_app: Share the site_config schema of app_service

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -172,36 +172,7 @@ func resourceArmFunctionApp() *schema.Resource {
 				Default:  false,
 			},
 
-			"site_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"always_on": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"use_32_bit_worker_process": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
-						"websockets_enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-						"linux_fx_version": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-						},
-					},
-				},
-			},
+			"site_config": azure.SchemaAppServiceSiteConfig(),
 
 			"site_credential": {
 				Type:     schema.TypeList,
@@ -274,7 +245,7 @@ func resourceArmFunctionAppCreate(d *schema.ResourceData, meta interface{}) erro
 
 	basicAppSettings := getBasicFunctionAppAppSettings(d, appServiceTier)
 
-	siteConfig := expandFunctionAppSiteConfig(d)
+	siteConfig := azure.ExpandAppServiceSiteConfig(d.Get("site_config"))
 	siteConfig.AppSettings = &basicAppSettings
 
 	siteEnvelope := web.Site{
@@ -345,7 +316,7 @@ func resourceArmFunctionAppUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	basicAppSettings := getBasicFunctionAppAppSettings(d, appServiceTier)
-	siteConfig := expandFunctionAppSiteConfig(d)
+	siteConfig := azure.ExpandAppServiceSiteConfig(d.Get("site_config"))
 	siteConfig.AppSettings = &basicAppSettings
 
 	siteEnvelope := web.Site{
@@ -387,7 +358,7 @@ func resourceArmFunctionAppUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("site_config") {
-		siteConfig := expandFunctionAppSiteConfig(d)
+		siteConfig := azure.ExpandAppServiceSiteConfig(d.Get("site_config"))
 		siteConfigResource := web.SiteConfigResource{
 			SiteConfig: &siteConfig,
 		}
@@ -509,8 +480,8 @@ func resourceArmFunctionAppRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error making Read request on AzureRM Function App Configuration %q: %+v", name, err)
 	}
 
-	siteConfig := flattenFunctionAppSiteConfig(configResp.SiteConfig)
-	if err = d.Set("site_config", siteConfig); err != nil {
+	siteConfig := azure.FlattenAppServiceSiteConfig(configResp.SiteConfig)
+	if err := d.Set("site_config", siteConfig); err != nil {
 		return err
 	}
 
@@ -617,64 +588,6 @@ func expandFunctionAppAppSettings(d *schema.ResourceData, appServiceTier string)
 	}
 
 	return output
-}
-
-func expandFunctionAppSiteConfig(d *schema.ResourceData) web.SiteConfig {
-	configs := d.Get("site_config").([]interface{})
-	siteConfig := web.SiteConfig{}
-
-	if len(configs) == 0 {
-		return siteConfig
-	}
-
-	config := configs[0].(map[string]interface{})
-
-	if v, ok := config["always_on"]; ok {
-		siteConfig.AlwaysOn = utils.Bool(v.(bool))
-	}
-
-	if v, ok := config["use_32_bit_worker_process"]; ok {
-		siteConfig.Use32BitWorkerProcess = utils.Bool(v.(bool))
-	}
-
-	if v, ok := config["websockets_enabled"]; ok {
-		siteConfig.WebSocketsEnabled = utils.Bool(v.(bool))
-	}
-
-	if v, ok := config["linux_fx_version"]; ok {
-		siteConfig.LinuxFxVersion = utils.String(v.(string))
-	}
-
-	return siteConfig
-}
-
-func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
-	results := make([]interface{}, 0)
-	result := make(map[string]interface{})
-
-	if input == nil {
-		log.Printf("[DEBUG] SiteConfig is nil")
-		return results
-	}
-
-	if input.AlwaysOn != nil {
-		result["always_on"] = *input.AlwaysOn
-	}
-
-	if input.Use32BitWorkerProcess != nil {
-		result["use_32_bit_worker_process"] = *input.Use32BitWorkerProcess
-	}
-
-	if input.WebSocketsEnabled != nil {
-		result["websockets_enabled"] = *input.WebSocketsEnabled
-	}
-
-	if input.LinuxFxVersion != nil {
-		result["linux_fx_version"] = *input.LinuxFxVersion
-	}
-
-	results = append(results, result)
-	return results
 }
 
 func expandFunctionAppConnectionStrings(d *schema.ResourceData) map[string]*web.ConnStringValueTypePair {

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -129,14 +129,67 @@ The following arguments are supported:
 
 `site_config` supports the following:
 
-* `always_on` - (Optional) Should the Function App be loaded at all times? Defaults to `false`.
-* `use_32_bit_worker_process` - (Optional) Should the Function App run in 32 bit mode, rather than 64 bit mode? Defaults to `true`.
+* `always_on` - (Optional) Should the app be loaded at all times? Defaults to `false`.
 
-~> **Note:** when using an App Service Plan in the `Free` or `Shared` Tiers `use_32_bit_worker_process` must be set to `true`.
+* `app_command_line` - (Optional) App command line to launch, e.g. `/sbin/myserver -b 0.0.0.0`.
+
+* `cors` - (Optional) A `cors` block as defined below.
+
+* `default_documents` - (Optional) The ordering of default documents to load, if an address isn't specified.
+
+* `dotnet_framework_version` - (Optional) The version of the .net framework's CLR used in this App Service. Possible values are `v2.0` (which will use the latest version of the .net framework for the .net CLR v2 - currently `.net 3.5`) and `v4.0` (which corresponds to the latest version of the .net CLR v4 - which at the time of writing is `.net 4.7.1`). [For more information on which .net CLR version to use based on the .net framework you're targeting - please see this table](https://en.wikipedia.org/wiki/.NET_Framework_version_history#Overview). Defaults to `v4.0`.
+
+* `ftps_state` - (Optional) State of FTP / FTPS service for this App Service. Possible values include: `AllAllowed`, `FtpsOnly` and `Disabled`.
+
+* `http2_enabled` - (Optional) Is HTTP2 Enabled on this App Service? Defaults to `false`.
+
+* `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.
+
+* `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7`, `1.8` and `11`.
+
+* `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.
+
+* `java_container_version` - (Optional) The version of the Java Container to use. If specified `java_version` and `java_container` must also be specified.
+
+* `local_mysql_enabled` - (Optional) Is "MySQL In App" Enabled? This runs a local MySQL instance with your app and shares resources from the App Service plan.
+
+~> **NOTE:** MySQL In App is not intended for production environments and will not scale beyond a single instance. Instead you may wish [to use Azure Database for MySQL](/docs/providers/azurerm/r/mysql_database.html).
+
+* `linux_fx_version` - (Optional) Linux App Framework and version for the App Service. Possible options are a Docker container (`DOCKER|<user/image:tag>`), a base-64 encoded Docker Compose file (`COMPOSE|${filebase64("compose.yml")}`) or a base-64 encoded Kubernetes Manifest (`KUBE|${filebase64("kubernetes.yml")}`).
+
+* `windows_fx_version` - (Optional) The Windows Docker container image (`DOCKER|<user/image:tag>`)
+
+Additional examples of how to run Containers via the `azurerm_app_service` resource can be found in [the `./examples/app-service` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/app-service).
+
+* `managed_pipeline_mode` - (Optional) The Managed Pipeline Mode. Possible values are `Integrated` and `Classic`. Defaults to `Integrated`.
+
+* `min_tls_version` - (Optional) The minimum supported TLS version for the app service. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new app services.
+
+* `php_version` - (Optional) The version of PHP to use in this App Service. Possible values are `5.5`, `5.6`, `7.0`, `7.1` and `7.2`.
+
+* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7` and `3.4`.
+
+* `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.
+
+* `remote_debugging_version` - (Optional) Which version of Visual Studio should the Remote Debugger be compatible with? Possible values are `VS2012`, `VS2013`, `VS2015` and `VS2017`.
+
+* `scm_type` - (Optional) The type of Source Control enabled for this App Service. Defaults to `None`. Possible values are: `BitbucketGit`, `BitbucketHg`, `CodePlexGit`, `CodePlexHg`, `Dropbox`, `ExternalGit`, `ExternalHg`, `GitHub`, `LocalGit`, `None`, `OneDrive`, `Tfs`, `VSO` and `VSTSRM`
+
+* `use_32_bit_worker_process` - (Optional) Should the App Service run in 32 bit mode, rather than 64 bit mode?
+
+~> **NOTE:** when using an App Service Plan in the `Free` or `Shared` Tiers `use_32_bit_worker_process` must be set to `true`.
+
+* `virtual_network_name` - (Optional) The name of the Virtual Network which this App Service should be attached to.
 
 * `websockets_enabled` - (Optional) Should WebSockets be enabled?
 
-* `linux_fx_version` - (Optional) Linux App Framework and version for the AppService, e.g. `DOCKER|(golang:latest)`.
+---
+
+A `cors` block supports the following:
+
+* `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+
+* `support_credentials` - (Optional) Are credentials supported?
 
 ---
 


### PR DESCRIPTION
Fixes: #1374

The API and SDK intrinsically links these as the *same* config block
therefore, we can share the schema and take advantage of all of that
of the app_service site_config block

I added the new documentation to function_app to reflect the changes
based in app_service. Also added a new test to show the enhancement
request this was all to fix - addition of cors_support

```
▶ acctests azurerm TestAccAzureRMFunctionApp_
=== RUN   TestAccAzureRMFunctionApp_basic
=== PAUSE TestAccAzureRMFunctionApp_basic
=== RUN   TestAccAzureRMFunctionApp_requiresImport
--- SKIP: TestAccAzureRMFunctionApp_requiresImport (0.00s)
    resource_arm_function_app_test.go:49: Skipping since resources aren't required to be imported
=== RUN   TestAccAzureRMFunctionApp_tags
=== PAUSE TestAccAzureRMFunctionApp_tags
=== RUN   TestAccAzureRMFunctionApp_tagsUpdate
=== PAUSE TestAccAzureRMFunctionApp_tagsUpdate
=== RUN   TestAccAzureRMFunctionApp_appSettings
=== PAUSE TestAccAzureRMFunctionApp_appSettings
=== RUN   TestAccAzureRMFunctionApp_siteConfig
=== PAUSE TestAccAzureRMFunctionApp_siteConfig
=== RUN   TestAccAzureRMFunctionApp_linuxFxVersion
=== PAUSE TestAccAzureRMFunctionApp_linuxFxVersion
=== RUN   TestAccAzureRMFunctionApp_connectionStrings
=== PAUSE TestAccAzureRMFunctionApp_connectionStrings
=== RUN   TestAccAzureRMFunctionApp_siteConfigMulti
=== PAUSE TestAccAzureRMFunctionApp_siteConfigMulti
=== RUN   TestAccAzureRMFunctionApp_updateVersion
=== PAUSE TestAccAzureRMFunctionApp_updateVersion
=== RUN   TestAccAzureRMFunctionApp_3264bit
=== PAUSE TestAccAzureRMFunctionApp_3264bit
=== RUN   TestAccAzureRMFunctionApp_httpsOnly
=== PAUSE TestAccAzureRMFunctionApp_httpsOnly
=== RUN   TestAccAzureRMFunctionApp_consumptionPlan
=== PAUSE TestAccAzureRMFunctionApp_consumptionPlan
=== RUN   TestAccAzureRMFunctionApp_consumptionPlanUppercaseName
=== PAUSE TestAccAzureRMFunctionApp_consumptionPlanUppercaseName
=== RUN   TestAccAzureRMFunctionApp_createIdentity
=== PAUSE TestAccAzureRMFunctionApp_createIdentity
=== RUN   TestAccAzureRMFunctionApp_updateIdentity
=== PAUSE TestAccAzureRMFunctionApp_updateIdentity
=== RUN   TestAccAzureRMFunctionApp_loggingDisabled
=== PAUSE TestAccAzureRMFunctionApp_loggingDisabled
=== RUN   TestAccAzureRMFunctionApp_updateLogging
=== PAUSE TestAccAzureRMFunctionApp_updateLogging
=== RUN   TestAccAzureRMFunctionApp_corsSettings
=== PAUSE TestAccAzureRMFunctionApp_corsSettings
=== CONT  TestAccAzureRMFunctionApp_basic
=== CONT  TestAccAzureRMFunctionApp_3264bit
=== CONT  TestAccAzureRMFunctionApp_linuxFxVersion
=== CONT  TestAccAzureRMFunctionApp_updateVersion
--- PASS: TestAccAzureRMFunctionApp_basic (138.80s)
=== CONT  TestAccAzureRMFunctionApp_siteConfigMulti
--- PASS: TestAccAzureRMFunctionApp_linuxFxVersion (151.18s)
=== CONT  TestAccAzureRMFunctionApp_connectionStrings
--- PASS: TestAccAzureRMFunctionApp_3264bit (174.06s)
=== CONT  TestAccAzureRMFunctionApp_appSettings
--- PASS: TestAccAzureRMFunctionApp_updateVersion (175.55s)
=== CONT  TestAccAzureRMFunctionApp_siteConfig
--- PASS: TestAccAzureRMFunctionApp_connectionStrings (135.78s)
=== CONT  TestAccAzureRMFunctionApp_updateIdentity
--- PASS: TestAccAzureRMFunctionApp_siteConfig (142.55s)
=== CONT  TestAccAzureRMFunctionApp_updateLogging
--- PASS: TestAccAzureRMFunctionApp_appSettings (211.50s)
=== CONT  TestAccAzureRMFunctionApp_loggingDisabled
--- PASS: TestAccAzureRMFunctionApp_updateIdentity (168.26s)
=== CONT  TestAccAzureRMFunctionApp_tags
--- PASS: TestAccAzureRMFunctionApp_siteConfigMulti (354.83s)
=== CONT  TestAccAzureRMFunctionApp_tagsUpdate
--- PASS: TestAccAzureRMFunctionApp_updateLogging (206.62s)
=== CONT  TestAccAzureRMFunctionApp_consumptionPlanUppercaseName
--- PASS: TestAccAzureRMFunctionApp_loggingDisabled (144.01s)
=== CONT  TestAccAzureRMFunctionApp_createIdentity
--- PASS: TestAccAzureRMFunctionApp_tags (136.79s)
=== CONT  TestAccAzureRMFunctionApp_consumptionPlan
--- PASS: TestAccAzureRMFunctionApp_consumptionPlanUppercaseName (165.62s)
=== CONT  TestAccAzureRMFunctionApp_httpsOnly
--- PASS: TestAccAzureRMFunctionApp_createIdentity (165.89s)
--- PASS: TestAccAzureRMFunctionApp_tagsUpdate (205.60s)
--- PASS: TestAccAzureRMFunctionApp_consumptionPlan (172.33s)
--- PASS: TestAccAzureRMFunctionApp_httpsOnly (126.97s)
=== CONT  TestAccAzureRMFunctionApp_corsSettings
--- PASS: TestAccAzureRMFunctionApp_corsSettings (138.49s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	817.367s
```