### PR TITLE
r/storage_table: switching over to using the new sdk

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -901,22 +901,3 @@ func (c *ArmClient) getBlobStorageClientForStorageAccount(ctx context.Context, r
 	blobClient := storageClient.GetBlobService()
 	return &blobClient, true, nil
 }
-
-func (c *ArmClient) getTableServiceClientForStorageAccount(ctx context.Context, resourceGroupName, storageAccountName string) (*mainStorage.TableServiceClient, bool, error) {
-	key, accountExists, err := c.getKeyForStorageAccount(ctx, resourceGroupName, storageAccountName)
-	if err != nil {
-		return nil, accountExists, err
-	}
-	if !accountExists {
-		return nil, false, nil
-	}
-
-	storageClient, err := mainStorage.NewClient(storageAccountName, key, c.environment.StorageEndpointSuffix,
-		mainStorage.DefaultAPIVersion, true)
-	if err != nil {
-		return nil, true, fmt.Errorf("Error creating storage client for storage storeAccount %q: %s", storageAccountName, err)
-	}
-
-	tableClient := storageClient.GetTableService()
-	return &tableClient, true, nil
-}

--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/file/shares"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/queue/queues"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/entities"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables"
 )
 
 type Client struct {
@@ -94,6 +95,7 @@ func (client Client) QueuesClient(ctx context.Context, resourceGroup, accountNam
 	queuesClient.Client.Authorizer = storageAuth
 	return &queuesClient, nil
 }
+
 func (client Client) TableEntityClient(ctx context.Context, resourceGroup, accountName string) (*entities.Client, error) {
 	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
 	if err != nil {
@@ -104,6 +106,18 @@ func (client Client) TableEntityClient(ctx context.Context, resourceGroup, accou
 	entitiesClient := entities.New()
 	entitiesClient.Client.Authorizer = storageAuth
 	return &entitiesClient, nil
+}
+
+func (client Client) TablesClient(ctx context.Context, resourceGroup, accountName string) (*tables.Client, error) {
+	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
+	}
+
+	storageAuth := authorizers.NewSharedKeyLiteTableAuthorizer(accountName, *accountKey)
+	tablesClient := tables.New()
+	tablesClient.Client.Authorizer = storageAuth
+	return &tablesClient, nil
 }
 
 func (client Client) findAccountKey(ctx context.Context, resourceGroup, accountName string) (*string, error) {

--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -60,7 +60,7 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 
 	client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
 	if err != nil {
-		return fmt.Errorf("Error building File Share Client: %s", err)
+		return fmt.Errorf("Error building Table Client: %s", err)
 	}
 
 	id := client.GetResourceID(accountName, tableName)
@@ -108,7 +108,7 @@ func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error
 
 	client, err := storageClient.TablesClient(ctx, *resourceGroup, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error building File Share Client: %s", err)
+		return fmt.Errorf("Error building Table Client: %s", err)
 	}
 
 	exists, err := client.Exists(ctx, id.AccountName, id.TableName)
@@ -155,7 +155,7 @@ func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) err
 
 	client, err := storageClient.TablesClient(ctx, *resourceGroup, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error building File Share Client: %s", err)
+		return fmt.Errorf("Error building Table Client: %s", err)
 	}
 
 	log.Printf("[INFO] Deleting Table %q in Storage Account %q", id.TableName, id.AccountName)

--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -3,14 +3,13 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"net/url"
 	"regexp"
-	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables"
 )
 
 func resourceArmStorageTable() *schema.Resource {
@@ -31,14 +30,140 @@ func resourceArmStorageTable() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateArmStorageTableName,
 			},
-			"resource_group_name": azure.SchemaResourceGroupName(),
+
 			"storage_account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateArmStorageAccountName,
 			},
+
+			// TODO: deprecate this in the docs
+			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(),
+
+			// TODO: support for ACL's
 		},
 	}
