### PR TITLE
refactor: moving the legacy blob storage client -> storage package

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -3,20 +3,13 @@ package azurerm
 import (
 	"context"
 	"fmt"
-	"log"
-	"os"
-	"strings"
-	"sync"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
-	mainStorage "github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/go-azure-helpers/sender"
-	"github.com/hashicorp/terraform/httpclient"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/analysisservices"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement"
@@ -67,13 +60,11 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicefabric"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/signalr"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/sql"
-	intStor "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/streamanalytics"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/subscription"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/trafficmanager"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-	"github.com/terraform-providers/terraform-provider-azurerm/version"
 )
 
 // ArmClient contains the handles to all the specific Azure Resource Manager
@@ -138,15 +129,12 @@ type ArmClient struct {
 	servicebus       *servicebus.Client
 	serviceFabric    *servicefabric.Client
 	signalr          *signalr.Client
-	storage          *intStor.Client
+	storage          *storage.Client
 	streamanalytics  *streamanalytics.Client
 	subscription     *subscription.Client
 	sql              *sql.Client
 	trafficManager   *trafficmanager.Client
 	web              *web.Client
-
-	// Storage
-	storageServiceClient storage.AccountsClient
 }
 
 // getArmClient is a helper method which returns a fully instantiated
@@ -279,118 +267,11 @@ func getArmClient(c *authentication.Config, skipProviderRegistration bool, partn
 	client.scheduler = scheduler.BuildClient(o)
 	client.signalr = signalr.BuildClient(o)
 	client.streamanalytics = streamanalytics.BuildClient(o)
+	client.storage = storage.BuildClient(o)
 	client.subscription = subscription.BuildClient(o)
 	client.sql = sql.BuildClient(o)
 	client.trafficManager = trafficmanager.BuildClient(o)
 	client.web = web.BuildClient(o)
 
-	client.registerStorageClients(endpoint, c.SubscriptionID, auth, o)
-
 	return &client, nil
-}
-
-func (c *ArmClient) configureClient(client *autorest.Client, auth autorest.Authorizer) {
-	setUserAgent(client, c.partnerId)
-	client.Authorizer = auth
-	client.RequestInspector = common.WithCorrelationRequestID(common.CorrelationRequestID())
-	client.Sender = sender.BuildSender("AzureRM")
-	client.SkipResourceProviderRegistration = c.skipProviderRegistration
-	client.PollingDuration = 180 * time.Minute
-}
-
-func setUserAgent(client *autorest.Client, partnerID string) {
-	// TODO: This is the SDK version not the CLI version, once we are on 0.12, should revisit
-	tfUserAgent := httpclient.UserAgentString()
-
-	pv := version.ProviderVersion
-	providerUserAgent := fmt.Sprintf("%s terraform-provider-azurerm/%s", tfUserAgent, pv)
-	client.UserAgent = strings.TrimSpace(fmt.Sprintf("%s %s", client.UserAgent, providerUserAgent))
-
-	// append the CloudShell version to the user agent if it exists
-	if azureAgent := os.Getenv("AZURE_HTTP_USER_AGENT"); azureAgent != "" {
-		client.UserAgent = fmt.Sprintf("%s %s", client.UserAgent, azureAgent)
-	}
-
-	if partnerID != "" {
-		client.UserAgent = fmt.Sprintf("%s pid-%s", client.UserAgent, partnerID)
-	}
-
-	log.Printf("[DEBUG] AzureRM Client User Agent: %s\n", client.UserAgent)
-}
-
-func (c *ArmClient) registerStorageClients(endpoint, subscriptionId string, auth autorest.Authorizer, options *common.ClientOptions) {
-	accountsClient := storage.NewAccountsClientWithBaseURI(endpoint, subscriptionId)
-	c.configureClient(&accountsClient.Client, auth)
-	c.storageServiceClient = accountsClient
-
-	c.storage = intStor.BuildClient(accountsClient, options)
-}
-
-var (
-	storageKeyCacheMu sync.RWMutex
-	storageKeyCache   = make(map[string]string)
-)
-
-func (c *ArmClient) getKeyForStorageAccount(ctx context.Context, resourceGroupName, storageAccountName string) (string, bool, error) {
-	cacheIndex := resourceGroupName + "/" + storageAccountName
-	storageKeyCacheMu.RLock()
-	key, ok := storageKeyCache[cacheIndex]
-	storageKeyCacheMu.RUnlock()
-
-	if ok {
-		return key, true, nil
-	}
-
-	storageKeyCacheMu.Lock()
-	defer storageKeyCacheMu.Unlock()
-	key, ok = storageKeyCache[cacheIndex]
-	if !ok {
-		accountKeys, err := c.storageServiceClient.ListKeys(ctx, resourceGroupName, storageAccountName)
-		if utils.ResponseWasNotFound(accountKeys.Response) {
-			return "", false, nil
-		}
-		if err != nil {
-			// We assume this is a transient error rather than a 404 (which is caught above),  so assume the
-			// storeAccount still exists.
-			return "", true, fmt.Errorf("Error retrieving keys for storage storeAccount %q: %s", storageAccountName, err)
-		}
-
-		if accountKeys.Keys == nil {
-			return "", false, fmt.Errorf("Nil key returned for storage storeAccount %q", storageAccountName)
-		}
-
-		keys := *accountKeys.Keys
-		if len(keys) <= 0 {
-			return "", false, fmt.Errorf("No keys returned for storage storeAccount %q", storageAccountName)
-		}
-
-		keyPtr := keys[0].Value
-		if keyPtr == nil {
-			return "", false, fmt.Errorf("The first key returned is nil for storage storeAccount %q", storageAccountName)
-		}
-
-		key = *keyPtr
-		storageKeyCache[cacheIndex] = key
-	}
-
-	return key, true, nil
-}
-
-func (c *ArmClient) getBlobStorageClientForStorageAccount(ctx context.Context, resourceGroupName, storageAccountName string) (*mainStorage.BlobStorageClient, bool, error) {
-	key, accountExists, err := c.getKeyForStorageAccount(ctx, resourceGroupName, storageAccountName)
-	if err != nil {
-		return nil, accountExists, err
-	}
-	if !accountExists {
-		return nil, false, nil
-	}
-
-	storageClient, err := mainStorage.NewClient(storageAccountName, key, c.environment.StorageEndpointSuffix,
-		mainStorage.DefaultAPIVersion, true)
-	if err != nil {
-		return nil, true, fmt.Errorf("Error creating storage client for storage storeAccount %q: %s", storageAccountName, err)
-	}
-
-	blobClient := storageClient.GetBlobService()
-	return &blobClient, true, nil
 }

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -147,7 +147,6 @@ type ArmClient struct {
 
 	// Storage
 	storageServiceClient storage.AccountsClient
-	storageUsageClient   storage.UsagesClient
 }
 
 // getArmClient is a helper method which returns a fully instantiated
