### PR TITLE
[WIP] `azurerm_app_service`: support for setting fields within the `source_control` block

### DIFF
--- a/azurerm/data_source_app_service.go
+++ b/azurerm/data_source_app_service.go
@@ -211,7 +211,7 @@ func dataSourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	scm := flattenAppServiceSourceControl(scmResp.SiteSourceControlProperties)
+	scm := azure.FlattenAppServiceSourceControl(scmResp.SiteSourceControlProperties)
 	if err := d.Set("source_control", scm); err != nil {
 		return err
 	}

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -616,6 +616,45 @@ func SchemaAppServiceStorageAccounts() *schema.Schema {
 	}
 }
 
+func SchemaAppServiceSourceControl() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"repo_url": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validate.NoEmptyStrings,
+				},
+				"branch": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Default:      "master",
+					ValidateFunc: validate.NoEmptyStrings,
+				},
+				"is_manual_integration": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"deployment_rollback_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+				"is_mercurial": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}
+
 func SchemaAppServiceDataSourceSiteConfig() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
@@ -1638,4 +1677,68 @@ func FlattenAppServiceStorageAccounts(input map[string]*web.AzureStorageInfoValu
 	}
 
 	return results
+}
+
+func ExpandAppServiceSourceControl(input []interface{}) web.SiteSourceControlProperties {
+	sourceControlProperties := web.SiteSourceControlProperties{}
+
+	if len(input) == 0 {
+		return sourceControlProperties
+	}
+
+	sourceControl := input[0].(map[string]interface{})
+
+	if v, ok := sourceControl["repo_url"]; ok {
+		sourceControlProperties.RepoURL = utils.String(v.(string))
+	}
+
+	if v, ok := sourceControl["branch"]; ok {
+		sourceControlProperties.Branch = utils.String(v.(string))
+	}
+
+	if v, ok := sourceControl["is_manual_integration"]; ok {
+		sourceControlProperties.IsManualIntegration = utils.Bool(v.(bool))
+	}
+
+	if v, ok := sourceControl["deployment_rollback_enabled"]; ok {
+		sourceControlProperties.DeploymentRollbackEnabled = utils.Bool(v.(bool))
+	}
+
+	if v, ok := sourceControl["is_mercurial"]; ok {
+		sourceControlProperties.IsMercurial = utils.Bool(v.(bool))
+	}
+
+	return sourceControlProperties
+}
+
+func FlattenAppServiceSourceControl(input *web.SiteSourceControlProperties) []interface{} {
+	results := make([]interface{}, 0)
+	result := make(map[string]interface{})
+
+	if input == nil {
+		log.Printf("[DEBUG] SiteSourceControlProperties is nil")
+		return results
+	}
+
+	if input.RepoURL != nil {
+		result["repo_url"] = *input.RepoURL
+	}
+
+	if input.Branch != nil {
+		result["branch"] = *input.Branch
+	}
+
+	if input.IsManualIntegration != nil {
+		result["is_manual_integration"] = *input.IsManualIntegration
+	}
+
+	if input.DeploymentRollbackEnabled != nil {
+		result["deployment_rollback_enabled"] = *input.DeploymentRollbackEnabled
+	}
+
+	if input.IsMercurial != nil {
+		result["is_mercurial"] = *input.IsMercurial
+	}
+
+	return append(results, result)
 }

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -89,6 +89,8 @@ The following arguments are supported:
 
 * `site_config` - (Optional) A `site_config` block as defined below.
 
+* `source_control` - (Optional) A Source Control block as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `identity` - (Optional) A Managed Service Identity block as defined below.
@@ -227,6 +229,20 @@ Additional examples of how to run Containers via the `azurerm_app_service` resou
 
 ---
 
+A `source_control` block supports the following:
+
+* `repo_url` - (Required) The repository or source control URL.
+
+* `branch` - (Optional) The name of branch to use for deployment. Defaults to `master`.
+
+* `is_manual_integration` - (Optional) Is manual integration enabled, rather than continuous integration (which configures webhooks into online repos like GitHub)? Defaults to `false`.
+
+* `deployment_rollback_enabled` - (Optional) Should deployment rollback be enabled? Defaults to `false`.
+
+* `is_mercurial` - (Optional) Is the repository Mercurial, rather than Git? Defaults to `false`.
+
+---
+
 A `cors` block supports the following:
 
 * `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
@@ -357,8 +373,6 @@ The following attributes are exported:
 
 * `possible_outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12,52.143.43.17` - not all of which are necessarily in use. Superset of `outbound_ip_addresses`.
 
-* `source_control` - A `source_control` block as defined below, which contains the Source Control information when `scm_type` is set to `LocalGit`.
-
 * `site_credential` - A `site_credential` block as defined below, which contains the site-level credentials used to publish to this App Service.
 
 * `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this App Service.
@@ -381,13 +395,6 @@ A `site_credential` block exports the following:
 * `password` - The password associated with the username, which can be used to publish to this App Service.
 
 ~> **NOTE:** both `username` and `password` for the `site_credential` block are only exported when `scm_type` is set to `LocalGit`
-
----
-
-A `source_control` block exports the following:
-
-* `repo_url` - URL of the Git repository for this App Service.
-* `branch` - Branch name of the Git repository for this App Service.
 
 ## Import
 


### PR DESCRIPTION
Reference to #4214

Not sure how to best manage setting fields within `source_control` block together with `scm_type` field within `site_config` block for best user experience. I only ever used this field for `LocalGit` and setting it when using other source control providers might cause conflict (ref. #3696). It seems this field and allowed values was added without thinking about it's functionality. Will test this further over the next few days, then commit the changes. A suggestion is to ~~move `scm_type` from `site_config` block to `source_control` block, rename it to `type` and then modify it's behaviour~~ not make breaking changes, which makes this a bit of hack. Any feedback is appreciated.

FYI the changes currently proposed in this pull request will not work because there is a conflict when setting `scm_type` within `site_config` block before updating `source_control`. 

TODO:
- [ ] Add examples to the examples folder