### PR TITLE
Update storage_account.html.markdown

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -148,7 +148,7 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 
 ---
 
-`queue_properties` supports the following:
+`queue_properties` supports the following: not applicable when storage account type is **BlobStorage**
 
 * `cors_rule` - (Optional) A `cors_rule` block as defined below.
 


### PR DESCRIPTION
enabling queue_properties block is not applicable if the storage account type is set to BlobStorage. this information is currently not called out.