### PR TITLE
r/storage_blob: making `metadata` computed

### DIFF
--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -119,6 +119,7 @@ func resourceArmStorageBlob() *schema.Resource {
 			"metadata": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validate.NoEmptyStrings,


### PR DESCRIPTION
Fixes TestAccAzureRMVirtualMachine_basicLinuxMachine_storageBlob_attach

```
------- Stdout: -------
=== RUN   TestAccAzureRMVirtualMachine_basicLinuxMachine_storageBlob_attach
=== PAUSE TestAccAzureRMVirtualMachine_basicLinuxMachine_storageBlob_attach
=== CONT  TestAccAzureRMVirtualMachine_basicLinuxMachine_storageBlob_attach
--- FAIL: TestAccAzureRMVirtualMachine_basicLinuxMachine_storageBlob_attach (548.77s)
    testing.go:568: Step 2 error: After applying this step and refreshing, the plan was not empty:

        DIFF:

        UPDATE: azurerm_storage_blob.test
          attempts:                                         "1" => "1"
          content_type:                                     "application/octet-stream" => "application/octet-stream"
          id:                                               "https://accsa190712152930379829.blob.core.windows.net/vhds/datadisk1.vhd" => "https://accsa190712152930379829.blob.core.windows.net/vhds/datadisk1.vhd"
          metadata.microsoftazurecompute_diskid:            "12713d7a-226f-4e95-8b45-91fd268582cd" => ""
          metadata.microsoftazurecompute_diskname:          "datadisk1.vhd" => ""
          metadata.microsoftazurecompute_disksizeingb:      "45" => ""
          metadata.microsoftazurecompute_disktype:          "DataDisk" => ""
          metadata.microsoftazurecompute_resourcegroupname: "acctestRG-190712152930379829" => ""
          metadata.microsoftazurecompute_vmname:            "acctvm-190712152930379829" => ""
          name:                                             "datadisk1.vhd" => "datadisk1.vhd"
          parallelism:                                      "8" => "8"
          resource_group_name:                              "acctestRG-190712152930379829" => "acctestRG-190712152930379829"
          size:                                             "0" => "0"
          source_uri:                                       "https://accsa190712152930379829.blob.core.windows.net/vhds/myosdisk1.vhd" => "https://accsa190712152930379829.blob.core.windows.net/vhds/myosdisk1.vhd"
          storage_account_name:                             "accsa190712152930379829" => "accsa190712152930379829"
          storage_container_name:                           "vhds" => "vhds"
          type:                                             "page" => "page"
          url:                                              "https://accsa190712152930379829.blob.core.windows.net/vhds/datadisk1.vhd" => "https://accsa190712152930379829.blob.core.windows.net/vhds/datadisk1.vhd"
```