### PR TITLE
Updates to Load balancer to support PublicIPPrefix as frontendipconfiguration

### DIFF
--- a/azurerm/resource_arm_loadbalancer.go
+++ b/azurerm/resource_arm_loadbalancer.go
@@ -81,6 +81,13 @@ func resourceArmLoadBalancer() *schema.Resource {
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
 						},
 
+						"public_ip_prefix_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: azure.ValidateResourceIDOrEmpty,
+						},
+
 						"private_ip_address_allocation": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -311,6 +318,12 @@ func expandAzureRmLoadBalancerFrontendIpConfigurations(d *schema.ResourceData) *
 			}
 		}
 
+		if v := data["public_ip_prefix_id"].(string); v != "" {
+			properties.PublicIPPrefix = &network.SubResource{
+				ID: &v,
+			}
+		}
+
 		if v := data["subnet_id"].(string); v != "" {
 			properties.Subnet = &network.Subnet{
 				ID: &v,
@@ -363,6 +376,10 @@ func flattenLoadBalancerFrontendIpConfiguration(ipConfigs *[]network.FrontendIPC
 
 			if pip := props.PublicIPAddress; pip != nil {
 				ipConfig["public_ip_address_id"] = *pip.ID
+			}
+
+			if pip := props.PublicIPPrefix; pip != nil {
+				ipConfig["public_ip_prefix_id"] = *pip.ID
 			}
 
 			loadBalancingRules := make([]interface{}, 0)

--- a/azurerm/resource_arm_loadbalancer_outbound_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_outbound_rule_test.go
@@ -145,6 +145,41 @@ func TestAccAzureRMLoadBalancerOutboundRule_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLoadBalancerOutboundRule_withPublicIPPrefix(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := tf.AccRandTimeInt()
+	outboundRuleName := fmt.Sprintf("OutboundRule-%d", ri)
+
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	outboundRuleId := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestRG-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/outboundRules/%s",
+		subscriptionID, ri, ri, outboundRuleName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerOutboundRule_withPublicIPPrefix(ri, outboundRuleName, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerOutboundRuleExists(outboundRuleName, &lb),
+					resource.TestCheckResourceAttr(
+						"azurerm_lb_outbound_rule.test", "id", outboundRuleId),
+				),
+			},
+			{
+				ResourceName:      "azurerm_lb.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// location is deprecated and was never actually used
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}
+
 func TestAccAzureRMLoadBalancerOutboundRule_disappears(t *testing.T) {
 	var lb network.LoadBalancer
 	ri := tf.AccRandTimeInt()
@@ -466,4 +501,53 @@ resource "azurerm_lb_outbound_rule" "test2" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, outboundRuleName, rInt, outboundRule2Name, rInt)
+}
+
+func testAccAzureRMLoadBalancerOutboundRule_withPublicIPPrefix(rInt int, outboundRuleName string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "test-ip-%d"
+  location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+	prefix_length   = 31
+
+}
+
+resource "azurerm_lb" "test" {
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
+
+
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_prefix_id = "${azurerm_public_ip_prefix.test.id}"
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "be-%d"
+}
+
+resource "azurerm_lb_outbound_rule" "test" {
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.test.id}"
+  protocol                       = "All"
+
+
+  frontend_ip_configuration {
+    name = "one-%d"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, outboundRuleName, rInt)
 }

--- a/azurerm/resource_arm_loadbalancer_rule.go
+++ b/azurerm/resource_arm_loadbalancer_rule.go
@@ -228,13 +228,10 @@ func resourceArmLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("protocol", properties.Protocol)
 		d.Set("frontend_port", properties.FrontendPort)
 		d.Set("backend_port", properties.BackendPort)
+		d.Set("disable_outbound_snat", properties.DisableOutboundSnat)
 
 		if properties.EnableFloatingIP != nil {
 			d.Set("enable_floating_ip", properties.EnableFloatingIP)
-		}
-
-		if properties.DisableOutboundSnat != nil {
-			d.Set("disable_outbound_snat", properties.DisableOutboundSnat)
 		}
 
 		if properties.IdleTimeoutInMinutes != nil {

--- a/azurerm/resource_arm_loadbalancer_rule.go
+++ b/azurerm/resource_arm_loadbalancer_rule.go
@@ -98,6 +98,12 @@ func resourceArmLoadBalancerRule() *schema.Resource {
 				Default:  false,
 			},
 
+			"disable_outbound_snat": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"idle_timeout_in_minutes": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -227,6 +233,10 @@ func resourceArmLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) e
 			d.Set("enable_floating_ip", properties.EnableFloatingIP)
 		}
 
+		if properties.DisableOutboundSnat != nil {
+			d.Set("disable_outbound_snat", properties.DisableOutboundSnat)
+		}
+
 		if properties.IdleTimeoutInMinutes != nil {
 			d.Set("idle_timeout_in_minutes", properties.IdleTimeoutInMinutes)
 		}
