### PR TITLE
Updated api_management_api_policy for XML file explanation

### DIFF
--- a/website/docs/r/api_management_api_policy.html.markdown
+++ b/website/docs/r/api_management_api_policy.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service exists. Changing this forces a new resource to be created.
 
-* `xml_content` - (Optional) The XML Content for this Policy.
+* `xml_content` - (Optional) The XML Content for this Policy as a string. Note instead of parameter for Microsoft's PolicyFilePath. xml-content can take a file by using Terraform's [file function](https://www.terraform.io/docs/configuration/functions/file.html)
 
 * `xml_link` - (Optional) A link to a Policy XML Document, which must be publicly available.
 

--- a/website/docs/r/api_management_api_policy.html.markdown
+++ b/website/docs/r/api_management_api_policy.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service exists. Changing this forces a new resource to be created.
 
-* `xml_content` - (Optional) The XML Content for this Policy as a string. Note instead of parameter for Microsoft's PolicyFilePath. xml-content can take a file by using Terraform's [file function](https://www.terraform.io/docs/configuration/functions/file.html)
+* `xml_content` - (Optional) The XML Content for this Policy as a string. An XML file can be used here with Terraform's [file function](https://www.terraform.io/docs/configuration/functions/file.html) that is similar to Microsoft's `PolicyFilePath` option.
 
 * `xml_link` - (Optional) A link to a Policy XML Document, which must be publicly available.
 


### PR DESCRIPTION
Added a note for those seeking to utilize `-PolicyFilePath` from https://docs.microsoft.com/en-us/powershell/module/azurerm.apimanagement/set-azurermapimanagementpolicy?view=azurermps-6.13.0#parameters

Tested in Azure, this works and would prevent work on implementing PolicyFilePath as another parameter.