### PR TITLE
r/dev_test_schedule: adding the missing link to the sidebar

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -955,6 +955,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/dev_test_schedule.html">azurerm_dev_test_schedule</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/dev_test_virtual_network.html">azurerm_dev_test_virtual_network</a>
                 </li>
 

--- a/website/docs/r/dev_test_schedule.html.markdown
+++ b/website/docs/r/dev_test_schedule.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_schedule"
-sidebar_current: "docs-azurerm-dev-test-lab-schedule"
+sidebar_current: "docs-azurerm-dev-test-schedule"
 description: |-
     Manages automated startup and shutdown schedules for Azure Dev Test Lab.
 ---


### PR DESCRIPTION
Noticed this was missing when replying to #4255 