### PR TITLE
r/storage_blob: support for `access_tier`, append blobs and `source_content`

### DIFF
--- a/azurerm/internal/services/storage/blobs.go
+++ b/azurerm/internal/services/storage/blobs.go
@@ -65,9 +65,8 @@ func (sbu BlobUpload) Create(ctx context.Context) error {
 		if sbu.SourceUri != "" {
 			return sbu.copy(ctx)
 		}
-
 		if sbu.SourceContent != "" {
-			return sbu.uploadPageBlobFromContent(ctx)
+			return fmt.Errorf("`source_content` cannot be specified for a Page blob")
 		}
 		if sbu.Source != "" {
 			return sbu.uploadPageBlob(ctx)
@@ -164,22 +163,6 @@ func (sbu BlobUpload) createEmptyPageBlob(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (sbu BlobUpload) uploadPageBlobFromContent(ctx context.Context) error {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "upload-")
-	if err != nil {
-		return fmt.Errorf("Error creating temporary file: %s", err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err = tmpFile.Write([]byte(sbu.SourceContent)); err != nil {
-		return fmt.Errorf("Error writing Source Content to Temp File: %s", err)
-	}
-	defer tmpFile.Close()
-
-	sbu.Source = tmpFile.Name()
-	return sbu.uploadPageBlob(ctx)
 }
 
 func (sbu BlobUpload) uploadPageBlob(ctx context.Context) error {

--- a/azurerm/internal/services/storage/blobs.go
+++ b/azurerm/internal/services/storage/blobs.go
@@ -40,7 +40,9 @@ func (sbu BlobUpload) Create(ctx context.Context) error {
 
 	blobType := strings.ToLower(sbu.BlobType)
 
-	// TODO: new feature for 'append' blobs?
+	if blobType == "append" {
+		return sbu.createEmptyAppendBlob(ctx)
+	}
 
 	if blobType == "block" {
 		if sbu.Source != "" {
@@ -68,6 +70,18 @@ func (sbu BlobUpload) copy(ctx context.Context) error {
 	}
 	if err := sbu.Client.CopyAndWait(ctx, sbu.AccountName, sbu.ContainerName, sbu.BlobName, input, pollingInterval); err != nil {
 		return fmt.Errorf("Error copy/waiting: %s", err)
+	}
+
+	return nil
+}
+
+func (sbu BlobUpload) createEmptyAppendBlob(ctx context.Context) error {
+	input := blobs.PutAppendBlobInput{
+		ContentType: utils.String(sbu.ContentType),
+		MetaData:    sbu.MetaData,
+	}
+	if _, err := sbu.Client.PutAppendBlob(ctx, sbu.AccountName, sbu.ContainerName, sbu.BlobName, input); err != nil {
+		return fmt.Errorf("Error PutAppendBlob: %s", err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -51,10 +51,14 @@ func resourceArmStorageBlob() *schema.Resource {
 			},
 
 			"type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"block", "page"}, true),
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"append",
+					"block",
+					"page",
+				}, true),
 			},
 
 			"size": {

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -53,7 +53,7 @@ func resourceArmStorageBlob() *schema.Resource {
 
 			"type": {
 				Type:             schema.TypeString,
-				Optional:         true,
+				Required:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: suppress.CaseDifference, // TODO: remove in 2.0
 				ValidateFunc: validation.StringInSlice([]string{

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
 )
 
-// TODO: with the new SDK: changing the Tier of Blobs
-
 func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
 	resourceName := "azurerm_storage_blob.test"
 	ri := tf.AccRandTimeInt()
@@ -145,6 +143,48 @@ func TestAccAzureRMStorageBlob_blockEmptyMetaData(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "type"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStorageBlob_blockEmptyAccessTier(t *testing.T) {
+	resourceName := "azurerm_storage_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageBlob_blockEmptyAccessTier(ri, rs, location, blobs.Cool),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageBlobExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_tier", "Cool"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "type"},
+			},
+			{
+				Config: testAccAzureRMStorageBlob_blockEmptyAccessTier(ri, rs, location, blobs.Hot),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageBlobExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_tier", "Hot"),
+				),
+			},
+			{
+				Config: testAccAzureRMStorageBlob_blockEmptyAccessTier(ri, rs, location, blobs.Cool),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageBlobExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "access_tier", "Cool"),
+				),
 			},
 		},
 	})
@@ -802,6 +842,22 @@ resource "azurerm_storage_blob" "test" {
 `, template)
 }
 
+func testAccAzureRMStorageBlob_blockEmptyAccessTier(rInt int, rString string, location string, accessTier blobs.AccessTier) string {
+	template := testAccAzureRMStorageBlob_templateBlockBlobStorage(rInt, rString, location, "private")
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "example.vhd"
+  resource_group_name    = "${azurerm_resource_group.test.name}"
+  storage_account_name   = "${azurerm_storage_account.test.name}"
+  storage_container_name = "${azurerm_storage_container.test.name}"
+  type                   = "block"
+  access_tier            = "%s"
+}
+`, template, string(accessTier))
+}
+
 func testAccAzureRMStorageBlob_blockFromPublicBlob(rInt int, rString, location string) string {
 	template := testAccAzureRMStorageBlob_template(rInt, rString, location, "blob")
 	return fmt.Sprintf(`
@@ -1088,6 +1144,31 @@ resource "azurerm_storage_blob" "import" {
   size                   = "${azurerm_storage_blob.test.size}"
 }
 `, template)
+}
+
+func testAccAzureRMStorageBlob_templateBlockBlobStorage(rInt int, rString, location, accessLevel string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "test"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "%s"
+}
+`, rInt, location, rString, accessLevel)
 }
 
 func testAccAzureRMStorageBlob_update(rInt int, rString, location string) string {

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -509,33 +509,6 @@ func TestAccAzureRMStorageBlob_pageFromExistingBlob(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMStorageBlob_pageFromInlineContent(t *testing.T) {
-	resourceName := "azurerm_storage_blob.test"
-	ri := tf.AccRandTimeInt()
-	rs := strings.ToLower(acctest.RandString(11))
-	location := testLocation()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMStorageBlob_pageFromInlineContent(ri, rs, location),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageBlobExists(resourceName),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "source_content", "type"},
-			},
-		},
-	})
-}
-
 func TestAccAzureRMStorageBlob_pageFromLocalFile(t *testing.T) {
 	sourceBlob, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -1148,22 +1121,6 @@ resource "azurerm_storage_blob" "test" {
   type                   = "page"
   source_uri             = "${azurerm_storage_blob.source.id}"
   content_type           = "${azurerm_storage_blob.source.content_type}"
-}
-`, template)
-}
-
-func testAccAzureRMStorageBlob_pageFromInlineContent(rInt int, rString, location string) string {
-	template := testAccAzureRMStorageBlob_template(rInt, rString, location, "private")
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_storage_blob" "test" {
-  name                   = "rick.morty"
-  resource_group_name    = "${azurerm_resource_group.test.name}"
-  storage_account_name   = "${azurerm_storage_account.test.name}"
-  storage_container_name = "${azurerm_storage_container.test.name}"
-  type                   = "page"
-  source_content         = "Wubba Lubba Dub Dub"
 }
 `, template)
 }

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -17,9 +17,7 @@ import (
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/blobs"
 )
 
-// TODO: with the new SDK: changing the Tier of Blobs. Content type for Block blobs
-
-var supportsNewStorageFeatures = false
+// TODO: with the new SDK: changing the Tier of Blobs
 
 func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
 	resourceName := "azurerm_storage_blob.test"
@@ -45,10 +43,6 @@ func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
 }
 
 func TestAccAzureRMStorageBlob_appendEmpty(t *testing.T) {
-	if !supportsNewStorageFeatures {
-		t.Skip("Resource doesn't support Append Blobs Yet..")
-	}
-
 	resourceName := "azurerm_storage_blob.test"
 	ri := tf.AccRandTimeInt()
 	rs := strings.ToLower(acctest.RandString(11))
@@ -76,10 +70,6 @@ func TestAccAzureRMStorageBlob_appendEmpty(t *testing.T) {
 }
 
 func TestAccAzureRMStorageBlob_appendEmptyMetaData(t *testing.T) {
-	if !supportsNewStorageFeatures {
-		t.Skip("Resource doesn't support Append Blobs Yet..")
-	}
-
 	resourceName := "azurerm_storage_blob.test"
 	ri := tf.AccRandTimeInt()
 	rs := strings.ToLower(acctest.RandString(11))
@@ -520,10 +510,6 @@ func TestAccAzureRMStorageBlob_requiresImport(t *testing.T) {
 }
 
 func TestAccAzureRMStorageBlob_update(t *testing.T) {
-	if !supportsNewStorageFeatures {
-		t.Skip("Current implementation doesn't support updating the Content Type..")
-	}
-
 	resourceName := "azurerm_storage_blob.test"
 	ri := tf.AccRandTimeInt()
 	rs := strings.ToLower(acctest.RandString(11))

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -190,6 +190,33 @@ func TestAccAzureRMStorageBlob_blockEmptyAccessTier(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageBlob_blockFromInlineContent(t *testing.T) {
+	resourceName := "azurerm_storage_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageBlob_blockFromInlineContent(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageBlobExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "source_content", "type"},
+			},
+		},
+	})
+}
+
 func TestAccAzureRMStorageBlob_blockFromPublicBlob(t *testing.T) {
 	resourceName := "azurerm_storage_blob.test"
 	ri := tf.AccRandTimeInt()
@@ -477,6 +504,33 @@ func TestAccAzureRMStorageBlob_pageFromExistingBlob(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "source_uri", "type"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMStorageBlob_pageFromInlineContent(t *testing.T) {
+	resourceName := "azurerm_storage_blob.test"
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageBlob_pageFromInlineContent(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageBlobExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"attempts", "parallelism", "size", "source_content", "type"},
 			},
 		},
 	})
@@ -858,6 +912,22 @@ resource "azurerm_storage_blob" "test" {
 `, template, string(accessTier))
 }
 
