### PR TITLE
[Docs] Fixed spelling errors in website documentation

### DIFF
--- a/website/docs/d/maps_account.html.markdown
+++ b/website/docs/d/maps_account.html.markdown
@@ -37,7 +37,7 @@ output "maps_account_id" {
 
 * `primary_access_key` - The primary key used to authenticate and authorize access to the Maps REST APIs.
 
-* `secondary_access_key` - The primary key used to authenticate and authorize access to the Maps REST APIs. The second key is given to provide seemless key regeneration.
+* `secondary_access_key` - The primary key used to authenticate and authorize access to the Maps REST APIs. The second key is given to provide seamless key regeneration.
 
 * `x_ms_client_id` - A unique identifier for the Maps Account.
 

--- a/website/docs/d/redis_cache.html.markdown
+++ b/website/docs/d/redis_cache.html.markdown
@@ -67,7 +67,7 @@ output "hostname" {
 
 ---
 
-A `patch_schedule` block supports the following (Requires Premium SKU's, attempting to access this value on Basic or Standard SKU's will result in an errro):
+A `patch_schedule` block supports the following (Requires Premium SKU's, attempting to access this value on Basic or Standard SKU's will result in an error):
 
 * `day_of_week` - the Weekday name for the patch item
 

--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `admin_users` - (Optional) List of email addresses of admin users.
 
-* `querypool_connection_mode` - (Optional) Controls how the read-write server is used in the query pool. If this values is set to `All` then read-write servers are also used for queries. Otherwise with `ReadOnly` theses servers do not participate in query operations.
+* `querypool_connection_mode` - (Optional) Controls how the read-write server is used in the query pool. If this values is set to `All` then read-write servers are also used for queries. Otherwise with `ReadOnly` these servers do not participate in query operations.
 
 * `enable_power_bi_service` - (Optional) Indicates if the Power BI service is allowed to access or not.
 

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -119,7 +119,7 @@ A `network_acls` block supports the following:
 
 * `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_subnet_ids`. Possible values are `Allow` and `Deny`.
 
-* `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access thie Key Vault.
+* `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Key Vault.
 
 * `virtual_network_subnet_ids` - (Optional) One or more Subnet ID's which should be able to access this Key Vault.
 

--- a/website/docs/r/recovery_services_protection_policy_vm.markdown
+++ b/website/docs/r/recovery_services_protection_policy_vm.markdown
@@ -91,7 +91,7 @@ The `backup` block supports:
 
 * `frequency` - (Required) Sets the backup frequency. Must be either `Daily` or`Weekly`. 
 
-* `times` - (Required) The time of day to preform the backup in 24hour format.
+* `times` - (Required) The time of day to perform the backup in 24hour format.
 
 * `weekdays` - (Optional) The days of the week to perform backups on. Must be one of `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` or `Saturday`.
 


### PR DESCRIPTION
Found a few spelling errors in the documentation and wanted to clean them up