### PR TITLE
azurerm_monitor_diagnostic_setting - added LogAnalyticsDestinationType

### DIFF
--- a/azurerm/resource_arm_monitor_diagnostic_setting.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting.go
@@ -73,6 +73,19 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
+			"log_analytics_destination_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+					v := val.(string)
+					if v != "Dedicated" {
+						errs = append(errs, fmt.Errorf("%q must be 'Dedicated'", key, v))
+					}
+					return
+				},
+			},
+
 			"log": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -232,6 +245,11 @@ func resourceArmMonitorDiagnosticSettingCreateUpdate(d *schema.ResourceData, met
 	if storageAccountId != "" {
 		properties.DiagnosticSettings.StorageAccountID = utils.String(storageAccountId)
 		valid = true
+	}
+
+	logAnalyticsDestinationType := d.Get("log_analytics_destination_type").(string)
+	if logAnalyticsDestinationType != "" {
+		properties.DiagnosticSettings.LogAnalyticsDestinationType = utils.String(logAnalyticsDestinationType)
 	}
 
 	if !valid {

--- a/azurerm/resource_arm_monitor_diagnostic_setting.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting.go
@@ -74,16 +74,10 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 			},
 
 			"log_analytics_destination_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if v != "Dedicated" {
-						errs = append(errs, fmt.Errorf("%q must be 'Dedicated', got %q", key, v))
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.StringInSlice([]string{"Dedicated"}, false),
 			},
 
 			"log": {
@@ -247,9 +241,8 @@ func resourceArmMonitorDiagnosticSettingCreateUpdate(d *schema.ResourceData, met
 		valid = true
 	}
 
-	logAnalyticsDestinationType := d.Get("log_analytics_destination_type").(string)
-	if logAnalyticsDestinationType != "" {
-		properties.DiagnosticSettings.LogAnalyticsDestinationType = utils.String(logAnalyticsDestinationType)
+	if v := d.Get("log_analytics_destination_type").(string); v != "" {
+		properties.DiagnosticSettings.LogAnalyticsDestinationType = &v
 	}
 
 	if !valid {
@@ -304,6 +297,8 @@ func resourceArmMonitorDiagnosticSettingRead(d *schema.ResourceData, meta interf
 	d.Set("eventhub_authorization_rule_id", resp.EventHubAuthorizationRuleID)
 	d.Set("log_analytics_workspace_id", resp.WorkspaceID)
 	d.Set("storage_account_id", resp.StorageAccountID)
+
+	d.Set("log_analytics_destination_type", resp.LogAnalyticsDestinationType)
 
 	if err := d.Set("log", flattenMonitorDiagnosticLogs(resp.Logs)); err != nil {
 		return fmt.Errorf("Error setting `log`: %+v", err)

--- a/azurerm/resource_arm_monitor_diagnostic_setting.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting.go
@@ -80,7 +80,7 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
 					if v != "Dedicated" {
-						errs = append(errs, fmt.Errorf("%q must be 'Dedicated'", key, v))
+						errs = append(errs, fmt.Errorf("%q must be 'Dedicated', got %q", key, v))
 					}
 					return
 				},

--- a/azurerm/resource_arm_monitor_diagnostic_setting.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting.go
@@ -76,7 +76,7 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 			"log_analytics_destination_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				ForceNew: false,
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
 					v := val.(string)
 					if v != "Dedicated" {

--- a/azurerm/resource_arm_monitor_diagnostic_setting.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting.go
@@ -242,7 +242,11 @@ func resourceArmMonitorDiagnosticSettingCreateUpdate(d *schema.ResourceData, met
 	}
 
 	if v := d.Get("log_analytics_destination_type").(string); v != "" {
-		properties.DiagnosticSettings.LogAnalyticsDestinationType = &v
+		if workspaceId != "" {
+			properties.DiagnosticSettings.LogAnalyticsDestinationType = &v
+		} else {
+			return fmt.Errorf("`log_analytics_workspace_id` must be set for `log_analytics_destination_type` to be used")
+		}
 	}
 
 	if !valid {

--- a/azurerm/resource_arm_monitor_diagnostic_setting_test.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting_test.go
@@ -86,11 +86,43 @@ func TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspace(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMonitorDiagnosticSettingExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "log_analytics_workspace_id"),
-					resource.TestCheckResourceAttr(resourceName, "log_analytics_destination_type", "Dedicated"),
 					resource.TestCheckResourceAttr(resourceName, "log.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "log.782743152.category", "AuditEvent"),
 					resource.TestCheckResourceAttr(resourceName, "metric.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric.1439188313.category", "AllMetrics"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated(t *testing.T) {
+	resourceName := "azurerm_monitor_diagnostic_setting.test"
+	ri := acctest.RandIntRange(10000, 99999)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMMonitorDiagnosticSettingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMonitorDiagnosticSettingExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "log_analytics_workspace_id"),
+					resource.TestCheckResourceAttr(resourceName, "log_analytics_destination_type", "Dedicated"),
+					resource.TestCheckResourceAttr(resourceName, "log.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "log.3188484811.category", "ActivityRuns"),
+					resource.TestCheckResourceAttr(resourceName, "log.595859111.category", "PipelineRuns"),
+					resource.TestCheckResourceAttr(resourceName, "log.2542277390.category", "TriggerRuns"),
+					resource.TestCheckResourceAttr(resourceName, "metric.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metric.4109484471.category", "AllMetrics"),
 				),
 			},
 			{
@@ -319,8 +351,6 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   target_resource_id         = "${azurerm_key_vault.test.id}"
   log_analytics_workspace_id = "${azurerm_log_analytics_workspace.test.id}"
 
-  log_analytics_destination_type = "Dedicated"
-
   log {
     category = "AuditEvent"
     enabled  = false
@@ -332,6 +362,74 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
 
   metric {
     category = "AllMetrics"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+}
+`, rInt, location, rInt, rInt, rInt)
+}
+
+func testAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated(rInt int, location string) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestlaw%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                       = "acctestds%d"
+  target_resource_id         = "${azurerm_data_factory.test.id}"
+  log_analytics_workspace_id = "${azurerm_log_analytics_workspace.test.id}"
+
+  log_analytics_destination_type = "Dedicated"
+
+  log {
+    category = "ActivityRuns"
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  log {
+    category = "PipelineRuns"
+    enabled = false
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  log {
+    category = "TriggerRuns"
+    enabled = false
+
+    retention_policy {
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled = false
 
     retention_policy {
       enabled = false

--- a/azurerm/resource_arm_monitor_diagnostic_setting_test.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting_test.go
@@ -86,6 +86,7 @@ func TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspace(t *testing.T) 
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMonitorDiagnosticSettingExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "log_analytics_workspace_id"),
+					resource.TestCheckResourceAttr(resourceName, "log_analytics_destination_type", "Dedicated"),
 					resource.TestCheckResourceAttr(resourceName, "log.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "log.782743152.category", "AuditEvent"),
 					resource.TestCheckResourceAttr(resourceName, "metric.#", "1"),
@@ -317,6 +318,8 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   name                       = "acctestds%d"
   target_resource_id         = "${azurerm_key_vault.test.id}"
   log_analytics_workspace_id = "${azurerm_log_analytics_workspace.test.id}"
+
+  log_analytics_destination_type = "Dedicated"
 
   log {
     category = "AuditEvent"

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -87,6 +87,10 @@ The following arguments are supported:
 
 -> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id` and `storage_account_id` must be specified.
 
+* `` - (Optional) When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
+
+-> ***NOTE:** This setting will only have an effect if a `log_analytics_workspace_id` is provided, and the resource is available for resource-specific logs.  As of July 2019, this only includes Azure Data Factory. Please  [see the documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific) for more information.
+
 ---
 
 A `log` block supports the following:

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 -> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id` and `storage_account_id` must be specified.
 
-* `` - (Optional) When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
+* `log_analytics_destination_type` - (Optional) When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
 
 -> ***NOTE:** This setting will only have an effect if a `log_analytics_workspace_id` is provided, and the resource is available for resource-specific logs.  As of July 2019, this only includes Azure Data Factory. Please  [see the documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific) for more information.
 

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 * `log_analytics_destination_type` - (Optional) When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
 
--> ***NOTE:** This setting will only have an effect if a `log_analytics_workspace_id` is provided, and the resource is available for resource-specific logs.  As of July 2019, this only includes Azure Data Factory. Please  [see the documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific) for more information.
+-> **NOTE:** This setting will only have an effect if a `log_analytics_workspace_id` is provided, and the resource is available for resource-specific logs.  As of July 2019, this only includes Azure Data Factory. Please [see the documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific) for more information.
 
 ---
 


### PR DESCRIPTION
Added the argument log_analytics_destination_type to the resource azurerm_monitor_diagnostic_setting.

This allows logs sent to a Log Analytics Workspace to go to dedicated resource tables, instead of to the AzureDiagnostics table.  This is only relevant to Azure Data Factory right now, but is planned to be extended to all resources over time.

https://azure.microsoft.com/en-au/updates/adf-logs-in-dedicated-tables/
https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific