### PR TITLE
`azurerm_app_service` Fixed documentation to reflect correct property name

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -319,7 +319,7 @@ A `microsoft` block supports the following:
 
 A `backup` block supports the following:
 
-* `backup_name` (Required) Specifies the name for this Backup.
+* `name` (Required) Specifies the name for this Backup.
 
 * `enabled` - (Required) Is this Backup enabled?
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/4223