### PR TITLE
storage_account: gracefully degrading when there's a Write Lock or the user doesn't have permissions

### DIFF
--- a/azurerm/data_source_storage_account.go
+++ b/azurerm/data_source_storage_account.go
@@ -2,8 +2,10 @@ package azurerm
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 
+	azautorest "github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -273,12 +275,32 @@ func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(*resp.ID)
 
+	// handle the user not having permissions to list the keys
+	d.Set("primary_connection_string", "")
+	d.Set("secondary_connection_string", "")
+	d.Set("primary_blob_connection_string", "")
+	d.Set("secondary_blob_connection_string", "")
+	d.Set("primary_access_key", "")
+	d.Set("secondary_access_key", "")
+
 	keys, err := client.ListKeys(ctx, resourceGroup, name)
 	if err != nil {
-		return err
+		// the API returns a 200 with an inner error of a 409..
+		var hasWriteLock bool
+		var doesntHavePermissions bool
+		if e, ok := err.(azautorest.DetailedError); ok {
+			if status, ok := e.StatusCode.(int); ok {
+				hasWriteLock = status == http.StatusConflict
+				doesntHavePermissions = status == http.StatusUnauthorized
+			}
+		}
+
+		if !hasWriteLock && !doesntHavePermissions {
+			return fmt.Errorf("Error listing Keys for Storage Account %q (Resource Group %q): %s", name, resourceGroup, err)
+		}
 	}
 
-	accessKeys := *keys.Keys
+	accountKeys := keys.Keys
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -316,39 +338,49 @@ func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("primary_location", props.PrimaryLocation)
 		d.Set("secondary_location", props.SecondaryLocation)
 
