### PR TITLE
fix role assignment when using role definition name

### DIFF
--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -81,7 +81,7 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 		roleDefinitionId = v.(string)
 	} else if v, ok := d.GetOk("role_definition_name"); ok {
 		roleName := v.(string)
-		roleDefinitions, err := roleDefinitionsClient.List(ctx, "", fmt.Sprintf("roleName eq '%s'", roleName))
+		roleDefinitions, err := roleDefinitionsClient.List(ctx, scope, fmt.Sprintf("roleName eq '%s'", roleName))
 		if err != nil {
 			return fmt.Errorf("Error loading Role Definition List: %+v", err)
 		}


### PR DESCRIPTION
I tried to assign a role to service principal using the role name (custom role), this is my TF file:
```
resource "azurerm_role_assignment" "test" {
  principal_id                 = "<>"
  role_definition_name = "some-identity-role-definition"
  scope        = "<>"
}
```
And I noticed that I'm getting the following error:
```
Error: Error loading Role Definition List: could not find role 'some-identity-role-definition'

  on file.tf line 7, in resource "azurerm_role_assignment" "test":
   7: resource "azurerm_role_assignment" "test" {
``
So I started investigating. Testing using Azure CLI worked:
```
az role definition list --query "[?roleName == 'some-identity-role-definition']" 
```
This returned the roles as expected - so it's exist in Azure. I replicated the bug in a smaller program:
```go
package main

import (
	"context"
	"fmt"

	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2018-01-01-preview/authorization"
	"github.com/Azure/go-autorest/autorest/azure/auth"
)

func main() {
	fmt.Println("Hello, world.")

	client := authorization.NewRoleDefinitionsClient("<>")
	authorizer, err := auth.NewAuthorizerFromCLI()
	if err == nil {
		client.Authorizer = authorizer
	}
	name := "some-identity-role-definition"

	roleDefinitions, err := client.List(context.Background(), "", fmt.Sprintf("roleName eq '%s'", name))
	if err != nil {
		fmt.Printf("Error loading Role Definition List: %+v", err)
	}

	len := len(roleDefinitions.Values())

	fmt.Printf("len: %+v", len)
}
```
And noticed that the problem is with the scope. When the scope is empty (`""` or `"/"`) no value is returned, but when it's the scope of the subscription (`"/subscriptions/<>/"`) or anything under it, it is working. When I enabled terrform debug logs I noticed the expected behavior - this is the HTTP request:
```
//providers/Microsoft.Authorization/roleDefinitions?%24filter=roleName+eq+%27some-identity-role-definition%27&api-version=2018-01-01-preview HTTP/1.1
```
see the `//`? it's because of the missing scope. I added a small change to use the scope supplied by the user, tested locally using my little program and it worked.

BTW looking at the role definition data source, look like it pass the scope correctly (see [this line](https://github.com/terraform-providers/terraform-provider-azurerm/blob/3f5d9f1f5f50f0198fb894542c49305c8a9481c8/azurerm/data_source_role_definition.go#L122)) the same as I did here.