### PR TITLE
azurerm_app_service: Updated  documentation to show correct argument

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -323,7 +323,7 @@ A `microsoft` block supports the following:
 
 A `backup` block supports the following:
 
-* `backup_name` (Required) Specifies the name for this Backup.
+* `name` (Required) Specifies the name for this Backup.
 
 * `enabled` - (Required) Is this Backup enabled?
 


### PR DESCRIPTION
Fixes #4223. Documentation incorrectly states `backup` block uses `backup_name` attribute. Updated to `name`.