### PR TITLE
storage: switching to use SharedKey for authentication

### DIFF
--- a/azurerm/internal/authorizers/authorizer_shared_key.go
+++ b/azurerm/internal/authorizers/authorizer_shared_key.go
@@ -80,19 +80,26 @@ func computeSharedKey(verb, url string, accountName string, headers http.Header)
 }
 
 func buildCanonicalizedStringForSharedKey(verb string, headers http.Header, canonicalizedHeaders, canonicalizedResource string) string {
+	lengthString := headers.Get(HeaderContentLength)
+
+	// empty string when zero
+	if lengthString == "0" {
+		lengthString = ""
+	}
+
 	return strings.Join([]string{
-		verb,
-		"",
-		"",
-		"",
-		headers.Get(HeaderContentMD5),
-		headers.Get(HeaderContentType),
-		"", // date should be nil, apparently :shrug:
-		"",
-		"",
-		"",
-		"",
-		"",
+		verb,                           // HTTP Verb
+		"",                             // Content-Encoding
+		"",                             // Content-Language
+		lengthString,                   // Content-Length (empty string when zero)
+		headers.Get(HeaderContentMD5),  // Content-MD5
+		headers.Get(HeaderContentType), // Content-Type
+		"",                             // date should be nil, apparently :shrug:
+		"",                             // If-Modified-Since
+		"",                             // If-Match
+		"",                             // If-None-Match
+		"",                             // If-Unmodified-Since
+		"",                             // Range
 		canonicalizedHeaders,
 		canonicalizedResource,
 	}, "\n")

--- a/azurerm/internal/authorizers/authorizer_shared_key.go
+++ b/azurerm/internal/authorizers/authorizer_shared_key.go
@@ -88,18 +88,18 @@ func buildCanonicalizedStringForSharedKey(verb string, headers http.Header, cano
 	}
 
 	return strings.Join([]string{
-		verb,                           // HTTP Verb
-		"",                             // Content-Encoding
-		"",                             // Content-Language
-		lengthString,                   // Content-Length (empty string when zero)
-		headers.Get(HeaderContentMD5),  // Content-MD5
-		headers.Get(HeaderContentType), // Content-Type
-		"",                             // date should be nil, apparently :shrug:
-		"",                             // If-Modified-Since
-		"",                             // If-Match
-		"",                             // If-None-Match
-		"",                             // If-Unmodified-Since
-		"",                             // Range
+		verb,                                 // HTTP Verb
+		headers.Get(HeaderContentEncoding),   // Content-Encoding
+		headers.Get(HeaderContentLanguage),   // Content-Language
+		lengthString,                         // Content-Length (empty string when zero)
+		headers.Get(HeaderContentMD5),        // Content-MD5
+		headers.Get(HeaderContentType),       // Content-Type
+		"",                                   // date should be nil, apparently :shrug:
+		headers.Get(HeaderIfModifiedSince),   // If-Modified-Since
+		headers.Get(HeaderIfMatch),           // If-Match
+		headers.Get(HeaderIfNoneMatch),       // If-None-Match
+		headers.Get(HeaderIfUnmodifiedSince), // If-Unmodified-Since
+		headers.Get(HeaderRange),             // Range
 		canonicalizedHeaders,
 		canonicalizedResource,
 	}, "\n")

--- a/azurerm/internal/authorizers/authorizer_shared_key_lite.go
+++ b/azurerm/internal/authorizers/authorizer_shared_key_lite.go
@@ -81,7 +81,7 @@ func computeSharedKeyLite(verb, url string, accountName string, headers http.Hea
 func buildCanonicalizedStringForSharedKeyLite(verb string, headers http.Header, canonicalizedHeaders, canonicalizedResource string) string {
 	return strings.Join([]string{
 		verb,
-		headers.Get(HeaderContentMD5), // TODO: this appears to always be empty?
+		headers.Get(HeaderContentMD5),
 		headers.Get(HeaderContentType),
 		"", // date should be nil, apparently :shrug:
 		canonicalizedHeaders,

--- a/azurerm/internal/authorizers/authorizer_shared_key_lite_table.go
+++ b/azurerm/internal/authorizers/authorizer_shared_key_lite_table.go
@@ -70,7 +70,7 @@ func buildSharedKeyLiteTable(accountName, storageAccountKey string, r *http.Requ
 // NOTE: this function assumes that the `x-ms-date` field is set
 func computeSharedKeyLiteTable(url string, accountName string, headers http.Header) (*string, error) {
 	dateHeader := headers.Get("x-ms-date")
-	canonicalizedResource, err := buildCanonicalizedResource(url, accountName)
+	canonicalizedResource, err := buildCanonicalizedResource(url, accountName, true)
 	if err != nil {
 		return nil, err
 	}

--- a/azurerm/internal/authorizers/helpers.go
+++ b/azurerm/internal/authorizers/helpers.go
@@ -48,7 +48,7 @@ func buildCanonicalizedHeader(headers http.Header) string {
 }
 
 // buildCanonicalizedResource builds the Canonical Resource required for to sign Storage Account requests
-func buildCanonicalizedResource(uri, accountName string) (*string, error) {
+func buildCanonicalizedResource(uri, accountName string, sharedKeyLite bool) (*string, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
@@ -67,9 +67,36 @@ func buildCanonicalizedResource(uri, accountName string) (*string, error) {
 		cr.WriteString(u.EscapedPath())
 	}
 
-	// TODO: replace this with less of a hack
-	if comp := u.Query().Get("comp"); comp != "" {
-		cr.WriteString(fmt.Sprintf("?comp=%s", comp))
+	if sharedKeyLite {
+		if comp := u.Query().Get("comp"); comp != "" {
+			cr.WriteString(fmt.Sprintf("?comp=%s", comp))
+		}
+	} else {
+		// Convert all parameter names to lowercase.
+		// URL-decode each query parameter name and value.
+		// Sort the query parameters lexicographically by parameter name, in ascending order.
+		keys := make([]string, 0)
+		keysWithValues := make(map[string]string, len(u.Query()))
+		for k, unsortedValues := range u.Query() {
+			key := strings.ToLower(k)
+			keys = append(keys, key)
+
+			// If a query parameter has more than one value, sort all values lexicographically, then include them in a comma-separated list:
+			sortedValues := make([]string, 0)
+			for _, value := range unsortedValues {
+				sortedValues = append(sortedValues, value)
+			}
+			sort.Strings(sortedValues)
+			keysWithValues[key] = strings.Join(sortedValues, ",")
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			values := keysWithValues[key]
+			// Include a new-line character (\n) before each name-value pair.
+			// Append each query parameter name and value to the string in the following format, making sure to include the colon (:) between the name and the value
+			cr.WriteString(fmt.Sprintf("\n%s:%s", key, values))
+		}
 	}
 
 	out := cr.String()

--- a/azurerm/internal/authorizers/helpers.go
+++ b/azurerm/internal/authorizers/helpers.go
@@ -83,9 +83,7 @@ func buildCanonicalizedResource(uri, accountName string, sharedKeyLite bool) (*s
 
 			// If a query parameter has more than one value, sort all values lexicographically, then include them in a comma-separated list:
 			sortedValues := make([]string, 0)
-			for _, value := range unsortedValues {
-				sortedValues = append(sortedValues, value)
-			}
+			sortedValues = append(sortedValues, unsortedValues...)
 			sort.Strings(sortedValues)
 			keysWithValues[key] = strings.Join(sortedValues, ",")
 		}

--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -41,7 +41,7 @@ func (client Client) BlobsClient(ctx context.Context, resourceGroup, accountName
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
 	blobsClient := blobs.NewWithEnvironment(client.environment)
 	blobsClient.Client.Authorizer = storageAuth
 	return &blobsClient, nil
@@ -53,7 +53,7 @@ func (client Client) ContainersClient(ctx context.Context, resourceGroup, accoun
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
 	containersClient := containers.NewWithEnvironment(client.environment)
 	containersClient.Client.Authorizer = storageAuth
 	return &containersClient, nil
@@ -65,7 +65,7 @@ func (client Client) FileShareDirectoriesClient(ctx context.Context, resourceGro
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
 	directoriesClient := directories.NewWithEnvironment(client.environment)
 	directoriesClient.Client.Authorizer = storageAuth
 	return &directoriesClient, nil
@@ -77,7 +77,7 @@ func (client Client) FileSharesClient(ctx context.Context, resourceGroup, accoun
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
 	directoriesClient := shares.NewWithEnvironment(client.environment)
 	directoriesClient.Client.Authorizer = storageAuth
 	return &directoriesClient, nil
@@ -89,7 +89,7 @@ func (client Client) QueuesClient(ctx context.Context, resourceGroup, accountNam
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
 	queuesClient := queues.NewWithEnvironment(client.environment)
 	queuesClient.Client.Authorizer = storageAuth
 	return &queuesClient, nil

--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -41,7 +41,7 @@ func (client Client) BlobsClient(ctx context.Context, resourceGroup, accountName
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
 	blobsClient := blobs.NewWithEnvironment(client.environment)
 	blobsClient.Client.Authorizer = storageAuth
 	return &blobsClient, nil

--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -89,7 +89,7 @@ func (client Client) QueuesClient(ctx context.Context, resourceGroup, accountNam
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
 	queuesClient := queues.NewWithEnvironment(client.environment)
 	queuesClient.Client.Authorizer = storageAuth
 	return &queuesClient, nil

--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -41,7 +41,7 @@ func (client Client) BlobsClient(ctx context.Context, resourceGroup, accountName
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
 	blobsClient := blobs.NewWithEnvironment(client.environment)
 	blobsClient.Client.Authorizer = storageAuth
 	return &blobsClient, nil

--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -65,7 +65,7 @@ func (client Client) FileShareDirectoriesClient(ctx context.Context, resourceGro
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
 	directoriesClient := directories.NewWithEnvironment(client.environment)
 	directoriesClient.Client.Authorizer = storageAuth
 	return &directoriesClient, nil
@@ -77,7 +77,7 @@ func (client Client) FileSharesClient(ctx context.Context, resourceGroup, accoun
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
 	directoriesClient := shares.NewWithEnvironment(client.environment)
 	directoriesClient.Client.Authorizer = storageAuth
 	return &directoriesClient, nil

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/satori/uuid v0.0.0-20160927100844-b061729afc07
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/terraform-providers/terraform-provider-azuread v0.6.0
-	github.com/tombuildsstuff/giovanni v0.4.0
+	github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190502183928-7f726cade0ab
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/satori/uuid v0.0.0-20160927100844-b061729afc07
 	github.com/sirupsen/logrus v1.2.0 // indirect
 	github.com/terraform-providers/terraform-provider-azuread v0.6.0
-	github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a
+	github.com/tombuildsstuff/giovanni v0.5.0
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190502183928-7f726cade0ab
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,10 @@ github.com/tombuildsstuff/giovanni v0.3.3-0.20190823094657-ff85ec2ac5d5 h1:M5CRm
 github.com/tombuildsstuff/giovanni v0.3.3-0.20190823094657-ff85ec2ac5d5/go.mod h1:3UHcoRZCvWTjXMWCJ0epD1VROlPMwZeeof3vfP6NiWM=
 github.com/tombuildsstuff/giovanni v0.4.0 h1:MHJuSqcRkYqoNMIBpOjn3ljwAmABR5GPmtFH11bm/Vo=
 github.com/tombuildsstuff/giovanni v0.4.0/go.mod h1:Xu/XU+DiRrKTDoCnJNGuh9ysD0eJyi/zU/naFh2aN9I=
+github.com/tombuildsstuff/giovanni v0.4.1-0.20190903215726-2cef302b48fa h1:s49bFLgKvyf4HH+3Hk1Lfa1wuTmJ/0PQW9Jbhi3mgTw=
+github.com/tombuildsstuff/giovanni v0.4.1-0.20190903215726-2cef302b48fa/go.mod h1:Xu/XU+DiRrKTDoCnJNGuh9ysD0eJyi/zU/naFh2aN9I=
+github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a h1:Ucv3t1V9CERUzQTmdjzzgPnA0oRIdc+WYfry6BaL3P0=
+github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a/go.mod h1:Xu/XU+DiRrKTDoCnJNGuh9ysD0eJyi/zU/naFh2aN9I=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5 h1:cMjKdf4PxEBN9K5HaD9UMW8gkTbM0kMzkTa9SJe0WNQ=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/go.sum
+++ b/go.sum
@@ -515,6 +515,8 @@ github.com/tombuildsstuff/giovanni v0.4.1-0.20190903215726-2cef302b48fa h1:s49bF
 github.com/tombuildsstuff/giovanni v0.4.1-0.20190903215726-2cef302b48fa/go.mod h1:Xu/XU+DiRrKTDoCnJNGuh9ysD0eJyi/zU/naFh2aN9I=
 github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a h1:Ucv3t1V9CERUzQTmdjzzgPnA0oRIdc+WYfry6BaL3P0=
 github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a/go.mod h1:Xu/XU+DiRrKTDoCnJNGuh9ysD0eJyi/zU/naFh2aN9I=
+github.com/tombuildsstuff/giovanni v0.5.0 h1:ih4qTvjOOAHubTdINDWtrTpHyHNzrqam4xcIWQY9A1A=
+github.com/tombuildsstuff/giovanni v0.5.0/go.mod h1:Xu/XU+DiRrKTDoCnJNGuh9ysD0eJyi/zU/naFh2aN9I=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5 h1:cMjKdf4PxEBN9K5HaD9UMW8gkTbM0kMzkTa9SJe0WNQ=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/clusters.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/clusters.go
@@ -111,8 +111,8 @@ func (client ClustersClient) CheckNameAvailabilityPreparer(ctx context.Context, 
 // CheckNameAvailabilitySender sends the CheckNameAvailability request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) CheckNameAvailabilitySender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // CheckNameAvailabilityResponder handles the response to the CheckNameAvailability request. The method always
@@ -192,9 +192,9 @@ func (client ClustersClient) CreateOrUpdatePreparer(ctx context.Context, resourc
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) CreateOrUpdateSender(req *http.Request) (future ClustersCreateOrUpdateFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -269,9 +269,9 @@ func (client ClustersClient) DeletePreparer(ctx context.Context, resourceGroupNa
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) DeleteSender(req *http.Request) (future ClustersDeleteFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -351,8 +351,8 @@ func (client ClustersClient) GetPreparer(ctx context.Context, resourceGroupName 
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) GetSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -423,8 +423,8 @@ func (client ClustersClient) ListPreparer(ctx context.Context) (*http.Request, e
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) ListSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListResponder handles the response to the List request. The method always
@@ -498,8 +498,8 @@ func (client ClustersClient) ListByResourceGroupPreparer(ctx context.Context, re
 // ListByResourceGroupSender sends the ListByResourceGroup request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) ListByResourceGroupSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListByResourceGroupResponder handles the response to the ListByResourceGroup request. The method always
@@ -570,8 +570,8 @@ func (client ClustersClient) ListSkusPreparer(ctx context.Context) (*http.Reques
 // ListSkusSender sends the ListSkus request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) ListSkusSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListSkusResponder handles the response to the ListSkus request. The method always
@@ -647,8 +647,8 @@ func (client ClustersClient) ListSkusByResourcePreparer(ctx context.Context, res
 // ListSkusByResourceSender sends the ListSkusByResource request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) ListSkusByResourceSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListSkusByResourceResponder handles the response to the ListSkusByResource request. The method always
@@ -718,9 +718,9 @@ func (client ClustersClient) StartPreparer(ctx context.Context, resourceGroupNam
 // StartSender sends the Start request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) StartSender(req *http.Request) (future ClustersStartFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -794,9 +794,9 @@ func (client ClustersClient) StopPreparer(ctx context.Context, resourceGroupName
 // StopSender sends the Stop request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) StopSender(req *http.Request) (future ClustersStopFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -873,9 +873,9 @@ func (client ClustersClient) UpdatePreparer(ctx context.Context, resourceGroupNa
 // UpdateSender sends the Update request. The method will close the
 // http.Response Body if it receives an error.
 func (client ClustersClient) UpdateSender(req *http.Request) (future ClustersUpdateFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/databases.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/databases.go
@@ -108,8 +108,8 @@ func (client DatabasesClient) AddPrincipalsPreparer(ctx context.Context, resourc
 // AddPrincipalsSender sends the AddPrincipals request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) AddPrincipalsSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // AddPrincipalsResponder handles the response to the AddPrincipals request. The method always
@@ -195,8 +195,8 @@ func (client DatabasesClient) CheckNameAvailabilityPreparer(ctx context.Context,
 // CheckNameAvailabilitySender sends the CheckNameAvailability request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) CheckNameAvailabilitySender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // CheckNameAvailabilityResponder handles the response to the CheckNameAvailability request. The method always
@@ -271,9 +271,9 @@ func (client DatabasesClient) CreateOrUpdatePreparer(ctx context.Context, resour
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) CreateOrUpdateSender(req *http.Request) (future DatabasesCreateOrUpdateFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -350,9 +350,9 @@ func (client DatabasesClient) DeletePreparer(ctx context.Context, resourceGroupN
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) DeleteSender(req *http.Request) (future DatabasesDeleteFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -434,8 +434,8 @@ func (client DatabasesClient) GetPreparer(ctx context.Context, resourceGroupName
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) GetSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -511,8 +511,8 @@ func (client DatabasesClient) ListByClusterPreparer(ctx context.Context, resourc
 // ListByClusterSender sends the ListByCluster request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) ListByClusterSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListByClusterResponder handles the response to the ListByCluster request. The method always
@@ -590,8 +590,8 @@ func (client DatabasesClient) ListPrincipalsPreparer(ctx context.Context, resour
 // ListPrincipalsSender sends the ListPrincipals request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) ListPrincipalsSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListPrincipalsResponder handles the response to the ListPrincipals request. The method always
@@ -672,8 +672,8 @@ func (client DatabasesClient) RemovePrincipalsPreparer(ctx context.Context, reso
 // RemovePrincipalsSender sends the RemovePrincipals request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) RemovePrincipalsSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // RemovePrincipalsResponder handles the response to the RemovePrincipals request. The method always
@@ -748,9 +748,9 @@ func (client DatabasesClient) UpdatePreparer(ctx context.Context, resourceGroupN
 // UpdateSender sends the Update request. The method will close the
 // http.Response Body if it receives an error.
 func (client DatabasesClient) UpdateSender(req *http.Request) (future DatabasesUpdateFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/dataconnections.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/dataconnections.go
@@ -115,8 +115,8 @@ func (client DataConnectionsClient) CheckNameAvailabilityPreparer(ctx context.Co
 // CheckNameAvailabilitySender sends the CheckNameAvailability request. The method will close the
 // http.Response Body if it receives an error.
 func (client DataConnectionsClient) CheckNameAvailabilitySender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // CheckNameAvailabilityResponder handles the response to the CheckNameAvailability request. The method always
@@ -193,9 +193,9 @@ func (client DataConnectionsClient) CreateOrUpdatePreparer(ctx context.Context, 
 // CreateOrUpdateSender sends the CreateOrUpdate request. The method will close the
 // http.Response Body if it receives an error.
 func (client DataConnectionsClient) CreateOrUpdateSender(req *http.Request) (future DataConnectionsCreateOrUpdateFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -281,8 +281,8 @@ func (client DataConnectionsClient) DataConnectionValidationMethodPreparer(ctx c
 // DataConnectionValidationMethodSender sends the DataConnectionValidationMethod request. The method will close the
 // http.Response Body if it receives an error.
 func (client DataConnectionsClient) DataConnectionValidationMethodSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // DataConnectionValidationMethodResponder handles the response to the DataConnectionValidationMethod request. The method always
@@ -356,9 +356,9 @@ func (client DataConnectionsClient) DeletePreparer(ctx context.Context, resource
 // DeleteSender sends the Delete request. The method will close the
 // http.Response Body if it receives an error.
 func (client DataConnectionsClient) DeleteSender(req *http.Request) (future DataConnectionsDeleteFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}
@@ -442,8 +442,8 @@ func (client DataConnectionsClient) GetPreparer(ctx context.Context, resourceGro
 // GetSender sends the Get request. The method will close the
 // http.Response Body if it receives an error.
 func (client DataConnectionsClient) GetSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // GetResponder handles the response to the Get request. The method always
@@ -521,8 +521,8 @@ func (client DataConnectionsClient) ListByDatabasePreparer(ctx context.Context, 
 // ListByDatabaseSender sends the ListByDatabase request. The method will close the
 // http.Response Body if it receives an error.
 func (client DataConnectionsClient) ListByDatabaseSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListByDatabaseResponder handles the response to the ListByDatabase request. The method always
@@ -599,9 +599,9 @@ func (client DataConnectionsClient) UpdatePreparer(ctx context.Context, resource
 // UpdateSender sends the Update request. The method will close the
 // http.Response Body if it receives an error.
 func (client DataConnectionsClient) UpdateSender(req *http.Request) (future DataConnectionsUpdateFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
 	var resp *http.Response
-	resp, err = autorest.SendWithSender(client, req,
-		azure.DoRetryWithRegistration(client.Client))
+	resp, err = autorest.SendWithSender(client, req, sd...)
 	if err != nil {
 		return
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/operations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto/operations.go
@@ -94,8 +94,8 @@ func (client OperationsClient) ListPreparer(ctx context.Context) (*http.Request,
 // ListSender sends the List request. The method will close the
 // http.Response Body if it receives an error.
 func (client OperationsClient) ListSender(req *http.Request) (*http.Response, error) {
-	return autorest.SendWithSender(client, req,
-		autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	sd := autorest.GetSendDecorators(req.Context(), autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	return autorest.SendWithSender(client, req, sd...)
 }
 
 // ListResponder handles the response to the List request. The method always

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/append_block.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/append_block.go
@@ -122,6 +122,9 @@ func (client Client) AppendBlockPreparer(ctx context.Context, accountName, conta
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	decorators := []autorest.PrepareDecorator{
 		autorest.AsPut(),

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/put_block.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/put_block.go
@@ -80,7 +80,8 @@ func (client Client) PutBlockPreparer(ctx context.Context, accountName, containe
 	}
 
 	headers := map[string]interface{}{
-		"x-ms-version": APIVersion,
+		"x-ms-version":   APIVersion,
+		"Content-Length": int(len(input.Content)),
 	}
 
 	if input.ContentMD5 != nil {

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/put_block_blob.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/put_block_blob.go
@@ -102,6 +102,9 @@ func (client Client) PutBlockBlobPreparer(ctx context.Context, accountName, cont
 	if input.LeaseID != nil {
 		headers["x-ms-lease-id"] = *input.LeaseID
 	}
+	if input.Content != nil {
+		headers["Content-Length"] = int(len(*input.Content))
+	}
 
 	headers = metadata.SetIntoHeaders(headers, input.MetaData)
 

--- a/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/put_page_update.go
+++ b/vendor/github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs/put_page_update.go
@@ -99,6 +99,7 @@ func (client Client) PutPageUpdatePreparer(ctx context.Context, accountName, con
 		"x-ms-version":    APIVersion,
 		"x-ms-page-write": "update",
 		"x-ms-range":      fmt.Sprintf("bytes=%d-%d", input.StartByte, input.EndByte),
+		"Content-Length":  int(len(input.Content)),
 	}
 
 	if input.LeaseID != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -328,7 +328,7 @@ github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/slices
 github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/tf
 github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate
 github.com/terraform-providers/terraform-provider-azuread/version
-# github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a
+# github.com/tombuildsstuff/giovanni v0.5.0
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/file/directories

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,6 +30,7 @@ github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub
 github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac
 github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault
 github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault
+github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto
 github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2016-06-01/logic
 github.com/Azure/azure-sdk-for-go/services/maps/mgmt/2018-05-01/maps
 github.com/Azure/azure-sdk-for-go/services/mariadb/mgmt/2018-06-01/mariadb
@@ -72,7 +73,6 @@ github.com/Azure/azure-sdk-for-go/services/streamanalytics/mgmt/2016-03-01/strea
 github.com/Azure/azure-sdk-for-go/services/trafficmanager/mgmt/2018-04-01/trafficmanager
 github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web
 github.com/Azure/azure-sdk-for-go/storage
-github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2019-01-21/kusto
 github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/subscriptions
 github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2016-02-01/resources
 github.com/Azure/azure-sdk-for-go/version
@@ -328,7 +328,7 @@ github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/slices
 github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/tf
 github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate
 github.com/terraform-providers/terraform-provider-azuread/version
-# github.com/tombuildsstuff/giovanni v0.4.0
+# github.com/tombuildsstuff/giovanni v0.4.1-0.20190904054847-5e2f814cba5a
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers
 github.com/tombuildsstuff/giovanni/storage/2018-11-09/file/directories


### PR DESCRIPTION
This PR switches the Blobs and Containers Clients over to using SharedKey rather than SharedKeyLite for authentication, which fixes uploading data using a premium storage account. This PR also adds some additional test cases in this area