### PR TITLE
azurerm_container_group: make `storage_account_key` field in `volume` block sensitive

### DIFF
--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -357,6 +357,7 @@ func resourceArmContainerGroup() *schema.Resource {
 									"storage_account_key": {
 										Type:         schema.TypeString,
 										Required:     true,
+										Sensitive:    true,
 										ForceNew:     true,
 										ValidateFunc: validate.NoEmptyStrings,
 									},


### PR DESCRIPTION
This makes the `storage_account_key` field in the `volume` block (within `container`) in the `azurerm_container_group` resource sensitive.