### PR TITLE
r/databricks_workspace: support for workspace parameters

### DIFF
--- a/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
+++ b/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
@@ -69,7 +69,7 @@ func resourceArmDatabricksWorkspace() *schema.Resource {
 				ValidateFunc: validate.NoEmptyStrings,
 			},
 
-			"workspace_custom_parameters": {
+			"custom_parameters": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
@@ -220,7 +220,7 @@ func resourceArmDatabricksWorkspaceRead(d *schema.ResourceData, meta interface{}
 		}
 		d.Set("managed_resource_group_id", props.ManagedResourceGroupID)
 		d.Set("managed_resource_group_name", managedResourceGroupID.ResourceGroup)
-		d.Set("workspace_custom_parameters", flattenWorkspaceCustomParameters(props.Parameters))
+		d.Set("custom_parameters", flattenWorkspaceCustomParameters(props.Parameters))
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -260,22 +260,28 @@ func flattenWorkspaceCustomParameters(p *databricks.WorkspaceCustomParameters) [
 
 	parameters := make(map[string]interface{})
 	if privateSubnet := p.CustomPrivateSubnetName; privateSubnet != nil {
-		parameters["private_subnet_name"] = *privateSubnet.Value
+		if privateSubnet.Value != nil {
+			parameters["private_subnet_name"] = *privateSubnet.Value
+		}
 	}
 
 	if publicSubnet := p.CustomPublicSubnetName; publicSubnet != nil {
-		parameters["public_subnet_name"] = *publicSubnet.Value
+		if publicSubnet.Value != nil {
+			parameters["public_subnet_name"] = *publicSubnet.Value
+		}
 	}
 
 	if vnetID := p.CustomVirtualNetworkID; vnetID != nil {
-		parameters["virtual_network_id"] = *vnetID.Value
+		if vnetID.Value != nil {
+			parameters["virtual_network_id"] = *vnetID.Value
+		}
 	}
 
 	return []interface{}{parameters}
 }
 
 func expandWorkspaceCustomParameters(d *schema.ResourceData) *databricks.WorkspaceCustomParameters {
-	configList, ok := d.GetOkExists("workspace_custom_parameters")
+	configList, ok := d.GetOkExists("custom_parameters")
 	if !ok {
 		return nil
 	}

--- a/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
+++ b/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
@@ -69,6 +69,32 @@ func resourceArmDatabricksWorkspace() *schema.Resource {
 				ValidateFunc: validate.NoEmptyStrings,
 			},
 
+			"workspace_custom_parameters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"public_subnet_name": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+						},
+						"private_subnet_name": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+						},
+						"virtual_network_id": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Optional: true,
+						},
+					},
+				},
+			},
+
 			"managed_resource_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -125,6 +151,7 @@ func resourceArmDatabricksWorkspaceCreateUpdate(d *schema.ResourceData, meta int
 		Location: utils.String(location),
 		WorkspaceProperties: &databricks.WorkspaceProperties{
 			ManagedResourceGroupID: &managedResourceGroupID,
+			Parameters:             expandWorkspaceCustomParameters(d),
 		},
 		Tags: expandedTags,
 	}
@@ -193,6 +220,7 @@ func resourceArmDatabricksWorkspaceRead(d *schema.ResourceData, meta interface{}
 		}
 		d.Set("managed_resource_group_id", props.ManagedResourceGroupID)
 		d.Set("managed_resource_group_name", managedResourceGroupID.ResourceGroup)
+		d.Set("workspace_custom_parameters", flattenWorkspaceCustomParameters(props.Parameters))
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -223,6 +251,56 @@ func resourceArmDatabricksWorkspaceDelete(d *schema.ResourceData, meta interface
 	}
 
 	return nil
