### PR TITLE
Update monitor_metric_alert.html.markdown

### DIFF
--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Metric Alert. Changing this forces a new resource to be created.
 * `resource_group_name` - (Required) The name of the resource group in which to create the Metric Alert instance.
-* `scopes` - (Required) The resource ID at which the metric criteria should be applied.
+* `scopes` - (Required) A set of strings of resource IDs at which the metric criteria should be applied.
 * `criteria` - (Required) One or more `criteria` blocks as defined below.
 * `action` - (Optional) One or more `action` blocks as defined below.
 * `enabled` - (Optional) Should this Metric Alert be enabled? Defaults to `true`.


### PR DESCRIPTION
Scopes requires a set of strings to be passed to it. The documentation does not specify that.