### PR TITLE
only running the requires import tests if the features enabled

### DIFF
--- a/azurerm/resource_arm_api_management_api_operation_policy_test.go
+++ b/azurerm/resource_arm_api_management_api_operation_policy_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMApiManagementAPIOperationPolicy_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementAPIOperationPolicy_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_api_operation_test.go
+++ b/azurerm/resource_arm_api_management_api_operation_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMApiManagementApiOperation_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementApiOperation_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_api_policy_test.go
+++ b/azurerm/resource_arm_api_management_api_policy_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMApiManagementAPIPolicy_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementAPIPolicy_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_api_schema_test.go
+++ b/azurerm/resource_arm_api_management_api_schema_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMApiManagementApiSchema_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementApiSchema_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_api_test.go
+++ b/azurerm/resource_arm_api_management_api_test.go
@@ -66,7 +66,7 @@ func TestAccAzureRMApiManagementApi_wordRevision(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementApi_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_api_version_set_test.go
+++ b/azurerm/resource_arm_api_management_api_version_set_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMApiManagementApiVersionSet_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementApiVersionSet_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_authorization_server_test.go
+++ b/azurerm/resource_arm_api_management_authorization_server_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMAPIManagementAuthorizationServer_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAPIManagementAuthorizationServer_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_backend_test.go
+++ b/azurerm/resource_arm_api_management_backend_test.go
@@ -214,7 +214,7 @@ func TestAccAzureRMApiManagementBackend_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementBackend_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_certificate_test.go
+++ b/azurerm/resource_arm_api_management_certificate_test.go
@@ -45,7 +45,7 @@ func TestAccAzureRMAPIManagementCertificate_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAPIManagementCertificate_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_group_test.go
+++ b/azurerm/resource_arm_api_management_group_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMAPIManagementGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAPIManagementGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_group_user_test.go
+++ b/azurerm/resource_arm_api_management_group_user_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMAPIManagementGroupUser_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAPIManagementGroupUser_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_logger_test.go
+++ b/azurerm/resource_arm_api_management_logger_test.go
@@ -42,7 +42,7 @@ func TestAccAzureRMApiManagementLogger_basicEventHub(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementLogger_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_openid_connect_provider_test.go
+++ b/azurerm/resource_arm_api_management_openid_connect_provider_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMApiManagementOpenIDConnectProvider_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementOpenIDConnectProvider_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_product_api_test.go
+++ b/azurerm/resource_arm_api_management_product_api_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMAPIManagementProductApi_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAPIManagementProductApi_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_product_group_test.go
+++ b/azurerm/resource_arm_api_management_product_group_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMAPIManagementProductGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAPIManagementProductGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_product_policy_test.go
+++ b/azurerm/resource_arm_api_management_product_policy_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMApiManagementProductPolicy_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementProductPolicy_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -45,7 +45,7 @@ func TestAccAzureRMApiManagementProduct_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementProduct_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_subscription_test.go
+++ b/azurerm/resource_arm_api_management_subscription_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMAPIManagementSubscription_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAPIManagementSubscription_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMApiManagement_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagement_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_api_management_user_test.go
+++ b/azurerm/resource_arm_api_management_user_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMApiManagementUser_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApiManagementUser_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_app_service_custom_hostname_binding_test.go
+++ b/azurerm/resource_arm_app_service_custom_hostname_binding_test.go
@@ -76,7 +76,7 @@ func testAccAzureRMAppServiceCustomHostnameBinding_basic(t *testing.T, appServic
 }
 
 func testAccAzureRMAppServiceCustomHostnameBinding_requiresImport(t *testing.T, appServiceEnv, domainEnv string) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_app_service_plan_test.go
+++ b/azurerm/resource_arm_app_service_plan_test.go
@@ -110,7 +110,7 @@ func TestAccAzureRMAppServicePlan_basicLinux(t *testing.T) {
 }
 
 func TestAccAzureRMAppServicePlan_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_app_service_slot_test.go
+++ b/azurerm/resource_arm_app_service_slot_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMAppServiceSlot_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAppServiceSlot_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_app_service_test.go
+++ b/azurerm/resource_arm_app_service_test.go
@@ -84,7 +84,7 @@ func TestAccAzureRMAppService_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAppService_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -189,7 +189,7 @@ func TestAccAzureRMApplicationGateway_http2(t *testing.T) {
 }
 
 func TestAccAzureRMApplicationGateway_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_application_insights_api_key_test.go
+++ b/azurerm/resource_arm_application_insights_api_key_test.go
@@ -31,7 +31,7 @@ func TestAccAzureRMApplicationInsightsAPIKey_no_permission(t *testing.T) {
 }
 
 func TestAccAzureRMApplicationInsightsAPIKey_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMApplicationInsights_basicWeb(t *testing.T) {
 }
 
 func TestAccAzureRMApplicationInsights_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_application_insights_webtests_test.go
+++ b/azurerm/resource_arm_application_insights_webtests_test.go
@@ -102,7 +102,7 @@ func TestAccAzureRMApplicationInsightsWebTests_update(t *testing.T) {
 }
 
 func TestAccAzureRMApplicationInsightsWebTests_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_application_security_group_test.go
+++ b/azurerm/resource_arm_application_security_group_test.go
@@ -33,7 +33,7 @@ func TestAccAzureRMApplicationSecurityGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMApplicationSecurityGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_account_test.go
+++ b/azurerm/resource_arm_automation_account_test.go
@@ -87,7 +87,7 @@ func TestAccAzureRMAutomationAccount_basicNotDefined(t *testing.T) {
 }
 
 func TestAccAzureRMAutomationAccount_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_credential_test.go
+++ b/azurerm/resource_arm_automation_credential_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMAutomationCredential_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAutomationCredential_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_dsc_configuration_test.go
+++ b/azurerm/resource_arm_automation_dsc_configuration_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMAutomationDscConfiguration_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAutomationDscConfiguration_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMAutomationDscNodeConfiguration_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAutomationDscNodeConfiguration_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_module_test.go
+++ b/azurerm/resource_arm_automation_module_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMAutomationModule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAutomationModule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_runbook_test.go
+++ b/azurerm/resource_arm_automation_runbook_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMAutomationRunbook_PSWorkflow(t *testing.T) {
 }
 
 func TestAccAzureRMAutomationRunbook_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_schedule_test.go
+++ b/azurerm/resource_arm_automation_schedule_test.go
@@ -35,7 +35,7 @@ func TestAccAzureRMAutomationSchedule_oneTime_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMAutomationSchedule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_autoscale_setting_test.go
+++ b/azurerm/resource_arm_autoscale_setting_test.go
@@ -44,7 +44,7 @@ func TestAccAzureRMAutoScaleSetting_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAutoScaleSetting_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_availability_set_test.go
+++ b/azurerm/resource_arm_availability_set_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 }
 
 func TestAccAzureRMAvailabilitySet_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_azuread_service_principal_password_test.go
+++ b/azurerm/resource_arm_azuread_service_principal_password_test.go
@@ -45,7 +45,7 @@ func TestAccAzureRMActiveDirectoryServicePrincipalPassword_basic(t *testing.T) {
 }
 
 func TestAccAzureRMActiveDirectoryServicePrincipalPassword_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_azuread_service_principal_test.go
+++ b/azurerm/resource_arm_azuread_service_principal_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMActiveDirectoryServicePrincipal_basic(t *testing.T) {
 }
 
 func TestAccAzureRMActiveDirectoryServicePrincipal_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_batch_account_test.go
+++ b/azurerm/resource_arm_batch_account_test.go
@@ -65,7 +65,7 @@ func TestAccAzureRMBatchAccount_basic(t *testing.T) {
 }
 
 func TestAccAzureRMBatchAccount_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_batch_pool_test.go
+++ b/azurerm/resource_arm_batch_pool_test.go
@@ -47,7 +47,7 @@ func TestAccAzureRMBatchPool_basic(t *testing.T) {
 }
 
 func TestAccAzureRMBatchPool_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/resource_arm_cdn_endpoint_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 }
 
 func TestAccAzureRMCdnEndpoint_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_cdn_profile_test.go
