### PR TITLE
Upgrading to v0.5.0 of github.com/hashicorp/go-azure-helpers

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -475,6 +475,9 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			SupportsClientSecretAuth:       true,
 			SupportsManagedServiceIdentity: d.Get("use_msi").(bool),
 			SupportsAzureCliToken:          true,
+
+			// Doc Links
+			ClientSecretDocsLink: "https://www.terraform.io/docs/providers/azurerm/auth/service_principal_client_secret.html",
 		}
 
 		config, err := builder.Build()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/google/uuid v1.1.1
-	github.com/hashicorp/go-azure-helpers v0.4.1
+	github.com/hashicorp/go-azure-helpers v0.5.0
 	github.com/hashicorp/go-getter v1.3.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-uuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.0.0-20190129193224-166dfd221bb2/go.mod h1:lu62V//auUow6k0IykxLK2DCNW8qTmpm8KqhYVWattA=
 github.com/hashicorp/go-azure-helpers v0.4.1 h1:aEWYW4hxAVVmxmq7nPXGK8F44A6HBXQ4m0vB1M3/20g=
 github.com/hashicorp/go-azure-helpers v0.4.1/go.mod h1:lu62V//auUow6k0IykxLK2DCNW8qTmpm8KqhYVWattA=
+github.com/hashicorp/go-azure-helpers v0.5.0 h1:GW5YJKeeMfyIEZjiVf84Av2W6FizMwS1OYLtDwDwah0=
+github.com/hashicorp/go-azure-helpers v0.5.0/go.mod h1:1kVoV5ZV0b/Wc/Rck7dKgW0MhmUrZiRxt/OnG42Yeow=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_token.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/auth_method_azure_cli_token.go
@@ -15,6 +15,7 @@ import (
 
 type azureCliTokenAuth struct {
 	profile *azureCLIProfile
+	servicePrincipalAuthDocsLink string
 }
 
 func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
@@ -25,6 +26,7 @@ func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
 			subscriptionId: b.SubscriptionID,
 			tenantId:       b.TenantID,
 		},
+		servicePrincipalAuthDocsLink: b.ClientSecretDocsLink,
 	}
 	profilePath, err := cli.ProfilePath()
 	if err != nil {
@@ -37,6 +39,17 @@ func (a azureCliTokenAuth) build(b Builder) (authMethod, error) {
 	}
 
 	auth.profile.profile = profile
+
+	// Authenticating as a Service Principal doesn't return all of the information we need for authentication purposes
+	// as such Service Principal authentication is supported using the specific auth method
+	if authenticatedAsAUser := auth.profile.verifyAuthenticatedAsAUser(); !authenticatedAsAUser {
+		return nil, fmt.Errorf(`Authenticating using the Azure CLI is only supported as a User (not a Service Principal).
+
+To authenticate to Azure using a Service Principal, you can use the separate 'Authenticate using a Service Principal'
+auth method - instructions for which can be found here: %s
+
+Alternatively you can authenticate using the Azure CLI by using a User Account.`, auth.servicePrincipalAuthDocsLink)
+	}
 
 	err = auth.profile.populateFields()
 	if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/azure_cli_profile.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/azure_cli_profile.go
@@ -1,6 +1,8 @@
 package authentication
 
 import (
+	"strings"
+
 	"github.com/Azure/go-autorest/autorest/azure/cli"
 )
 
@@ -32,4 +34,19 @@ func (a *azureCLIProfile) populateFields() error {
 
 	// always pull the environment from the Azure CLI, since the Access Token's associated with it
 	return a.populateEnvironment()
+}
+
+func (a *azureCLIProfile) verifyAuthenticatedAsAUser() bool {
+	for _, subscription := range a.profile.Subscriptions {
+		if subscription.User == nil {
+			continue
+		}
+
+		authenticatedAsAUser := strings.EqualFold(subscription.User.Type, "user")
+		if authenticatedAsAUser {
+			return true
+		}
+	}
+
+	return false
 }

--- a/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/authentication/builder.go
@@ -33,6 +33,7 @@ type Builder struct {
 	// Service Principal (Client Secret) Auth
 	SupportsClientSecretAuth bool
 	ClientSecret             string
+	ClientSecretDocsLink     string
 }
 
 // Build takes the configuration from the Builder and builds up a validated Config

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,7 +184,7 @@ github.com/grpc-ecosystem/grpc-gateway/utilities
 github.com/grpc-ecosystem/grpc-gateway/internal
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap
-# github.com/hashicorp/go-azure-helpers v0.4.1
+# github.com/hashicorp/go-azure-helpers v0.5.0
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender


### PR DESCRIPTION
This PR updates to using v0.5.0 of github.com/hashicorp/go-azure-helpers - which exposes one new feature intended to work around a slew of bug reports we're seeing of late. From v0.5.0 when attempting to authenticate using a Service Principal to the Azure CLI - we raise an error stating to use the separate Service Principal authentication method instead. Unfortunately whilst the Azure CLI does expose some of the functionality when authenticated as a Service Principal; not all fields are present and at the moment the error is unhelpful; which is leading to a ton of issues.

When authenticated using the Azure CLI and a Service Principal - we now expose an error with a link to [this page](https://www.terraform.io/docs/providers/azurerm/auth/service_principal_client_secret.html) explaining how to authenticate using a Service Principal directly.