### PR TITLE
azurerm_storage_account: the `account_kind` property now supports `FileStorage`

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -519,6 +519,13 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
+	// AccountTier must be Premium for FileStorage
+	if accountKind == string(storage.FileStorage) {
+		if string(parameters.Sku.Tier) == string(storage.StandardLRS) {
+			return fmt.Errorf("A `account_tier` of `Standard` is not supported for FileStorage accounts.")
+		}
+	}
+
 	// Create
 	future, err := client.Create(ctx, resourceGroupName, storageAccountName, parameters)
 	if err != nil {

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -505,7 +505,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// AccessTier is only valid for BlobStorage and StorageV2 accounts
-	if accountKind == string(storage.BlobStorage) || accountKind == string(storage.StorageV2) {
+	if accountKind == string(storage.BlobStorage) || accountKind == string(storage.StorageV2) || accountKind == string(storage.FileStorage) {
 		accessTier, ok := d.GetOk("access_tier")
 		if !ok {
 			// default to "Hot"

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -504,7 +504,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	// AccessTier is only valid for BlobStorage and StorageV2 accounts
+	// AccessTier is only valid for BlobStorage, StorageV2, and FileStorage accounts
 	if accountKind == string(storage.BlobStorage) || accountKind == string(storage.StorageV2) || accountKind == string(storage.FileStorage) {
 		accessTier, ok := d.GetOk("access_tier")
 		if !ok {

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -51,6 +51,7 @@ func resourceArmStorageAccount() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(storage.Storage),
 					string(storage.BlobStorage),
+					string(storage.FileStorage),
 					string(storage.StorageV2),
 				}, true),
 				Default: string(storage.Storage),

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -1033,8 +1033,8 @@ resource "azurerm_storage_account" "testsa" {
   location                 = "${azurerm_resource_group.testrg.location}"
   account_kind             = "FileStorage"
   account_tier             = "Premium"
-	account_replication_type = "LRS"
-	access_tier              = "Hot"
+  account_replication_type = "LRS"
+  access_tier              = "Hot"
 
   tags = {
     environment = "production"
@@ -1057,8 +1057,8 @@ resource "azurerm_storage_account" "testsa" {
   location                 = "${azurerm_resource_group.testrg.location}"
   account_kind             = "FileStorage"
   account_tier             = "Premium"
-	account_replication_type = "LRS"
-	access_tier              = "Cool"
+  account_replication_type = "LRS"
+  access_tier              = "Cool"
 
   tags = {
     environment = "production"

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -414,6 +414,7 @@ func TestAccAzureRMStorageAccount_fileStorageWithUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(resourceName),
 					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_kind", "FileStorage"),
+					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_tier", "Premium"),
 					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "access_tier", "Hot"),
 				),
 			},
@@ -426,6 +427,7 @@ func TestAccAzureRMStorageAccount_fileStorageWithUpdate(t *testing.T) {
 				Config: postConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(resourceName),
+					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_tier", "Premium"),
 					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "access_tier", "Cool"),
 				),
 			},
@@ -1030,8 +1032,9 @@ resource "azurerm_storage_account" "testsa" {
 
   location                 = "${azurerm_resource_group.testrg.location}"
   account_kind             = "FileStorage"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_tier             = "Premium"
+	account_replication_type = "LRS"
+	access_tier              = "Hot"
 
   tags = {
     environment = "production"
@@ -1053,11 +1056,12 @@ resource "azurerm_storage_account" "testsa" {
 
   location                 = "${azurerm_resource_group.testrg.location}"
   account_kind             = "FileStorage"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_tier             = "Premium"
+	account_replication_type = "LRS"
+	access_tier              = "Cool"
 
   tags = {
-    environment = "production2"
+    environment = "production"
   }
 }
 `, rInt, location, rString)

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -396,7 +396,42 @@ func TestAccAzureRMStorageAccount_blobStorageWithUpdate(t *testing.T) {
 		},
 	})
 }
+func TestAccAzureRMStorageAccount_fileStorageWithUpdate(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+	preConfig := testAccAzureRMStorageAccount_fileStorage(ri, rs, location)
+	postConfig := testAccAzureRMStorageAccount_fileStorageUpdate(ri, rs, location)
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(resourceName),
+					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "account_kind", "FileStorage"),
+					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "access_tier", "Hot"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(resourceName),
+					resource.TestCheckResourceAttr("azurerm_storage_account.testsa", "access_tier", "Cool"),
+				),
+			},
+		},
+	})
+}
 func TestAccAzureRMStorageAccount_storageV2WithUpdate(t *testing.T) {
 	resourceName := "azurerm_storage_account.testsa"
 	ri := tf.AccRandTimeInt()
@@ -977,6 +1012,52 @@ resource "azurerm_storage_account" "testsa" {
 
   tags = {
     environment = "production"
+  }
+}
+`, rInt, location, rString)
+}
+
+func testAccAzureRMStorageAccount_fileStorage(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "testrg" {
+  name     = "acctestAzureRMSA-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "testsa" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = "${azurerm_resource_group.testrg.name}"
+
+  location                 = "${azurerm_resource_group.testrg.location}"
+  account_kind             = "FileStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "production"
+  }
+}
+`, rInt, location, rString)
+}
+
+func testAccAzureRMStorageAccount_fileStorageUpdate(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "testrg" {
+  name     = "acctestAzureRMSA-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "testsa" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = "${azurerm_resource_group.testrg.name}"
+
+  location                 = "${azurerm_resource_group.testrg.location}"
+  account_kind             = "FileStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "production2"
   }
 }
 `, rInt, location, rString)

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -78,25 +78,19 @@ resource "azurerm_storage_account" "testsa" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the storage account. Changing this forces a
-    new resource to be created. This must be unique across the entire Azure service,
-    not just within the resource group.
+* `name` - (Required) Specifies the name of the storage account. Changing this forces a new resource to be created. This must be unique across the entire Azure service, not just within the resource group.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the storage account. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the storage account. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the
-    resource exists. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `account_kind` - (Optional) Defines the Kind of account. Valid options are `Storage`,
-    `StorageV2`,  `BlobStorage`, and `FileStorage`. Changing this forces a new resource to be created.
-    Defaults to `Storage`.
+* `account_kind` - (Optional) Defines the Kind of account. Valid options are `Storage`, `StorageV2`,  `BlobStorage`, and `FileStorage`. Changing this forces a new resource to be created. Defaults to `Storage`.
 
 * `account_tier` - (Required) Defines the Tier to use for this storage account. Valid options are `Standard` and `Premium`. For `FileStorage` accounts only `Premium` is valid. Changing this forces a new resource to be created.
 
 * `account_replication_type` - (Required) Defines the type of replication to use for this storage account. Valid options are `LRS`, `GRS`, `RAGRS` and `ZRS`.
 
-* `access_tier` - (Optional) Defines the access tier for `BlobStorage` and `StorageV2` accounts. Valid options are `Hot` and `Cool`, defaults to `Hot`.
+* `access_tier` - (Optional) Defines the access tier for `BlobStorage`, `FileStorage` and `StorageV2` accounts. Valid options are `Hot` and `Cool`, defaults to `Hot`.
 
 * `enable_blob_encryption` - (Optional) Boolean flag which controls if Encryption Services are enabled for Blob storage, see [here](https://azure.microsoft.com/en-us/documentation/articles/storage-service-encryption/) for more information. Defaults to `true`.
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
     resource exists. Changing this forces a new resource to be created.
 
 * `account_kind` - (Optional) Defines the Kind of account. Valid options are `Storage`,
-    `StorageV2` and `BlobStorage`. Changing this forces a new resource to be created.
+    `StorageV2`,  `BlobStorage`, and `FileStorage`. Changing this forces a new resource to be created.
     Defaults to `Storage`.
 
 * `account_tier` - (Required) Defines the Tier to use for this storage account. Valid options are `Standard` and `Premium`. Changing this forces a new resource to be created

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
     `StorageV2`,  `BlobStorage`, and `FileStorage`. Changing this forces a new resource to be created.
     Defaults to `Storage`.
 
-* `account_tier` - (Required) Defines the Tier to use for this storage account. Valid options are `Standard` and `Premium`. Changing this forces a new resource to be created
+* `account_tier` - (Required) Defines the Tier to use for this storage account. Valid options are `Standard` and `Premium`. For `FileStorage` accounts only `Premium` is valid. Changing this forces a new resource to be created.
 
 * `account_replication_type` - (Required) Defines the type of replication to use for this storage account. Valid options are `LRS`, `GRS`, `RAGRS` and `ZRS`.
 


### PR DESCRIPTION
This PR is for adding the FileStorage kind as an option on Storage Accounts.

Description of the FileStorage kind.
https://docs.microsoft.com/en-us/azure/storage/common/storage-account-overview#filestorage-storage-accounts

API Reference: https://docs.microsoft.com/en-us/rest/api/storagerp/storageaccounts/create#kind

(fixes #3756)