+++ b/azurerm/resource_arm_cdn_profile_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 }
 
 func TestAccAzureRMCdnProfile_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_cognitive_account_test.go
+++ b/azurerm/resource_arm_cognitive_account_test.go
@@ -71,7 +71,7 @@ func TestAccAzureRMCognitiveAccount_speechServices(t *testing.T) {
 }
 
 func TestAccAzureRMCognitiveAccount_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_connection_monitor_test.go
+++ b/azurerm/resource_arm_connection_monitor_test.go
@@ -44,7 +44,7 @@ func testAccAzureRMConnectionMonitor_addressBasic(t *testing.T) {
 }
 
 func testAccAzureRMConnectionMonitor_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -248,7 +248,7 @@ func TestAccAzureRMContainerGroup_linuxBasic(t *testing.T) {
 }
 
 func TestAccAzureRMContainerGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_container_registry_test.go
+++ b/azurerm/resource_arm_container_registry_test.go
@@ -96,7 +96,7 @@ func TestAccAzureRMContainerRegistry_basic_basic(t *testing.T) {
 }
 
 func TestAccAzureRMContainerRegistry_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_container_service_test.go
+++ b/azurerm/resource_arm_container_service_test.go
@@ -97,7 +97,7 @@ func TestAccAzureRMContainerService_dcosBasic(t *testing.T) {
 }
 
 func TestAccAzureRMContainerService_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_cosmosdb_account_test.go
+++ b/azurerm/resource_arm_cosmosdb_account_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMCosmosDBAccount_eventualConsistency(t *testing.T) {
 	})
 }
 func TestAccAzureRMCosmosDBAccount_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_data_lake_analytics_account_test.go
+++ b/azurerm/resource_arm_data_lake_analytics_account_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDataLakeAnalyticsAccount_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDataLakeAnalyticsAccount_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
+++ b/azurerm/resource_arm_data_lake_analytics_firewall_rule_test.go
@@ -42,7 +42,7 @@ func TestAccAzureRMDataLakeAnalyticsFirewallRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDataLakeAnalyticsFirewallRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_data_lake_store_file_test.go
+++ b/azurerm/resource_arm_data_lake_store_file_test.go
@@ -112,7 +112,7 @@ func TestAccAzureRMDataLakeStoreFile_largefiles(t *testing.T) {
 }
 
 func TestAccAzureRMDataLakeStoreFile_requiresimport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_data_lake_store_firewall_rule_test.go
