### PR TITLE
Fix documentation for azurerm_subscriptions

### DIFF
--- a/website/docs/d/subscriptions.html.markdown
+++ b/website/docs/d/subscriptions.html.markdown
@@ -35,6 +35,7 @@ output "first_available_subscription_display_name" {
 
 The `subscription` block contains:
 
+* `subscription_id` - The subscription GUID.
 * `display_name` - The subscription display name.
 * `state` - The subscription state. Possible values are Enabled, Warned, PastDue, Disabled, and Deleted.
 * `location_placement_id` - The subscription location placement ID.


### PR DESCRIPTION
the `subscription` block also returns `subscription_id` in addtion to the others.