### PR TITLE
print error when checking role assignment failed

### DIFF
--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -109,7 +109,7 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 		existing, err := roleAssignmentsClient.Get(ctx, scope, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Role Assignment ID for %q (Scope %q)", name, scope)
+				return fmt.Errorf("Error checking for presence of existing Role Assignment ID for %q (Scope %q): %+v", name, scope, err)
 			}
 		}
 


### PR DESCRIPTION
Today the error is swallowed and not propagated back to the end user