### PR TITLE
Fix documentation for azurerm_key_vault_access_policy

### DIFF
--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -41,8 +41,7 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_access_policy" "test" {
-  vault_name          = "${azurerm_key_vault.test.name}"
-  resource_group_name = "${azurerm_key_vault.test.resource_group_name}"
+  key_vault_id          = "${azurerm_key_vault.test.id}"
 
   tenant_id = "00000000-0000-0000-0000-000000000000"
   object_id = "11111111-1111-1111-1111-111111111111"

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -61,10 +61,15 @@ resource "azurerm_key_vault_access_policy" "test" {
 
 The following arguments are supported:
 
-* `vault_name` - (Required) Specifies the name of the Key Vault resource. Changing this
+* `key_vault_id` - (Required) Specifies the id of the Key Vault resource. Changing this
     forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+-> **NOTE:** At this time the Key Vault `<->` Key Vault Access Policy associations need to be configured using the field `key_vault_id` or using both fields `vault_name` and `resource_group_name`. These fields are now deprecated and will be removed in favour of `key_vault_id` in the next major version (2.0) of the AzureRM Provider.
+
+* `vault_name` - (Required / **Deprecated**) Specifies the name of the Key Vault resource. Changing this
+    forces a new resource to be created.
+
+* `resource_group_name` - (Required / **Deprecated**) The name of the resource group in which to
     create the namespace. Changing this forces a new resource to be created.
 
 * `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used


### PR DESCRIPTION
Vault_name and resource_group_name was deprecated but documentation was not updated.

See changelog:

DEPRECATIONS
* `azurerm_key_vault_access_policy` - deprecating the `vault_name` and `resource_group_name` properties in favour of `key_vault_id` ([#2820](https://github.com/terraform-providers/terraform-provider-azurerm/issues/2820))

#2820