+++ b/azurerm/resource_arm_data_lake_store_firewall_rule_test.go
@@ -44,7 +44,7 @@ func TestAccAzureRMDataLakeStoreFirewallRule_basic(t *testing.T) {
 //
 
 func TestAccAzureRMDataLakeStoreFirewallRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_data_lake_store_test.go
+++ b/azurerm/resource_arm_data_lake_store_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMDataLakeStore_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMDataLakeStore_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_databricks_workspace_test.go
+++ b/azurerm/resource_arm_databricks_workspace_test.go
@@ -94,7 +94,7 @@ func TestAccAzureRMDatabricksWorkspace_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDatabricksWorkspace_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_ddos_protection_plan_test.go
+++ b/azurerm/resource_arm_ddos_protection_plan_test.go
@@ -38,7 +38,7 @@ func testAccAzureRMDDoSProtectionPlan_basic(t *testing.T) {
 }
 
 func testAccAzureRMDDoSProtectionPlan_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dev_test_lab_test.go
+++ b/azurerm/resource_arm_dev_test_lab_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMDevTestLab_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDevTestLab_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dev_test_linux_virtual_machine_test.go
+++ b/azurerm/resource_arm_dev_test_linux_virtual_machine_test.go
@@ -45,7 +45,7 @@ func TestAccAzureRMDevTestLinuxVirtualMachine_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDevTestLinuxVirtualMachine_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dev_test_policy_test.go
+++ b/azurerm/resource_arm_dev_test_policy_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDevTestPolicy_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDevTestPolicy_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dev_test_virtual_network_test.go
+++ b/azurerm/resource_arm_dev_test_virtual_network_test.go
@@ -66,7 +66,7 @@ func TestAccAzureRMDevTestVirtualNetwork_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDevTestVirtualNetwork_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dev_test_windows_virtual_machine_test.go
+++ b/azurerm/resource_arm_dev_test_windows_virtual_machine_test.go
@@ -45,7 +45,7 @@ func TestAccAzureRMDevTestVirtualMachine_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDevTestVirtualMachine_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_devspace_controller_test.go
+++ b/azurerm/resource_arm_devspace_controller_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDevSpaceController_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDevSpaceController_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_a_record_test.go
+++ b/azurerm/resource_arm_dns_a_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsARecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsARecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_aaaa_record_test.go
+++ b/azurerm/resource_arm_dns_aaaa_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsAAAARecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsAAAARecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_caa_record_test.go
+++ b/azurerm/resource_arm_dns_caa_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsCaaRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsCaaRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_cname_record_test.go
+++ b/azurerm/resource_arm_dns_cname_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsCNameRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsCNameRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_mx_record_test.go
+++ b/azurerm/resource_arm_dns_mx_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsMxRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsMxRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_ns_record_test.go
+++ b/azurerm/resource_arm_dns_ns_record_test.go
@@ -59,7 +59,7 @@ func TestAccAzureRMDnsNsRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsNsRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_ptr_record_test.go
+++ b/azurerm/resource_arm_dns_ptr_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsPtrRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsPtrRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_srv_record_test.go
+++ b/azurerm/resource_arm_dns_srv_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsSrvRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsSrvRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_txt_record_test.go
+++ b/azurerm/resource_arm_dns_txt_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMDnsTxtRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsTxtRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_dns_zone_test.go
+++ b/azurerm/resource_arm_dns_zone_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMDnsZone_basic(t *testing.T) {
 }
 
 func TestAccAzureRMDnsZone_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_eventgrid_topic_test.go
+++ b/azurerm/resource_arm_eventgrid_topic_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMEventGridTopic_basic(t *testing.T) {
 }
 
 func TestAccAzureRMEventGridTopic_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/resource_arm_eventhub_authorization_rule_test.go
@@ -62,7 +62,7 @@ func testAccAzureRMEventHubAuthorizationRule(t *testing.T, listen, send, manage 
 }
 
 func TestAccAzureRMEventHubAuthorizationRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_eventhub_consumer_group_test.go
+++ b/azurerm/resource_arm_eventhub_consumer_group_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMEventHubConsumerGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMEventHubConsumerGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_eventhub_namespace_authorization_rule_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_authorization_rule_test.go
@@ -61,7 +61,7 @@ func testAccAzureRMEventHubNamespaceAuthorizationRule(t *testing.T, listen, send
 }
 
 func TestAccAzureRMEventHubNamespaceAuthorizationRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMEventHubNamespace_basic(t *testing.T) {
 }
 
 func TestAccAzureRMEventHubNamespace_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_eventhub_test.go
+++ b/azurerm/resource_arm_eventhub_test.go
@@ -220,7 +220,7 @@ func TestAccAzureRMEventHub_basicOnePartition(t *testing.T) {
 }
 
 func TestAccAzureRMEventHub_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_express_route_circuit_authorization_test.go
+++ b/azurerm/resource_arm_express_route_circuit_authorization_test.go
@@ -38,7 +38,7 @@ func testAccAzureRMExpressRouteCircuitAuthorization_basic(t *testing.T) {
 }
 
 func testAccAzureRMExpressRouteCircuitAuthorization_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_express_route_circuit_peering_test.go
+++ b/azurerm/resource_arm_express_route_circuit_peering_test.go
@@ -41,7 +41,7 @@ func testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeering(t *testing.T) 
 }
 
 func testAccAzureRMExpressRouteCircuitPeering_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_express_route_circuit_test.go
+++ b/azurerm/resource_arm_express_route_circuit_test.go
@@ -82,7 +82,7 @@ func testAccAzureRMExpressRouteCircuit_basicMetered(t *testing.T) {
 }
 
 func testAccAzureRMExpressRouteCircuit_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_firewall_application_rule_collection_test.go
+++ b/azurerm/resource_arm_firewall_application_rule_collection_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMFirewallApplicationRuleCollection_basic(t *testing.T) {
 }
 
 func TestAccAzureRMFirewallApplicationRuleCollection_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_firewall_nat_rule_collection_test.go
+++ b/azurerm/resource_arm_firewall_nat_rule_collection_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMFirewallNatRuleCollection_basic(t *testing.T) {
 }
 
 func TestAccAzureRMFirewallNatRuleCollection_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_firewall_network_rule_collection_test.go
+++ b/azurerm/resource_arm_firewall_network_rule_collection_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMFirewallNetworkRuleCollection_basic(t *testing.T) {
 }
 
 func TestAccAzureRMFirewallNetworkRuleCollection_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_firewall_test.go
+++ b/azurerm/resource_arm_firewall_test.go
@@ -111,7 +111,7 @@ func TestAccAzureRMFirewall_basic(t *testing.T) {
 }
 
 func TestAccAzureRMFirewall_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -47,7 +47,7 @@ func TestAccAzureRMFunctionApp_basic(t *testing.T) {
 }
 
 func TestAccAzureRMFunctionApp_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_hadoop_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_hadoop_cluster_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMHDInsightHadoopCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightHadoopCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_hbase_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_hbase_cluster_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMHDInsightHBaseCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightHBaseCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_interactive_query_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_interactive_query_cluster_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMHDInsightInteractiveQueryCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightInteractiveQueryCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_kafka_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_kafka_cluster_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMHDInsightKafkaCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightKafkaCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_ml_services_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_ml_services_cluster_test.go
