### PR TITLE
auth: dynamically requesting an authorizer for storage

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -196,11 +196,14 @@ func getArmClient(c *authentication.Config, skipProviderRegistration bool, partn
 	}
 
 	// Storage Endpoints
-	storageEndpoint := env.ResourceIdentifiers.Storage
-	storageAuth, err := c.GetAuthorizationToken(sender, oauthConfig, storageEndpoint)
-	if err != nil {
-		return nil, err
-	}
+	storageAuth := autorest.NewBearerAuthorizerCallback(sender, func(tenantID, resource string) (*autorest.BearerAuthorizer, error) {
+		storageSpt, err := c.GetAuthorizationToken(sender, oauthConfig, resource)
+		if err != nil {
+			return nil, err
+		}
+
+		return storageSpt, nil
+	})
 
 	// Key Vault Endpoints
 	keyVaultAuth := autorest.NewBearerAuthorizerCallback(sender, func(tenantID, resource string) (*autorest.BearerAuthorizer, error) {


### PR DESCRIPTION
This PR changes the Authorizer used for Storage to ensure it requests a token that's valid for `storage.azure.com` - used to access the Storage API's.

This requires a little more testing prior to merging - but in testing appears to resolve this both in CloudShell and when authenticating using the Azure CLI

Fixes #3997