### PR TITLE
Note added for forced casing at runtime.

### DIFF
--- a/azurerm/helpers/azure/mysql.go
+++ b/azurerm/helpers/azure/mysql.go
@@ -1,0 +1,15 @@
+package azure
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+)
+
+func ValidateMySqlServerName(i interface{}, k string) (_ []string, errors []error) {
+	if m, regexErrs := validate.RegExHelper(i, k, `^[0-9a-z]([-0-9a-z]{0,61}[0-9a-z])?$`); !m {
+		errors = append(regexErrs, fmt.Errorf("%q can contain only lowercase letters, numbers, and '-', but can't start or end with '-' or have more than 63 characters.", k))
+	}
+
+	return nil, errors
+}

--- a/azurerm/resource_arm_mysql_configuration.go
+++ b/azurerm/resource_arm_mysql_configuration.go
@@ -15,6 +15,7 @@ func resourceArmMySQLConfiguration() *schema.Resource {
 		Create: resourceArmMySQLConfigurationCreate,
 		Read:   resourceArmMySQLConfigurationRead,
 		Delete: resourceArmMySQLConfigurationDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -32,6 +33,7 @@ func resourceArmMySQLConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 
 			"value": {

--- a/azurerm/resource_arm_mysql_configuration.go
+++ b/azurerm/resource_arm_mysql_configuration.go
@@ -30,9 +30,9 @@ func resourceArmMySQLConfiguration() *schema.Resource {
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"server_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 

--- a/azurerm/resource_arm_mysql_database.go
+++ b/azurerm/resource_arm_mysql_database.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
-	`github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress`
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -32,9 +32,9 @@ func resourceArmMySqlDatabase() *schema.Resource {
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"server_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 

--- a/azurerm/resource_arm_mysql_database.go
+++ b/azurerm/resource_arm_mysql_database.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	`github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress`
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -16,6 +17,7 @@ func resourceArmMySqlDatabase() *schema.Resource {
 		Create: resourceArmMySqlDatabaseCreate,
 		Read:   resourceArmMySqlDatabaseRead,
 		Delete: resourceArmMySqlDatabaseDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -33,12 +35,13 @@ func resourceArmMySqlDatabase() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 
 			"charset": {
 				Type:             schema.TypeString,
 				Required:         true,
-				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
+				DiffSuppressFunc: suppress.CaseDifference,
 				ForceNew:         true,
 			},
 

--- a/azurerm/resource_arm_mysql_firewall_rule.go
+++ b/azurerm/resource_arm_mysql_firewall_rule.go
@@ -32,9 +32,9 @@ func resourceArmMySqlFirewallRule() *schema.Resource {
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"server_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 

--- a/azurerm/resource_arm_mysql_firewall_rule.go
+++ b/azurerm/resource_arm_mysql_firewall_rule.go
@@ -17,6 +17,7 @@ func resourceArmMySqlFirewallRule() *schema.Resource {
 		Read:   resourceArmMySqlFirewallRuleRead,
 		Update: resourceArmMySqlFirewallRuleCreateUpdate,
 		Delete: resourceArmMySqlFirewallRuleDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -34,6 +35,7 @@ func resourceArmMySqlFirewallRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 
 			"start_ip_address": {

--- a/azurerm/resource_arm_mysql_server.go
+++ b/azurerm/resource_arm_mysql_server.go
@@ -28,9 +28,9 @@ func resourceArmMySqlServer() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 

--- a/azurerm/resource_arm_mysql_server.go
+++ b/azurerm/resource_arm_mysql_server.go
@@ -21,6 +21,7 @@ func resourceArmMySqlServer() *schema.Resource {
 		Read:   resourceArmMySqlServerRead,
 		Update: resourceArmMySqlServerUpdate,
 		Delete: resourceArmMySqlServerDelete,
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -30,6 +31,7 @@ func resourceArmMySqlServer() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: azure.ValidateMySqlServerName,
 			},
 
 			"location": azure.SchemaLocation(),

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -49,7 +49,7 @@ resource "azurerm_mysql_server" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the MySQL Server. Changing this forces a new resource to be created. This needs to be globally unique within Azure. 
+* `name` - (Required) Specifies the name of the MySQL Server. Changing this forces a new resource to be created. This needs to be globally unique within Azure.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the MySQL Server. Changing this forces a new resource to be created.
 

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -49,7 +49,7 @@ resource "azurerm_mysql_server" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the MySQL Server (_Note:_ This will be forced to lowercase when provisioned). Changing this forces a new resource to be created. This needs to be globally unique within Azure. 
+* `name` - (Required) Specifies the name of the MySQL Server. Changing this forces a new resource to be created. This needs to be globally unique within Azure. 
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the MySQL Server. Changing this forces a new resource to be created.
 

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -49,7 +49,7 @@ resource "azurerm_mysql_server" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the MySQL Server. Changing this forces a new resource to be created. This needs to be globally unique within Azure.
+* `name` - (Required) Specifies the name of the MySQL Server (_Note:_ This will be forced to lowercase when provisioned). Changing this forces a new resource to be created. This needs to be globally unique within Azure. 
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the MySQL Server. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
While working with the Azure MySQL PaaS it was identified that the `name` of the resource was forced to lower case in Azure at apply time; If uppercase letters were used in the Terraform Plan it was immediately out-of-date once applied and flagged the freshly created resource Destroy/Create at next `planning`.