### PR TITLE
storage: caching the Resource Group Name / Account Key

### DIFF
--- a/azurerm/internal/services/storage/helpers.go
+++ b/azurerm/internal/services/storage/helpers.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 
@@ -14,6 +15,20 @@ var (
 	resourceGroupNamesCache = map[string]string{}
 	writeLock               = sync.RWMutex{}
 )
+
+func (client Client) ClearFromCache(resourceGroup, accountName string) {
+	writeLock.Lock()
+
+	log.Printf("[DEBUG] Removing Account %q (Resource Group %q) from the cache", accountName, resourceGroup)
+	accountCacheKey := fmt.Sprintf("%s-%s", resourceGroup, accountName)
+	delete(accountKeysCache, accountCacheKey)
+
+	resourceGroupsCacheKey := accountName
+	delete(resourceGroupNamesCache, resourceGroupsCacheKey)
+
+	log.Printf("[DEBUG] Removed Account %q (Resource Group %q) from the cache", accountName, resourceGroup)
+	writeLock.Unlock()
+}
 
 func (client Client) FindResourceGroup(ctx context.Context, accountName string) (*string, error) {
 	cacheKey := accountName

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1100,7 +1100,8 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storage.AccountsClient
+	storageClient := meta.(*ArmClient).storage
+	client := storageClient.AccountsClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -1149,6 +1150,9 @@ func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error issuing delete request for Storage Account %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
+
+	// remove this from the cache
+	storageClient.ClearFromCache(resourceGroup, name)
 
 	return nil
 }

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -336,12 +336,10 @@ func testCheckAzureRMStorageContainerDestroy(s *terraform.State) error {
 
 		props, err := client.GetProperties(ctx, accountName, containerName)
 		if err != nil {
-			if utils.ResponseWasNotFound(props.Response) {
-				return nil
-			}
-
-			return fmt.Errorf("Error retrieving Container %q in Storage Account %q: %s", containerName, accountName, err)
+			return nil
 		}
+
+		return fmt.Errorf("Container still exists: %+v", props)
 	}
 
 	return nil

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -213,16 +213,12 @@ func testCheckAzureRMStorageQueueDestroy(s *terraform.State) error {
 			return fmt.Errorf("Error building Queues Client: %s", err)
 		}
 
-		metaData, err := queueClient.GetMetaData(ctx, accountName, name)
+		props, err := queueClient.GetMetaData(ctx, accountName, name)
 		if err != nil {
-			if utils.ResponseWasNotFound(metaData.Response) {
-				return nil
-			}
-
-			return fmt.Errorf("Unexpected error getting MetaData for Queue %q: %s", name, err)
+			return nil
 		}
 
-		return fmt.Errorf("Bad: Storage Queue %q (storage account: %q) still exists", name, accountName)
+		return fmt.Errorf("Queue still exists: %+v", props)
 	}
 
 	return nil

--- a/azurerm/resource_arm_storage_share_directory_test.go
+++ b/azurerm/resource_arm_storage_share_directory_test.go
@@ -249,12 +249,10 @@ func testCheckAzureRMStorageShareDirectoryDestroy(s *terraform.State) error {
 
 		resp, err := client.Get(ctx, accountName, shareName, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on FileShareDirectoriesClient: %+v", err)
+			return nil
 		}
 
-		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("File Share still exists:\n%#v", resp)
-		}
+		return fmt.Errorf("File Share still exists:\n%#v", resp)
 	}
 
 	return nil

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMStorageShare_basic(t *testing.T) {
@@ -289,14 +288,10 @@ func testCheckAzureRMStorageShareDestroy(s *terraform.State) error {
 
 		props, err := client.GetProperties(ctx, accountName, shareName)
 		if err != nil {
-			if utils.ResponseWasNotFound(props.Response) {
-				return nil
-			}
-
-			return fmt.Errorf("Error retrieving Share %q: %s", shareName, accountName)
+			return nil
 		}
 
-		return fmt.Errorf("Bad: Share %q (storage account: %q) still exists", shareName, accountName)
+		return fmt.Errorf("Share still exists: %+v", props)
 	}
 
 	return nil

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -240,14 +240,10 @@ func testCheckAzureRMStorageTableDestroy(s *terraform.State) error {
 
 		props, err := client.Exists(ctx, accountName, tableName)
 		if err != nil {
-			if utils.ResponseWasNotFound(props) {
-				return nil
-			}
-
-			return fmt.Errorf("Error retrieving Table %q: %s", tableName, accountName)
+			return nil
 		}
 
-		return fmt.Errorf("Bad: Table %q (storage account: %q) still exists", tableName, accountName)
+		return fmt.Errorf("Table still exists: %+v", props)
 	}
 
 	return nil


### PR DESCRIPTION
This PR introduces caching for both the Resource Group Name and the Account Key for a Storage Account. Due to the way this works the test check functions had to be updated to confirm we get an error (404) rather than the resource group name being not found