### PR TITLE
azurerm_sql_failover_group: Fixed documentation to remove unneeded punctuation

### DIFF
--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -54,7 +54,7 @@ resource "azurerm_sql_failover_group" "example" {
       id = "${azurerm_sql_server.secondary.id}"
   }
 
-  read_write_endpoint_failover_policy = {
+  read_write_endpoint_failover_policy {
     mode = "Automatic"
     grace_minutes = 60
   }


### PR DESCRIPTION
Fixes #4230. Removes unneeded `=` from `read_write_endpoint_failover_policy` block.