### PR TITLE
r/hdinsight: switching tests to use Standard_A4_v2

### DIFF
--- a/azurerm/resource_arm_hdinsight_spark_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_spark_cluster_test.go
@@ -279,13 +279,13 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_A3"
+      vm_size  = "Standard_A4_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
 
     worker_node {
-      vm_size               = "Standard_A3"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3
@@ -354,13 +354,13 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_A3"
+      vm_size  = "Standard_A4_V2"
       username = "acctestusrvm"
       ssh_keys = ["${var.ssh_key}"]
     }
 
     worker_node {
-      vm_size               = "Standard_A3"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       ssh_keys              = ["${var.ssh_key}"]
       target_instance_count = 3
@@ -406,13 +406,13 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_A3"
+      vm_size  = "Standard_A4_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
 
     worker_node {
-      vm_size               = "Standard_A3"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 5
@@ -476,7 +476,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
 
   roles {
     head_node {
-      vm_size            = "Standard_A3"
+      vm_size            = "Standard_A4_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = "${azurerm_subnet.test.id}"
@@ -484,7 +484,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     }
 
     worker_node {
-      vm_size               = "Standard_A3"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3
@@ -548,7 +548,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
 
   roles {
     head_node {
-      vm_size            = "Standard_A3"
+      vm_size            = "Standard_A4_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = "${azurerm_subnet.test.id}"
@@ -556,7 +556,7 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
     }
 
     worker_node {
-      vm_size               = "Standard_A3"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3

--- a/azurerm/resource_arm_hdinsight_storm_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_storm_cluster_test.go
@@ -279,13 +279,13 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_A3"
+      vm_size  = "Standard_A4_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
 
     worker_node {
-      vm_size               = "Standard_DS3_V2"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3
@@ -354,13 +354,13 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_A3"
+      vm_size  = "Standard_A4_V2"
       username = "acctestusrvm"
       ssh_keys = ["${var.ssh_key}"]
     }
 
     worker_node {
-      vm_size               = "Standard_D3_V2"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       ssh_keys              = ["${var.ssh_key}"]
       target_instance_count = 3
@@ -406,13 +406,13 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
 
   roles {
     head_node {
-      vm_size  = "Standard_A3"
+      vm_size  = "Standard_A4_V2"
       username = "acctestusrvm"
       password = "AccTestvdSC4daf986!"
     }
 
     worker_node {
-      vm_size               = "Standard_D3_V2"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 5
@@ -476,7 +476,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
 
   roles {
     head_node {
-      vm_size            = "Standard_A3"
+      vm_size            = "Standard_A4_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = "${azurerm_subnet.test.id}"
@@ -484,7 +484,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
     }
 
     worker_node {
-      vm_size               = "Standard_D3_V2"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3
@@ -548,7 +548,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
 
   roles {
     head_node {
-      vm_size            = "Standard_A3"
+      vm_size            = "Standard_A4_V2"
       username           = "acctestusrvm"
       password           = "AccTestvdSC4daf986!"
       subnet_id          = "${azurerm_subnet.test.id}"
@@ -556,7 +556,7 @@ resource "azurerm_hdinsight_storm_cluster" "test" {
     }
 
     worker_node {
-      vm_size               = "Standard_D3_V2"
+      vm_size               = "Standard_A4_V2"
       username              = "acctestusrvm"
       password              = "AccTestvdSC4daf986!"
       target_instance_count = 3


### PR DESCRIPTION
Some API changes mean that `Standard_A3` is no longer an option when creating a cluster - as such this PR updates to handle that.

In addition, it appears the API now returns that the cluster's deleted before it's actually gone when the clusters attached to a virtual network - as such I'll open a separate API issue about the broken API:

```
Error deleting Subnet "acctestsubnet190815055954212166" (Virtual Network "acctestvirtnet190815055954212166" / Resource Group "acctestRG-190815055954212166"): network.SubnetsClient#Delete: Failure sending request: StatusCode=400 -- Original Error: Code="InUseSubnetCannotBeDeleted" Message="Subnet acctestsubnet190815055954212166 is in use by /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG-190815055954212166/providers/Microsoft.Network/networkInterfaces/nic-workernode-2-44b1824df702469f9a8e34f083580083/ipConfigurations/ipConfig1 and cannot be deleted. In order to delete the subnet, delete all the resources within the subnet. See aka.ms/deletesubnet." Details=[]
```