### PR TITLE
Sending nil certificate when no certificate is specified

### DIFF
--- a/azurerm/resource_arm_api_management_backend.go
+++ b/azurerm/resource_arm_api_management_backend.go
@@ -385,7 +385,10 @@ func expandApiManagementBackendCredentials(input []interface{}) *apimanagement.B
 		contract.Authorization = authorization
 	}
 	if certificate := v["certificate"]; certificate != nil {
-		contract.Certificate = utils.ExpandStringSlice(certificate.([]interface{}))
+		certificates := utils.ExpandStringSlice(certificate.([]interface{}))
+		if certificates != nil && len(*certificates) > 0 {
+			contract.Certificate = certificates
+		}
 	}
 	if headerRaw := v["header"]; headerRaw != nil {
 		header := expandApiManagementBackendCredentialsObject(headerRaw.(map[string]interface{}))

--- a/azurerm/resource_arm_api_management_backend_test.go
+++ b/azurerm/resource_arm_api_management_backend_test.go
@@ -82,6 +82,31 @@ func TestAccAzureRMApiManagementBackend_allProperties(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApiManagementBackend_credentialsNoCertificate(t *testing.T) {
+	resourceName := "azurerm_api_management_backend.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementBackend_credentialsNoCertificate(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementBackendExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMApiManagementBackend_update(t *testing.T) {
 	resourceName := "azurerm_api_management_backend.test"
 	ri := tf.AccRandTimeInt()
@@ -464,4 +489,45 @@ resource "azurerm_api_management" "test" {
   }
 }
 `, rInt, testName, location, rInt, testName)
+}
+
+func testAccAzureRMApiManagementBackend_credentialsNoCertificate(rInt int, location string) string {
+	template := testAccAzureRMApiManagementBackend_template(rInt, "all", location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_backend" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  protocol            = "http"
+  url                 = "https://acctest"
+  description         = "description"
+  resource_id         = "https://resourceid"
+  title               = "title"
+  credentials {
+    authorization {
+      parameter = "parameter"
+      scheme    = "scheme"
+    }
+    header = {
+      header1 = "header1value1,header1value2"
+      header2 = "header2value1,header2value2"
+    }
+    query = {
+      query1 = "query1value1,query1value2"
+      query2 = "query2value1,query2value2"
+    }
+  }
+  proxy {
+    url      = "http://192.168.1.1:8080"
+    username = "username"
+    password = "password"
+  }
+  tls {
+    validate_certificate_chain = false
+    validate_certificate_name  = true
+  }
+}
+`, template, rInt)
 }


### PR DESCRIPTION
This PR addresses #3929 by sending a nil certificate object instead of an empty certificate object to the api.

