### PR TITLE
Correct casing in example code

### DIFF
--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_application_insights" "test" {
   name                = "tf-test-appinsights"
   location            = "West Europe"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  application_type    = "Web"
+  application_type    = "web"
 }
 
 output "instrumentation_key" {


### PR DESCRIPTION
The application_type is case **sensitive** according to the description, so the value specified in the example code will be ignored (even though by default the same value will be chosen).