### PR TITLE
azurerm_cosmosdb_account: validate max_interval_in_seconds and max_staleness_prefix correctly when using more then 1 geo_location

### DIFF
--- a/azurerm/resource_arm_cosmosdb_account_failover_test.go
+++ b/azurerm/resource_arm_cosmosdb_account_failover_test.go
@@ -315,8 +315,8 @@ resource "azurerm_cosmosdb_account" "test" {
 
   consistency_policy {
     consistency_level       = "BoundedStaleness"
-    max_interval_in_seconds = 10
-    max_staleness_prefix    = 200
+    max_interval_in_seconds = 333
+    max_staleness_prefix    = 101101
   }
 
   failover_policy {

--- a/azurerm/resource_arm_cosmosdb_account_test.go
+++ b/azurerm/resource_arm_cosmosdb_account_test.go
@@ -825,7 +825,12 @@ func testAccAzureRMCosmosDBAccount_capabilityDocLevelTTL(rInt int, location stri
 }
 
 func testAccAzureRMCosmosDBAccount_geoReplicated(rInt int, location string, altLocation string) string {
-	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", fmt.Sprintf(`
+	co := `
+	max_interval_in_seconds = 373
+	max_staleness_prefix    = 100001
+`
+
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), co, fmt.Sprintf(`
         geo_location {
             location          = "%s"
             failover_priority = 1
@@ -835,7 +840,12 @@ func testAccAzureRMCosmosDBAccount_geoReplicated(rInt int, location string, altL
 }
 
 func testAccAzureRMCosmosDBAccount_multiMaster(rInt int, location string, altLocation string) string {
-	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", fmt.Sprintf(`
+	co := `
+	max_interval_in_seconds = 373
+	max_staleness_prefix    = 100001
+`
+
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), co, fmt.Sprintf(`
         enable_multiple_write_locations = true
 
         geo_location {
@@ -847,7 +857,12 @@ func testAccAzureRMCosmosDBAccount_multiMaster(rInt int, location string, altLoc
 }
 
 func testAccAzureRMCosmosDBAccount_geoReplicated_customId(rInt int, location string, altLocation string) string {
-	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", fmt.Sprintf(`
+	co := `
+	max_interval_in_seconds = 373
+	max_staleness_prefix    = 100001
+`
+
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), co, fmt.Sprintf(`
         geo_location {
             prefix            = "acctest-%d-custom-id"
             location          = "%s"
@@ -858,7 +873,11 @@ func testAccAzureRMCosmosDBAccount_geoReplicated_customId(rInt int, location str
 }
 
 func testAccAzureRMCosmosDBAccount_complete(rInt int, location string, altLocation string) string {
-	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", fmt.Sprintf(`
+	co := `
+	max_interval_in_seconds = 373
+	max_staleness_prefix    = 100001
+`
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), co, fmt.Sprintf(`
 		ip_range_filter				= "104.42.195.92,40.76.54.131,52.176.6.30,52.169.50.45/32,52.187.184.26,10.20.0.0/16"
 		enable_automatic_failover	= true
 
@@ -871,7 +890,12 @@ func testAccAzureRMCosmosDBAccount_complete(rInt int, location string, altLocati
 }
 
 func testAccAzureRMCosmosDBAccount_emptyIpFilter(rInt int, location string, altLocation string) string {
-	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), "", fmt.Sprintf(`
+	co := `
+	max_interval_in_seconds = 373
+	max_staleness_prefix    = 100001
+`
+
+	return testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.BoundedStaleness), co, fmt.Sprintf(`
 		ip_range_filter				= ""
 		enable_automatic_failover	= true
 


### PR DESCRIPTION
fixes #3551 