### PR TITLE
Fix bug for Network Interface

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -87,7 +87,6 @@ func resourceArmNetworkInterface() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  string(network.IPv4),
-							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(network.IPv4),
 								string(network.IPv6),


### PR DESCRIPTION
Issue:
Terraform azurerm recreates network interface when the ip configuration is changed.

Root cause:
The parameter "private_ip_address_version" under ip_configuration object is set to "ForceNew: true,", which causes that terraform destroy and create a new network interface when ip configuration is update.

Fix:
Remove the attribute "ForceNew: true,". Then terraform will just update ip configuration settings under network interface after updated ip configuration.