### PR TITLE
fix to allow multiple rule setup in the redis firewall resource

### DIFF
--- a/azurerm/resource_arm_redis_firewall_rule.go
+++ b/azurerm/resource_arm_redis_firewall_rule.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/services/redis/mgmt/2018-03-01/redis"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -84,21 +85,24 @@ func resourceArmRedisFirewallRuleCreateUpdate(d *schema.ResourceData, meta inter
 		},
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resourceGroup, cacheName, name, parameters); err != nil {
-		return err
-	}
+	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 
-	read, err := client.Get(ctx, resourceGroup, cacheName, name)
-	if err != nil {
-		return err
-	}
-	if read.ID == nil {
-		return fmt.Errorf("Cannot read Redis Firewall Rule %q (cache %q / resource group %q) ID", name, cacheName, resourceGroup)
-	}
+		if _, err := client.CreateOrUpdate(ctx, resourceGroup, cacheName, name, parameters); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Error creating the rule: %s", err))
+		}
 
-	d.SetId(*read.ID)
+		read, err := client.Get(ctx, resourceGroup, cacheName, name)
+		if err != nil {
+			return resource.RetryableError(fmt.Errorf("Expected instance to be created but was in non existent state, retrying"))
+		}
+		if read.ID == nil {
+			return resource.NonRetryableError(fmt.Errorf("Cannot read Redis Firewall Rule %q (cache %q / resource group %q) ID", name, cacheName, resourceGroup))
+		}
 
-	return resourceArmRedisFirewallRuleRead(d, meta)
+		d.SetId(*read.ID)
+
+		return resource.NonRetryableError(resourceArmRedisFirewallRuleRead(d, meta))
+	})
 }
 
 func resourceArmRedisFirewallRuleRead(d *schema.ResourceData, meta interface{}) error {

--- a/azurerm/resource_arm_redis_firewall_rule_test.go
+++ b/azurerm/resource_arm_redis_firewall_rule_test.go
@@ -75,6 +75,37 @@ func TestAccAzureRMRedisFirewallRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMRedisFirewallRule_multi(t *testing.T) {
+	ruleOne := "azurerm_redis_firewall_rule.test"
+	ruleTwo := "azurerm_redis_firewall_rule.double"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRedisFirewallRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMRedisFirewallRule_multi(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMRedisFirewallRuleExists(ruleOne),
+					testCheckAzureRMRedisFirewallRuleExists(ruleTwo),
+				),
+			},
+			{
+				ResourceName:      ruleOne,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      ruleTwo,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMRedisFirewallRule_requiresImport(t *testing.T) {
 	if !requireResourcesToBeImported {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -211,6 +242,20 @@ resource "azurerm_redis_firewall_rule" "test" {
   end_ip              = "2.3.4.5"
 }
 `, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMRedisFirewallRule_multi(rInt int, location string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_redis_firewall_rule" "double" {
+	name                = "fwruletwo%d"
+	redis_cache_name    = "${azurerm_redis_cache.test.name}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+	start_ip            = "4.5.6.7"
+	end_ip              = "8.9.0.1"
+  }
+`, testAccAzureRMRedisFirewallRule_basic(rInt, location), rInt)
 }
 
 func testAccAzureRMRedisFirewallRule_requiresImport(rInt int, location string) string {


### PR DESCRIPTION
At the moment Redis SDK return success when 2+ rules are being setup in the terraform configuration where in reality create operation does not create more than 1 rule returning success for all operations which results in the read error happening in the resourceArmRedisFirewallRuleCreateUpdate

```
module.redis_test.azurerm_redis_firewall_rule.hosting[1]: Creating...
module.redis_test.azurerm_redis_firewall_rule.hosting[0]: Creating...
module.redis_test.azurerm_redis_firewall_rule.hosting[0]: Creation complete after 3s [id=/subscriptions/89731d00-1ebf-435f-919e-45920d73b538/resourceGroups/rgpazewtmlit001tftest/providers/Microsoft.Cache/Redis/redis-stack-tst2/firewallRules/rule_0]

Error: redis.FirewallRulesClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="A requested resource could not be found. It may already have been deleted.\r\nRequestID=15c4d104-5eb2-48c5-9e99-1e00ad04ddab"
```

As a fix I've added a retry logic to the resourceArmRedisFirewallRuleCreateUpdate which will loop through the create process until all reads are successful or create operation fails.

(fixes #2830)