-		if len(accessKeys) > 0 {
-			pcs := fmt.Sprintf("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s", *resp.Name, *accessKeys[0].Value, endpointSuffix)
-			d.Set("primary_connection_string", pcs)
-		}
+		if accessKeys := accountKeys; accessKeys != nil {
+			storageAccessKeys := *accessKeys
+			if len(storageAccessKeys) > 0 {
+				pcs := fmt.Sprintf("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s", *resp.Name, *storageAccessKeys[0].Value, endpointSuffix)
+				d.Set("primary_connection_string", pcs)
+			}
 
-		if len(accessKeys) > 1 {
-			scs := fmt.Sprintf("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s", *resp.Name, *accessKeys[1].Value, endpointSuffix)
-			d.Set("secondary_connection_string", scs)
+			if len(storageAccessKeys) > 1 {
+				scs := fmt.Sprintf("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=%s", *resp.Name, *storageAccessKeys[1].Value, endpointSuffix)
+				d.Set("secondary_connection_string", scs)
+			}
 		}
 
 		if err := flattenAndSetAzureRmStorageAccountPrimaryEndpoints(d, props.PrimaryEndpoints); err != nil {
 			return fmt.Errorf("error setting primary endpoints and hosts for blob, queue, table and file: %+v", err)
 		}
 
-		var primaryBlobConnectStr string
-		if v := props.PrimaryEndpoints; v != nil {
-			primaryBlobConnectStr = getBlobConnectionString(v.Blob, resp.Name, accessKeys[0].Value)
+		if accessKeys := accountKeys; accessKeys != nil {
+			var primaryBlobConnectStr string
+			if v := props.PrimaryEndpoints; v != nil {
+				primaryBlobConnectStr = getBlobConnectionString(v.Blob, resp.Name, (*accessKeys)[0].Value)
+			}
+			d.Set("primary_blob_connection_string", primaryBlobConnectStr)
 		}
-		d.Set("primary_blob_connection_string", primaryBlobConnectStr)
 
 		if err := flattenAndSetAzureRmStorageAccountSecondaryEndpoints(d, props.SecondaryEndpoints); err != nil {
 			return fmt.Errorf("error setting secondary endpoints and hosts for blob, queue, table: %+v", err)
 		}
 
-		var secondaryBlobConnectStr string
-		if v := props.SecondaryEndpoints; v != nil {
-			secondaryBlobConnectStr = getBlobConnectionString(v.Blob, resp.Name, accessKeys[1].Value)
+		if accessKeys := accountKeys; accessKeys != nil {
+			var secondaryBlobConnectStr string
+			if v := props.SecondaryEndpoints; v != nil {
+				secondaryBlobConnectStr = getBlobConnectionString(v.Blob, resp.Name, (*accessKeys)[1].Value)
+			}
+			d.Set("secondary_blob_connection_string", secondaryBlobConnectStr)
 		}
-		d.Set("secondary_blob_connection_string", secondaryBlobConnectStr)
 	}
 
-	d.Set("primary_access_key", accessKeys[0].Value)
-	d.Set("secondary_access_key", accessKeys[1].Value)
+	if accessKeys := accountKeys; accessKeys != nil {
+		storageAccountKeys := *accessKeys
+		d.Set("primary_access_key", storageAccountKeys[0].Value)
+		d.Set("secondary_access_key", storageAccountKeys[1].Value)
+	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/azurerm/data_source_storage_account_test.go
+++ b/azurerm/data_source_storage_account_test.go
@@ -38,6 +38,37 @@ func TestAccDataSourceAzureRMStorageAccount_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMStorageAccount_withWriteLock(t *testing.T) {
+	dataSourceName := "data.azurerm_storage_account.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMStorageAccount_basicWriteLock(ri, rs, location),
+			},
+			{
+				Config: testAccDataSourceAzureRMStorageAccount_basicWriteLockWithDataSource(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "account_tier", "Standard"),
+					resource.TestCheckResourceAttr(dataSourceName, "account_replication_type", "LRS"),
+					resource.TestCheckResourceAttr(dataSourceName, "primary_connection_string", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "secondary_connection_string", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "primary_blob_connection_string", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "secondary_blob_connection_string", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "primary_access_key", ""),
+					resource.TestCheckResourceAttr(dataSourceName, "secondary_access_key", ""),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAzureRMStorageAccount_basic(rInt int, rString string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -60,8 +91,33 @@ resource "azurerm_storage_account" "test" {
 `, rInt, location, rString)
 }
 
+func testAccDataSourceAzureRMStorageAccount_basicWriteLock(rInt int, rString string, location string) string {
+	template := testAccDataSourceAzureRMStorageAccount_basic(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_management_lock" "test" {
+  name       = "acctestlock-%d"
+  scope      = "${azurerm_storage_account.test.id}"
+  lock_level = "ReadOnly"
+}
+`, template, rInt)
+}
+
 func testAccDataSourceAzureRMStorageAccount_basicWithDataSource(rInt int, rString string, location string) string {
 	config := testAccDataSourceAzureRMStorageAccount_basic(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_storage_account" "test" {
+  name                = "${azurerm_storage_account.test.name}"
+  resource_group_name = "${azurerm_storage_account.test.resource_group_name}"
+}
+`, config)
+}
+
+func testAccDataSourceAzureRMStorageAccount_basicWriteLockWithDataSource(rInt int, rString string, location string) string {
+	config := testAccDataSourceAzureRMStorageAccount_basicWriteLock(rInt, rString, location)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -128,6 +128,46 @@ func TestAccAzureRMStorageAccount_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageAccount_writeLock(t *testing.T) {
+	resourceName := "azurerm_storage_account.testsa"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageAccount_writeLock(ri, rs, location),
+			},
+			{
+				// works around a bug in the test suite where the Storage Account won't be re-read after the Lock's provisioned
+				Config: testAccAzureRMStorageAccount_writeLock(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "account_tier", "Standard"),
+					resource.TestCheckResourceAttr(resourceName, "account_replication_type", "LRS"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.environment", "production"),
+					resource.TestCheckResourceAttr(resourceName, "primary_connection_string", ""),
+					resource.TestCheckResourceAttr(resourceName, "secondary_connection_string", ""),
+					resource.TestCheckResourceAttr(resourceName, "primary_blob_connection_string", ""),
+					resource.TestCheckResourceAttr(resourceName, "secondary_blob_connection_string", ""),
+					resource.TestCheckResourceAttr(resourceName, "primary_access_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "secondary_access_key", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMStorageAccount_premium(t *testing.T) {
 	resourceName := "azurerm_storage_account.testsa"
 	ri := tf.AccRandTimeInt()
@@ -858,6 +898,19 @@ resource "azurerm_storage_account" "import" {
   account_replication_type = "${azurerm_storage_account.testrg.account_replication_type}"
 }
 `, template)
+}
+
+func testAccAzureRMStorageAccount_writeLock(rInt int, rString, location string) string {
+	template := testAccAzureRMStorageAccount_basic(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_management_lock" "test" {
+  name       = "acctestlock-%d"
+  scope      = "${azurerm_storage_account.testsa.id}"
+  lock_level = "ReadOnly"
+}
+`, template, rInt)
 }
 
 func testAccAzureRMStorageAccount_premium(rInt int, rString string, location string) string {

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -124,6 +124,7 @@ output "storage_account_tier" {
 
 * `secondary_blob_connection_string` - The connection string associated with the secondary blob location
 
+~> **NOTE:** If there's a Write Lock on the Storage Account, or the account doesn't have permission then these fields will have an empty value [due to a bug in the Azure API](https://github.com/Azure/azure-rest-api-specs/issues/6363)
 ---
 
 * `custom_domain` supports the following:

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -13,15 +13,15 @@ Manages an Azure Storage Account.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "testrg" {
-  name     = "resourceGroupName"
-  location = "westus"
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
-resource "azurerm_storage_account" "testsa" {
+resource "azurerm_storage_account" "test" {
   name                     = "storageaccountname"
-  resource_group_name      = "${azurerm_resource_group.testrg.name}"
-  location                 = "westus"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
   account_tier             = "Standard"
   account_replication_type = "GRS"
 
@@ -34,21 +34,21 @@ resource "azurerm_storage_account" "testsa" {
 ## Example Usage with Network Rules
 
 ```hcl
-resource "azurerm_resource_group" "testrg" {
-  name     = "resourceGroupName"
-  location = "westus"
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_virtual_network" "test" {
   name                = "virtnetname"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.testrg.location}"
-  resource_group_name = "${azurerm_resource_group.testrg.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
   name                 = "subnetname"
-  resource_group_name  = "${azurerm_resource_group.testrg.name}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.2.0/24"
   service_endpoints    = ["Microsoft.Sql", "Microsoft.Storage"]
@@ -56,9 +56,9 @@ resource "azurerm_subnet" "test" {
 
 resource "azurerm_storage_account" "testsa" {
   name                = "storageaccountname"
-  resource_group_name = "${azurerm_resource_group.testrg.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-  location                 = "${azurerm_resource_group.testrg.location}"
+  location                 = "${azurerm_resource_group.test.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
 
@@ -282,6 +282,8 @@ The following attributes are exported in addition to the arguments listed above:
 * `primary_blob_connection_string` - The connection string associated with the primary blob location.
 
 * `secondary_blob_connection_string` - The connection string associated with the secondary blob location.
+
+~> **NOTE:** If there's a Write Lock on the Storage Account, or the account doesn't have permission then these fields will have an empty value [due to a bug in the Azure API](https://github.com/Azure/azure-rest-api-specs/issues/6363)
 
 * `identity` - An `identity` block as defined below, which contains the Identity information for this Storage Account.
 


### PR DESCRIPTION
When the user doesn't have permissions to access the ListKeys endpoint, either because the
Resource has a Write Lock (where ListKeys counts as a Write Operation, which is being tracked
in https://github.com/Azure/azure-rest-api-specs/issues/6363) or because the user doesn't have
permissions - this now degrades these fields into empty values, rather than outright failing.

fixes #4138