### PR TITLE
Bug Fix: `azurerm_storage_table` - Migrate id to new format

### DIFF
--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -23,8 +23,20 @@ func resourceArmStorageTable() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		SchemaVersion: 1,
-		MigrateState:  resourceStorageTableMigrateState,
+		SchemaVersion: 2,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				// this should have been applied from pre-0.12 migration system; backporting just in-case
+				Type:    resourceStorageTableStateResourceV0V1().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceStorageTableStateUpgradeV0ToV1,
+				Version: 0,
+			},
+			{
+				Type:    resourceStorageTableStateResourceV0V1().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceStorageTableStateUpgradeV1ToV2,
+				Version: 1,
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {


### PR DESCRIPTION
Addressing #3924 by migrating the old id to the new id

```
=== RUN   TestAzureRMStorageTableMigrateStateV0ToV1
--- PASS: TestAzureRMStorageTableMigrateStateV1ToV2 (0.00s)
```