@@ -52,7 +52,7 @@ func TestAccAzureRMHDInsightMLServicesCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightMLServicesCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_rserver_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_rserver_cluster_test.go
@@ -52,7 +52,7 @@ func TestAccAzureRMHDInsightRServerCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightRServerCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_spark_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_spark_cluster_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMHDInsightSparkCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightSparkCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_hdinsight_storm_cluster_test.go
+++ b/azurerm/resource_arm_hdinsight_storm_cluster_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMHDInsightStormCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMHDInsightStormCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -97,7 +97,7 @@ func TestAccAzureRMImage_standaloneImageZoneRedundant(t *testing.T) {
 }
 
 func TestAccAzureRMImage_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iot_dps_certificate_test.go
+++ b/azurerm/resource_arm_iot_dps_certificate_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMIotDPSCertificate_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotDPSCertificate_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iot_dps_test.go
+++ b/azurerm/resource_arm_iot_dps_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMIotDPS_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotDPS_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_consumer_group_test.go
+++ b/azurerm/resource_arm_iothub_consumer_group_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMIotHubConsumerGroup_events(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubConsumerGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_shared_access_policy_test.go
+++ b/azurerm/resource_arm_iothub_shared_access_policy_test.go
@@ -60,7 +60,7 @@ func TestAccAzureRMIotHubSharedAccessPolicy_writeWithoutRead(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubSharedAccessPolicy_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_test.go
+++ b/azurerm/resource_arm_iothub_test.go
@@ -61,7 +61,7 @@ func TestAccAzureRMIotHub_ipFilterRules(t *testing.T) {
 }
 
 func TestAccAzureRMIotHub_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/resource_arm_key_vault_access_policy_test.go
@@ -70,7 +70,7 @@ func TestAccAzureRMKeyVaultAccessPolicy_basicClassic(t *testing.T) {
 }
 
 func TestAccAzureRMKeyVaultAccessPolicy_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/resource_arm_key_vault_certificate_test.go
@@ -69,7 +69,7 @@ func TestAccAzureRMKeyVaultCertificate_basicImportPFXClassic(t *testing.T) {
 }
 
 func TestAccAzureRMKeyVaultCertificate_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_key_vault_key_test.go
+++ b/azurerm/resource_arm_key_vault_key_test.go
@@ -67,7 +67,7 @@ func TestAccAzureRMKeyVaultKey_basicECClassic(t *testing.T) {
 }
 
 func TestAccAzureRMKeyVaultKey_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_key_vault_secret_test.go
+++ b/azurerm/resource_arm_key_vault_secret_test.go
@@ -67,7 +67,7 @@ func TestAccAzureRMKeyVaultSecret_basicClassic(t *testing.T) {
 }
 
 func TestAccAzureRMKeyVaultSecret_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -146,7 +146,7 @@ func TestAccAzureRMKeyVault_basicClassic(t *testing.T) {
 }
 
 func TestAccAzureRMKeyVault_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -53,7 +53,7 @@ func TestAccAzureRMKubernetesCluster_basic(t *testing.T) {
 }
 
 func TestAccAzureRMKubernetesCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
+++ b/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
@@ -48,7 +48,7 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMLoadBalancerBackEndAddressPool_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLoadBalancerNatPool_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLoadBalancerNatRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_loadbalancer_outbound_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_outbound_rule_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMLoadBalancerOutboundRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLoadBalancerOutboundRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMLoadBalancerProbe_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLoadBalancerProbe_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -141,7 +141,7 @@ func TestAccAzureRMLoadBalancerRule_disableoutboundsnat(t *testing.T) {
 }
 
 func TestAccAzureRMLoadBalancerRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_loadbalancer_test.go
+++ b/azurerm/resource_arm_loadbalancer_test.go
@@ -73,7 +73,7 @@ func TestAccAzureRMLoadBalancer_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLoadBalancer_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_local_network_gateway_test.go
+++ b/azurerm/resource_arm_local_network_gateway_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMLocalNetworkGateway_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLocalNetworkGateway_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_log_analytics_linked_service_test.go
+++ b/azurerm/resource_arm_log_analytics_linked_service_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMLogAnalyticsLinkedService_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLogAnalyticsLinkedService_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_log_analytics_solution_test.go
+++ b/azurerm/resource_arm_log_analytics_solution_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMLogAnalyticsSolution_basicContainerMonitoring(t *testing.T) {
 }
 
 func TestAccAzureRMLogAnalyticsSolution_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
+++ b/azurerm/resource_arm_log_analytics_workspace_linked_service_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMLogAnalyticsWorkspaceLinkedService_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLogAnalyticsWorkspaceLinkedService_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_log_analytics_workspace_test.go
+++ b/azurerm/resource_arm_log_analytics_workspace_test.go
@@ -78,7 +78,7 @@ func TestAccAzureRMLogAnalyticsWorkspace_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLogAnalyticsWorkspace_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_logic_app_action_custom_test.go
+++ b/azurerm/resource_arm_logic_app_action_custom_test.go
@@ -35,7 +35,7 @@ func TestAccAzureRMLogicAppActionCustom_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLogicAppActionCustom_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_logic_app_action_http_test.go
+++ b/azurerm/resource_arm_logic_app_action_http_test.go
@@ -34,7 +34,7 @@ func TestAccAzureRMLogicAppActionHttp_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLogicAppActionHttp_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_logic_app_trigger_custom_test.go
+++ b/azurerm/resource_arm_logic_app_trigger_custom_test.go
@@ -34,7 +34,7 @@ func TestAccAzureRMLogicAppTriggerCustom_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLogicAppTriggerCustom_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_logic_app_trigger_http_request_test.go
+++ b/azurerm/resource_arm_logic_app_trigger_http_request_test.go
@@ -35,7 +35,7 @@ func TestAccAzureRMLogicAppTriggerHttpRequest_basic(t *testing.T) {
 }
 
 func TestAccAzureRMLogicAppTriggerHttpRequest_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_logic_app_trigger_recurrence_test.go
+++ b/azurerm/resource_arm_logic_app_trigger_recurrence_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMLogicAppTriggerRecurrence_month(t *testing.T) {
 }
 
 func TestAccAzureRMLogicAppTriggerRecurrence_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_logic_app_workflow_test.go
+++ b/azurerm/resource_arm_logic_app_workflow_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMLogicAppWorkflow_empty(t *testing.T) {
 }
 
 func TestAccAzureRMLogicAppWorkflow_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_managed_disk_test.go
+++ b/azurerm/resource_arm_managed_disk_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMManagedDisk_empty(t *testing.T) {
 }
 
 func TestAccAzureRMManagedDisk_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_management_group_test.go
+++ b/azurerm/resource_arm_management_group_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMManagementGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMManagementGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_management_lock_test.go
+++ b/azurerm/resource_arm_management_lock_test.go
@@ -68,7 +68,7 @@ func TestAccAzureRMManagementLock_resourceGroupReadOnlyBasic(t *testing.T) {
 }
 
 func TestAccAzureRMManagementLock_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mariadb_database_test.go
+++ b/azurerm/resource_arm_mariadb_database_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMMariaDbDatabase_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMariaDbDatabase_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mariadb_firewall_rule_test.go
+++ b/azurerm/resource_arm_mariadb_firewall_rule_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMMariaDBFirewallRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMariaDBFirewallRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mariadb_server_test.go
+++ b/azurerm/resource_arm_mariadb_server_test.go
@@ -43,7 +43,7 @@ func TestAccAzureRMMariaDbServer_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMariaDbServer_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mariadb_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_mariadb_virtual_network_rule_test.go
@@ -33,7 +33,7 @@ func TestAccAzureRMMariaDBVirtualNetworkRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMariaDBVirtualNetworkRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_metric_alertrule_test.go
+++ b/azurerm/resource_arm_metric_alertrule_test.go
@@ -106,7 +106,7 @@ func TestAccAzureRMMetricAlertRule_virtualMachineCpu(t *testing.T) {
 }
 
 func TestAccAzureRMMetricAlertRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_monitor_action_group_test.go
+++ b/azurerm/resource_arm_monitor_action_group_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMMonitorActionGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMonitorActionGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_monitor_activity_log_alert_test.go
+++ b/azurerm/resource_arm_monitor_activity_log_alert_test.go
@@ -44,7 +44,7 @@ func TestAccAzureRMMonitorActivityLogAlert_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMonitorActivityLogAlert_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_monitor_autoscale_setting_test.go
+++ b/azurerm/resource_arm_monitor_autoscale_setting_test.go
@@ -44,7 +44,7 @@ func TestAccAzureRMMonitorAutoScaleSetting_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMonitorAutoScaleSetting_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_monitor_diagnostic_setting_test.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting_test.go
@@ -44,7 +44,7 @@ func TestAccAzureRMMonitorDiagnosticSetting_eventhub(t *testing.T) {
 }
 
 func TestAccAzureRMMonitorDiagnosticSetting_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_monitor_log_profile_test.go
+++ b/azurerm/resource_arm_monitor_log_profile_test.go
@@ -73,7 +73,7 @@ func testAccAzureRMMonitorLogProfile_basic(t *testing.T) {
 }
 
 func testAccAzureRMMonitorLogProfile_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_monitor_metric_alert_test.go
+++ b/azurerm/resource_arm_monitor_metric_alert_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMMonitorMetricAlert_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMonitorMetricAlert_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_monitor_metric_alertrule_test.go
+++ b/azurerm/resource_arm_monitor_metric_alertrule_test.go
@@ -106,7 +106,7 @@ func TestAccAzureRMMonitorMetricAlertRule_virtualMachineCpu(t *testing.T) {
 }
 
 func TestAccAzureRMMonitorMetricAlertRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mssql_elasticpool_test.go
+++ b/azurerm/resource_arm_mssql_elasticpool_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMMsSqlElasticPool_basic_DTU(t *testing.T) {
 }
 
 func TestAccAzureRMMsSqlElasticPool_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mysql_database_test.go
+++ b/azurerm/resource_arm_mysql_database_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMMySQLDatabase_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMySQLDatabase_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mysql_firewall_rule_test.go
+++ b/azurerm/resource_arm_mysql_firewall_rule_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMMySQLFirewallRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMySQLFirewallRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mysql_server_test.go
+++ b/azurerm/resource_arm_mysql_server_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMMySQLServer_basicFiveSix(t *testing.T) {
 }
 
 func TestAccAzureRMMySQLServer_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}
@@ -67,7 +67,7 @@ func TestAccAzureRMMySQLServer_requiresImport(t *testing.T) {
 }
 
 func TestAccAzureRMMySQLServer_basicFiveSeven(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_mysql_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_mysql_virtual_network_rule_test.go
@@ -33,7 +33,7 @@ func TestAccAzureRMMySqlVirtualNetworkRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMMySqlVirtualNetworkRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_connection_monitor_test.go
+++ b/azurerm/resource_arm_network_connection_monitor_test.go
@@ -44,7 +44,7 @@ func testAccAzureRMNetworkConnectionMonitor_addressBasic(t *testing.T) {
 }
 
 func testAccAzureRMNetworkConnectionMonitor_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_ddos_protection_plan_test.go
+++ b/azurerm/resource_arm_network_ddos_protection_plan_test.go
@@ -67,7 +67,7 @@ func testAccAzureRMNetworkDDoSProtectionPlan_basic(t *testing.T) {
 }
 
 func testAccAzureRMNetworkDDoSProtectionPlan_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_interface_application_gateway_association_test.go
+++ b/azurerm/resource_arm_network_interface_application_gateway_association_test.go
@@ -32,7 +32,7 @@ func TestAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociati
 }
 
 func TestAccAzureRMNetworkInterfaceApplicationGatewayBackendAddressPoolAssociation_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_interface_application_security_group_association_test.go
+++ b/azurerm/resource_arm_network_interface_application_security_group_association_test.go
@@ -32,7 +32,7 @@ func TestAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_basic(t *
 }
 
 func TestAccAzureRMNetworkInterfaceApplicationSecurityGroupAssociation_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_interface_backend_address_pool_association_test.go
+++ b/azurerm/resource_arm_network_interface_backend_address_pool_association_test.go
@@ -32,7 +32,7 @@ func TestAccAzureRMNetworkInterfaceBackendAddressPoolAssociation_basic(t *testin
 }
 
 func TestAccAzureRMNetworkInterfaceBackendAddressPoolAssociation_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_interface_nat_rule_association_test.go
+++ b/azurerm/resource_arm_network_interface_nat_rule_association_test.go
@@ -32,7 +32,7 @@ func TestAccAzureRMNetworkInterfaceNATRuleAssociation_basic(t *testing.T) {
 }
 
 func TestAccAzureRMNetworkInterfaceNATRuleAssociation_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -32,7 +32,7 @@ func TestAccAzureRMNetworkInterface_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMNetworkInterface_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_packet_capture_test.go
+++ b/azurerm/resource_arm_network_packet_capture_test.go
@@ -39,7 +39,7 @@ func testAccAzureRMNetworkPacketCapture_localDisk(t *testing.T) {
 }
 
 func testAccAzureRMNetworkPacketCapture_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_profile_test.go
+++ b/azurerm/resource_arm_network_profile_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMNetworkProfile_basic(t *testing.T) {
 }
 
 func TestAccAzureRMNetworkProfile_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_security_group_test.go
+++ b/azurerm/resource_arm_network_security_group_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMNetworkSecurityGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMNetworkSecurityGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_security_rule_test.go
+++ b/azurerm/resource_arm_network_security_rule_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMNetworkSecurityRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMNetworkSecurityRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_network_watcher_test.go
+++ b/azurerm/resource_arm_network_watcher_test.go
@@ -104,7 +104,7 @@ func testAccAzureRMNetworkWatcher_basic(t *testing.T) {
 }
 
 func testAccAzureRMNetworkWatcher_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_notification_hub_authorization_rule_test.go
+++ b/azurerm/resource_arm_notification_hub_authorization_rule_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMNotificationHubAuthorizationRule_listen(t *testing.T) {
 }
 
 func TestAccAzureRMNotificationHubAuthorizationRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_notification_hub_namespace_test.go
+++ b/azurerm/resource_arm_notification_hub_namespace_test.go
@@ -79,7 +79,7 @@ func TestAccAzureRMNotificationHubNamespace_freeNotDefined(t *testing.T) {
 }
 
 func TestAccAzureRMNotificationHubNamespace_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_notification_hub_test.go
+++ b/azurerm/resource_arm_notification_hub_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMNotificationHub_basic(t *testing.T) {
 }
 
 func TestAccAzureRMNotificationHub_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_packet_capture_test.go
+++ b/azurerm/resource_arm_packet_capture_test.go
@@ -39,7 +39,7 @@ func testAccAzureRMPacketCapture_localDisk(t *testing.T) {
 }
 
 func testAccAzureRMPacketCapture_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_policy_assignment_test.go
+++ b/azurerm/resource_arm_policy_assignment_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMPolicyAssignment_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPolicyAssignment_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_policy_definition_test.go
+++ b/azurerm/resource_arm_policy_definition_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMPolicyDefinition_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPolicyDefinition_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_policy_set_definition_test.go
+++ b/azurerm/resource_arm_policy_set_definition_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMPolicySetDefinition_builtIn(t *testing.T) {
 }
 
 func TestAccAzureRMPolicySetDefinition_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_postgresql_database_test.go
+++ b/azurerm/resource_arm_postgresql_database_test.go
@@ -33,7 +33,7 @@ func TestAccAzureRMPostgreSQLDatabase_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPostgreSQLDatabase_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_postgresql_firewall_rule_test.go
+++ b/azurerm/resource_arm_postgresql_firewall_rule_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMPostgreSQLFirewallRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPostgreSQLFirewallRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_postgresql_server_test.go
+++ b/azurerm/resource_arm_postgresql_server_test.go
@@ -134,7 +134,7 @@ func TestAccAzureRMPostgreSQLServer_basicEleven(t *testing.T) {
 }
 
 func TestAccAzureRMPostgreSQLServer_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_postgresql_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_postgresql_virtual_network_rule_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMPostgreSQLVirtualNetworkRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPostgreSQLVirtualNetworkRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_private_dns_a_record_test.go
+++ b/azurerm/resource_arm_private_dns_a_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMPrivateDnsARecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPrivateDnsARecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_private_dns_cname_record_test.go
+++ b/azurerm/resource_arm_private_dns_cname_record_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMPrivateDnsCNameRecord_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPrivateDnsCNameRecord_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_private_dns_zone_test.go
+++ b/azurerm/resource_arm_private_dns_zone_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMPrivateDnsZone_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPrivateDnsZone_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_public_ip_test.go
+++ b/azurerm/resource_arm_public_ip_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 }
 
 func TestAccAzureRMPublicIpStatic_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_recovery_services_protected_vm_test.go
