### PR TITLE
I noticed at the top of the page, it still said azurerm_dns_a_record …

### DIFF
--- a/website/docs/r/private_dns_a_record.html.markdown
+++ b/website/docs/r/private_dns_a_record.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages a Private DNS A Record.
 ---
 
-# azurerm_dns_a_record
+# azurerm_private_dns_a_record
 
 Enables you to manage DNS A Records within Azure Private DNS.
 


### PR DESCRIPTION
…instead of azurerm_private_dns_a_record