+}
+
+func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) error {
+	ctx := meta.(*ArmClient).StopContext
+	storageClient := meta.(*ArmClient).storage
+
+	tableName := d.Get("name").(string)
+	accountName := d.Get("storage_account_name").(string)
+
+	resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+	if err != nil {
+		return fmt.Errorf("Error locating Resource Group: %s", err)
+	}
+
+	client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
+	if err != nil {
+		return fmt.Errorf("Error building File Share Client: %s", err)
+	}
+
+	id := client.GetResourceID(accountName, tableName)
+	if requireResourcesToBeImported {
+		existing, err := client.Exists(ctx, *resourceGroup, tableName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing) {
+				return fmt.Errorf("Error checking for existence of existing Storage Table %q (Account %q / Resource Group %q): %+v", tableName, accountName, *resourceGroup, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(existing) {
+			return tf.ImportAsExistsError("azurerm_storage_table", id)
+		}
+	}
+
+	log.Printf("[DEBUG] Creating Table %q in Storage Account %q.", tableName, accountName)
+	if _, err := client.Create(ctx, accountName, tableName); err != nil {
+		return fmt.Errorf("Error creating Table %q within Storage Account %q: %s", tableName, accountName, err)
+	}
+
+	d.SetId(id)
+	return resourceArmStorageTableRead(d, meta)
+}
+
+func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error {
+	storageClient := meta.(*ArmClient).storage
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := tables.ParseResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	if err != nil {
+		return fmt.Errorf("Error locating Resource Group: %s", err)
+	}
+
+	if resourceGroup == nil {
+		log.Printf("Unable to determine Resource Group for Storage Account %q (assuming removed)", id.AccountName)
+		d.SetId("")
+		return nil
+	}
+
+	client, err := storageClient.TablesClient(ctx, *resourceGroup, id.AccountName)
+	if err != nil {
+		return fmt.Errorf("Error building File Share Client: %s", err)
+	}
+
+	exists, err := client.Exists(ctx, id.AccountName, id.TableName)
+	if err != nil {
+		if utils.ResponseWasNotFound(exists) {
+			log.Printf("[DEBUG] Storage Account %q not found, removing table %q from state", id.AccountName, id.TableName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Table %q in Storage Account %q: %s", id.TableName, id.AccountName, err)
+	}
+
+	_, err = client.GetACL(ctx, id.AccountName, id.TableName)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Table %q in Storage Account %q: %s", id.TableName, id.AccountName, err)
+	}
+
+	d.Set("name", id.TableName)
+	d.Set("storage_account_name", id.AccountName)
+	d.Set("resource_group_name", resourceGroup)
+
+	return nil
+}
+
+func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) error {
+	storageClient := meta.(*ArmClient).storage
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := tables.ParseResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	if err != nil {
+		return fmt.Errorf("Error locating Resource Group: %s", err)
+	}
+
+	if resourceGroup == nil {
+		log.Printf("Unable to determine Resource Group for Storage Account %q (assuming removed)", id.AccountName)
+		return nil
+	}
+
+	client, err := storageClient.TablesClient(ctx, *resourceGroup, id.AccountName)
+	if err != nil {
+		return fmt.Errorf("Error building File Share Client: %s", err)
+	}
+
+	log.Printf("[INFO] Deleting Table %q in Storage Account %q", id.TableName, id.AccountName)
+	if _, err := client.Delete(ctx, id.AccountName, id.TableName); err != nil {
+		return fmt.Errorf("Error deleting Table %q from Storage Account %q: %s", id.TableName, id.AccountName, err)
+	}
+
+	return nil
 }
 
 func validateArmStorageTableName(v interface{}, k string) (warnings []string, errors []error) {
@@ -55,176 +180,4 @@ func validateArmStorageTableName(v interface{}, k string) (warnings []string, er
 	}
 
 	return warnings, errors
-}
-
-func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) error {
-	armClient := meta.(*ArmClient)
-	ctx := armClient.StopContext
-	environment := armClient.environment
-
-	name := d.Get("name").(string)
-	resourceGroupName := d.Get("resource_group_name").(string)
-	storageAccountName := d.Get("storage_account_name").(string)
-
-	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, resourceGroupName, storageAccountName)
-	if err != nil {
-		return err
-	}
-	if !accountExists {
-		return fmt.Errorf("Storage Account %q Not Found", storageAccountName)
-	}
-
-	table := tableClient.GetTableReference(name)
-	id := fmt.Sprintf("https://%s.table.%s/%s", storageAccountName, environment.StorageEndpointSuffix, name)
-
-	if requireResourcesToBeImported {
-		metaDataLevel := storage.MinimalMetadata
-		options := &storage.QueryTablesOptions{}
-		tables, e := tableClient.QueryTables(metaDataLevel, options)
-		if e != nil {
-			return fmt.Errorf("Error checking if Table %q exists (Account %q / Resource Group %q): %s", name, storageAccountName, resourceGroupName, e)
-		}
-
-		for _, table := range tables.Tables {
-			if table.Name == name {
-				return tf.ImportAsExistsError("azurerm_storage_table", id)
-			}
-		}
-	}
-
-	log.Printf("[INFO] Creating table %q in storage account %q.", name, storageAccountName)
-	timeout := uint(60)
-	options := &storage.TableOptions{}
-	err = table.Create(timeout, storage.NoMetadata, options)
-	if err != nil {
-		return fmt.Errorf("Error creating table %q in storage account %q: %s", name, storageAccountName, err)
-	}
-
-	d.SetId(id)
-	return resourceArmStorageTableRead(d, meta)
-}
-
-func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error {
-	armClient := meta.(*ArmClient)
-	ctx := armClient.StopContext
-
-	id, err := parseStorageTableID(d.Id())
-	if err != nil {
-		return err
-	}
-
-	resourceGroup, err := determineResourceGroupForStorageAccount(id.storageAccountName, armClient)
-	if err != nil {
-		return err
-	}
-
-	if resourceGroup == nil {
-		log.Printf("Unable to determine Resource Group for Storage Account %q (assuming removed)", id.storageAccountName)
-		d.SetId("")
-		return nil
-	}
-
-	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
-	if err != nil {
-		return err
-	}
-
-	if !accountExists {
-		log.Printf("[DEBUG] Storage account %q not found, removing table %q from state", id.storageAccountName, id.tableName)
-		d.SetId("")
-		return nil
-	}
-
-	metaDataLevel := storage.MinimalMetadata
-	options := &storage.QueryTablesOptions{}
-	tables, err := tableClient.QueryTables(metaDataLevel, options)
-	if err != nil {
-		return fmt.Errorf("Failed to retrieve Tables in Storage Account %q: %s", id.tableName, err)
-	}
-
-	var storageTable *storage.Table
-	for _, table := range tables.Tables {
-		if table.Name == id.tableName {
-			storageTable = &table
-			break
-		}
-	}
-
-	if storageTable == nil {
-		log.Printf("[INFO] Table %q does not exist in Storage Account %q, removing from state...", id.tableName, id.storageAccountName)
-		d.SetId("")
-		return nil
-	}
-
-	d.Set("name", id.tableName)
-	d.Set("storage_account_name", id.storageAccountName)
-	d.Set("resource_group_name", resourceGroup)
-
-	return nil
-}
-
-func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) error {
-	armClient := meta.(*ArmClient)
-	ctx := armClient.StopContext
-
-	id, err := parseStorageTableID(d.Id())
-	if err != nil {
-		return err
-	}
-
-	resourceGroup, err := determineResourceGroupForStorageAccount(id.storageAccountName, armClient)
-	if err != nil {
-		return err
-	}
-
-	if resourceGroup == nil {
-		log.Printf("Unable to determine Resource Group for Storage Account %q (assuming removed)", id.storageAccountName)
-		return nil
-	}
-
-	tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
-	if err != nil {
-		return err
-	}
-	if !accountExists {
-		log.Printf("[INFO] Storage Account %q doesn't exist so the table won't exist", id.storageAccountName)
-		return nil
-	}
-
-	table := tableClient.GetTableReference(id.tableName)
-	timeout := uint(60)
-	options := &storage.TableOptions{}
-
-	log.Printf("[INFO] Deleting Table %q in Storage Account %q", id.tableName, id.storageAccountName)
-	if err := table.Delete(timeout, options); err != nil {
-		return fmt.Errorf("Error deleting table %q from Storage Account %q: %s", id.tableName, id.storageAccountName, err)
-	}
-
-	return nil
-}
-
-type storageTableId struct {
-	storageAccountName string
-	tableName          string
-}
-
-func parseStorageTableID(input string) (*storageTableId, error) {
-	// https://myaccount.table.core.windows.net/table1
-	uri, err := url.Parse(input)
-	if err != nil {
-		return nil, fmt.Errorf("Error parsing %q as a URI: %+v", input, err)
-	}
-
-	segments := strings.Split(uri.Host, ".")
-	if len(segments) > 0 {
-		storageAccountName := segments[0]
-		table := strings.Replace(uri.Path, "/", "", 1)
-		id := storageTableId{
-			storageAccountName: storageAccountName,
-			tableName:          table,
-		}
-		return &id, nil
-	}
-
-	return nil, nil
 }

