### PR TITLE
azurerm_cosmosdb_account: ignore 500 responses from CheckNameExists() call

### DIFF
--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	`net/http`
 	"regexp"
 	"strings"
 	"time"

--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -328,7 +328,10 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 
 	r, err := client.CheckNameExists(ctx, name)
 	if err != nil {
-		return fmt.Errorf("Error checking if CosmosDB Account %q already exists (Resource Group %q): %+v", name, resourceGroup, err)
+		// todo remove when https://github.com/Azure/azure-sdk-for-go/issues/5157 is fixed
+		if !utils.ResponseWasStatusCode(r, 500) {
+			return fmt.Errorf("Error checking if CosmosDB Account %q already exists (Resource Group %q): %+v", name, resourceGroup, err)
+		}
 	}
 	if !utils.ResponseWasNotFound(r) {
 		return fmt.Errorf("CosmosDB Account %s already exists, please import the resource via terraform import", name)

--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -332,10 +332,12 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 		if !utils.ResponseWasStatusCode(r, 500) {
 			return fmt.Errorf("Error checking if CosmosDB Account %q already exists (Resource Group %q): %+v", name, resourceGroup, err)
 		}
+	} else {
+		if !utils.ResponseWasNotFound(r) {
+			return fmt.Errorf("CosmosDB Account %s already exists, please import the resource via terraform import", name)
+		}
 	}
-	if !utils.ResponseWasNotFound(r) {
-		return fmt.Errorf("CosmosDB Account %s already exists, please import the resource via terraform import", name)
-	}
+
 
 	//hacky, todo fix up once deprecated field 'failover_policy' is removed
 	var geoLocations []documentdb.Location

--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -329,7 +329,7 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 	r, err := client.CheckNameExists(ctx, name)
 	if err != nil {
 		// todo remove when https://github.com/Azure/azure-sdk-for-go/issues/5157 is fixed
-		if !utils.ResponseWasStatusCode(r, 500) {
+		if !utils.ResponseWasStatusCode(r, http.StatusInternalServerError) {
 			return fmt.Errorf("Error checking if CosmosDB Account %q already exists (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	} else {

--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	`net/http`
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -338,7 +338,6 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("CosmosDB Account %s already exists, please import the resource via terraform import", name)
 		}
 	}
-
 
 	//hacky, todo fix up once deprecated field 'failover_policy' is removed
 	var geoLocations []documentdb.Location

--- a/azurerm/utils/response.go
+++ b/azurerm/utils/response.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ResponseWasNotFound(resp autorest.Response) bool {
-	return responseWasStatusCode(resp, http.StatusNotFound)
+	return ResponseWasStatusCode(resp, http.StatusNotFound)
 }
 
 func ResponseErrorIsRetryable(err error) bool {
@@ -26,7 +26,7 @@ func ResponseErrorIsRetryable(err error) bool {
 	return false
 }
 
-func responseWasStatusCode(resp autorest.Response, statusCode int) bool { // nolint: unparam
+func ResponseWasStatusCode(resp autorest.Response, statusCode int) bool { // nolint: unparam
 	if r := resp.Response; r != nil {
 		if r.StatusCode == statusCode {
 			return true


### PR DESCRIPTION
The API is suddenly failing with 500s when we check the DB name, so lets ignore it for now.

SDK issue: https://github.com/Azure/azure-sdk-for-go/issues/5157

fixes #3739