### PR TITLE
New Resource: `azurerm_app_service_source_control_token`

### DIFF
--- a/azurerm/internal/features/requires_import.go
+++ b/azurerm/internal/features/requires_import.go
@@ -20,7 +20,9 @@ import (
 // Operators wishing to adopt this behaviour can opt-into this behaviour in 1.x versions of the
 // Azure Provider by setting the Environment Variable 'ARM_PROVIDER_STRICT' to 'true'
 func ShouldResourcesBeImported() bool {
-	// NOTE: we'll need to add an infobox to MySQL|PostgreSQL Configuration when this goes live
+	// NOTE: we'll need to add an infobox to the following resources when this goes live:
+	// * App Service Source Control Token
+	// * MySQL|PostgreSQL Configuration
 	// since these resources can't support import
 	// in addition the virtual resources will need adjusting
 	return strings.EqualFold(os.Getenv("ARM_PROVIDER_STRICT"), "true")

--- a/azurerm/internal/services/web/client.go
+++ b/azurerm/internal/services/web/client.go
@@ -9,6 +9,7 @@ type Client struct {
 	AppServicePlansClient *web.AppServicePlansClient
 	AppServicesClient     *web.AppsClient
 	CertificatesClient    *web.CertificatesClient
+	BaseClient            *web.BaseClient
 }
 
 func BuildClient(o *common.ClientOptions) *Client {
@@ -22,9 +23,13 @@ func BuildClient(o *common.ClientOptions) *Client {
 	CertificatesClient := web.NewCertificatesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&CertificatesClient.Client, o.ResourceManagerAuthorizer)
 
+	BaseClient := web.NewWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&BaseClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		AppServicePlansClient: &AppServicePlansClient,
 		AppServicesClient:     &AppServicesClient,
 		CertificatesClient:    &CertificatesClient,
+		BaseClient:            &BaseClient,
 	}
 }

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -148,6 +148,7 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_app_service_custom_hostname_binding":                resourceArmAppServiceCustomHostnameBinding(),
 		"azurerm_app_service_plan":                                   resourceArmAppServicePlan(),
 		"azurerm_app_service_slot":                                   resourceArmAppServiceSlot(),
+		"azurerm_app_service_source_control_token":                   resourceArmAppServiceSourceControlToken(),
 		"azurerm_app_service":                                        resourceArmAppService(),
 		"azurerm_application_gateway":                                resourceArmApplicationGateway(),
 		"azurerm_application_insights_api_key":                       resourceArmApplicationInsightsAPIKey(),

--- a/azurerm/resource_arm_app_service_source_control_token.go
+++ b/azurerm/resource_arm_app_service_source_control_token.go
@@ -1,0 +1,119 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+var appServiceSourceControlTokenResourceName = "azurerm_app_service_source_control_token"
+
+func resourceArmAppServiceSourceControlToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAppServiceSourceControlTokenCreateOrUpdate,
+		Read:   resourceArmAppServiceSourceControlTokenRead,
+		Update: resourceArmAppServiceSourceControlTokenCreateOrUpdate,
+		Delete: schema.Noop,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"BitBucket",
+					"Dropbox",
+					"GitHub",
+					"OneDrive",
+				}, false),
+			},
+
+			"token": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceArmAppServiceSourceControlTokenCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).web.BaseClient
+	ctx := meta.(*ArmClient).StopContext
+
+	log.Printf("[INFO] preparing arguments for App Service Source Control Token creation.")
+
+	scmType := d.Get("type").(string)
+	token := d.Get("token").(string)
+
+	locks.ByName(scmType, appServiceSourceControlTokenResourceName)
+	defer locks.UnlockByName(scmType, appServiceSourceControlTokenResourceName)
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.GetSourceControl(ctx, scmType)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing App Service Source Control Token (Type %q): %s", scmType, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError(appServiceSourceControlTokenResourceName, *existing.ID)
+		}
+	}
+
+	properties := web.SourceControl{
+		SourceControlProperties: &web.SourceControlProperties{
+			Token: utils.String(token),
+		},
+	}
+
+	if _, err := client.UpdateSourceControl(ctx, scmType, properties); err != nil {
+		return fmt.Errorf("Error updating App Service Source Control Token (Type %q): %s", scmType, err)
+	}
+
+	read, err := client.GetSourceControl(ctx, scmType)
+	if err != nil {
+		return fmt.Errorf("Error retrieving App Service Source Control Token (Type %q): %s", scmType, err)
+	}
+	if read.Name == nil {
+		return fmt.Errorf("Cannot read App Service Source Control Token (Type %q)", scmType)
+	}
+
+	d.SetId(*read.Name)
+
+	return resourceArmAppServiceSourceControlTokenRead(d, meta)
+}
+
+func resourceArmAppServiceSourceControlTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).web.BaseClient
+	ctx := meta.(*ArmClient).StopContext
+
+	scmType := d.Id()
+
+	resp, err := client.GetSourceControl(ctx, scmType)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] App Service Source Control Token (Type %q) was not found - removing from state", scmType)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on App Service Source Control Token (Type %q): %+v", scmType, err)
+	}
+
+	d.Set("type", resp.Name)
+
+	if props := resp.SourceControlProperties; props != nil {
+		d.Set("token", props.Token)
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_app_service_source_control_token_test.go
+++ b/azurerm/resource_arm_app_service_source_control_token_test.go
@@ -14,8 +14,9 @@ import (
 func TestAccAzureRMAppServiceSourceControlToken(t *testing.T) {
 	resourceName := "azurerm_app_service_source_control_token.test"
 	token := strings.ToLower(acctest.RandString(41))
+	tokenSecret := strings.ToLower(acctest.RandString(41))
 
-	config := testAccAzureRMAppServiceSourceControlToken(token)
+	config := testAccAzureRMAppServiceSourceControlToken(token, tokenSecret)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,6 +28,7 @@ func TestAccAzureRMAppServiceSourceControlToken(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "type", "GitHub"),
 					resource.TestCheckResourceAttr(resourceName, "token", token),
+					resource.TestCheckResourceAttr(resourceName, "token_secret", tokenSecret),
 				),
 			},
 			{
@@ -38,13 +40,14 @@ func TestAccAzureRMAppServiceSourceControlToken(t *testing.T) {
 	})
 }
 
