### PR TITLE
Increase timeout for azurerm_app_service_plan to accommodate creation of Isolated SKUs that take a long time to provision

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -1201,6 +1201,7 @@ func (c *ArmClient) registerTrafficManagerClients(endpoint, subscriptionId strin
 func (c *ArmClient) registerWebClients(endpoint, subscriptionId string, auth autorest.Authorizer) {
 	appServicePlansClient := web.NewAppServicePlansClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&appServicePlansClient.Client, auth)
+	appServicePlansClient.PollingDuration = 180 * time.Minute
 	c.appServicePlansClient = appServicePlansClient
 
 	appsClient := web.NewAppsClientWithBaseURI(endpoint, subscriptionId)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -288,7 +288,7 @@ func (c *ArmClient) configureClient(client *autorest.Client, auth autorest.Autho
 	client.RequestInspector = azure.WithCorrelationRequestID(azure.CorrelationRequestID())
 	client.Sender = azure.BuildSender()
 	client.SkipResourceProviderRegistration = c.skipProviderRegistration
-	client.PollingDuration = 60 * time.Minute
+	client.PollingDuration = 180 * time.Minute
 }
 
 func setUserAgent(client *autorest.Client, partnerID string) {
@@ -1201,7 +1201,6 @@ func (c *ArmClient) registerTrafficManagerClients(endpoint, subscriptionId strin
 func (c *ArmClient) registerWebClients(endpoint, subscriptionId string, auth autorest.Authorizer) {
 	appServicePlansClient := web.NewAppServicePlansClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&appServicePlansClient.Client, auth)
-	appServicePlansClient.PollingDuration = 180 * time.Minute
 	c.appServicePlansClient = appServicePlansClient
 
 	appsClient := web.NewAppsClientWithBaseURI(endpoint, subscriptionId)

--- a/azurerm/internal/ar/client.go
+++ b/azurerm/internal/ar/client.go
@@ -18,7 +18,7 @@ func ConfigureClient(client *autorest.Client, auth autorest.Authorizer, partnerI
 	setUserAgent(client, partnerId)
 	client.Authorizer = auth
 	client.Sender = sender.BuildSender("AzureRM")
-	client.PollingDuration = 60 * time.Minute
+	client.PollingDuration = 180 * time.Minute
 	client.SkipResourceProviderRegistration = skipProviderReg
 	client.RequestInspector = azure.WithCorrelationRequestID(azure.CorrelationRequestID())
 


### PR DESCRIPTION
`azurerm_app_service_plan` resources that are created with an `Isolated` sku can take quite some time to create because they resources being created are not shared and take a long time to create within Azure itself. 

This change increases the timeout to 3 hours when creating `azurerm_app_service_plan` resources. This covers nearly all of the scenarios, as most will create in <= 1.5 hours.

Note: I'm aware that this will be fixed by https://github.com/terraform-providers/terraform-provider-azurerm/issues/171 but I thought that since this is an expected scenario that we should fix it up front