### PR TITLE
r/kubernetes_cluster: autoscaling-related improvements

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -156,6 +156,17 @@ A `agent_pool_profile` block supports the following:
 
 * `count` - (Optional) Number of Agents (VMs) in the Pool. Possible values must be in the range of 1 to 100 (inclusive). Defaults to `1`.
 
+~> **NOTE:** When `enable_auto_scaling` parameter is set to true, this value will dynamically change depending on the cluster's load. It is recommended to ignore changes to it with autoscaling enabled, since autoscaled clusters cannot be scaled manually.  This can be done by adding following lifecycle hook to the resource for each agent pool profile with autoscaling enabled.
+```
+resource "azurerm_kubernetes_cluster" "test" {
+  ...
+  lifecycle {
+    ignore_changes = [
+      "agent_pool_profile.0.count"
+    ]
+  }
+}
+```
 * `vm_size` - (Required) The size of each VM in the Agent Pool (e.g. `Standard_F1`). Changing this forces a new resource to be created.
 
 * `availability_zones` - (Optional)  Availability zones for nodes. The property `type` of the `agent_pool_profile` must be set to `VirtualMachineScaleSets` in order to use availability zones.


### PR DESCRIPTION
Currently, on every update, agentPoolProfiles are build from scratch
based on pool definition from Terraform. With autoscaled clusters, this
attempts to remove 'Count' property, which triggers manual scaling
action, which is forbidden for clusters with autoscaling enabled. That
breaks any updates to the cluster, including adding tags or updating
kubernetes version.

With this PR, we always try to fetch defintion of the cluster from
the API and if we update, we only modify profile parameters using Terraform
configuration, rather than building profiles from scratch. This makes
sure that all parameters set by API will be preserved.

To enforce this behavior, we should fail when we are updating the
resource, but we are not able to fetch it from the API.

'expandKubernetesClusterAgentPoolProfiles' function now accepts profiles
slice, which it will work on and returns modified copy, rather than
newly build profiles slice.

Also currently autoscaling cannot be disabled gracefully on the cluster and
cluster cannot be scaled when disabling autoscaling either.

This PR adds validation that when autoscaling is disabled, min_count
and max_count parametes must also be unset.

When Terraform disables autoscaling (enable_auto_scaling = false), then
it also unsets MinCount and MaxCount fields in profile obtained from
API.

This PR also adds documentation note, that cluster cannot be
manually scaled when autoscaling is enabled and suggests how to ignore
changes to the 'count' parameter, which will by dynamically changed by
cluster autoscaler.

Closes #4075