+}
+
+func flattenWorkspaceCustomParameters(p *databricks.WorkspaceCustomParameters) []interface{} {
+	if p == nil {
+		return nil
+	}
+
+	parameters := make(map[string]interface{})
+	if privateSubnet := p.CustomPrivateSubnetName; privateSubnet != nil {
+		parameters["private_subnet_name"] = *privateSubnet.Value
+	}
+
+	if publicSubnet := p.CustomPublicSubnetName; publicSubnet != nil {
+		parameters["public_subnet_name"] = *publicSubnet.Value
+	}
+
+	if vnetID := p.CustomVirtualNetworkID; vnetID != nil {
+		parameters["virtual_network_id"] = *vnetID.Value
+	}
+
+	return []interface{}{parameters}
+}
+
+func expandWorkspaceCustomParameters(d *schema.ResourceData) *databricks.WorkspaceCustomParameters {
+	configList, ok := d.GetOkExists("workspace_custom_parameters")
+	if !ok {
+		return nil
+	}
+	config := configList.([]interface{})[0].(map[string]interface{})
+	parameters := databricks.WorkspaceCustomParameters{}
+
+	if v := config["public_subnet_name"].(string); v != "" {
+		parameters.CustomPublicSubnetName = &databricks.WorkspaceCustomStringParameter{
+			Value: &v,
+		}
+	}
+
+	if v := config["private_subnet_name"].(string); v != "" {
+		parameters.CustomPrivateSubnetName = &databricks.WorkspaceCustomStringParameter{
+			Value: &v,
+		}
+	}
+
+	if v := config["virtual_network_id"].(string); v != "" {
+		parameters.CustomVirtualNetworkID = &databricks.WorkspaceCustomStringParameter{
+			Value: &v,
+		}
+	}
+
+	return &parameters
 }
 
 func ValidateDatabricksWorkspaceName(i interface{}, k string) (warnings []string, errors []error) {

--- a/azurerm/internal/services/databricks/tests/resource_arm_databricks_workspace_test.go
+++ b/azurerm/internal/services/databricks/tests/resource_arm_databricks_workspace_test.go
@@ -131,6 +131,9 @@ func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 					testCheckAzureRMDatabricksWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_id"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_custom_parameters.0.virtual_network_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.public_subnet_name", "public"),
+					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.private_subnet_name", "private"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Environment", "Production"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Pricing", "Standard"),
@@ -142,6 +145,9 @@ func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 					testCheckAzureRMDatabricksWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_id"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_custom_parameters.0.virtual_network_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.public_subnet_name", "public"),
+					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.private_subnet_name", "private"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Pricing", "Standard"),
 				),