--- a/azurerm/resource_arm_storage_table_entity.go
+++ b/azurerm/resource_arm_storage_table_entity.go
@@ -32,7 +32,7 @@ func resourceArmStorageTableEntity() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NoEmptyStrings,
+				ValidateFunc: validateArmStorageAccountName,
 			},
 			"partition_key": {
 				Type:         schema.TypeString,

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -2,7 +2,6 @@ package azurerm
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMStorageTable_basic(t *testing.T) {
@@ -105,42 +105,32 @@ func testCheckAzureRMStorageTableExists(resourceName string, t *storage.Table) r
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		name := rs.Primary.Attributes["name"]
-		storageAccountName := rs.Primary.Attributes["storage_account_name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", name)
-		}
+		tableName := rs.Primary.Attributes["name"]
+		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		armClient := testAccProvider.Meta().(*ArmClient)
-		ctx := armClient.StopContext
-		tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, resourceGroup, storageAccountName)
+		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
 		if err != nil {
-			return err
+			return fmt.Errorf("Error finding Resource Group: %s", err)
 		}
-		if !accountExists {
-			return fmt.Errorf("Bad: Storage Account %q does not exist", storageAccountName)
+		if resourceGroup == nil {
+			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", t.Name)
 		}
 
-		options := &storage.QueryTablesOptions{}
-		tables, err := tableClient.QueryTables(storage.MinimalMetadata, options)
+		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
 		if err != nil {
-			return fmt.Errorf("Error querying Storage Table %q (storage account: %q) : %+v", name, storageAccountName, err)
-		}
-		if len(tables.Tables) == 0 {
-			return fmt.Errorf("Bad: Storage Table %q (storage account: %q) does not exist", name, storageAccountName)
+			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}
 
-		var found bool
-		for _, table := range tables.Tables {
-			if table.Name == name {
-				found = true
-				*t = table
+		props, err := client.Exists(ctx, accountName, tableName)
+		if err != nil {
+			if utils.ResponseWasNotFound(props) {
+				return fmt.Errorf("Table %q doesn't exist in Account %q!", tableName, accountName)
 			}
-		}
 
-		if !found {
-			return fmt.Errorf("Bad: Storage Table %q (storage account: %q) does not exist", name, storageAccountName)
+			return fmt.Errorf("Error retrieving Table %q: %s", tableName, accountName)
 		}
 
 		return nil
@@ -154,28 +144,39 @@ func testAccARMStorageTableDisappears(resourceName string, t *storage.Table) res
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		armClient := testAccProvider.Meta().(*ArmClient)
-		ctx := armClient.StopContext
+		tableName := rs.Primary.Attributes["name"]
+		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageAccountName := rs.Primary.Attributes["storage_account_name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
+		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		if err != nil {
+			return fmt.Errorf("Error finding Resource Group: %s", err)
+		}
+		if resourceGroup == nil {
 			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", t.Name)
 		}
 
-		tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, resourceGroup, storageAccountName)
+		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
 		if err != nil {
-			return err
-		}
-		if !accountExists {
-			log.Printf("[INFO]Storage Account %q doesn't exist so the table won't exist", storageAccountName)
-			return nil
+			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}
 
-		table := tableClient.GetTableReference(t.Name)
-		timeout := uint(60)
-		options := &storage.TableOptions{}
-		return table.Delete(timeout, options)
+		props, err := client.Exists(ctx, accountName, tableName)
+		if err != nil {
+			if utils.ResponseWasNotFound(props) {
+				return fmt.Errorf("Table %q doesn't exist in Account %q so it can't be deleted!", tableName, accountName)
+			}
+
+			return fmt.Errorf("Error retrieving Table %q: %s", tableName, accountName)
+		}
+
+		if _, err := client.Delete(ctx, accountName, tableName); err != nil {
+			return fmt.Errorf("Error deleting Table %q: %s", tableName, err)
+		}
+
+		return nil
 	}
 }
 
@@ -185,40 +186,35 @@ func testCheckAzureRMStorageTableDestroy(s *terraform.State) error {
 			continue
 		}
 
-		name := rs.Primary.Attributes["name"]
-		storageAccountName := rs.Primary.Attributes["storage_account_name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for storage table: %s", name)
-		}
+		tableName := rs.Primary.Attributes["name"]
+		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		armClient := testAccProvider.Meta().(*ArmClient)
-		ctx := armClient.StopContext
-		tableClient, accountExists, err := armClient.getTableServiceClientForStorageAccount(ctx, resourceGroup, storageAccountName)
+		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
 		if err != nil {
-			//If we can't get keys then the table can't exist
-			return nil
+			return fmt.Errorf("Error finding Resource Group: %s", err)
 		}