+func testAccAzureRMStorageBlob_blockFromInlineContent(rInt int, rString, location string) string {
+	template := testAccAzureRMStorageBlob_template(rInt, rString, location, "blob")
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "rick.morty"
+  resource_group_name    = "${azurerm_resource_group.test.name}"
+  storage_account_name   = "${azurerm_storage_account.test.name}"
+  storage_container_name = "${azurerm_storage_container.test.name}"
+  type                   = "block"
+  source_content         = "Wubba Lubba Dub Dub"
+}
+`, template)
+}
+
 func testAccAzureRMStorageBlob_blockFromPublicBlob(rInt int, rString, location string) string {
 	template := testAccAzureRMStorageBlob_template(rInt, rString, location, "blob")
 	return fmt.Sprintf(`
@@ -1078,6 +1148,22 @@ resource "azurerm_storage_blob" "test" {
   type                   = "page"
   source_uri             = "${azurerm_storage_blob.source.id}"
   content_type           = "${azurerm_storage_blob.source.content_type}"
+}
+`, template)
+}
+
+func testAccAzureRMStorageBlob_pageFromInlineContent(rInt int, rString, location string) string {
+	template := testAccAzureRMStorageBlob_template(rInt, rString, location, "private")
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_blob" "test" {
+  name                   = "rick.morty"
+  resource_group_name    = "${azurerm_resource_group.test.name}"
+  storage_account_name   = "${azurerm_storage_account.test.name}"
+  storage_container_name = "${azurerm_storage_container.test.name}"
+  type                   = "page"
+  source_content         = "Wubba Lubba Dub Dub"
 }
 `, template)
 }

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -1232,31 +1232,6 @@ resource "azurerm_storage_blob" "import" {
 `, template)
 }
 
-func testAccAzureRMStorageBlob_templateBlockBlobStorage(rInt int, rString, location, accessLevel string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_storage_account" "test" {
-  name                     = "acctestacc%s"
-  resource_group_name      = "${azurerm_resource_group.test.name}"
-  location                 = "${azurerm_resource_group.test.location}"
-  account_kind             = "StorageV2"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-}
-
-resource "azurerm_storage_container" "test" {
-  name                  = "test"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
-  storage_account_name  = "${azurerm_storage_account.test.name}"
-  container_access_type = "%s"
-}
-`, rInt, location, rString, accessLevel)
-}
-
 func testAccAzureRMStorageBlob_update(rInt int, rString, location string) string {
 	template := testAccAzureRMStorageBlob_template(rInt, rString, location, "private")
 	return fmt.Sprintf(`
@@ -1309,6 +1284,31 @@ resource "azurerm_storage_account" "test" {
   name                     = "acctestacc%s"
   resource_group_name      = "${azurerm_resource_group.test.name}"
   location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "test"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "%s"
+}
+`, rInt, location, rString, accessLevel)
+}
+
+func testAccAzureRMStorageBlob_templateBlockBlobStorage(rInt int, rString, location, accessLevel string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_kind             = "StorageV2"
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -58,14 +58,16 @@ The following arguments are supported:
 
 * `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0.
 
-* `access_tier` - (Optional) The access tier of the storage blob. Possible values are `Archive`, `Cool` and `Hot`. Defaults to `Hot`.
+* `access_tier` - (Optional) The access tier of the storage blob. Possible values are `Archive`, `Cool` and `Hot`.
 
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
 
-* `source` - (Optional) An absolute path to a file on the local system. Cannot be defined if `source_uri` is defined.
+* `source` - (Optional) An absolute path to a file on the local system. Cannot be specified if `source_content` or `source_uri` is specified.
+
+* `source_content` - (Optional) The content for this blob which should be defined inline. Cannot be specified if `source` or `source_uri` is specified.
 
 * `source_uri` - (Optional) The URI of an existing blob, or a file in the Azure File service, to use as the source contents
-    for the blob to be created. Changing this forces a new resource to be created. Cannot be defined if `source` is defined.
+    for the blob to be created. Changing this forces a new resource to be created. Cannot be specified if `source` or `source_content` is specified.
 
 * `parallelism` - (Optional) The number of workers per CPU core to run for concurrent uploads. Defaults to `8`.
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -62,12 +62,12 @@ The following arguments are supported:
 
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
 
-* `source` - (Optional) An absolute path to a file on the local system. Cannot be specified if `source_content` or `source_uri` is specified.
+* `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and annot be specified if `source_content` or `source_uri` is specified.
 
-* `source_content` - (Optional) The content for this blob which should be defined inline. Cannot be specified if `source` or `source_uri` is specified.
+* `source_content` - (Optional) The content for this blob which should be defined inline. This field can only be specified for Block blobs and cannot be specified if `source` or `source_uri` is specified.
 
 * `source_uri` - (Optional) The URI of an existing blob, or a file in the Azure File service, to use as the source contents
-    for the blob to be created. Changing this forces a new resource to be created. Cannot be specified if `source` or `source_content` is specified.
+    for the blob to be created. Changing this forces a new resource to be created. This field cannot be specified for Append blobs and cannot be specified if `source` or `source_content` is specified.
 
 * `parallelism` - (Optional) The number of workers per CPU core to run for concurrent uploads. Defaults to `8`.
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -54,8 +54,7 @@ The following arguments are supported:
 
 * `storage_container_name` - (Required) The name of the storage container in which this blob should be created.
 
-* `type` - (Optional) The type of the storage blob to be created. One of either `Append`, `Block` or `Page`. When not copying from an existing blob,
-    this becomes required.
+* `type` - (Required) The type of the storage blob to be created. Possible values are `Append`, `Block` or `Page`. Changing this forces a new resource to be created.
 
 * `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0.
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -14,12 +14,12 @@ Manages a Blob within a Storage Container.
 
 ```hcl
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-d"
-  location = "westus"
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "acctestaccs"
+  name                     = "examplestoracc"
   resource_group_name      = "${azurerm_resource_group.test.name}"
   location                 = "${azurerm_resource_group.test.location}"
   account_tier             = "Standard"
@@ -27,21 +27,19 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_storage_container" "test" {
-  name                  = "vhds"
+  name                  = "content"
   resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }
 
