### PR TITLE
r/storage_share: support for configuring ACL's and MetaData

### DIFF
--- a/azurerm/resource_arm_storage_share.go
+++ b/azurerm/resource_arm_storage_share.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/file/shares"
@@ -49,8 +50,44 @@ func resourceArmStorageShare() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 5120),
 			},
 
-			// TODO: support for MetaData and ACL's
 			"metadata": storage.MetaDataSchema(),
+
+			"acl": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 64),
+						},
+						"access_policy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"start": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validate.NoEmptyStrings,
+									},
+									"expiry": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validate.NoEmptyStrings,
+									},
+									"permissions": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validate.NoEmptyStrings,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 
 			"url": {
 				Type:     schema.TypeString,
@@ -69,6 +106,9 @@ func resourceArmStorageShareCreate(d *schema.ResourceData, meta interface{}) err
 
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := storage.ExpandMetaData(metaDataRaw)
+
+	aclsRaw := d.Get("acl").(*schema.Set).List()
+	acls := expandStorageShareACLs(aclsRaw)
 
 	resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
 	if err != nil {
@@ -102,6 +142,10 @@ func resourceArmStorageShareCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	if _, err := client.Create(ctx, accountName, shareName, input); err != nil {
 		return fmt.Errorf("Error creating Share %q (Account %q / Resource Group %q): %+v", shareName, accountName, *resourceGroup, err)
+	}
+
+	if _, err := client.SetACL(ctx, accountName, shareName, acls); err != nil {
+		return fmt.Errorf("Error setting ACL's for Share %q (Account %q / Resource Group %q): %+v", shareName, accountName, *resourceGroup, err)
 	}
 
 	d.SetId(id)
@@ -143,6 +187,11 @@ func resourceArmStorageShareRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error retrieving File Share %q (Account %q / Resource Group %q): %s", id.ShareName, id.AccountName, *resourceGroup, err)
 	}
 
+	acls, err := client.GetACL(ctx, id.AccountName, id.ShareName)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ACL's for File Share %q (Account %q / Resource Group %q): %s", id.ShareName, id.AccountName, *resourceGroup, err)
+	}
+
 	d.Set("name", id.ShareName)
 	d.Set("storage_account_name", id.AccountName)
 	d.Set("url", client.GetResourceID(id.AccountName, id.ShareName))
@@ -150,6 +199,10 @@ func resourceArmStorageShareRead(d *schema.ResourceData, meta interface{}) error
 
 	if err := d.Set("metadata", storage.FlattenMetaData(props.MetaData)); err != nil {
 		return fmt.Errorf("Error flattening `metadata`: %+v", err)
+	}
+
+	if err := d.Set("acl", flattenStorageShareACLs(acls)); err != nil {
+		return fmt.Errorf("Error flattening `acl`: %+v", err)
 	}
 
 	// Deprecated: remove in 2.0
@@ -205,6 +258,19 @@ func resourceArmStorageShareUpdate(d *schema.ResourceData, meta interface{}) err
 		log.Printf("[DEBUG] Updated the MetaData for File Share %q (Storage Account %q)", id.ShareName, id.AccountName)
 	}
 
+	if d.HasChange("acl") {
+		log.Printf("[DEBUG] Updating the ACL's for File Share %q (Storage Account %q)", id.ShareName, id.AccountName)
+
+		aclsRaw := d.Get("acl").(*schema.Set).List()
+		acls := expandStorageShareACLs(aclsRaw)
+
+		if _, err := client.SetACL(ctx, id.AccountName, id.ShareName, acls); err != nil {
+			return fmt.Errorf("Error updating ACL's for File Share %q (Storage Account %q): %s", id.ShareName, id.AccountName, err)
+		}
+
+		log.Printf("[DEBUG] Updated the ACL's for File Share %q (Storage Account %q)", id.ShareName, id.AccountName)
+	}
+
 	return resourceArmStorageShareRead(d, meta)
 }
 
@@ -238,6 +304,50 @@ func resourceArmStorageShareDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	return nil
+}
+
+func expandStorageShareACLs(input []interface{}) []shares.SignedIdentifier {
+	results := make([]shares.SignedIdentifier, 0)
+
+	for _, v := range input {
+		vals := v.(map[string]interface{})
+
+		policies := vals["access_policy"].([]interface{})
+		policy := policies[0].(map[string]interface{})
+
+		identifier := shares.SignedIdentifier{
+			Id: vals["id"].(string),
+			AccessPolicy: shares.AccessPolicy{
+				Start:      policy["start"].(string),
+				Expiry:     policy["expiry"].(string),
+				Permission: policy["permissions"].(string),
+			},
+		}
+		results = append(results, identifier)
+	}
+
+	return results
+}
+
+func flattenStorageShareACLs(input shares.GetACLResult) []interface{} {
+	result := make([]interface{}, 0)
+
+	for _, v := range input.SignedIdentifiers {
+		output := map[string]interface{}{
+			"id": v.Id,
+			"access_policy": []interface{}{
+				map[string]interface{}{
+					"start":       v.AccessPolicy.Start,
+					"expiry":      v.AccessPolicy.Expiry,
+					"permissions": v.AccessPolicy.Permission,
+				},
+			},
+		}
+
+		result = append(result, output)
+	}
+
+	return result
 }
 
 // Following the naming convention as laid out in the docs https://msdn.microsoft.com/library/azure/dn167011.aspx

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -47,6 +47,7 @@ The following arguments are supported:
 
 * `quota` - (Optional) The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5 TB (5120 GB). Default is 5120.
 
+* `metadata` - (Optional) A mapping of MetaData for this File Share.
 
 ## Attributes Reference
 

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -42,12 +42,32 @@ The following arguments are supported:
 * `storage_account_name` - (Required) Specifies the storage account in which to create the share.
  Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Optional / **Deprecated**) The name of the resource group in which to
-    create the share. Changing this forces a new resource to be created.
+* `acl` - (Optional) One or more `acl` blocks as defined below.
 
 * `quota` - (Optional) The maximum size of the share, in gigabytes. Must be greater than 0, and less than or equal to 5 TB (5120 GB). Default is 5120.
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.
+
+* `resource_group_name` - (Optional / **Deprecated**) The name of the resource group in which to
+    create the share. Changing this forces a new resource to be created.
+    
+---
+
+A `acl` block supports the following:
+
+* `id` - (Required) The ID which should be used for this Shared Identifier.
+
+* `access_policy` - (Required) An `access_policy` block as defined below.
+
+---
+
+A `access_policy` block supports the following: 
+
+* `expiry` - (Required) The ISO8061 UTC time at which this Access Policy should be valid until.
+
+* `permissions` - (Required) The permissions which should associated with this Shared Identifier.
+
+* `start` - (Required) The ISO8061 UTC time at which this Access Policy should be valid from.
 
 ## Attributes Reference
 

--- a/website/docs/r/storage_share_directory.html.markdown
+++ b/website/docs/r/storage_share_directory.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_storage_share" "test" {
 }
 
 resource "azurerm_storage_share_directory" "test" {
-  name                 = "example-"
+  name                 = "example"
   share_name           = "${azurerm_storage_share.test.name}"
   storage_account_name = "${azurerm_storage_account.test.name}"
 }


### PR DESCRIPTION
This PR is dependent on #3722 

This PR adds support for configuring both ACL's and MetaData for the `azurerm_storage_share` resource. It also updates the documentation for both the Storage Share and the Storage Share Directory resource.