### PR TITLE
Updates tags limits from 15 to 50 per resource

### DIFF
--- a/azurerm/deprecated_test.go
+++ b/azurerm/deprecated_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestValidateMaximumNumberOfARMTags(t *testing.T) {
 	tagsMap := make(map[string]interface{})
-	for i := 0; i < 16; i++ {
+	for i := 0; i < 51; i++ {
 		tagsMap[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
 	}
 
@@ -18,7 +18,7 @@ func TestValidateMaximumNumberOfARMTags(t *testing.T) {
 		t.Fatal("Expected one validation error for too many tags")
 	}
 
-	if !strings.Contains(es[0].Error(), "a maximum of 15 tags") {
+	if !strings.Contains(es[0].Error(), "a maximum of 50 tags") {
 		t.Fatal("Wrong validation error message for too many tags")
 	}
 }

--- a/azurerm/internal/tags/validation.go
+++ b/azurerm/internal/tags/validation.go
@@ -5,8 +5,8 @@ import "fmt"
 func Validate(v interface{}, _ string) (warnings []string, errors []error) {
 	tagsMap := v.(map[string]interface{})
 
-	if len(tagsMap) > 15 {
-		errors = append(errors, fmt.Errorf("a maximum of 15 tags can be applied to each ARM resource"))
+	if len(tagsMap) > 50 {
+		errors = append(errors, fmt.Errorf("a maximum of 50 tags can be applied to each ARM resource"))
 	}
 
 	for k, v := range tagsMap {

--- a/azurerm/internal/tags/validation_test.go
+++ b/azurerm/internal/tags/validation_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestValidateMaximumNumberOfTags(t *testing.T) {
 	tagsMap := make(map[string]interface{})
-	for i := 0; i < 16; i++ {
+	for i := 0; i < 51; i++ {
 		tagsMap[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
 	}
 
@@ -18,7 +18,7 @@ func TestValidateMaximumNumberOfTags(t *testing.T) {
 		t.Fatal("Expected one validation error for too many tags")
 	}
 
-	if !strings.Contains(es[0].Error(), "a maximum of 15 tags") {
+	if !strings.Contains(es[0].Error(), "a maximum of 50 tags") {
 		t.Fatal("Wrong validation error message for too many tags")
 	}
 }

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -579,7 +579,7 @@ func validateAzureRMStorageAccountTags(v interface{}, _ string) (warnings []stri
 	tagsMap := v.(map[string]interface{})
 
 	if len(tagsMap) > 15 {
-		errors = append(errors, fmt.Errorf("a maximum of 15 tags can be applied to each ARM resource"))
+		errors = append(errors, fmt.Errorf("a maximum of 15 tags can be applied to storage account ARM resource"))
 	}
 
 	for k, v := range tagsMap {


### PR DESCRIPTION
The PR fixes an issue described in https://github.com/terraform-providers/terraform-provider-azurerm/issues/4070 where is not possible to apply more than 15 tags for any Azure resource because of hard validation (15 is a maximum in the code). But Azure right now supports 50 tags per resource (except storage account, which has own validation and there is still 15).

reference:  https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-using-tags