-		if !accountExists {
+		if resourceGroup == nil {
 			return nil
 		}
 
-		options := &storage.QueryTablesOptions{}
-		tables, err := tableClient.QueryTables(storage.NoMetadata, options)
+		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
 		if err != nil {
-			return nil
+			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}
 
-		var found bool
-		for _, table := range tables.Tables {
-			if table.Name == name {
-				found = true
+		props, err := client.Exists(ctx, accountName, tableName)
+		if err != nil {
+			if utils.ResponseWasNotFound(props) {
+				return nil
 			}
+
+			return fmt.Errorf("Error retrieving Table %q: %s", tableName, accountName)
 		}
 
-		if found {
-			return fmt.Errorf("Bad: Storage Table %q (storage account: %q) still exist", name, storageAccountName)
-		}
+		return fmt.Errorf("Bad: Table %q (storage account: %q) still exists", tableName, accountName)
 	}
 
 	return nil

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -121,7 +121,7 @@ func testCheckAzureRMStorageTableExists(resourceName string, t *storage.Table) r
 
 		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
 		if err != nil {
-			return fmt.Errorf("Error building FileShare Client: %s", err)
+			return fmt.Errorf("Error building Table Client: %s", err)
 		}
 
 		props, err := client.Exists(ctx, accountName, tableName)
@@ -160,7 +160,7 @@ func testAccARMStorageTableDisappears(resourceName string, t *storage.Table) res
 
 		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
 		if err != nil {
-			return fmt.Errorf("Error building FileShare Client: %s", err)
+			return fmt.Errorf("Error building Table Client: %s", err)
 		}
 
 		props, err := client.Exists(ctx, accountName, tableName)
@@ -202,7 +202,7 @@ func testCheckAzureRMStorageTableDestroy(s *terraform.State) error {
 
 		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
 		if err != nil {
-			return fmt.Errorf("Error building FileShare Client: %s", err)
+			return fmt.Errorf("Error building Table Client: %s", err)
 		}
 
 		props, err := client.Exists(ctx, accountName, tableName)

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/README.md
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/README.md
@@ -1,0 +1,39 @@
+## Table Storage Tables SDK for API version 2018-11-09
+
+This package allows you to interact with the Tables Table Storage API
+
+### Supported Authorizers
+
+* SharedKeyLite (Table)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+	
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    tableName := "mytable"
+    
+    storageAuth := autorest.NewSharedKeyLiteTableAuthorizer(accountName, storageAccountKey)
+    tablesClient := tables.New()
+    tablesClient.Client.Authorizer = storageAuth
+    
+    ctx := context.TODO()
+    if _, err := tablesClient.Insert(ctx, accountName, tableName); err != nil {
+        return fmt.Errorf("Error creating Table: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/acl_get.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/acl_get.go
@@ -1,0 +1,93 @@
+package tables
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type GetACLResult struct {
+	autorest.Response
+
+	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+}
+
+// GetACL returns the Access Control List for the specified Table
+func (client Client) GetACL(ctx context.Context, accountName, tableName string) (result GetACLResult, err error) {
+	if accountName == "" {
+		return result, validation.NewError("tables.Client", "GetACL", "`accountName` cannot be an empty string.")
+	}
+	if tableName == "" {
+		return result, validation.NewError("tables.Client", "GetACL", "`tableName` cannot be an empty string.")
+	}
+
+	req, err := client.GetACLPreparer(ctx, accountName, tableName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "GetACL", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.GetACLSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "tables.Client", "GetACL", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.GetACLResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "GetACL", resp, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// GetACLPreparer prepares the GetACL request.
+func (client Client) GetACLPreparer(ctx context.Context, accountName, tableName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"tableName": autorest.Encode("path", tableName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"comp": autorest.Encode("query", "acl"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/xml; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(endpoints.GetTableEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{tableName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// GetACLSender sends the GetACL request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) GetACLSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// GetACLResponder handles the response to the GetACL request. The method always
+// closes the http.Response Body.
+func (client Client) GetACLResponder(resp *http.Response) (result GetACLResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingXML(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+
+	return
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/acl_set.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/acl_set.go
@@ -1,0 +1,98 @@
+package tables
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type setAcl struct {
+	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+
+	XMLName xml.Name `xml:"SignedIdentifiers"`
+}
+
+// SetACL sets the specified Access Control List for the specified Table
+func (client Client) SetACL(ctx context.Context, accountName, tableName string, acls []SignedIdentifier) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("tables.Client", "SetACL", "`accountName` cannot be an empty string.")
+	}
+	if tableName == "" {
+		return result, validation.NewError("tables.Client", "SetACL", "`tableName` cannot be an empty string.")
+	}
+
+	req, err := client.SetACLPreparer(ctx, accountName, tableName, acls)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "SetACL", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.SetACLSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "tables.Client", "SetACL", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.SetACLResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "SetACL", resp, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// SetACLPreparer prepares the SetACL request.
+func (client Client) SetACLPreparer(ctx context.Context, accountName, tableName string, acls []SignedIdentifier) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"tableName": autorest.Encode("path", tableName),
+	}
+
+	queryParameters := map[string]interface{}{
+		"comp": autorest.Encode("query", "acl"),
+	}
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+	}
+
+	input := setAcl{
+		SignedIdentifiers: acls,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/xml; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(endpoints.GetTableEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/{tableName}", pathParameters),
+		autorest.WithQueryParameters(queryParameters),
+		autorest.WithHeaders(headers),
+		autorest.WithXML(&input))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// SetACLSender sends the SetACL request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) SetACLSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// SetACLResponder handles the response to the SetACL request. The method always
+// closes the http.Response Body.
+func (client Client) SetACLResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/client.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/client.go
@@ -1,0 +1,25 @@
+package tables
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Client is the base client for Table Storage Shares.
+type Client struct {
+	autorest.Client
+	BaseURI string
+}
+
+// New creates an instance of the Client client.
+func New() Client {
+	return NewWithEnvironment(azure.PublicCloud)
+}
+
+// NewWithEnvironment creates an instance of the Client client.
+func NewWithEnvironment(environment azure.Environment) Client {
+	return Client{
+		Client:  autorest.NewClientWithUserAgent(UserAgent()),
+		BaseURI: environment.StorageEndpointSuffix,
+	}
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/create.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/create.go
@@ -1,0 +1,90 @@
+package tables
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type createTableRequest struct {
+	TableName string `json:"TableName"`
+}
+
+// Create creates a new table in the storage account.
+func (client Client) Create(ctx context.Context, accountName, tableName string) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("tables.Client", "Create", "`accountName` cannot be an empty string.")
+	}
+	if tableName == "" {
+		return result, validation.NewError("tables.Client", "Create", "`tableName` cannot be an empty string.")
+	}
+
+	req, err := client.CreatePreparer(ctx, accountName, tableName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.CreateSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "tables.Client", "Create", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.CreateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Create", resp, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// CreatePreparer prepares the Create request.
+func (client Client) CreatePreparer(ctx context.Context, accountName, tableName string) (*http.Request, error) {
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+		// NOTE: we could support returning metadata here, but it doesn't appear to be directly useful
+		// vs making a request using the Get methods as-necessary?
+		"Accept": "application/json;odata=nometadata",
+		"Prefer": "return-no-content",
+	}
+
+	body := createTableRequest{
+		TableName: tableName,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(endpoints.GetTableEndpoint(client.BaseURI, accountName)),
+		autorest.WithPath("/Tables"),
+		autorest.WithJSON(body),
+		autorest.WithHeaders(headers))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// CreateSender sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) CreateSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// CreateResponder handles the response to the Create request. The method always
+// closes the http.Response Body.
+func (client Client) CreateResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/delete.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/delete.go
@@ -1,0 +1,79 @@
+package tables
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// Delete deletes the specified table and any data it contains.
+func (client Client) Delete(ctx context.Context, accountName, tableName string) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("tables.Client", "Delete", "`accountName` cannot be an empty string.")
+	}
+	if tableName == "" {
+		return result, validation.NewError("tables.Client", "Delete", "`tableName` cannot be an empty string.")
+	}
+
+	req, err := client.DeletePreparer(ctx, accountName, tableName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.DeleteSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "tables.Client", "Delete", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.DeleteResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Delete", resp, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// DeletePreparer prepares the Delete request.
+func (client Client) DeletePreparer(ctx context.Context, accountName, tableName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"tableName": autorest.Encode("path", tableName),
+	}
+
+	// NOTE: whilst the API documentation says that API Version is Optional
+	// apparently specifying it causes an "invalid content type" to always be returned
+	// as such we omit it here :shrug:
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsDelete(),
+		autorest.WithBaseURL(endpoints.GetTableEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/Tables('{tableName}')", pathParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// DeleteSender sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) DeleteSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// DeleteResponder handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (client Client) DeleteResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/exists.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/exists.go
@@ -1,0 +1,80 @@
+package tables
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// Exists checks that the specified table exists
+func (client Client) Exists(ctx context.Context, accountName, tableName string) (result autorest.Response, err error) {
+	if accountName == "" {
+		return result, validation.NewError("tables.Client", "Exists", "`accountName` cannot be an empty string.")
+	}
+	if tableName == "" {
+		return result, validation.NewError("tables.Client", "Exists", "`tableName` cannot be an empty string.")
+	}
+
+	req, err := client.ExistsPreparer(ctx, accountName, tableName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Exists", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.ExistsSender(req)
+	if err != nil {
+		result = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "tables.Client", "Exists", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.ExistsResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Exists", resp, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// ExistsPreparer prepares the Exists request.
+func (client Client) ExistsPreparer(ctx context.Context, accountName, tableName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"tableName": autorest.Encode("path", tableName),
+	}
+
+	// NOTE: whilst the API documentation says that API Version is Optional
+	// apparently specifying it causes an "invalid content type" to always be returned
+	// as such we omit it here :shrug:
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.AsContentType("application/xml"),
+		autorest.WithBaseURL(endpoints.GetTableEndpoint(client.BaseURI, accountName)),
+		autorest.WithPathParameters("/Tables('{tableName}')", pathParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ExistsSender sends the Exists request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) ExistsSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// ExistsResponder handles the response to the Exists request. The method always
+// closes the http.Response Body.
+func (client Client) ExistsResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result = autorest.Response{Response: resp}
+
+	return
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/models.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/models.go
@@ -1,0 +1,29 @@
+package tables
+
+type MetaDataLevel string
+
+var (
+	NoMetaData      MetaDataLevel = "nometadata"
+	MinimalMetaData MetaDataLevel = "minimalmetadata"
+	FullMetaData    MetaDataLevel = "fullmetadata"
+)
+
+type GetResultItem struct {
+	TableName string `json:"TableName"`
+
+	// Optional, depending on the MetaData Level
+	ODataType     string `json:"odata.type,omitempty"`
+	ODataID       string `json:"odata.id,omitEmpty"`
+	ODataEditLink string `json:"odata.editLink,omitEmpty"`
+}
+
+type SignedIdentifier struct {
+	Id           string       `xml:"Id"`
+	AccessPolicy AccessPolicy `xml:"AccessPolicy"`
+}
+
+type AccessPolicy struct {
+	Start      string `xml:"Start"`
+	Expiry     string `xml:"Expiry"`
+	Permission string `xml:"Permission"`
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/query.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/query.go
@@ -1,0 +1,87 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/validation"
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+type GetResult struct {
+	autorest.Response
+
+	MetaData string          `json:"odata.metadata,omitempty"`
+	Tables   []GetResultItem `json:"value"`
+}
+
+// Query returns a list of tables under the specified account.
+func (client Client) Query(ctx context.Context, accountName string, metaDataLevel MetaDataLevel) (result GetResult, err error) {
+	if accountName == "" {
+		return result, validation.NewError("tables.Client", "Query", "`accountName` cannot be an empty string.")
+	}
+
+	req, err := client.QueryPreparer(ctx, accountName, metaDataLevel)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Query", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.QuerySender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "tables.Client", "Query", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.QueryResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "tables.Client", "Query", resp, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// QueryPreparer prepares the Query request.
+func (client Client) QueryPreparer(ctx context.Context, accountName string, metaDataLevel MetaDataLevel) (*http.Request, error) {
+	// NOTE: whilst this supports ContinuationTokens and 'Top'
+	// it appears that 'Skip' returns a '501 Not Implemented'
+	// as such, we intentionally don't support those right now
+
+	headers := map[string]interface{}{
+		"x-ms-version": APIVersion,
+		"Accept":       fmt.Sprintf("application/json;odata=%s", metaDataLevel),
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsGet(),
+		autorest.WithBaseURL(endpoints.GetTableEndpoint(client.BaseURI, accountName)),
+		autorest.WithPath("/Tables"),
+		autorest.WithHeaders(headers))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// QuerySender sends the Query request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) QuerySender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// QueryResponder handles the response to the Query request. The method always
+// closes the http.Response Body.
+func (client Client) QueryResponder(resp *http.Response) (result GetResult, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+
+	return
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/resource_id.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/resource_id.go
@@ -1,0 +1,54 @@
+package tables
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/tombuildsstuff/giovanni/storage/internal/endpoints"
+)
+
+// GetResourceID returns the Resource ID for the given Table
+// This can be useful when, for example, you're using this as a unique identifier
+func (client Client) GetResourceID(accountName, tableName string) string {
+	domain := endpoints.GetTableEndpoint(client.BaseURI, accountName)
+	return fmt.Sprintf("%s/Tables('%s')", domain, tableName)
+}
+
+type ResourceID struct {
+	AccountName string
+	TableName   string
+}
+
+// ParseResourceID parses the Resource ID and returns an object which
+// can be used to interact with the Table within the specified Storage Account
+func ParseResourceID(id string) (*ResourceID, error) {
+	// example: https://foo.table.core.windows.net/Table('foo')
+	if id == "" {
+		return nil, fmt.Errorf("`id` was empty")
+	}
+
+	uri, err := url.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing ID as a URL: %s", err)
+	}
+
+	accountName, err := endpoints.GetAccountNameFromEndpoint(uri.Host)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Account Name: %s", err)
+	}
+
+	// assume there a `Table('')`
+	path := strings.TrimPrefix(uri.Path, "/")
+	if !strings.HasPrefix(path, "Tables('") || !strings.HasSuffix(path, "')") {
+		return nil, fmt.Errorf("Expected the Table Name to be in the format `Tables('name')` but got %q", path)
+	}
+
+	// strip off the `Table('')`
+	tableName := strings.TrimPrefix(uri.Path, "/Tables('")
+	tableName = strings.TrimSuffix(tableName, "')")
+	return &ResourceID{
+		AccountName: *accountName,
+		TableName:   tableName,
+	}, nil
+}

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/version.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables/version.go
@@ -1,0 +1,14 @@
+package tables
+
+import (
+	"fmt"
+
+	"github.com/tombuildsstuff/giovanni/version"
+)
+
+// APIVersion is the version of the API used for all Storage API Operations
+const APIVersion = "2018-11-09"
+
+func UserAgent() string {
+	return fmt.Sprintf("tombuildsstuff/giovanni/%s storage/%s", version.Number, APIVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -340,9 +340,10 @@ github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/valida
 github.com/terraform-providers/terraform-provider-azuread/version
 # github.com/tombuildsstuff/giovanni v0.2.1
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/file/directories
-github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/entities
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/file/shares
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/queue/queues
+github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/entities
+github.com/tombuildsstuff/giovanni/storage/2018-11-09/table/tables
 github.com/tombuildsstuff/giovanni/storage/internal/endpoints
 github.com/tombuildsstuff/giovanni/storage/internal/metadata
 github.com/tombuildsstuff/giovanni/version

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -347,6 +347,10 @@ The deprecated `resource_group_name` field will be removed, since this is no lon
 
 The deprecated `resource_group_name` field will be removed, since this is no longer used.
 
+### Resource: `azurerm_storage_table`
+
+The deprecated `resource_group_name` field will be removed, since this is no longer used.
+
 ### Resource: `azurerm_subnet`
 
 The deprecated field `network_security_group_id` will be removed. This has been replaced by the `azurerm_subnet_network_security_group_association` resource.

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -3,25 +3,25 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_table"
 sidebar_current: "docs-azurerm-resource-storage-table-x"
 description: |-
-  Manages a Azure Storage Table.
+  Manage a Table within an Azure Storage Account.
 ---
 
 # azurerm_storage_table
 
-Manage an Azure Storage Table.
+Manage a Table within an Azure Storage Account.
 
 ## Example Usage
 
 ```hcl
 resource "azurerm_resource_group" "test" {
   name     = "azuretest"
-  location = "westus"
+  location = "West Europe"
 }
 
 resource "azurerm_storage_account" "test" {
   name                     = "azureteststorage1"
   resource_group_name      = "${azurerm_resource_group.test.name}"
-  location                 = "westus"
+  location                 = "${azurerm_resource_group.test.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
@@ -39,21 +39,20 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the storage table. Must be unique within the storage account the table is located.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the storage table. Changing this forces a new resource to be created.
-
 * `storage_account_name` - (Required) Specifies the storage account in which to create the storage table.
  Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Optional / **Deprecated**) The name of the resource group in which to create the storage table.
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The ID of the Storage Table.
+* `id` - The ID of the Table within the Storage Account.
 
 ## Import
 
-Storage Table's can be imported using the `resource id`, e.g.
+Table's within a Storage Account can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_storage_table.table1 https://example.table.core.windows.net/table1


### PR DESCRIPTION
```
$ acctests azurerm TestAccAzureRMStorageTable_
=== RUN   TestAccAzureRMStorageTable_basic
=== PAUSE TestAccAzureRMStorageTable_basic
=== RUN   TestAccAzureRMStorageTable_requiresImport
--- SKIP: TestAccAzureRMStorageTable_requiresImport (0.00s)
    resource_arm_storage_table_test.go:46: Skipping since resources aren't required to be imported
=== RUN   TestAccAzureRMStorageTable_disappears
=== PAUSE TestAccAzureRMStorageTable_disappears
=== CONT  TestAccAzureRMStorageTable_basic
--- PASS: TestAccAzureRMStorageTable_basic (117.02s)
=== CONT  TestAccAzureRMStorageTable_disappears
--- PASS: TestAccAzureRMStorageTable_disappears (103.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	220.621s
```