### PR TITLE
d/cosmosdb_account: handling the document endpoint being nil

### DIFF
--- a/azurerm/data_source_cosmos_db_account.go
+++ b/azurerm/data_source_cosmos_db_account.go
@@ -238,18 +238,30 @@ func dataSourceArmCosmosDbAccountRead(d *schema.ResourceData, meta interface{}) 
 		readEndpoints := make([]string, 0)
 		if locations := props.ReadLocations; locations != nil {
 			for _, l := range *locations {
+				if l.DocumentEndpoint == nil {
+					continue
+				}
+
 				readEndpoints = append(readEndpoints, *l.DocumentEndpoint)
 			}
 		}
-		d.Set("read_endpoints", readEndpoints)
+		if err := d.Set("read_endpoints", readEndpoints); err != nil {
+			return fmt.Errorf("Error setting `read_endpoints`: %s", err)
+		}
 
 		writeEndpoints := make([]string, 0)
 		if locations := props.WriteLocations; locations != nil {
 			for _, l := range *locations {
+				if l.DocumentEndpoint == nil {
+					continue
+				}
+
 				writeEndpoints = append(writeEndpoints, *l.DocumentEndpoint)
 			}
 		}
-		d.Set("write_endpoints", writeEndpoints)
+		if err := d.Set("write_endpoints", writeEndpoints); err != nil {
+			return fmt.Errorf("Error setting `write_endpoints`: %s", err)
+		}
 
 		d.Set("enable_multiple_write_locations", resp.EnableMultipleWriteLocations)
 	}

--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -619,20 +619,32 @@ func resourceArmCosmosDbAccountRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error setting `virtual_network_rule`: %+v", err)
 	}
 
+	readEndpoints := make([]string, 0)
 	if p := resp.ReadLocations; p != nil {
-		readEndpoints := make([]string, 0)
 		for _, l := range *p {
+			if l.DocumentEndpoint == nil {
+				continue
+			}
+
 			readEndpoints = append(readEndpoints, *l.DocumentEndpoint)
 		}
-		d.Set("read_endpoints", readEndpoints)
+	}
+	if err := d.Set("read_endpoints", readEndpoints); err != nil {
+		return fmt.Errorf("Error setting `read_endpoints`: %s", err)
 	}
 
+	writeEndpoints := make([]string, 0)
 	if p := resp.WriteLocations; p != nil {
-		writeEndpoints := make([]string, 0)
 		for _, l := range *p {
+			if l.DocumentEndpoint == nil {
+				continue
+			}
+
 			writeEndpoints = append(writeEndpoints, *l.DocumentEndpoint)
 		}
-		d.Set("write_endpoints", writeEndpoints)
+	}
+	if err := d.Set("write_endpoints", writeEndpoints); err != nil {
+		return fmt.Errorf("Error setting `write_endpoints`: %s", err)
 	}
 
 	// ListKeys returns a data structure containing a DatabaseAccountListReadOnlyKeysResult pointer


### PR DESCRIPTION
Handling a crash in the Read found from a test:

```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccDataSourceAzureRMCosmosDBAccount_complete
=== PAUSE TestAccDataSourceAzureRMCosmosDBAccount_complete
=== CONT  TestAccDataSourceAzureRMCosmosDBAccount_complete

------- Stderr: -------
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x29f1b1b]

goroutine 396 [running]:
github.com/terraform-providers/terraform-provider-azurerm/azurerm.dataSourceArmCosmosDbAccountRead(0xc00035d1f0, 0x3871bc0, 0xc000816000, 0xc00035d1f0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_cosmos_db_account.go:241 +0x152b
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Resource).ReadDataApply(0xc000465e80, 0xc001a9f580, 0x3871bc0, 0xc000816000, 0xc0002ad158, 0x1, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/resource.go:390 +0x88
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema.(*Provider).ReadDataApply(0xc000760300, 0xc0015cda78, 0xc001a9f580, 0xc001a9f580, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/schema/provider.go:442 +0x92
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/plugin.(*GRPCProviderServer).ReadDataSource(0xc000c28198, 0x4138b00, 0xc000bd7dd0, 0xc001aa04c0, 0xc000c28198, 0xc000bd7aa0, 0x3598ec0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/helper/plugin/grpc_provider.go:990 +0x499
github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/internal/tfplugin5._Provider_ReadDataSource_Handler(0x388c040, 0xc000c28198, 0x4138b00, 0xc000bd7dd0, 0xc001349220, 0x0, 0x0, 0x0, 0xc000dbc600, 0x1e2)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/github.com/hashicorp/terraform/internal/tfplugin5/tfplugin5.pb.go:3055 +0x23e
github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc000784c00, 0x4157f40, 0xc000784d80, 0xc001120300, 0xc000214d80, 0x72b8af0, 0x0, 0x0, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:972 +0x4a2
github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).handleStream(0xc000784c00, 0x4157f40, 0xc000784d80, 0xc001120300, 0x0)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:1252 +0xe02
github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000646990, 0xc000784c00, 0x4157f40, 0xc000784d80, 0xc001120300)
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:691 +0x9f
created by github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
	/opt/teamcity-agent/work/458e5e4800bd94f6/src/github.com/terraform-providers/terraform-provider-azurerm/vendor/google.golang.org/grpc/server.go:689 +0xa1
```