### PR TITLE
Bug Fix: `azurerm_virtual_network_peering` prevent nil object from being read

### DIFF
--- a/azurerm/resource_arm_virtual_network_peering.go
+++ b/azurerm/resource_arm_virtual_network_peering.go
@@ -147,17 +147,18 @@ func resourceArmVirtualNetworkPeeringRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error making Read request on Azure virtual network peering %q: %+v", name, err)
 	}
 
-	peer := *resp.VirtualNetworkPeeringPropertiesFormat
-
 	// update appropriate values
 	d.Set("resource_group_name", resGroup)
 	d.Set("name", resp.Name)
 	d.Set("virtual_network_name", vnetName)
-	d.Set("allow_virtual_network_access", peer.AllowVirtualNetworkAccess)
-	d.Set("allow_forwarded_traffic", peer.AllowForwardedTraffic)
-	d.Set("allow_gateway_transit", peer.AllowGatewayTransit)
-	d.Set("use_remote_gateways", peer.UseRemoteGateways)
-	d.Set("remote_virtual_network_id", peer.RemoteVirtualNetwork.ID)
+
+	if peer := resp.VirtualNetworkPeeringPropertiesFormat; peer != nil {
+		d.Set("allow_virtual_network_access", peer.AllowVirtualNetworkAccess)
+		d.Set("allow_forwarded_traffic", peer.AllowForwardedTraffic)
+		d.Set("allow_gateway_transit", peer.AllowGatewayTransit)
+		d.Set("use_remote_gateways", peer.UseRemoteGateways)
+		d.Set("remote_virtual_network_id", peer.RemoteVirtualNetwork.ID)
+	}
 
 	return nil
 }

--- a/azurerm/resource_arm_virtual_network_peering.go
+++ b/azurerm/resource_arm_virtual_network_peering.go
@@ -158,7 +158,7 @@ func resourceArmVirtualNetworkPeeringRead(d *schema.ResourceData, meta interface
 		d.Set("allow_gateway_transit", peer.AllowGatewayTransit)
 		d.Set("use_remote_gateways", peer.UseRemoteGateways)
 		if network := peer.RemoteVirtualNetwork; network != nil {
-			d.Set("remote_virtual_network_id", .ID)
+			d.Set("remote_virtual_network_id", network.ID)
 		}
 	}
 

--- a/azurerm/resource_arm_virtual_network_peering.go
+++ b/azurerm/resource_arm_virtual_network_peering.go
@@ -157,7 +157,9 @@ func resourceArmVirtualNetworkPeeringRead(d *schema.ResourceData, meta interface
 		d.Set("allow_forwarded_traffic", peer.AllowForwardedTraffic)
 		d.Set("allow_gateway_transit", peer.AllowGatewayTransit)
 		d.Set("use_remote_gateways", peer.UseRemoteGateways)
-		d.Set("remote_virtual_network_id", peer.RemoteVirtualNetwork.ID)
+		if network := peer.RemoteVirtualNetwork; network != nil {
+			d.Set("remote_virtual_network_id", .ID)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Addressing #4169 

```
--- PASS: TestAccAzureRMVirtualNetworkPeering_disappears (128.76s)
--- PASS: TestAccAzureRMVirtualNetworkPeering_basic (202.19s)
--- FAIL: TestAccAzureRMVirtualNetworkPeering_requiresImport (240.15s)
--- PASS: TestAccAzureRMVirtualNetworkPeering_update (243.41s)
```