### PR TITLE
Update CosmosDB to accept virtual_network_subnet_ids list

### DIFF
--- a/azurerm/data_source_cosmos_db_account.go
+++ b/azurerm/data_source_cosmos_db_account.go
@@ -111,17 +111,12 @@ func dataSourceArmCosmosDbAccount() *schema.Resource {
 				Computed: true,
 			},
 
-			"virtual_network_rule": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
+			"virtual_network_subnet_ids": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
 				},
+				Computed: true,
 			},
 
 			"enable_multiple_write_locations": {
@@ -231,8 +226,8 @@ func dataSourceArmCosmosDbAccountRead(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("Error setting `capabilities`: %+v", err)
 		}
 
-		if err = d.Set("virtual_network_rule", flattenAzureRmCosmosDBAccountVirtualNetworkRulesAsList(props.VirtualNetworkRules)); err != nil {
-			return fmt.Errorf("Error setting `virtual_network_rule`: %+v", err)
+		if err = d.Set("virtual_network_subnet_ids", flattenAzureRmCosmosDBAccountVirtualNetworkRulesAsList(props.VirtualNetworkRules)); err != nil {
+			return fmt.Errorf("Error setting `virtual_network_subnet_ids`: %+v", err)
 		}
 
 		readEndpoints := make([]string, 0)
@@ -288,16 +283,14 @@ func flattenAzureRmCosmosDBAccountCapabilitiesAsList(capabilities *[]documentdb.
 	return &slice
 }
 
-func flattenAzureRmCosmosDBAccountVirtualNetworkRulesAsList(rules *[]documentdb.VirtualNetworkRule) []map[string]interface{} {
+func flattenAzureRmCosmosDBAccountVirtualNetworkRulesAsList(rules *[]documentdb.VirtualNetworkRule) []interface{} {
 	if rules == nil {
-		return []map[string]interface{}{}
+		return []interface{}{}
 	}
 
-	virtualNetworkRules := make([]map[string]interface{}, len(*rules))
+	virtualNetworkRules := make([]interface{}, len(*rules))
 	for i, r := range *rules {
-		virtualNetworkRules[i] = map[string]interface{}{
-			"id": *r.ID,
-		}
+		virtualNetworkRules[i] = *r.ID
 	}
 	return virtualNetworkRules
 }

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -53,7 +53,7 @@ The following attributes are exported:
 
 * `is_virtual_network_filter_enabled` - If virtual network filtering is enabled for this Cosmos DB account.
 
-* `virtual_network_rule` - Subnets that are allowed to access this CosmosDB account.
+* `virtual_network_subnet_ids` - Subnets that are allowed to access this CosmosDB account.
 
 * `enable_multiple_write_locations` - If multi-master is enabled for this Cosmos DB account.
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `is_virtual_network_filter_enabled` - (Optional) Enables virtual network filtering for this Cosmos DB account.
 
-* `virtual_network_rule` - (Optional) Specifies a `virtual_network_rules` resource, used to define which subnets are allowed to access this CosmosDB account.
+* `virtual_network_subnet_ids` - (Optional) One or more Subnet ID's which should be able to access this Cosmos DB account.
 
 * `enable_multiple_write_locations` - (Optional) Enable multi-master support for this Cosmos DB account.
 
@@ -102,10 +102,6 @@ The following arguments are supported:
 * `name` - (Required) The capability to enable - Possible values are `EnableTable`, `EnableCassandra`, and `EnableGremlin`.
 
 **NOTE:** The `prefix` and `failover_priority` fields of a location cannot be changed for the location with a failover priority of `0`.
-
-`virtual_network_rule` Configures the virtual network subnets allowed to access this Cosmos DB account and supports the following:
-
-* `id` - (Required) The ID of the virtual network subnet.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds ability to pass in list of virtual_network_subnet_ids. Fixes #3625 

Started to go down the path of emulating network_rules block in resources like storage account, but that didn't match the underlying CosmosDB model from the Azure SDK. Definitely open to suggestions.