### PR TITLE
Added support for custom resource group name in AKS

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -75,6 +75,12 @@ func resourceArmKubernetesCluster() *schema.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
+			"custom_node_resource_group": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
 			"dns_prefix": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -574,6 +580,7 @@ func resourceArmKubernetesClusterCreateUpdate(d *schema.ResourceData, meta inter
 	log.Printf("[INFO] preparing arguments for Managed Kubernetes Cluster create/update.")
 
 	resGroup := d.Get("resource_group_name").(string)
+	nodeResGroup := d.Get("custom_node_resource_group").(string)
 	name := d.Get("name").(string)
 
 	if requireResourcesToBeImported && d.IsNewResource() {
@@ -636,6 +643,7 @@ func resourceArmKubernetesClusterCreateUpdate(d *schema.ResourceData, meta inter
 			KubernetesVersion:           utils.String(kubernetesVersion),
 			LinuxProfile:                linuxProfile,
 			NetworkProfile:              networkProfile,
+			NodeResourceGroup:           &nodeResGroup,
 			ServicePrincipalProfile:     servicePrincipalProfile,
 		},
 		Tags: expandTags(tags),

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -50,6 +50,46 @@ func TestAccAzureRMKubernetesCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMKubernetesCluster_nodeResourceGroup(t *testing.T) {
+	resourceName := "azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMKubernetesCluster_nodeResourceGroup(ri, clientId, clientSecret, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "role_based_access_control.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "role_based_access_control.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "role_based_access_control.0.azure_active_directory.#", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "kube_config.0.client_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "kube_config.0.client_certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "kube_config.0.cluster_ca_certificate"),
+					resource.TestCheckResourceAttrSet(resourceName, "kube_config.0.host"),
+					resource.TestCheckResourceAttrSet(resourceName, "kube_config.0.username"),
+					resource.TestCheckResourceAttrSet(resourceName, "kube_config.0.password"),
+					resource.TestCheckResourceAttr(resourceName, "kube_admin_config.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "kube_admin_config_raw", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "agent_pool_profile.0.max_pods"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"custom_node_resource_group"},
+			},
+		},
+	})
+}
+
 func TestAccAzureRMKubernetesCluster_requiresImport(t *testing.T) {
 	if !requireResourcesToBeImported {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -821,6 +861,34 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, rInt, location, rInt, rInt, clientId, clientSecret)
+}
+
+func testAccAzureRMKubernetesCluster_nodeResourceGroup(rInt int, clientId string, clientSecret string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                			= "acctestaks%d"
+  location            			= "${azurerm_resource_group.test.location}"
+  resource_group_name 			= "${azurerm_resource_group.test.name}"
+  custom_node_resource_group 	= "acctestaksnode%d"
+  dns_prefix          			= "acctestaks%d"
+
+  agent_pool_profile {
+    name    = "default"
+    count   = "1"
+    vm_size = "Standard_DS2_v2"
+  }
+
+  service_principal {
+    client_id     = "%s"
+    client_secret = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, clientId, clientSecret)
 }
 
 func testAccAzureRMKubernetesCluster_requiresImport(rInt int, clientId, clientSecret, location string) string {


### PR DESCRIPTION
Hi,

I wanted to use Terraform for my project, but I found one particular thing missing - lack of possibility to enter a custom name for a node resource group in Azure Kubernetes Service. To make a long story short - by default, AKS creates an additional resource group holding all the infrastructure resources and keeping them separate from the managed cluster. That RG has a dummy name what makes following naming conventions difficult. This is why Microsoft added a `nodeResourceGroup` parameter in the 2019-04-01 API version.

From my investigation, Terraform supports that parameter but only as an output. This PR adds support for `nodeResourceGroup` by introducing a `custom_node_resource_group` parameter. I did not use `node_resource_group` name as it was already added as a computed result of running an AKS deployment.

Kamil