+++ b/azurerm/resource_arm_recovery_services_protected_vm_test.go
@@ -43,7 +43,7 @@ func TestAccAzureRMRecoveryServicesProtectedVm_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRecoveryServicesProtectedVm_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_recovery_services_protection_policy_vm_test.go
+++ b/azurerm/resource_arm_recovery_services_protection_policy_vm_test.go
@@ -35,7 +35,7 @@ func TestAccAzureRMRecoveryServicesProtectionPolicyVm_basicDaily(t *testing.T) {
 }
 
 func TestAccAzureRMRecoveryServicesProtectionPolicyVm_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_recovery_services_vault_test.go
+++ b/azurerm/resource_arm_recovery_services_vault_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMRecoveryServicesVault_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRecoveryServicesVault_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_redis_cache_test.go
+++ b/azurerm/resource_arm_redis_cache_test.go
@@ -131,7 +131,7 @@ func TestAccAzureRMRedisCache_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRedisCache_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_redis_firewall_rule_test.go
+++ b/azurerm/resource_arm_redis_firewall_rule_test.go
@@ -108,7 +108,7 @@ func TestAccAzureRMRedisFirewallRule_multi(t *testing.T) {
 }
 
 func TestAccAzureRMRedisFirewallRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_relay_namespace_test.go
