### PR TITLE
updated docs to highlight delegation

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -197,6 +197,23 @@ A `aci_connector_linux` block supports the following:
 
 * `subnet_name` - (Required) The subnet name for the virtual nodes to run.
 
+-> **Note:** AKS will add a delegation to the subnet named here. To prevent further runs from failing you should make sure that the subnet you create for virtual nodes has a delegation, like so.
+
+```
+resource "azurerm_subnet" "virtual" {
+  
+  ...
+
+  delegation {
+    name = "aciDelegation"
+    service_delegation {
+      name    = "Microsoft.ContainerInstance/containerGroups"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+```
+
 ---
 
 A `role_based_access_control` block supports the following:


### PR DESCRIPTION
After including the add on profile for ACI my second apply failed, even though I hadn't made any changes. It was attempting to modifiy my subnet I had just added specificly for ACI and failed because it was in use. Having a look at what it thought had changed I could see that a delegation had been added. 

I add the delegation into my subnet and it then stopped it thinking there was an issue.  I couldn't spot anything in the docs so though I would add a note to try and help people who hit the same issue.

## Broken pipeline
![image](https://user-images.githubusercontent.com/17758778/59662287-88f60780-91a4-11e9-8e8a-1794cc03772b.png)

## The change to my subnet
https://github.com/JimPaine/aks-quickstart/blob/master/env/vnet.tf#L21-L27
