### PR TITLE
Updated README to stipulate go-113

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ General Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.12.x (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.13.x (to build the provider plugin)
 
 Windows Specific Requirements
 -----------------------------
@@ -74,7 +74,7 @@ Further [usage documentation is available on the Terraform website](https://www.
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.12+ is **required**). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.13+ is **required**). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
Addressing #4262 - tweak to README to stipulate go version 1.13 is required to run `make build`