### PR TITLE
Increase the timeout of upserting a CosmosDB account

### DIFF
--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -773,7 +773,7 @@ func resourceArmCosmosDbAccountApiUpsert(client *documentdb.DatabaseAccountsClie
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"Creating", "Updating", "Deleting"},
 		Target:     []string{"Succeeded"},
-		Timeout:    60 * time.Minute,
+		Timeout:    180 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Delay:      30 * time.Second, // required because it takes some time before the 'creating' location shows up
 		Refresh: func() (interface{}, string, error) {


### PR DESCRIPTION
Currently, provisioning time for a Cosmos DB account grows linearly with the number of regions (10-15 minutes per region in my experience). 

I tried to create an account in `westeurope, westus, eastus, northeurope, southeastasia, eastasia` and it failed with a timeout:
```
Error waiting for the CosmosDB Account "test" (Resource Group "test") to finish creating/updating: Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded
```

As there's currently no support for custom timeouts in the provider, I suggest bumping the timeout to 3 hours.