### PR TITLE
azurerm_postgresql_server  - remove unsupported version `10.2`

### DIFF
--- a/azurerm/resource_arm_postgresql_server.go
+++ b/azurerm/resource_arm_postgresql_server.go
@@ -133,7 +133,6 @@ func resourceArmPostgreSQLServer() *schema.Resource {
 					string(postgresql.OneOne),
 					string(postgresql.OneZero),
 					string(postgresql.OneZeroFullStopZero),
-					string(postgresql.OneZeroFullStopTwo),
 				}, true),
 				DiffSuppressFunc: suppress.CaseDifference,
 			},

--- a/azurerm/resource_arm_postgresql_server_test.go
+++ b/azurerm/resource_arm_postgresql_server_test.go
@@ -102,36 +102,6 @@ func TestAccAzureRMPostgreSQLServer_basicTenPointZero(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMPostgreSQLServer_basicTenPointTwo(t *testing.T) {
-	resourceName := "azurerm_postgresql_server.test"
-	ri := tf.AccRandTimeInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPostgreSQLServerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMPostgreSQLServer_basicTenPointTwo(ri, testLocation()),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMPostgreSQLServerExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "administrator_login", "acctestun"),
-					resource.TestCheckResourceAttr(resourceName, "version", "10.2"),
-					resource.TestCheckResourceAttr(resourceName, "ssl_enforcement", "Enabled"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"administrator_login_password", // not returned as sensitive
-				},
-			},
-		},
-	})
-}
-
 func TestAccAzureRMPostgreSQLServer_basicEleven(t *testing.T) {
 	resourceName := "azurerm_postgresql_server.test"
 	ri := tf.AccRandTimeInt()
@@ -487,10 +457,6 @@ func testAccAzureRMPostgreSQLServer_basicNinePointSix(rInt int, location string)
 
 func testAccAzureRMPostgreSQLServer_basicTenPointZero(rInt int, location string) string {
 	return testAccAzureRMPostgreSQLServer_basic(rInt, location, "10.0")
-}
-
-func testAccAzureRMPostgreSQLServer_basicTenPointTwo(rInt int, location string) string {
-	return testAccAzureRMPostgreSQLServer_basic(rInt, location, "10.2")
 }
 
 func testAccAzureRMPostgreSQLServer_basicEleven(rInt int, location string) string {

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Required) The Password associated with the `administrator_login` for the PostgreSQL Server.
 
-* `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5`, `9.6`, `10`, `10.0`, and `10.2`. Changing this forces a new resource to be created.
+* `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5`, `9.6`, `10`, `10.0`, and `11`. Changing this forces a new resource to be created.
 
 * `ssl_enforcement` - (Required) Specifies if SSL should be enforced on connections. Possible values are `Enabled` and `Disabled`.
 


### PR DESCRIPTION
Add PostgreSQL 11 as supported version.

Drop support for 10.0 and 10.2 as Azure will only accept Major version numbers for provisioning and handles minor version updates automatically ( see https://docs.microsoft.com/en-us/azure/postgresql/concepts-supported-versions ). 9.5 and 9.6 are still major versions though ( see https://www.postgresql.org/support/versioning/ )

Closes #3327 