### PR TITLE
Feature: add general purpose cognitive service type

### DIFF
--- a/azurerm/resource_arm_cognitive_account.go
+++ b/azurerm/resource_arm_cognitive_account.go
@@ -53,6 +53,7 @@ func resourceArmCognitiveAccount() *schema.Resource {
 					"Bing.Speech",
 					"Bing.SpellCheck",
 					"Bing.SpellCheck.v7",
+					"CognitiveServices"
 					"ComputerVision",
 					"ContentModerator",
 					"CustomSpeech",

--- a/azurerm/resource_arm_cognitive_account.go
+++ b/azurerm/resource_arm_cognitive_account.go
@@ -53,7 +53,7 @@ func resourceArmCognitiveAccount() *schema.Resource {
 					"Bing.Speech",
 					"Bing.SpellCheck",
 					"Bing.SpellCheck.v7",
-					"CognitiveServices"
+					"CognitiveServices",
 					"ComputerVision",
 					"ContentModerator",
 					"CustomSpeech",

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `kind` - (Required) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `ComputerVision`, `ContentModerator`, `CustomSpeech`, `CustomVision.Prediction`, `CustomVision.Training`, `Emotion`, `Face`, `LUIS`, `QnAMaker`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechServices`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created.
+* `kind` - (Required) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `CognitiveServices`, `ComputerVision`, `ContentModerator`, `CustomSpeech`, `CustomVision.Prediction`, `CustomVision.Training`, `Emotion`, `Face`, `LUIS`, `QnAMaker`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechServices`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created.
 
 * `sku` - (Required) A `sku` block as defined below.
 


### PR DESCRIPTION
This PR introduces the new billing model for Cognitive Services, which requires only a single general purpose key for all services.

All Cognitive Services kinds can be listed using:
```shell
az cognitiveservices account list-kinds

[
  "AnomalyDetector",
  "Bing.Autosuggest.v7",
  "Bing.CustomSearch",
  "Bing.EntitySearch",
  "Bing.Search.v7",
  "Bing.SpellCheck.v7",
  "CognitiveServices",
  "ComputerVision",
  "ContentModerator",
  "CustomVision.Prediction",
  "CustomVision.Training",
  "Face",
  "ImmersiveReader",
  "InkRecognizer",
  "Internal.AllInOne",
  "LUIS",
  "LUIS.Authoring",
  "Personalizer",
  "QnAMaker",
  "SpeakerRecognition",
  "SpeechServices",
  "TextAnalytics",
  "TextTranslation"
]
```

The missing kind is `CognitiveServices`, which this PR proposes to add.