### PR TITLE
`azurerm_eventhub_namespace` Added ForceNew property to kafka_enabled setting

### DIFF
--- a/azurerm/resource_arm_eventhub_namespace.go
+++ b/azurerm/resource_arm_eventhub_namespace.go
@@ -73,6 +73,7 @@ func resourceArmEventHubNamespace() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 
 			"maximum_throughput_units": {

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `maximum_throughput_units` - (Optional) Specifies the maximum number of throughput units when Auto Inflate is Enabled. Valid values range from 1 - 20.
 
-* `kafka_enabled` - (Optional) Is Kafka enabled for the EventHub Namespace? Defaults to `false`.
+* `kafka_enabled` - (Optional) Is Kafka enabled for the EventHub Namespace? Defaults to `false`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/4239