### PR TITLE
r/storage_blob: switching to use the new SDK for assertions

### DIFF
--- a/azurerm/internal/services/storage/legacy.go
+++ b/azurerm/internal/services/storage/legacy.go
@@ -7,6 +7,9 @@ import (
 	legacy "github.com/Azure/azure-sdk-for-go/storage"
 )
 
+// NOTE: we'll remove this once #4238 and #4235 have been merged to avoid conflicts
+
+// nolint: deadcode unused
 func (client *Client) LegacyBlobClient(ctx context.Context, resourceGroup, accountName string) (*legacy.BlobStorageClient, bool, error) {
 	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
 	if err != nil {

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -266,7 +266,7 @@ func TestAccAzureRMStorageBlob_blockFromLocalFile(t *testing.T) {
 				Config: testAccAzureRMStorageBlob_blockFromLocalBlob(ri, rs, location, sourceBlob.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists(resourceName),
-					testCheckAzureRMStorageBlobMatchesFile(resourceName, storage.BlobTypeBlock, sourceBlob.Name()),
+					testCheckAzureRMStorageBlobMatchesFile(resourceName, "block", sourceBlob.Name()),
 				),
 			},
 			{
@@ -423,7 +423,7 @@ func TestAccAzureRMStorageBlob_pageFromLocalFile(t *testing.T) {
 				Config: testAccAzureRMStorageBlob_pageFromLocalBlob(ri, rs, location, sourceBlob.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists(resourceName),
-					testCheckAzureRMStorageBlobMatchesFile(resourceName, storage.BlobTypePage, sourceBlob.Name()),
+					testCheckAzureRMStorageBlobMatchesFile(resourceName, "page", sourceBlob.Name()),
 				),
 			},
 			{
@@ -590,7 +590,7 @@ func testCheckAzureRMStorageBlobDisappears(resourceName string) resource.TestChe
 	}
 }
 
-func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind storage.BlobType, filePath string) resource.TestCheckFunc {
+func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind string, filePath string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -623,7 +623,7 @@ func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind storage.Bl
 
 		properties := blobReference.Properties
 
-		if properties.BlobType != kind {
+		if string(properties.BlobType) != kind {
 			return fmt.Errorf("Bad: blob type %q does not match expected type %q", properties.BlobType, kind)
 		}
 


### PR DESCRIPTION
This PR switches the Test Assertions over to using the new [Giovanni SDK](https://github.com/tombuildsstuff/giovanni) from [the old, deprecated Storage SDK](https://github.com/Azure/azure-sdk-for-go/tree/master/storage)

Since #4238 and #4235 both make changes to the Vendor file - to avoid a conflict I'll send a separate PR to remove the old SDK once they've been merged