### PR TITLE
Fix documentation. Real resource name is azurerm_application_insights…

### DIFF
--- a/website/docs/r/application_insights_web_test.html.markdown
+++ b/website/docs/r/application_insights_web_test.html.markdown
@@ -46,15 +46,15 @@ XML
 }
 
 output "webtest_id" {
-  value = "${azurerm_application_insights_webtest.test.id}"
+  value = "${azurerm_application_insights_web_test.test.id}"
 }
 
 output "webtest_provisioning_state" {
-  value = "${azurerm_application_insights_webtest.test.provisioning_state}"
+  value = "${azurerm_application_insights_web_test.test.provisioning_state}"
 }
 
 output "webtests_synthetic_id" {
-  value = "${azurerm_application_insights_webtest.test.synthetic_monitor_id}"
+  value = "${azurerm_application_insights_web_test.test.synthetic_monitor_id}"
 }
 ```
 

--- a/website/docs/r/application_insights_web_tests.html.markdown
+++ b/website/docs/r/application_insights_web_tests.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_application_insights" "test" {
   application_type    = "web"
 }
 
-resource "azurerm_application_insights_webtest" "test" {
+resource "azurerm_application_insights_web_test" "test" {
   name                    = "tf-test-appinsights-webtest"
   location                = "${azurerm_resource_group.test.location}"
   resource_group_name     = "${azurerm_resource_group.test.name}"
@@ -46,15 +46,15 @@ XML
 }
 
 output "webtest_id" {
-  value = "${azurerm_application_insights_webtest.test.id}"
+  value = "${azurerm_application_insights_web_test.test.id}"
 }
 
 output "webtest_provisioning_state" {
-  value = "${azurerm_application_insights_webtest.test.provisioning_state}"
+  value = "${azurerm_application_insights_web_test.test.provisioning_state}"
 }
 
 output "webtests_synthetic_id" {
-  value = "${azurerm_application_insights_webtest.test.synthetic_monitor_id}"
+  value = "${azurerm_application_insights_web_test.test.synthetic_monitor_id}"
 }
 ```
 


### PR DESCRIPTION
Typo fix.
The documentation is wrong. The resource name is [azurerm_application_insights_web_test](https://github.com/terraform-providers/terraform-provider-azurerm/search?q=azurerm_application_insights_web_test&unscoped_q=azurerm_application_insights_web_test), not [azurerm_application_insights_webtest](https://github.com/terraform-providers/terraform-provider-azurerm/search?q=azurerm_application_insights_webtest&unscoped_q=azurerm_application_insights_webtest).

![image](https://user-images.githubusercontent.com/922368/61488831-e18e0f80-a9b1-11e9-9dc2-3eca016dd8cb.png)

![image](https://user-images.githubusercontent.com/922368/61488868-f7033980-a9b1-11e9-983a-4a8352ded35a.png)