+++ b/azurerm/resource_arm_relay_namespace_test.go
@@ -91,7 +91,7 @@ func TestAccAzureRMRelayNamespace_basicNotDefined(t *testing.T) {
 }
 
 func TestAccAzureRMRelayNamespace_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_resource_group_test.go
+++ b/azurerm/resource_arm_resource_group_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMResourceGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMResourceGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_role_assignment_test.go
+++ b/azurerm/resource_arm_role_assignment_test.go
@@ -97,7 +97,7 @@ func testAccAzureRMRoleAssignment_roleName(t *testing.T) {
 }
 
 func testAccAzureRMRoleAssignment_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_role_definition_test.go
+++ b/azurerm/resource_arm_role_definition_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMRoleDefinition_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRoleDefinition_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_route_table_test.go
+++ b/azurerm/resource_arm_route_table_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMRouteTable_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRouteTable_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_route_test.go
+++ b/azurerm/resource_arm_route_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMRoute_basic(t *testing.T) {
 }
 
 func TestAccAzureRMRoute_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_scheduler_job_collection_test.go
+++ b/azurerm/resource_arm_scheduler_job_collection_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMSchedulerJobCollection_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSchedulerJobCollection_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_scheduler_job_test.go
+++ b/azurerm/resource_arm_scheduler_job_test.go
@@ -42,7 +42,7 @@ func TestAccAzureRMSchedulerJob_web_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSchedulerJob_web_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMSearchService_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSearchService_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_security_center_contact_test.go
+++ b/azurerm/resource_arm_security_center_contact_test.go
@@ -62,7 +62,7 @@ func testAccAzureRMSecurityCenterContact_basic(t *testing.T) {
 }
 
 func testAccAzureRMSecurityCenterContact_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_security_center_workspace_test.go
