### PR TITLE
dns_zone: deprecating the `zone_type` field

### DIFF
--- a/azurerm/data_source_dns_zone.go
+++ b/azurerm/data_source_dns_zone.go
@@ -44,8 +44,9 @@ func dataSourceArmDnsZone() *schema.Resource {
 			},
 
 			"zone_type": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Private DNS Zones are now supported through a separate resource in Azure & Terraform",
 			},
 
 			"registration_virtual_network_ids": {

--- a/azurerm/resource_arm_dns_zone.go
+++ b/azurerm/resource_arm_dns_zone.go
@@ -49,9 +49,10 @@ func resourceArmDnsZone() *schema.Resource {
 			},
 
 			"zone_type": {
-				Type:     schema.TypeString,
-				Default:  string(dns.Public),
-				Optional: true,
+				Type:       schema.TypeString,
+				Default:    string(dns.Public),
+				Optional:   true,
+				Deprecated: "Use the `azurerm_private_dns_zone` resource instead.",
 				ValidateFunc: validation.StringInSlice([]string{
 					string(dns.Private),
 					string(dns.Public),

--- a/website/docs/d/dns_zone.html.markdown
+++ b/website/docs/d/dns_zone.html.markdown
@@ -38,7 +38,9 @@ in your subscription that matches `name` will be returned.
 * `max_number_of_record_sets` - Maximum number of Records in the zone.
 * `number_of_record_sets` - The number of records already in the zone.
 * `name_servers` - A list of values that make up the NS record for the zone.
-* `zone_type` - The type of this DNS zone, such as `Public` or `Private`.
 * `registration_virtual_network_ids` - A list of Virtual Network ID's that register hostnames in this DNS zone.
 * `resolution_virtual_network_ids` - A list of Virtual Network ID's that resolve records in this DNS zone.
 * `tags` - A mapping of tags to assign to the EventHub Namespace.
+* `zone_type` - (**Deprecated**) The type of this DNS zone, such as `Public` or `Private`.
+
+~> **NOTE:** This field is deprecated since Private DNS is now a separate resource and will be removed in 2.0 of the Azure Provider.

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -145,6 +145,10 @@ The AzureAD Data Sources and Resources have been moved to [the new AzureAD Provi
 
 A guide on how to migrate to using the new Provider [can be found here](https://www.terraform.io/docs/providers/azurerm/guides/migrating-to-azuread.html).
 
+### Data Source: `azurerm_dns_zone`
+
+The deprecated field `zone_type` will be removed. Private DNS Zones are now a separate resource in both Azure and Terraform.
+
 ### Data Source: `azurerm_kubernetes_cluster`
 
 The deprecated field `dns_prefix` within the `agent_pool_profile` block will be removed.
@@ -226,6 +230,10 @@ The `preference` field in the `record` block will change from a String to an Int
 ### Resource: `azurerm_dns_ns_record`
 
 The deprecated `record` field will be removed. This has been replaced by the `records` field which accepts multiple values.
+
+### Resource: `azurerm_dns_zone`
+
+The deprecated `zone_type` field will be removed. This has been replaced by the `azurerm_private_dns_zone` resource.
 
 ### Resource: `azurerm_eventhub`
 

--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -38,13 +38,15 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 
-* `zone_type` - (Required) Specifies the type of this DNS zone. Possible values are `Public` or `Private` (Defaults to `Public`).
-
 * `registration_virtual_network_ids` - (Optional) A list of Virtual Network ID's that register hostnames in this DNS zone. This field can only be set when `zone_type` is set to `Private`.
 
 * `resolution_virtual_network_ids` - (Optional) A list of Virtual Network ID's that resolve records in this DNS zone. This field can only be set when `zone_type` is set to `Private`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+* `zone_type` - (Optional / **Deprecated**) Specifies the type of this DNS zone. Possible values are `Public` or `Private` (Defaults to `Public`).
+
+~> **NOTE:** This field was part of the initial Preview for Private DNS Zones - which has been [replaced by the separate resource `azurerm_private_dns_zone`](private_dns_zone.html) and will be removed in v2.0 of the Azure Provider. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
Private DNS Zones are now managed using a separate resource in both Azure and Terraform - [as this changed during the Preview Refresh](https://azure.microsoft.com/en-us/updates/announcing-preview-refresh-for-azure-dns-private-zones-2/)

Whilst a Resource exists for Private DNS Zones - no Data Source does just yet, so this PR deprecated the fields where appropriate (and adds them to the upgrade guide)

Fixes #4017