### PR TITLE
r/storage_container: metadata should be computed

### DIFF
--- a/azurerm/internal/services/storage/metadata.go
+++ b/azurerm/internal/services/storage/metadata.go
@@ -16,6 +16,15 @@ func MetaDataSchema() *schema.Schema {
 	}
 }
 
+func MetaDataComputedSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeMap,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validateMetaDataKeys,
+	}
+}
+
 func ExpandMetaData(input map[string]interface{}) map[string]string {
 	output := make(map[string]string)
 

--- a/azurerm/resource_arm_storage_container.go
+++ b/azurerm/resource_arm_storage_container.go
@@ -53,7 +53,7 @@ func resourceArmStorageContainer() *schema.Resource {
 				}, false),
 			},
 
-			"metadata": storage.MetaDataSchema(),
+			"metadata": storage.MetaDataComputedSchema(),
 
 			// TODO: support for ACL's, Legal Holds and Immutability Policies
 			"has_immutability_policy": {

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -139,6 +139,17 @@ func TestAccAzureRMStorageContainer_metaData(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAzureRMStorageContainer_metaDataEmpty(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageContainerExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -375,6 +386,23 @@ resource "azurerm_storage_container" "test" {
   metadata = {
     hello = "world"
     panda = "pops"
+  }
+}
+`, template)
+}
+
+func testAccAzureRMStorageContainer_metaDataEmpty(rInt int, rString string, location string) string {
+	template := testAccAzureRMStorageContainer_template(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+
+  metadata = {
   }
 }
 `, template)


### PR DESCRIPTION
The MetaData for the Storage Container can be set by objects outside of the Storage Container; as such this PR makes this optional; which should fix the failing HDInsights tests (which stores the version of HDInsight used in the metadata for the storage container)

```
$ acctests azurerm TestAccAzureRMStorageContainer_metaData
=== RUN   TestAccAzureRMStorageContainer_metaData
=== PAUSE TestAccAzureRMStorageContainer_metaData
=== CONT  TestAccAzureRMStorageContainer_metaData
--- PASS: TestAccAzureRMStorageContainer_metaData (165.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	165.571s
```