### PR TITLE
azurerm_subnet - Fixed delegation (fixes #3730)

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -111,6 +111,7 @@ func resourceArmSubnet() *schema.Resource {
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 											ValidateFunc: validation.StringInSlice([]string{
+												"Microsoft.Network/virtualNetworks/subnets/action",
 												"Microsoft.Network/virtualNetworks/subnets/join/action",
 												"Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
 											}, false),

--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -111,7 +111,8 @@ func resourceArmSubnet() *schema.Resource {
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 											ValidateFunc: validation.StringInSlice([]string{
-												"Microsoft.Network/virtualNetworks/subnets/action",
+												"Microsoft.Network/virtualNetworks/subnets/join/action",
+												"Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
 											}, false),
 										},
 									},

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -74,7 +74,9 @@ The following arguments are supported:
 ---
 
 A `delegation` block supports the following:
+
 * `name` (Required) A name for this delegation.
+
 * `service_delegation` (Required) A `service_delegation` block as defined below.
 
 ---
@@ -83,9 +85,9 @@ A `service_delegation` block supports the following:
 
 -> **NOTE:** Delegating to services may not be available in all regions. Check that the service you are delegating to is available in your region using the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/network/vnet/subnet?view=azure-cli-latest#az-network-vnet-subnet-list-available-delegations)
 
-* `name` - (Required) The name of service to delegate to. Possible values include: `Microsoft.BareMetal/AzureVMware`, 
-`Microsoft.BareMetal/CrayServers`, `Microsoft.Batch/batchAccounts`, `Microsoft.ContainerInstance/containerGroups`, `Microsoft.Databricks/workspaces`, `Microsoft.HardwareSecurityModules/dedicatedHSMs`, `Microsoft.Logic/integrationServiceEnvironments`, `Microsoft.Netapp/volumes`, `Microsoft.ServiceFabricMesh/networks`, `Microsoft.Sql/managedInstances`, `Microsoft.Sql/servers`, `Microsoft.Web/hostingEnvironments` or `Microsoft.Web/serverFarms`.
-* `actions` - (Required) A list of Actions which should be delegated. Required values are: `Microsoft.Network/virtualNetworks/subnets/join/action ,  Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action`.
+* `name` - (Required) The name of service to delegate to. Possible values include `Microsoft.BareMetal/AzureVMware`, `Microsoft.BareMetal/CrayServers`, `Microsoft.Batch/batchAccounts`, `Microsoft.ContainerInstance/containerGroups`, `Microsoft.Databricks/workspaces`, `Microsoft.HardwareSecurityModules/dedicatedHSMs`, `Microsoft.Logic/integrationServiceEnvironments`, `Microsoft.Netapp/volumes`, `Microsoft.ServiceFabricMesh/networks`, `Microsoft.Sql/managedInstances`, `Microsoft.Sql/servers`, `Microsoft.Web/hostingEnvironments` and `Microsoft.Web/serverFarms`.
+
+* `actions` - (Required) A list of Actions which should be delegated. Possible values include `Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action`, `Microsoft.Network/virtualNetworks/subnets/action` and `Microsoft.Network/virtualNetworks/subnets/join/action`.
 
 ## Attributes Reference
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_subnet" "test" {
 
     service_delegation {
       name    = "Microsoft.ContainerInstance/containerGroups"
-      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action", "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action"]
     }
   }
 }
@@ -85,7 +85,7 @@ A `service_delegation` block supports the following:
 
 * `name` - (Required) The name of service to delegate to. Possible values include: `Microsoft.BareMetal/AzureVMware`, 
 `Microsoft.BareMetal/CrayServers`, `Microsoft.Batch/batchAccounts`, `Microsoft.ContainerInstance/containerGroups`, `Microsoft.Databricks/workspaces`, `Microsoft.HardwareSecurityModules/dedicatedHSMs`, `Microsoft.Logic/integrationServiceEnvironments`, `Microsoft.Netapp/volumes`, `Microsoft.ServiceFabricMesh/networks`, `Microsoft.Sql/managedInstances`, `Microsoft.Sql/servers`, `Microsoft.Web/hostingEnvironments` or `Microsoft.Web/serverFarms`.
-* `actions` - (Optional) A list of Actions which should be delegated. Possible values include: `Microsoft.Network/virtualNetworks/subnets/action`.
+* `actions` - (Required) A list of Actions which should be delegated. Required values are: `Microsoft.Network/virtualNetworks/subnets/join/action ,  Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This should fix #3730 

I've removed and deployed delegation, and removed again. When deployed, the delegation shows up in the console without complaints.

After applying a change, the next plan is empty.

