### PR TITLE
azurerm_container_group - allow empty log_type

### DIFF
--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -149,7 +149,7 @@ A `image_registry_credential` block supports:
 
 A `log_analytics` block supports:
 
-* `log_type` - (Required) The log type which should be used. Possible values are `ContainerInsights` and `ContainerInstanceLogs`. Changing this forces a new resource to be created.
+* `log_type` - (Optional) The log type which should be used. Possible values are `ContainerInsights` and `ContainerInstanceLogs`. Changing this forces a new resource to be created.
 
 * `workspace_id` - (Required) The Workspace ID of the Log Analytics Workspace. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This is not documented anywhere, as far as I can tell, but if you leave out the log type when creating a container group, you get the behavior of both `ContainerInsights` and `ContainerInstanceLogs` at once: there will be both the performance metrics (insights) and the container log output. This is the default when you create a container via Azure CLI. This patch enables the same via Terraform.