### PR TITLE
Updated docs w/ correct resource

### DIFF
--- a/website/docs/guides/migrating-between-renamed-resources.html.markdown
+++ b/website/docs/guides/migrating-between-renamed-resources.html.markdown
@@ -15,7 +15,7 @@ In v1.22 of the AzureRM Provider several resources have been deprecated in favou
 | ---------------------------------------------- | ------------------------------------ |
 | azurerm_log_analytics_workspace_linked_service | azurerm_log_analytics_linked_service |
 | azurerm_autoscale_setting                      | azurerm_monitor_autoscale_setting    |
-| azurerm_metric_alertrule                       | azurerm_monitor_metric_alertrule     |
+| azurerm_metric_alertrule                       | azurerm_monitor_metric_alert     |
 | azurerm_connection_monitor                     | azurerm_network_connection_monitor   |
 | azurerm_ddos_protection_plan                   | azurerm_network_ddos_protection_plan |
 | azurerm_packet_capture                         | azurerm_network_packet_capture       |

--- a/website/docs/r/metric_alertrule.html.markdown
+++ b/website/docs/r/metric_alertrule.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages a [metric-based alert rule](https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitor-quick-resource-metric-alert-portal) in Azure Monitor.
 
-~> **NOTE:** This resource has been deprecated in favour of the `azurerm_monitor_metric_alertrule` resource and will be removed in the next major version of the AzureRM Provider. The new resource shares the same fields as this one, and information on migrating across [can be found in this guide](../guides/migrating-between-renamed-resources.html).
+~> **NOTE:** This resource has been [deprecated](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/monitoring-classic-retirement) in favour of the `azurerm_monitor_metric_alert` resource and will be removed in the next major version of the AzureRM Provider. The new resource shares the same fields as this one, and information on migrating across [can be found in this guide](../guides/migrating-between-renamed-resources.html).
 
 ## Example Usage (CPU Percentage of a virtual machine)
 


### PR DESCRIPTION
Fixes #3791.

Docs & guide were linking to `azurerm_monitor_metric_alertrule` instead of `azurerm_monitor_metric_alert` which is the updated resource (classic alerts have been deprecated). Added link to MS docs about the deprecation. 