### PR TITLE
[resource_arm_function_app] Add missing vnet_name property

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -199,6 +199,11 @@ func resourceArmFunctionApp() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"vnet_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: false,
+						},
 						"cors": azure.SchemaWebCorsSettings(),
 					},
 				},
@@ -360,6 +365,7 @@ func resourceArmFunctionAppUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 	basicAppSettings := getBasicFunctionAppAppSettings(d, appServiceTier)
 	siteConfig := expandFunctionAppSiteConfig(d)
+
 	siteConfig.AppSettings = &basicAppSettings
 
 	siteEnvelope := web.Site{
@@ -688,6 +694,10 @@ func expandFunctionAppSiteConfig(d *schema.ResourceData) web.SiteConfig {
 		siteConfig.Cors = &expand
 	}
 
+	if v, ok := config["vnet_name"]; ok {
+		siteConfig.VnetName = utils.String(v.(string))
+	}
+
 	return siteConfig
 }
 
@@ -714,6 +724,10 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 
 	if input.LinuxFxVersion != nil {
 		result["linux_fx_version"] = *input.LinuxFxVersion
+	}
+
+	if input.VnetName != nil {
+		result["vnet_name"] = *input.VnetName
 	}
 
 	result["cors"] = azure.FlattenWebCorsSettings(input.Cors)

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -199,7 +199,7 @@ func resourceArmFunctionApp() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
-						"vnet_name": {
+						"virtual_network_name": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: false,
@@ -694,7 +694,7 @@ func expandFunctionAppSiteConfig(d *schema.ResourceData) web.SiteConfig {
 		siteConfig.Cors = &expand
 	}
 
-	if v, ok := config["vnet_name"]; ok {
+	if v, ok := config["virtual_network_name"]; ok {
 		siteConfig.VnetName = utils.String(v.(string))
 	}
 
@@ -727,7 +727,7 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 	}
 
 	if input.VnetName != nil {
-		result["vnet_name"] = *input.VnetName
+		result["virtual_network_name"] = *input.VnetName
 	}
 
 	result["cors"] = azure.FlattenWebCorsSettings(input.Cors)

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -665,6 +665,34 @@ func TestAccAzureRMFunctionApp_corsSettings(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFunctionApp_vnetName(t *testing.T) {
+	resourceName := "azurerm_function_app.test"
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	vnetName := strings.ToLower(acctest.RandString(11))
+	config := testAccAzureRMFunctionApp_vnetName(ri, rs, testLocation(), vnetName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFunctionAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.vnet_name", vnetName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMFunctionAppDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).web.AppServicesClient
 
@@ -1604,4 +1632,44 @@ resource "azurerm_function_app" "test" {
   }
 }
 `, rInt, location, storage)
+}
+
+func testAccAzureRMFunctionApp_vnetName(rInt int, storage, location, vnetName string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                      = "acctest-%[1]d-func"
+  location                  = "${azurerm_resource_group.test.location}"
+  resource_group_name       = "${azurerm_resource_group.test.name}"
+  app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+  storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+
+  site_config {
+    vnet_name = "%[4]s"
+  }
+}
+`, rInt, location, storage, vnetName)
 }

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -681,7 +681,7 @@ func TestAccAzureRMFunctionApp_vnetName(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFunctionAppExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.vnet_name", vnetName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.virtual_network_name", vnetName),
 				),
 			},
 			{
@@ -1668,7 +1668,7 @@ resource "azurerm_function_app" "test" {
   storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
 
   site_config {
-    vnet_name = "%[4]s"
+    virtual_network_name = "%[4]s"
   }
 }
 `, rInt, location, storage, vnetName)

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -138,6 +138,8 @@ The following arguments are supported:
 
 * `websockets_enabled` - (Optional) Should WebSockets be enabled?
 
+* `virtual_network_name` - (Optional) The name of the Virtual Network which this App Service should be attached to.
+
 * `linux_fx_version` - (Optional) Linux App Framework and version for the AppService, e.g. `DOCKER|(golang:latest)`.
 
 * `cors` - (Optional) A `cors` block as defined below.


### PR DESCRIPTION
Currently we see an issue where function app deployed with `vnet integration` enabled is broken on a `terraform apply`. 

This appears to be caused as the `tf` provider doesn't have a notion of the `vnetName` property so when it is set elsewhere `tf` then unwittingly overwrites it when doing an unrelated update as it submits a `siteConfig` object with `vnetName=nil`. 

This change makes this consistent with the `resource_arm_app_service` resource which has the property.

By adding this change we can choose to ignore it by adding an ignore or setting it ourselves. 

```
  lifecycle {
    ignore_changes = [
      # Ignore changes to the `site_config` property `virtual_network_name` 
      # as the `webapp_vnet` template updates these keys. 
      site_config.0.virtual_network_name,
    ]
  }
```

I've added an integration test with passes. 

Meta question: Disclaimer I've only done a little bit of research on this ... Does it make sense to have two providers for `app_service` and `function_app` as they both use `meta.(*ArmClient).web.AppServicesClient` but with `function_app` setting ‘kind=function

https://github.com/lawrencegripper/terraform-provider-azurerm/blob/34cc65f220e9bcef13efc436450f99c39221d71b/azurerm/resource_arm_function_app.go#L272-L280