@@ -242,12 +248,91 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+resource "azurerm_virtual_network" "test" {
+  name                = "test"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "public" {
+  name = "public"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  virtual_network_name  = "${azurerm_virtual_network.test.name}"
+  address_prefix        = "10.0.1.0/24"
+
+  delegation {
+    name = "acctest"
+
+    service_delegation {
+      name = "Microsoft.Databricks/workspaces"
+
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
+    }
+  }
+
+  lifecycle {
+    ignore_changes = ["network_security_group_id"]
+  }
+}
+
+resource "azurerm_subnet" "private" {
+  name                  = "private"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  virtual_network_name  = "${azurerm_virtual_network.test.name}"
+  address_prefix        = "10.0.2.0/24"
+
+  delegation {
+    name = "acctest"
+
+    service_delegation {
+      name = "Microsoft.Databricks/workspaces"
+
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+        "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+        "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+      ]
+    }
+  }
+
+  lifecycle {
+    ignore_changes = ["network_security_group_id"]
+  }
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "private-nsg"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "public" {
+  subnet_id                 = "${azurerm_subnet.public.id}"
+  network_security_group_id = "${azurerm_network_security_group.nsg.id}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "private" {
+  subnet_id                 = "${azurerm_subnet.private.id}"
+  network_security_group_id = "${azurerm_network_security_group.nsg.id}"
+}
+
 resource "azurerm_databricks_workspace" "test" {
   name                        = "acctestdbw-%d"
   resource_group_name         = "${azurerm_resource_group.test.name}"
   location                    = "${azurerm_resource_group.test.location}"
   sku                         = "standard"
   managed_resource_group_name = "acctestRG-%d-managed"
+
+  workspace_custom_parameters {
+    public_subnet_name  = "${azurerm_subnet.public.name}"
+    private_subnet_name = "${azurerm_subnet.private.name}"
+    virtual_network_id  = "${azurerm_virtual_network.test.id}"
+  }
 
   tags = {
     Environment = "Production"

--- a/azurerm/internal/services/databricks/tests/resource_arm_databricks_workspace_test.go
+++ b/azurerm/internal/services/databricks/tests/resource_arm_databricks_workspace_test.go
@@ -131,9 +131,9 @@ func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 					testCheckAzureRMDatabricksWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_id"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_name"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_custom_parameters.0.virtual_network_id"),
-					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.public_subnet_name", "public"),
-					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.private_subnet_name", "private"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "custom_parameters.0.virtual_network_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "custom_parameters.0.public_subnet_name", "public"),
+					resource.TestCheckResourceAttr(data.ResourceName, "custom_parameters.0.private_subnet_name", "private"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Environment", "Production"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Pricing", "Standard"),
@@ -145,9 +145,9 @@ func TestAccAzureRMDatabricksWorkspace_complete(t *testing.T) {
 					testCheckAzureRMDatabricksWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_id"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_name"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_custom_parameters.0.virtual_network_id"),
-					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.public_subnet_name", "public"),
-					resource.TestCheckResourceAttr(data.ResourceName, "workspace_custom_parameters.0.private_subnet_name", "private"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "custom_parameters.0.virtual_network_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "custom_parameters.0.public_subnet_name", "public"),
+					resource.TestCheckResourceAttr(data.ResourceName, "custom_parameters.0.private_subnet_name", "private"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Pricing", "Standard"),
 				),
@@ -256,10 +256,10 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "public" {
-  name = "public"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
-  virtual_network_name  = "${azurerm_virtual_network.test.name}"
-  address_prefix        = "10.0.1.0/24"
+  name                 = "public"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.1.0/24"
 
   delegation {
     name = "acctest"
@@ -281,10 +281,10 @@ resource "azurerm_subnet" "public" {
 }
 
 resource "azurerm_subnet" "private" {
-  name                  = "private"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
-  virtual_network_name  = "${azurerm_virtual_network.test.name}"
-  address_prefix        = "10.0.2.0/24"
+  name                 = "private"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 
   delegation {
     name = "acctest"
@@ -328,7 +328,7 @@ resource "azurerm_databricks_workspace" "test" {
   sku                         = "standard"
   managed_resource_group_name = "acctestRG-%d-managed"
 
-  workspace_custom_parameters {
+  custom_parameters {
     public_subnet_name  = "${azurerm_subnet.public.name}"
     private_subnet_name = "${azurerm_subnet.private.name}"
     virtual_network_id  = "${azurerm_virtual_network.test.id}"

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -46,7 +46,21 @@ The following arguments are supported:
 
 ~> **NOTE** Azure requires that this Resource Group does not exist in this Subscription (and that the Azure API creates it) - otherwise the deployment will fail.
 
+* `workspace_custom_parameters` - (Optional) A `workspace_custom_parameters` block as documented below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+`workspace_custom_parameters` supports the following:
+
+* `public_subnet_name` - (Optional) The name of the Public Subnet within the Virtual Network. Required if `virtual_network_id` is set.
+
+* `private_subnet_name` - (Optional) The name of the Private Subnet within the Virtual Network. Required if `virtual_network_id` is set.
+
+* `virtual_network_id` - (Optional) The ID of a Virtual Network where this Databricks Cluster should be created.
+
+~> **NOTE** Databricks requires that a network security group is associated with public and private subnets when `virtual_network_id` is set.
 
 ## Attributes Reference
 

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -46,13 +46,13 @@ The following arguments are supported:
 
 ~> **NOTE** Azure requires that this Resource Group does not exist in this Subscription (and that the Azure API creates it) - otherwise the deployment will fail.
 
-* `workspace_custom_parameters` - (Optional) A `workspace_custom_parameters` block as documented below.
+* `custom_parameters` - (Optional) A `custom_parameters` block as documented below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 
-`workspace_custom_parameters` supports the following:
+`custom_parameters` supports the following:
 
 * `public_subnet_name` - (Optional) The name of the Public Subnet within the Virtual Network. Required if `virtual_network_id` is set.
 


### PR DESCRIPTION
Allows for optional map of workspace parameter key/values (e.g. `customPrivateSubnetName`, `customPublicSubnetName`). [https://docs.microsoft.com/en-us/rest/api/databricks/workspaces/createorupdate#workspace](https://docs.microsoft.com/en-us/rest/api/databricks/workspaces/createorupdate#workspace)

The list of accepted parameter keys included in the doc updates was provided in a response through the sdk with a disallowed parameter. Can't find the list in any other documentation though.

Includes test updates.

Fixes #3001