### PR TITLE
Increases name length limit for user_assigned_identity to 128 chars

### DIFF
--- a/azurerm/data_source_user_assigned_identity.go
+++ b/azurerm/data_source_user_assigned_identity.go
@@ -17,7 +17,7 @@ func dataSourceArmUserAssignedIdentity() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringLenBetween(1, 24),
+				ValidateFunc: validation.StringLenBetween(3, 128),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),

--- a/azurerm/resource_arm_user_assigned_identity.go
+++ b/azurerm/resource_arm_user_assigned_identity.go
@@ -27,7 +27,7 @@ func resourceArmUserAssignedIdentity() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(3, 128da),
+				ValidateFunc: validation.StringLenBetween(3, 128),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/azurerm/resource_arm_user_assigned_identity.go
+++ b/azurerm/resource_arm_user_assigned_identity.go
@@ -27,7 +27,7 @@ func resourceArmUserAssignedIdentity() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 24),
+				ValidateFunc: validation.StringLenBetween(3, 128da),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),


### PR DESCRIPTION
AzureRM provider has hard validation on name string (1,24) for azurerm_user_assigned_identity, Azure increased the name length to 128 chars. Please see https://github.com/terraform-providers/terraform-provider-azurerm/issues/4093

Fixes #4093