@@ -323,10 +322,6 @@ func (c *ArmClient) registerStorageClients(endpoint, subscriptionId string, auth
 	accountsClient := storage.NewAccountsClientWithBaseURI(endpoint, subscriptionId)
 	c.configureClient(&accountsClient.Client, auth)
 	c.storageServiceClient = accountsClient
-
-	usageClient := storage.NewUsagesClientWithBaseURI(endpoint, subscriptionId)
-	c.configureClient(&usageClient.Client, auth)
-	c.storageUsageClient = usageClient
 
 	c.storage = intStor.BuildClient(accountsClient, options)
 }

--- a/azurerm/data_source_storage_account.go
+++ b/azurerm/data_source_storage_account.go
@@ -257,7 +257,7 @@ func dataSourceArmStorageAccount() *schema.Resource {
 
 func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storageServiceClient
+	client := meta.(*ArmClient).storage.AccountsClient
 	endpointSuffix := meta.(*ArmClient).environment.StorageEndpointSuffix
 
 	name := d.Get("name").(string)

--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -3,11 +3,9 @@ package storage
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	az "github.com/Azure/go-autorest/autorest/azure"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/authorizers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
@@ -20,52 +18,21 @@ import (
 )
 
 type Client struct {
-	// this is currently unexported since we only use it to look up the account key
-	// we could export/use this in the future - but there's no point it being public
-	// until that time
-	accountsClient storage.AccountsClient
-	environment    az.Environment
+	AccountsClient storage.AccountsClient
+
+	environment az.Environment
 }
 
-// NOTE: this temporarily diverges from the other clients until we move this client in here
-// once we have this, can take an Options like everything else
-func BuildClient(accountsClient storage.AccountsClient, options *common.ClientOptions) *Client {
+func BuildClient(options *common.ClientOptions) *Client {
+	accountsClient := storage.NewAccountsClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
+	options.ConfigureClient(&accountsClient.Client, options.ResourceManagerAuthorizer)
+
 	// TODO: switch Storage Containers to using the storage.BlobContainersClient
 	// (which should fix #2977) when the storage clients have been moved in here
 	return &Client{
-		accountsClient: accountsClient,
+		AccountsClient: accountsClient,
 		environment:    options.Environment,
 	}
-}
-
-func (client Client) FindResourceGroup(ctx context.Context, accountName string) (*string, error) {
-	accounts, err := client.accountsClient.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("Error listing Storage Accounts (to find Resource Group for %q): %s", accountName, err)
-	}
-
-	if accounts.Value == nil {
-		return nil, nil
-	}
-
-	var resourceGroup *string
-	for _, account := range *accounts.Value {
-		if account.Name == nil || account.ID == nil {
-			continue
-		}
-
-		if strings.EqualFold(accountName, *account.Name) {
-			id, err := azure.ParseAzureResourceID(*account.ID)
-			if err != nil {
-				return nil, fmt.Errorf("Error parsing ID for Storage Account %q: %s", accountName, err)
-			}
-
-			resourceGroup = &id.ResourceGroup
-			break
-		}
-	}
-
-	return resourceGroup, nil
 }
 
 func (client Client) BlobsClient(ctx context.Context, resourceGroup, accountName string) (*blobs.Client, error) {
@@ -150,19 +117,4 @@ func (client Client) TablesClient(ctx context.Context, resourceGroup, accountNam
 	tablesClient := tables.NewWithEnvironment(client.environment)
 	tablesClient.Client.Authorizer = storageAuth
 	return &tablesClient, nil
-}
-
-func (client Client) findAccountKey(ctx context.Context, resourceGroup, accountName string) (*string, error) {
-	props, err := client.accountsClient.ListKeys(ctx, resourceGroup, accountName)
-	if err != nil {
-		return nil, fmt.Errorf("Error Listing Keys for Storage Account %q (Resource Group %q): %+v", accountName, resourceGroup, err)
-	}
-
-	if props.Keys == nil || len(*props.Keys) == 0 {
-		return nil, fmt.Errorf("Keys were nil for Storage Account %q (Resource Group %q): %+v", accountName, resourceGroup, err)
-	}
-
-	keys := *props.Keys
-	firstKey := keys[0].Value
-	return firstKey, nil
 }

--- a/azurerm/internal/services/storage/helpers.go
+++ b/azurerm/internal/services/storage/helpers.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+func (client Client) FindResourceGroup(ctx context.Context, accountName string) (*string, error) {
+	accounts, err := client.AccountsClient.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Error listing Storage Accounts (to find Resource Group for %q): %s", accountName, err)
+	}
+
+	if accounts.Value == nil {
+		return nil, nil
+	}
+
+	var resourceGroup *string
+	for _, account := range *accounts.Value {
+		if account.Name == nil || account.ID == nil {
+			continue
+		}
+
+		if strings.EqualFold(accountName, *account.Name) {
+			id, err := azure.ParseAzureResourceID(*account.ID)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing ID for Storage Account %q: %s", accountName, err)
+			}
+
+			resourceGroup = &id.ResourceGroup
+			break
+		}
+	}
+
+	return resourceGroup, nil
+}
+
+func (client Client) findAccountKey(ctx context.Context, resourceGroup, accountName string) (*string, error) {
+	props, err := client.AccountsClient.ListKeys(ctx, resourceGroup, accountName)
+	if err != nil {
+		return nil, fmt.Errorf("Error Listing Keys for Storage Account %q (Resource Group %q): %+v", accountName, resourceGroup, err)
+	}
+
+	if props.Keys == nil || len(*props.Keys) == 0 {
+		return nil, fmt.Errorf("Keys were nil for Storage Account %q (Resource Group %q): %+v", accountName, resourceGroup, err)
+	}
+
+	keys := *props.Keys
+	firstKey := keys[0].Value
+	return firstKey, nil
+}

