### PR TITLE
aurerm_dev_test_virtual_network: generate subnet IDs in the correct format

### DIFF
--- a/azurerm/resource_arm_dev_test_virtual_network.go
+++ b/azurerm/resource_arm_dev_test_virtual_network.go
@@ -116,7 +116,7 @@ func resourceArmDevTestVirtualNetworkCreate(d *schema.ResourceData, meta interfa
 
 	subscriptionId := meta.(*ArmClient).subscriptionId
 	subnetsRaw := d.Get("subnet").([]interface{})
-	subnets := expandDevTestVirtualNetworkSubnets(subnetsRaw, subscriptionId, resourceGroup, labName, name)
+	subnets := expandDevTestVirtualNetworkSubnets(subnetsRaw, subscriptionId, resourceGroup, name)
 
 	parameters := dtl.VirtualNetwork{
 		Tags: expandTags(tags),
@@ -208,7 +208,7 @@ func resourceArmDevTestVirtualNetworkUpdate(d *schema.ResourceData, meta interfa
 
 	subscriptionId := meta.(*ArmClient).subscriptionId
 	subnetsRaw := d.Get("subnet").([]interface{})
-	subnets := expandDevTestVirtualNetworkSubnets(subnetsRaw, subscriptionId, resourceGroup, labName, name)
+	subnets := expandDevTestVirtualNetworkSubnets(subnetsRaw, subscriptionId, resourceGroup, name)
 
 	parameters := dtl.VirtualNetwork{
 		Tags: expandTags(tags),
@@ -282,12 +282,12 @@ func validateDevTestVirtualNetworkName() schema.SchemaValidateFunc {
 		"Virtual Network Name can only include alphanumeric characters, underscores, hyphens.")
 }
 
-func expandDevTestVirtualNetworkSubnets(input []interface{}, subscriptionId, resourceGroupName, labName, virtualNetworkName string) *[]dtl.SubnetOverride {
+func expandDevTestVirtualNetworkSubnets(input []interface{}, subscriptionId, resourceGroupName, virtualNetworkName string) *[]dtl.SubnetOverride {
 	results := make([]dtl.SubnetOverride, 0)
 	// default found from the Portal
 	name := fmt.Sprintf("%sSubnet", virtualNetworkName)
-	idFmt := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DevTestLab/labs/%s/virtualnetworks/%s/subnets/%s"
-	subnetId := fmt.Sprintf(idFmt, subscriptionId, resourceGroupName, labName, virtualNetworkName, name)
+	idFmt := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualnetworks/%s/subnets/%s"
+	subnetId := fmt.Sprintf(idFmt, subscriptionId, resourceGroupName, virtualNetworkName, name)
 	if len(input) == 0 {
 		result := dtl.SubnetOverride{
 			ResourceID:                   utils.String(subnetId),

--- a/azurerm/resource_arm_dev_test_virtual_network.go
+++ b/azurerm/resource_arm_dev_test_virtual_network.go
@@ -286,7 +286,7 @@ func expandDevTestVirtualNetworkSubnets(input []interface{}, subscriptionId, res
 	results := make([]dtl.SubnetOverride, 0)
 	// default found from the Portal
 	name := fmt.Sprintf("%sSubnet", virtualNetworkName)
-	idFmt := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualnetworks/%s/subnets/%s"
+	idFmt := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s"
 	subnetId := fmt.Sprintf(idFmt, subscriptionId, resourceGroupName, virtualNetworkName, name)
 	if len(input) == 0 {
 		result := dtl.SubnetOverride{


### PR DESCRIPTION
This commit fixes the existing acceptance tests for dev test labs virtual machines.

The existing virtual machine tests get the following error when run:
 
make testacc TESTARGS='-run=TestAccAzureRMDevTestLinuxVirtualMachine_basicSSH'

        FAIL: TestAccAzureRMDevTestLinuxVirtualMachine_basicSSH (495.56s) 
             testing.go:568: Step 0 error: errors during apply:

        Error: Error creating/updating DevTest Linux Virtual Machine "acctestvm-vm190622164302310846" (Lab "acctestdtl190622164302310846" / Resource Group "acctestRG-190622164302310846"): dtl.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidSubnetUsed" Message="Subnet acctestdtvn190622164302310846Subnet either is not enabled or is not part of specified virtual network /subscriptions/054c2f17-4700-4ce8-9aa7-2cfcfa4ad36f/resourcegroups/acctestrg-190622164302310846/providers/microsoft.devtestlab/labs/acctestdtl190622164302310846/virtualnetworks/acctestdtvn190622164302310846."
        
          on /tmp/tf-test370917857/main.tf line 29:
          (source code not available)
