### PR TITLE
correct name length for azurerm_resource_group

### DIFF
--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -47,8 +47,8 @@ func SchemaResourceGroupNameForDataSource() *schema.Schema {
 func validateResourceGroupName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 
-	if len(value) > 80 {
-		errors = append(errors, fmt.Errorf("%q may not exceed 80 characters in length", k))
+	if len(value) > 90 {
+		errors = append(errors, fmt.Errorf("%q may not exceed 90 characters in length", k))
 	}
 
 	if strings.HasSuffix(value, ".") {

--- a/azurerm/helpers/azure/resource_group_test.go
+++ b/azurerm/helpers/azure/resource_group_test.go
@@ -48,11 +48,11 @@ func TestValidateResourceGroupName(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
-			Value:    acctest.RandString(80),
+			Value:    acctest.RandString(90),
 			ErrCount: 0,
 		},
 		{
-			Value:    acctest.RandString(81),
+			Value:    acctest.RandString(91),
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
* correct length: `1-90`
* https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions

fixes #4232 