### PR TITLE
r/storage_blob: adding additional acceptance tests

### DIFF
--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -26,6 +26,8 @@ type Client struct {
 // NOTE: this temporarily diverges from the other clients until we move this client in here
 // once we have this, can take an Options like everything else
 func BuildClient(accountsClient storage.AccountsClient) *Client {
+	// TODO: switch Storage Containers to using the storage.BlobContainersClient
+	// (which should fix #2977) when the storage clients have been moved in here
 	return &Client{
 		accountsClient: accountsClient,
 	}

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -75,10 +75,9 @@ func resourceArmStorageBlob() *schema.Resource {
 			},
 
 			"content_type": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Default:       "application/octet-stream",
-				ConflictsWith: []string{"source_uri"},
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "application/octet-stream",
 			},
 
 			"source": {


### PR DESCRIPTION
This PR rewrites the acceptance tests for the `azurerm_storage_blob` resource to ensure that all of the currently supported use-cases (and a couple of new ones coming soon, feature toggled off) are covered. With these tests we should be able to swap out [the old Storage SDK](https://github.com/Azure/azure-sdk-for-go/tree/master/storage) for [the replacement Storage SDK](https://github.com/tombuildsstuff/giovanni)

In addition this also removes the `ConflictsWith` from the `content_type` <-> `source_uri` field, since otherwise this leads to a continual diff.

Fixes #676