### PR TITLE
azurerm_container_registry: support for `virtual_network_rule` in `network_rule_set`

### DIFF
--- a/azurerm/resource_arm_container_registry.go
+++ b/azurerm/resource_arm_container_registry.go
@@ -131,6 +131,28 @@ func resourceArmContainerRegistry() *schema.Resource {
 							}, false),
 						},
 
+						"virtual_network_rule": {
+							Type:       schema.TypeSet,
+							Optional:   true,
+							ConfigMode: schema.SchemaConfigModeAttr,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"action": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(containerregistry.Allow),
+										}, false),
+									},
+									"subnet_id": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: azure.ValidateResourceID,
+									},
+								},
+							},
+						},
+
 						"ip_rule": {
 							Type:       schema.TypeSet,
 							Optional:   true,
@@ -569,6 +591,18 @@ func expandNetworkRuleSet(profiles []interface{}) *containerregistry.NetworkRule
 
 	profile := profiles[0].(map[string]interface{})
 
+	virtualNetworkRuleConfigs := profile["virtual_network_rule"].(*schema.Set).List()
+	virtualNetworkRules := make([]containerregistry.VirtualNetworkRule, 0)
+
+	for _, virtualNetworkRuleInterface := range virtualNetworkRuleConfigs {
+		config := virtualNetworkRuleInterface.(map[string]interface{})
+		virtualNetworkRules =
+			append(virtualNetworkRules, containerregistry.VirtualNetworkRule{
+				Action:                   containerregistry.Action(config["action"].(string)),
+				VirtualNetworkResourceID: utils.String(config["subnet_id"].(string)),
+			})
+	}
+
 	ipRuleConfigs := profile["ip_rule"].(*schema.Set).List()
 	ipRules := make([]containerregistry.IPRule, 0)
 	for _, ipRuleInterface := range ipRuleConfigs {
@@ -581,8 +615,9 @@ func expandNetworkRuleSet(profiles []interface{}) *containerregistry.NetworkRule
 	}
 
 	networkRuleSet := containerregistry.NetworkRuleSet{
-		DefaultAction: containerregistry.DefaultAction(profile["default_action"].(string)),
-		IPRules:       &ipRules,
+		DefaultAction:       containerregistry.DefaultAction(profile["default_action"].(string)),
+		VirtualNetworkRules: &virtualNetworkRules,
+		IPRules:             &ipRules,
 	}
 	return &networkRuleSet
 }
@@ -611,6 +646,16 @@ func flattenNetworkRuleSet(networkRuleSet *containerregistry.NetworkRuleSet) []i
 	}
 
 	values["ip_rule"] = ipRules
+
+	virtualNetworkRules := make([]interface{}, 0)
+	for _, virtualNetworkRule := range *networkRuleSet.VirtualNetworkRules {
+		value := make(map[string]interface{})
+		value["action"] = string(virtualNetworkRule.Action)
+		value["subnet_id"] = virtualNetworkRule.VirtualNetworkResourceID
+		virtualNetworkRules = append(virtualNetworkRules, value)
+	}
+
+	values["virtual_network_rule"] = virtualNetworkRules
 
 	return []interface{}{values}
 }

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -62,7 +62,9 @@ The following arguments are supported:
 
 * `ip_rule` - (Optional) One or more `ip_rule` blocks as defined below.
 
-~> **NOTE:** `network_rule_set ` is only supported with the `Premium` SDK at this time.
+* `virtual_network_rule` - (Optional) One or more `virtual_network_rule` blocks as defined below.
+
+~> **NOTE:** `network_rule_set ` is only supported with the `Premium` SKU at this time.
 
 `ip_rule` supports the following:
 
@@ -70,6 +72,13 @@ The following arguments are supported:
 
 * `ip_range` - (Required) The CIDR block from which requests will match the rule.
 
+`virtual_network_rule` supports the following:
+
+* `action` - (Required) The behaviour for requests matching this rule. At this time the only supported value is `Allow`
+
+* `subnet_id` - (Required) The ID of the Subnet from which requests will match the rule.
+
+~> **NOTE:** The `subnet_id` target subnet must have Service Endpoint `Microsoft.ContainerRegistry` enabled.
 
 ---
 ## Attributes Reference


### PR DESCRIPTION
The parts of #3194 that are blocked by a broken API. azure-sdk-fo-go issue: https://github.com/Azure/azure-sdk-for-go/issues/5181