@@ -311,10 +321,11 @@ func resourceArmLoadBalancerRuleDelete(d *schema.ResourceData, meta interface{})
 func expandAzureRmLoadBalancerRule(d *schema.ResourceData, lb *network.LoadBalancer) (*network.LoadBalancingRule, error) {
 
 	properties := network.LoadBalancingRulePropertiesFormat{
-		Protocol:         network.TransportProtocol(d.Get("protocol").(string)),
-		FrontendPort:     utils.Int32(int32(d.Get("frontend_port").(int))),
-		BackendPort:      utils.Int32(int32(d.Get("backend_port").(int))),
-		EnableFloatingIP: utils.Bool(d.Get("enable_floating_ip").(bool)),
+		Protocol:            network.TransportProtocol(d.Get("protocol").(string)),
+		FrontendPort:        utils.Int32(int32(d.Get("frontend_port").(int))),
+		BackendPort:         utils.Int32(int32(d.Get("backend_port").(int))),
+		EnableFloatingIP:    utils.Bool(d.Get("enable_floating_ip").(bool)),
+		DisableOutboundSnat: utils.Bool(d.Get("disable_outbound_snat").(bool)),
 	}
 
 	if v, ok := d.GetOk("idle_timeout_in_minutes"); ok {

--- a/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -103,6 +103,41 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLoadBalancerRule_disableoutboundsnat(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := tf.AccRandTimeInt()
+	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	lbRule_id := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestRG-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
+		subscriptionID, ri, ri, lbRuleName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerRule_disableoutboundsnat(ri, lbRuleName, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test", "id", lbRule_id),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test", "disable_outbound_snat", "true"),
+				),
+			},
+			{
+				ResourceName:      "azurerm_lb.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// location is deprecated and was never actually used
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}
+
 func TestAccAzureRMLoadBalancerRule_requiresImport(t *testing.T) {
 	if !requireResourcesToBeImported {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -359,6 +394,49 @@ resource "azurerm_lb_rule" "test" {
 `, rInt, location, rInt, rInt, rInt, lbRuleName, rInt)
 }
 
+func testAccAzureRMLoadBalancerRule_disableoutboundsnat(rInt int, lbRuleName string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "test-ip-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	allocation_method   = "Static"
+	sku 								= "Standard"
+
+}
+
+resource "azurerm_lb" "test" {
+  name                = "arm-test-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	sku 								= "Standard"
+
+  frontend_ip_configuration {
+    name                 = "one-%d"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
+}
+
+resource "azurerm_lb_rule" "test" {
+  location                       = "${azurerm_resource_group.test.location}"
+  resource_group_name            = "${azurerm_resource_group.test.name}"
+  loadbalancer_id                = "${azurerm_lb.test.id}"
+  name                           = "%s"
+  protocol                       = "Tcp"
+  frontend_port                  = 3389
+  backend_port                   = 3389
+	frontend_ip_configuration_name = "one-%d"
+	disable_outbound_snat          = true
+
+}
+`, rInt, location, rInt, rInt, rInt, lbRuleName, rInt)
+}
+
 func testAccAzureRMLoadBalancerRule_requiresImport(rInt int, name string, location string) string {
 	template := testAccAzureRMLoadBalancerRule_basic(rInt, name, location)
 	return fmt.Sprintf(`
@@ -505,6 +583,7 @@ resource "azurerm_lb_rule" "test2" {
   backend_port                   = 3390
   frontend_ip_configuration_name = "one-%d"
 }
+
 `, rInt, location, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
 }
 
@@ -554,5 +633,6 @@ resource "azurerm_lb_rule" "test2" {
   backend_port                   = 3391
   frontend_ip_configuration_name = "one-%d"
 }
+
 `, rInt, location, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
 }

--- a/azurerm/resource_arm_loadbalancer_test.go
+++ b/azurerm/resource_arm_loadbalancer_test.go
@@ -426,7 +426,7 @@ resource "azurerm_lb" "test" {
 `, rInt, location, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMLoadBalancer_frontEndConfigRemoval(rInt int, location string) string {
+func testAccAzureRMLoadBalancer_ftestAccrontEndConfigRemoval(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"

--- a/azurerm/resource_arm_loadbalancer_test.go
+++ b/azurerm/resource_arm_loadbalancer_test.go
@@ -123,7 +123,32 @@ func TestAccAzureRMLoadBalancer_standard(t *testing.T) {
 		},
 	})
 }
+func TestAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resourceName := "azurerm_lb.test"
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists(resourceName, &lb),
+					resource.TestCheckResourceAttr(resourceName, "frontend_ip_configuration.#", "1"),
+				),
+			},
+			{
+				ResourceName:      "azurerm_lb.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 func TestAccAzureRMLoadBalancer_frontEndConfig(t *testing.T) {
 	var lb network.LoadBalancer
 	resourceName := "azurerm_lb.test"
@@ -387,7 +412,7 @@ resource "azurerm_lb" "test" {
   frontend_ip_configuration {
     name                 = "two-%d"
     public_ip_address_id = "${azurerm_public_ip.test1.id}"
-  }
+	}
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt)
 }
