### PR TITLE
Update resource_arm_mariadb_server.go to support version 10.3

### DIFF
--- a/azurerm/resource_arm_mariadb_server.go
+++ b/azurerm/resource_arm_mariadb_server.go
@@ -123,6 +123,7 @@ func resourceArmMariaDbServer() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"10.2",
+					"10.3",
 				}, false),
 			},
 

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Required) The Password associated with the `administrator_login` for the MariaDB Server.
 
-* `version` - (Required) Specifies the version of MariaDB to use. The valid value is `10.2`. Changing this forces a new resource to be created.
+* `version` - (Required) Specifies the version of MariaDB to use. Possible values are `10.2` and `10.3`. Changing this forces a new resource to be created.
 
 * `ssl_enforcement` - (Required) Specifies if SSL should be enforced on connections. Possible values are `Enabled` and `Disabled`.
 


### PR DESCRIPTION
Add MariaDB version 10.3 to supported version values. Added element "10.3" to slice of strings.