-resource "azurerm_storage_blob" "testsb" {
-  name = "sample.vhd"
-
+resource "azurerm_storage_blob" "test" {
+  name                   = "my-awesome-content.zip"
   resource_group_name    = "${azurerm_resource_group.test.name}"
   storage_account_name   = "${azurerm_storage_account.test.name}"
   storage_container_name = "${azurerm_storage_container.test.name}"
-
-  type = "page"
-  size = 5120
+  type                   = "blob"
+  source                 = "some-local-file.zip"
 }
 ```
 
@@ -56,10 +54,12 @@ The following arguments are supported:
 
 * `storage_container_name` - (Required) The name of the storage container in which this blob should be created.
 
-* `type` - (Optional) The type of the storage blob to be created. One of either `block` or `page`. When not copying from an existing blob,
+* `type` - (Optional) The type of the storage blob to be created. One of either `Append`, `Block` or `Page`. When not copying from an existing blob,
     this becomes required.
 
 * `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0.
+
+* `access_tier` - (Optional) The access tier of the storage blob. Possible values are `Archive`, `Cool` and `Hot`. Defaults to `Hot`.
 
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
 


### PR DESCRIPTION
This PR adds new functionality to the `azurerm_storage_blob` resource and fixes a number of bugs:

- adds support for creating Empty Append Blobs
- fixes #2006 by making the `type` field required (since this should always be set)
- fixes #3876 by allowing for content to be defined inline (via HEREDOC syntax) by writing this to a temp file before passing this to Giovanni
- updates the documentation to show how to upload a file, since this is a more common use-case than creating an empty page blob (imo)