@@ -426,7 +451,35 @@ resource "azurerm_lb" "test" {
 `, rInt, location, rInt, rInt, rInt, rInt)
 }
 
-func testAccAzureRMLoadBalancer_ftestAccrontEndConfigRemoval(rInt int, location string) string {
+func testAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "test-ip-prefix-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  prefix_length   = 31
+}
+
+resource "azurerm_lb" "test" {
+  name                = "acctest-loadbalancer-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+	sku = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "prefix-%d"
+    public_ip_prefix_id = "${azurerm_public_ip_prefix.test.id}"
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMLoadBalancer_frontEndConfigRemoval(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Load Balancer.
 * `resource_group_name` - (Required) The name of the Resource Group in which to create the Load Balancer.
 * `location` - (Required) Specifies the supported Azure Region where the Load Balancer should be created.
-* `frontend_ip_configuration` - (Optional) A `frontend_ip_configuration` block as documented below.
+* `frontend_ip_configuration` - (Optional) One or multiple `frontend_ip_configuration` blocks as documented below.
 * `sku` - (Optional) The SKU of the Azure Load Balancer. Accepted values are `Basic` and `Standard`. Defaults to `Basic`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -55,7 +55,8 @@ The following arguments are supported:
 * `subnet_id` - The ID of the Subnet which should be associated with the IP Configuration.
 * `private_ip_address` - (Optional) Private IP Address to assign to the Load Balancer. The last one and first four IPs in any range are reserved and cannot be manually assigned.
 * `private_ip_address_allocation` - (Optional) The allocation method for the Private IP Address used by this Load Balancer. Possible values as `Dynamic` and `Static`.
-* `public_ip_address_id` - (Optional) Th ID of a Public IP Address which should be associated with the Load Balancer.
+* `public_ip_address_id` - (Optional) The ID of a Public IP Address which should be associated with the Load Balancer.
+* `public_ip_prefix_id` - (Optional) The ID of a Public IP Prefix which should be associated with the Load Balancer. Public IP Prefix can only be used with outbound rules.
 * `zones` - (Optional) A list of Availability Zones which the Load Balancer's IP Addresses should be created in.
 
 -> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).

--- a/website/docs/r/loadbalancer_rule.html.markdown
+++ b/website/docs/r/loadbalancer_rule.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 * `enable_floating_ip` - (Optional) Floating IP is pertinent to failover scenarios: a "floating” IP is reassigned to a secondary server in case the primary server fails. Floating IP is required for SQL AlwaysOn.
 * `idle_timeout_in_minutes` - (Optional) Specifies the timeout for the Tcp idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to Tcp.
 * `load_distribution` - (Optional) Specifies the load balancing distribution type to be used by the Load Balancer. Possible values are: `Default` – The load balancer is configured to use a 5 tuple hash to map traffic to available servers. `SourceIP` – The load balancer is configured to use a 2 tuple hash to map traffic to available servers. `SourceIPProtocol` – The load balancer is configured to use a 3 tuple hash to map traffic to available servers. Also known as Session Persistence, where  the options are called `None`, `Client IP` and `Client IP and Protocol` respectively.
-
+* `disable_outbound_snat` - (Optional) Indicates whether outbound snat is disabled or enabled. Default false.
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Reason for the pull request: It was not possible to create a outboundrule using a PublicIpPrefix, as the frontendipconfiguration in terraform didn't support PublicIpPrefix. This PR contains that fix, plus also a minor update to a regular load balancer rule to allow the ```disableoutboundsnat``` to be set on a load balancer rule.
### Major contribution: PublicIPPrefix as frontendIPConfiguration
I made changes to  ```azurerm\resource_arm_loadbalancer.go``` to allow a PublicIPPrefix to be used for a frontendipconfiguration. I edited two test files to have the required tests to cover this: ```azurerm\resource_arm_loadbalancer_test.go``` and ```azurerm\resource_arm_loadbalancer_outbound_rule_test.go```
### Minor contribution: enable disableoutboundsnat on a load balancer rule to be set from Terraform.
I made changes to ```azurerm\resource_arm_loadbalancer_rule.go``` to allow the ```disableoutboundsnat``` parameter to be set. I also edited the test file for load balancer rule to have a new test scenario for these rules ```azurerm\resource_arm_loadbalancer_test.go```.