### PR TITLE
azurerm_postgresql_server  - support for version `11.0`

### DIFF
--- a/azurerm/resource_arm_postgresql_server.go
+++ b/azurerm/resource_arm_postgresql_server.go
@@ -130,6 +130,7 @@ func resourceArmPostgreSQLServer() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(postgresql.NineFullStopFive),
 					string(postgresql.NineFullStopSix),
+					string(postgresql.OneOne),
 					string(postgresql.OneZero),
 					string(postgresql.OneZeroFullStopZero),
 					string(postgresql.OneZeroFullStopTwo),

--- a/azurerm/resource_arm_postgresql_server_test.go
+++ b/azurerm/resource_arm_postgresql_server_test.go
@@ -102,6 +102,66 @@ func TestAccAzureRMPostgreSQLServer_basicTenPointZero(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPostgreSQLServer_basicTenPointTwo(t *testing.T) {
+	resourceName := "azurerm_postgresql_server.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPostgreSQLServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMPostgreSQLServer_basicTenPointTwo(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPostgreSQLServerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "administrator_login", "acctestun"),
+					resource.TestCheckResourceAttr(resourceName, "version", "10.2"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enforcement", "Enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"administrator_login_password", // not returned as sensitive
+				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMPostgreSQLServer_basicEleven(t *testing.T) {
+	resourceName := "azurerm_postgresql_server.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPostgreSQLServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMPostgreSQLServer_basicEleven(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPostgreSQLServerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "administrator_login", "acctestun"),
+					resource.TestCheckResourceAttr(resourceName, "version", "11"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enforcement", "Enabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"administrator_login_password", // not returned as sensitive
+				},
+			},
+		},
+	})
+}
+
 func TestAccAzureRMPostgreSQLServer_requiresImport(t *testing.T) {
 	if !requireResourcesToBeImported {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -384,7 +444,7 @@ func testCheckAzureRMPostgreSQLServerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMPostgreSQLServer_basicNinePointFive(rInt int, location string) string {
+func testAccAzureRMPostgreSQLServer_basic(rInt int, location string, version string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -411,76 +471,30 @@ resource "azurerm_postgresql_server" "test" {
 
   administrator_login          = "acctestun"
   administrator_login_password = "H@Sh1CoR3!"
-  version                      = "9.5"
+  version                      = "%s"
   ssl_enforcement              = "Enabled"
 }
-`, rInt, location, rInt)
+`, rInt, location, rInt, version)
+}
+
+func testAccAzureRMPostgreSQLServer_basicNinePointFive(rInt int, location string) string {
+	return testAccAzureRMPostgreSQLServer_basic(rInt, location, "9.5")
 }
 
 func testAccAzureRMPostgreSQLServer_basicNinePointSix(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_postgresql_server" "test" {
-  name                = "acctestpsqlsvr-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    name     = "GP_Gen5_2"
-    capacity = 2
-    tier     = "GeneralPurpose"
-    family   = "Gen5"
-  }
-
-  storage_profile {
-    storage_mb            = 51200
-    backup_retention_days = 7
-    geo_redundant_backup  = "Disabled"
-  }
-
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "9.6"
-  ssl_enforcement              = "Enabled"
-}
-`, rInt, location, rInt)
+	return testAccAzureRMPostgreSQLServer_basic(rInt, location, "9.6")
 }
 
 func testAccAzureRMPostgreSQLServer_basicTenPointZero(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+	return testAccAzureRMPostgreSQLServer_basic(rInt, location, "10.0")
 }
 
-resource "azurerm_postgresql_server" "test" {
-  name                = "acctestpsqlsvr-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    name     = "GP_Gen5_2"
-    capacity = 2
-    tier     = "GeneralPurpose"
-    family   = "Gen5"
-  }
-
-  storage_profile {
-    storage_mb            = 51200
-    backup_retention_days = 7
-    geo_redundant_backup  = "Disabled"
-  }
-
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "10.0"
-  ssl_enforcement              = "Enabled"
+func testAccAzureRMPostgreSQLServer_basicTenPointTwo(rInt int, location string) string {
+	return testAccAzureRMPostgreSQLServer_basic(rInt, location, "10.2")
 }
-`, rInt, location, rInt)
+
+func testAccAzureRMPostgreSQLServer_basicEleven(rInt int, location string) string {
+	return testAccAzureRMPostgreSQLServer_basic(rInt, location, "11")
 }
 
 func testAccAzureRMPostgreSQLServer_requiresImport(rInt int, location string) string {


### PR DESCRIPTION
Fixes #3969, and relates to #3327 even so it doesn't solve the problem for 10.X versions. The Azure SDK for go doesn't provide version 10.7 for example, see [here](https://github.com/Azure/azure-sdk-for-go/blob/7a9d2769e4a581b0b1bc609c71b59af043e05c98/services/postgresql/mgmt/2017-12-01/postgresql/models.go#L122). But fortunately it has a version 11.
I also introduced a minor refactor in the tests to avoid unnecessary copy pastes.