### PR TITLE
remove extra date from the DEBUG log

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -512,6 +512,10 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 	return func(d *schema.ResourceData) (interface{}, error) {
+
+		// remove date and time stamp from log output as the plugin SDK already adds its own
+		log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
 		builder := &authentication.Builder{
 			SubscriptionID:     d.Get("subscription_id").(string),
 			ClientID:           d.Get("client_id").(string),


### PR DESCRIPTION
attempts to fix up the debug log. this:
```
2019/08/06 15:11:11 [DEBUG] Starting graph walk: walkPlan
2019-08-06T15:11:11.208-0700 [DEBUG] plugin.terraform-provider-azurerm: 2019/08/06 15:11:11 Testing if Service Principal / Client Certificate is applicable for Authentication..
2019-08-06T15:11:11.208-0700 [DEBUG] plugin.terraform-provider-azurerm: 2019/08/06 15:11:11 Testing if Service Principal / Client Secret is applicable for Authentication..
2019-08-06T15:11:11.208-0700 [DEBUG] plugin.terraform-provider-azurerm: 2019/08/06 15:11:11 Using Service Principal / Client Secret for Authentication
2019-08-06T15:11:11.208-0700 [DEBUG] plugin.terraform-provider-azurerm: 2019/08/06 15:11:11 [DEBUG] Genereated Provider Correlation Request Id: ff9a9653-52d1-b26e-5432-341b9c419236
2019-08-06T15:11:11.209-0700 [DEBUG] plugin.terraform-provider-azurerm: 2019/08/06 15:11:11 [DEBUG] AzureRM Client User Agent: Go/go1.12.6 (amd64-darwin) go-autorest/v12.2.0 Azure-SDK-For-Go/v31.0.0 graphrbac/1.6 Terraform/0.12.0 terraform-provider-azurerm/dev
2019-08-06T15:11:11.209-0700 [DEBUG] plugin.terraform-provider-azurerm: 2019/08/06 15:11:11 [DEBUG] AzureRM Client User Agent: Go/go1.12.6 (amd64-darwin) go-autorest/v12.2.0 Azure-SDK-For-Go/v31.0.0 graphrbac/1.6 Terraform/0.12.0 terraform-provider-azurerm/dev
```
becomes
```
2019/08/06 15:17:36 [DEBUG] Starting graph walk: walkPlan
2019-08-06T15:17:36.853-0700 [DEBUG] plugin.terraform-provider-azurerm: Testing if Service Principal / Client Certificate is applicable for Authentication..
2019-08-06T15:17:36.853-0700 [DEBUG] plugin.terraform-provider-azurerm: Testing if Service Principal / Client Secret is applicable for Authentication..
2019-08-06T15:17:36.853-0700 [DEBUG] plugin.terraform-provider-azurerm: Using Service Principal / Client Secret for Authentication
2019-08-06T15:17:36.853-0700 [DEBUG] plugin.terraform-provider-azurerm: [DEBUG] Genereated Provider Correlation Request Id: 2f41da08-cef8-5568-5efc-6bb423843bd2
2019-08-06T15:17:36.854-0700 [DEBUG] plugin.terraform-provider-azurerm: [DEBUG] AzureRM Client User Agent: Go/go1.12.6 (amd64-darwin) go-autorest/v12.2.0 Azure-SDK-For-Go/v31.0.0 graphrbac/1.6 Terraform/0.12.0 terraform-provider-azurerm/dev
2019-08-06T15:17:36.854-0700 [DEBUG] plugin.terraform-provider-azurerm: [DEBUG] AzureRM Client User Agent: Go/go1.12.6 (amd64-darwin) go-autorest/v12.2.0 Azure-SDK-For-Go/v31.0.0 graphrbac/1.6 Terraform/0.12.0 terraform-provider-azurerm/dev
```

I'm not sure if this is entirely a good idea or will break something elsewhere (like logging in the tests)