+++ b/azurerm/resource_arm_security_center_workspace_test.go
@@ -44,7 +44,7 @@ func testAccAzureRMSecurityCenterWorkspace_basic(t *testing.T) {
 }
 
 func testAccAzureRMSecurityCenterWorkspace_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -98,7 +98,7 @@ func TestAccAzureRMServiceFabricCluster_basicNodeTypeUpdate(t *testing.T) {
 }
 
 func TestAccAzureRMServiceFabricCluster_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
@@ -103,7 +103,7 @@ func TestAccAzureRMServiceBusNamespaceAuthorizationRule_rightsUpdate(t *testing.
 	})
 }
 func TestAccAzureRMServiceBusNamespaceAuthorizationRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMServiceBusNamespace_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMServiceBusNamespace_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
@@ -103,7 +103,7 @@ func TestAccAzureRMServiceBusQueueAuthorizationRule_rightsUpdate(t *testing.T) {
 	})
 }
 func TestAccAzureRMServiceBusQueueAuthorizationRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMServiceBusQueue_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMServiceBusQueue_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_subscription_rule_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_rule_test.go
@@ -30,7 +30,7 @@ func TestAccAzureRMServiceBusSubscriptionRule_basicSqlFilter(t *testing.T) {
 	})
 }
 func TestAccAzureRMServiceBusSubscriptionRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMServiceBusSubscription_basic(t *testing.T) {
 }
 
 func TestAccAzureRMServiceBusSubscription_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
@@ -61,7 +61,7 @@ func testAccAzureRMServiceBusTopicAuthorizationRule(t *testing.T, listen, send, 
 }
 
 func TestAccAzureRMServiceBusTopicAuthorizationRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMServiceBusTopic_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_shared_image_gallery_test.go
+++ b/azurerm/resource_arm_shared_image_gallery_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMSharedImageGallery_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSharedImageGallery_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_shared_image_test.go
+++ b/azurerm/resource_arm_shared_image_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMSharedImage_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSharedImage_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -62,7 +62,7 @@ func TestAccAzureRMSharedImageVersion_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSharedImageVersion_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -45,7 +45,7 @@ func TestAccAzureRMSignalRService_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSignalRService_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_snapshot_test.go
+++ b/azurerm/resource_arm_snapshot_test.go
@@ -85,7 +85,7 @@ func TestAccAzureRMSnapshot_fromManagedDisk(t *testing.T) {
 	})
 }
 func TestAccAzureRMSnapshot_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_sql_administrator_test.go
+++ b/azurerm/resource_arm_sql_administrator_test.go
@@ -43,7 +43,7 @@ func TestAccAzureRMSqlAdministrator_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSqlAdministrator_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_sql_database_test.go
+++ b/azurerm/resource_arm_sql_database_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMSqlDatabase_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSqlDatabase_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_sql_elasticpool_test.go
+++ b/azurerm/resource_arm_sql_elasticpool_test.go
@@ -35,7 +35,7 @@ func TestAccAzureRMSqlElasticPool_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSqlElasticPool_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_sql_failover_group_test.go
+++ b/azurerm/resource_arm_sql_failover_group_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMSqlFailoverGroup_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSqlFailoverGroup_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skiiping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_sql_firewall_rule_test.go
+++ b/azurerm/resource_arm_sql_firewall_rule_test.go
@@ -45,7 +45,7 @@ func TestAccAzureRMSqlFirewallRule_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSqlFirewallRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -36,7 +36,7 @@ func TestAccAzureRMSqlServer_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSqlServer_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_sql_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_sql_virtual_network_rule_test.go
@@ -52,7 +52,7 @@ func TestAccAzureRMSqlVirtualNetworkRule_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSqlVirtualNetworkRule_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -99,7 +99,7 @@ func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStorageAccount_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMStorageContainer_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStorageContainer_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -80,7 +80,7 @@ func TestAccAzureRMStorageQueue_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStorageQueue_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_storage_share_directory_test.go
+++ b/azurerm/resource_arm_storage_share_directory_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMStorageShareDirectory_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStorageShareDirectory_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMStorageShare_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStorageShare_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_storage_table_entity_test.go
+++ b/azurerm/resource_arm_storage_table_entity_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMTableEntity_basic(t *testing.T) {
 }
 
 func TestAccAzureRMTableEntity_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMStorageTable_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStorageTable_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_function_javascript_udf_test.go
