### PR TITLE
Removes `Standard` SKU Public Preview status

### DIFF
--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -46,8 +46,6 @@ The following arguments are supported:
 
 -> **Note** Public IP Standard SKUs require `allocation_method` to be set to `Static`.
 
--> **Note:** The `Standard` SKU is currently in Public Preview on an opt-in basis. [More information, including how you can register for the Preview, and which regions `Standard` SKU's are available in are available here](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-overview)
-
 * `allocation_method` - (Required)  Defines the allocation method for this IP address. Possible values are `Static` or `Dynamic`.
 
 ~> **Note** `Dynamic` Public IP Addresses aren't allocated until they're assigned to a resource (such as a Virtual Machine or a Load Balancer) by design within Azure - [more information is available below](#ip_address).


### PR DESCRIPTION
Fixes #3644.  Removes note as `Standard` SKU is no longer in Public Preview.