-func testAccAzureRMAppServiceSourceControlToken(token string) string {
+func testAccAzureRMAppServiceSourceControlToken(token, tokenSecret string) string {
 	return fmt.Sprintf(`
 resource "azurerm_app_service_source_control_token" "test" {
-  type  = "GitHub"
-  token = "%s"
+  type         = "GitHub"
+  token        = "%s"
+  token_secret = "%s"
 }
-`, token)
+`, token, tokenSecret)
 }
 
 func testCheckAzureRMAppServiceSourceControlTokenDestroy(s *terraform.State) error {

--- a/azurerm/resource_arm_app_service_source_control_token_test.go
+++ b/azurerm/resource_arm_app_service_source_control_token_test.go
@@ -1,0 +1,72 @@
+package azurerm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMAppServiceSourceControlToken(t *testing.T) {
+	resourceName := "azurerm_app_service_source_control_token.test"
+	token := strings.ToLower(acctest.RandString(41))
+
+	config := testAccAzureRMAppServiceSourceControlToken(token)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSourceControlTokenDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "GitHub"),
+					resource.TestCheckResourceAttr(resourceName, "token", token),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAzureRMAppServiceSourceControlToken(token string) string {
+	return fmt.Sprintf(`
+resource "azurerm_app_service_source_control_token" "test" {
+  type  = "GitHub"
+  token = "%s"
+}
+`, token)
+}
+
+func testCheckAzureRMAppServiceSourceControlTokenDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).web.BaseClient
+	ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_app_service_source_control_token" {
+			continue
+		}
+
+		scmType := rs.Primary.Attributes["type"]
+
+		resp, err := conn.GetSourceControl(ctx, scmType)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -507,6 +507,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/app_service_source_control_token.html">azurerm_app_service_source_control_token</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/function_app.html">azurerm_function_app</a>
                 </li>
               </ul>

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_source_control_token"
+sidebar_current: "docs-azurerm-resource-app-service-source-control-token"
+description: |-
+  Manages an App Service source control token.
+
+---
+
+# azurerm_app_service_source_control_token
+
+Manages an App Service source control token.
+
+## Example Usage
+
+```hcl
+resource "azurerm_app_service_source_control_token" "test" {
+  type  = "GitHub"
+  token = "7e57735e77e577e57"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `type` - (Required) The source control type. Possible values are `BitBucket`, `Dropbox`, `GitHub` and `OneDrive`.
+
+* `token` - (Required) The OAuth access token.
+
+## Import
+
+App Service source control tokens can be imported using the `type`, e.g.
+
+```shell
+terraform import azurerm_app_service_source_control_token.test GitHub
+```

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages an App Service source control token.
 
-~> **NOTE:** A source control token is global and required only once per Azure account.
+~> **NOTE:** Source Control Token's are configured at the subscription level, not on each App Service - as such this can only be configured Subscription-wide
 
 ## Example Usage
 

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages an App Service source control token.
 
+~> **NOTE:** A source control token is global and required only once per Azure account.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -30,6 +30,8 @@ The following arguments are supported:
 
 * `token` - (Required) The OAuth access token.
 
+* `token_secret` - (Optional) The OAuth access token secret.
+
 ## Import
 
 App Service source control tokens can be imported using the `type`, e.g.


### PR DESCRIPTION
Reference to #3696.

This is first of multiple pull requests to enable support for [App Service deployment](https://docs.microsoft.com/en-us/azure/app-service/deploy-continuous-deployment) in Terraform AzureRM provider. 

This adds new resource `azurerm_app_service_source_control_token` for updating source control tokens. Another way of doing this is to run the [`az webapp deployment source update-token`](https://docs.microsoft.com/en-us/cli/azure/webapp/deployment/source?view=azure-cli-latest#az-webapp-deployment-source-update-token) command.

Have not implemented `Delete` for this resource because it only supports `Update`. Users can however set `token` to empty string. 

~~Not really sure about this resource, but~~ it would be nice to manage this in Terraform. Any advice is much appreciated.
