### PR TITLE
Don't try and update additional_unattend_config content

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -1520,7 +1520,7 @@ func expandAzureRmVirtualMachineOsProfileWindowsConfig(d *schema.ResourceData) (
 					SettingName:   compute.SettingNames(settingName),
 				}
 
-				if content != "" {
+				if content != "" && !d.IsNewResource() {
 					addContent.Content = &content
 				}
 

--- a/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -2100,7 +2100,7 @@ func expandAzureRmVirtualMachineScaleSetOsProfileWindowsConfig(d *schema.Resourc
 					SettingName:   compute.SettingNames(settingName),
 				}
 
-				if content != "" {
+				if content != "" && !d.IsNewResource() {
 					addContent.Content = &content
 				}
 


### PR DESCRIPTION
The API does not allow unattend config content to be updated

```json
{
  "error": {
    "code": "PropertyChangeNotAllowed",
    "message": "Changing property 'windowsConfiguration.additionalUnattendContent.content' is not allowed.",
    "target": "windowsConfiguration.additionalUnattendContent.content"
  }
}
```