+++ b/azurerm/resource_arm_stream_analytics_function_javascript_udf_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMStreamAnalyticsFunctionJavaScriptUDF_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsFunctionJavaScriptUDF_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_job_test.go
+++ b/azurerm/resource_arm_stream_analytics_job_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMStreamAnalyticsJob_basic(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsJob_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_output_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_blob_test.go
@@ -140,7 +140,7 @@ func TestAccAzureRMStreamAnalyticsOutputBlob_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsOutputBlob_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_output_eventhub_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_eventhub_test.go
@@ -172,7 +172,7 @@ func TestAccAzureRMStreamAnalyticsOutputEventHub_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsOutputEventHub_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_output_mssql_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_mssql_test.go
@@ -80,7 +80,7 @@ func TestAccAzureRMStreamAnalyticsOutputSql_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsOutputSql_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_output_servicebus_queue_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_servicebus_queue_test.go
@@ -134,7 +134,7 @@ func TestAccAzureRMStreamAnalyticsOutputServiceBusQueue_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsOutputServiceBusQueue_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_stream_input_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_blob_test.go
@@ -140,7 +140,7 @@ func TestAccAzureRMStreamAnalyticsStreamInputBlob_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsStreamInputBlob_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_stream_input_eventhub_test.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_eventhub_test.go
@@ -134,7 +134,7 @@ func TestAccAzureRMStreamAnalyticsStreamInputEventHub_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsStreamInputEventHub_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_stream_analytics_stream_input_iothub_test.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_iothub_test.go
@@ -134,7 +134,7 @@ func TestAccAzureRMStreamAnalyticsStreamInputIoTHub_update(t *testing.T) {
 }
 
 func TestAccAzureRMStreamAnalyticsStreamInputIoTHub_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_subnet_network_security_group_association_test.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association_test.go
@@ -39,7 +39,7 @@ func TestAccAzureRMSubnetNetworkSecurityGroupAssociation_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSubnetNetworkSecurityGroupAssociation_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_subnet_route_table_association_test.go
+++ b/azurerm/resource_arm_subnet_route_table_association_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMSubnetRouteTableAssociation_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMSubnetRouteTableAssociation_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_subnet_test.go
+++ b/azurerm/resource_arm_subnet_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 }
 
 func TestAccAzureRMSubnet_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_template_deployment_test.go
+++ b/azurerm/resource_arm_template_deployment_test.go
@@ -30,7 +30,7 @@ func TestAccAzureRMTemplateDeployment_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMTemplateDeployment_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_traffic_manager_endpoint_test.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint_test.go
@@ -40,7 +40,7 @@ func TestAccAzureRMTrafficManagerEndpoint_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMTrafficManagerEndpoint_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -47,7 +47,7 @@ func TestAccAzureRMTrafficManagerProfile_geographic(t *testing.T) {
 	})
 }
 func TestAccAzureRMTrafficManagerProfile_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_user_assigned_identity_test.go
+++ b/azurerm/resource_arm_user_assigned_identity_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMUserAssignedIdentity_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMUserAssignedIdentity_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
@@ -43,7 +43,7 @@ func TestAccAzureRMVirtualMachineDataDiskAttachment_basic(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualMachineDataDiskAttachment_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_machine_extension_test.go
+++ b/azurerm/resource_arm_virtual_machine_extension_test.go
@@ -49,7 +49,7 @@ func TestAccAzureRMVirtualMachineExtension_basic(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualMachineExtension_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_managed_disks_test.go
@@ -42,7 +42,7 @@ func TestAccAzureRMVirtualMachine_basicLinuxMachine_managedDisk_standardSSD(t *t
 }
 
 func TestAccAzureRMVirtualMachine_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -46,7 +46,7 @@ func TestAccAzureRMVirtualMachineScaleSet_basic(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualMachineScaleSet_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_network_gateway_connection_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_connection_test.go
@@ -37,7 +37,7 @@ func TestAccAzureRMVirtualNetworkGatewayConnection_sitetosite(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualNetworkGatewayConnection_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_network_gateway_test.go
+++ b/azurerm/resource_arm_virtual_network_gateway_test.go
@@ -38,7 +38,7 @@ func TestAccAzureRMVirtualNetworkGateway_basic(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualNetworkGateway_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_network_peering_test.go
+++ b/azurerm/resource_arm_virtual_network_peering_test.go
@@ -42,7 +42,7 @@ func TestAccAzureRMVirtualNetworkPeering_basic(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualNetworkPeering_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_network_test.go
+++ b/azurerm/resource_arm_virtual_network_test.go
@@ -73,7 +73,7 @@ func TestAccAzureRMVirtualNetwork_basicUpdated(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualNetwork_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_virtual_wan_test.go
+++ b/azurerm/resource_arm_virtual_wan_test.go
@@ -41,7 +41,7 @@ func TestAccAzureRMVirtualWan_basic(t *testing.T) {
 	})
 }
 func TestAccAzureRMVirtualWan_requiresImport(t *testing.T) {
-	if features.ShouldResourcesBeImported() {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}


### PR DESCRIPTION
This PR fixes the tests so that we only run the Requires Import tests if the features actually enabled; this was a find & replace error introduced in #4134 