--- a/azurerm/internal/services/storage/legacy.go
+++ b/azurerm/internal/services/storage/legacy.go
@@ -1,0 +1,24 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	legacy "github.com/Azure/azure-sdk-for-go/storage"
+)
+
+func (client *Client) LegacyBlobClient(ctx context.Context, resourceGroup, accountName string) (*legacy.BlobStorageClient, bool, error) {
+	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+	if err != nil {
+		return nil, false, fmt.Errorf("Error retrieving Account Key: %s", err)
+	}
+
+	apiVersion := legacy.DefaultAPIVersion
+	storageClient, err := legacy.NewClient(accountName, *accountKey, client.environment.StorageEndpointSuffix, apiVersion, true)
+	if err != nil {
+		return nil, true, fmt.Errorf("Error creating storage client for storage account %q: %s", accountName, err)
+	}
+
+	blobClient := storageClient.GetBlobService()
+	return &blobClient, true, nil
+}

--- a/azurerm/resource_arm_container_registry_migrate.go
+++ b/azurerm/resource_arm_container_registry_migrate.go
@@ -92,7 +92,7 @@ func updateV1ToV2StorageAccountName(is *terraform.InstanceState, meta interface{
 
 func findAzureStorageAccountIdFromName(name string, meta interface{}) (string, error) {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storageServiceClient
+	client := meta.(*ArmClient).storage.AccountsClient
 	accounts, err := client.List(ctx)
 	if err != nil {
 		return "", err

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -112,7 +112,7 @@ func createResourceGroup(ctx context.Context, client *ArmClient, resourceGroupNa
 }
 
 func createStorageAccount(client *ArmClient, resourceGroupName, storageAccountName, location string) (*storage.Account, error) {
-	storageClient := client.storageServiceClient
+	storageClient := client.storage.AccountsClient
 	createParams := storage.AccountCreateParameters{
 		Location: &location,
 		Kind:     storage.Storage,
@@ -141,7 +141,7 @@ func createStorageAccount(client *ArmClient, resourceGroupName, storageAccountNa
 
 func destroyStorageAccountAndResourceGroup(client *ArmClient, resourceGroupName, storageAccountName string) {
 	ctx := client.StopContext
-	if _, err := client.storageServiceClient.Delete(ctx, resourceGroupName, storageAccountName); err != nil {
+	if _, err := client.storage.AccountsClient.Delete(ctx, resourceGroupName, storageAccountName); err != nil {
 		log.Printf("[DEBUG] Error deleting Storage Account %q (Resource Group %q): %v", storageAccountName, resourceGroupName, err)
 	}
 	if _, err := client.resource.GroupsClient.Delete(ctx, resourceGroupName); err != nil {

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -603,7 +603,7 @@ func validateAzureRMStorageAccountTags(v interface{}, _ string) (warnings []stri
 
 func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storageServiceClient
+	client := meta.(*ArmClient).storage.AccountsClient
 	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
 
 	storageAccountName := d.Get("name").(string)
@@ -758,7 +758,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 // available requires a call to Update per parameter...
 func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storageServiceClient
+	client := meta.(*ArmClient).storage.AccountsClient
 	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -952,7 +952,7 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storageServiceClient
+	client := meta.(*ArmClient).storage.AccountsClient
 	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
 	endpointSuffix := meta.(*ArmClient).environment.StorageEndpointSuffix
 
@@ -1099,7 +1099,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storageServiceClient
+	client := meta.(*ArmClient).storage.AccountsClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -759,7 +759,7 @@ func testCheckAzureRMStorageAccountExists(resourceName string) resource.TestChec
 
 		// Ensure resource group exists in API
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		conn := testAccProvider.Meta().(*ArmClient).storageServiceClient
+		conn := testAccProvider.Meta().(*ArmClient).storage.AccountsClient
 
 		resp, err := conn.GetProperties(ctx, resourceGroup, storageAccount, "")
 		if err != nil {
@@ -787,7 +787,7 @@ func testCheckAzureRMStorageAccountDisappears(resourceName string) resource.Test
 
 		// Ensure resource group exists in API
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		conn := testAccProvider.Meta().(*ArmClient).storageServiceClient
+		conn := testAccProvider.Meta().(*ArmClient).storage.AccountsClient
 
 		if _, err := conn.Delete(ctx, resourceGroup, storageAccount); err != nil {
 			return fmt.Errorf("Bad: Delete on storageServiceClient: %+v", err)
@@ -799,7 +799,7 @@ func testCheckAzureRMStorageAccountDisappears(resourceName string) resource.Test
 
 func testCheckAzureRMStorageAccountDestroy(s *terraform.State) error {
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
-	conn := testAccProvider.Meta().(*ArmClient).storageServiceClient
+	conn := testAccProvider.Meta().(*ArmClient).storage.AccountsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_storage_account" {

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -136,7 +136,7 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 	resourceGroupName := d.Get("resource_group_name").(string)
 	storageAccountName := d.Get("storage_account_name").(string)
 
-	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroupName, storageAccountName)
+	blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, resourceGroupName, storageAccountName)
 	if err != nil {
 		return err
 	}
@@ -560,7 +560,7 @@ func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Unable to determine Resource Group for Storage Account %q", id.storageAccountName)
 	}
 
-	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
+	blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, *resourceGroup, id.storageAccountName)
 	if err != nil {
 		return fmt.Errorf("Error getting storage account %s: %+v", id.storageAccountName, err)
 	}
@@ -611,7 +611,7 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Unable to determine Resource Group for Storage Account %q", id.storageAccountName)
 	}
 
-	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
+	blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, *resourceGroup, id.storageAccountName)
 	if err != nil {
 		return err
 	}
@@ -687,7 +687,7 @@ func resourceArmStorageBlobDelete(d *schema.ResourceData, meta interface{}) erro
 		return nil
 	}
 
-	blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, *resourceGroup, id.storageAccountName)
+	blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, *resourceGroup, id.storageAccountName)
 	if err != nil {
 		return err
 	}
@@ -739,7 +739,7 @@ func parseStorageBlobID(input string, environment azauto.Environment) (*storageB
 }
 
 func determineResourceGroupForStorageAccount(accountName string, client *ArmClient) (*string, error) {
-	storageClient := client.storageServiceClient
+	storageClient := client.storage.AccountsClient
 	ctx := client.StopContext
 
 	// first locate which resource group the storage account is in

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -521,7 +521,7 @@ func testCheckAzureRMStorageBlobExists(resourceName string) resource.TestCheckFu
 
 		armClient := testAccProvider.Meta().(*ArmClient)
 		ctx := armClient.StopContext
-		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, resourceGroup, storageAccountName)
 		if err != nil {
 			return err
 		}
@@ -559,7 +559,7 @@ func testCheckAzureRMStorageBlobDisappears(resourceName string) resource.TestChe
 
 		armClient := testAccProvider.Meta().(*ArmClient)
 		ctx := armClient.StopContext
-		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, resourceGroup, storageAccountName)
 		if err != nil {
 			return err
 		}
@@ -590,7 +590,7 @@ func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind storage.Bl
 
 		armClient := testAccProvider.Meta().(*ArmClient)
 		ctx := armClient.StopContext
-		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, resourceGroup, storageAccountName)
 		if err != nil {
 			return err
 		}
@@ -653,7 +653,7 @@ func testCheckAzureRMStorageBlobDestroy(s *terraform.State) error {
 
 		armClient := testAccProvider.Meta().(*ArmClient)
 		ctx := armClient.StopContext
-		blobClient, accountExists, err := armClient.getBlobStorageClientForStorageAccount(ctx, resourceGroup, storageAccountName)
+		blobClient, accountExists, err := armClient.storage.LegacyBlobClient(ctx, resourceGroup, storageAccountName)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
As a part of the refactoring work to move Data Sources and Resources into packages - this PR moves the Legacy Blob Storage Client into the Storage folder, so that the `config.go` just contains a reference to the services being used; which will enable us to move this file into the `internal` folder (and therefore move resources).

(it also removes the `StorageUsageClient` since it's not used)