### PR TITLE
azurerm_cosmosdb_account: correctly validate `max_interval_in_seconds` & `max_staleness_prefix` for geo replicated accounts

### DIFF
--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -378,7 +378,8 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 
 	// additional validation on MaxStalenessPrefix as it varies depending on if the DB is multi region or not
 
-	if cp := account.DatabaseAccountCreateUpdateProperties.ConsistencyPolicy; len(geoLocations) > 1 && cp != nil {
+	cp := account.DatabaseAccountCreateUpdateProperties.ConsistencyPolicy
+	if len(geoLocations) > 1 && cp != nil && cp.DefaultConsistencyLevel == documentdb.BoundedStaleness {
 		if msp := cp.MaxStalenessPrefix; msp != nil && *msp < 100000 {
 			return fmt.Errorf("Error max_staleness_prefix (%d) must be greater then 100000 when more then one geo_location is used", *msp)
 		}


### PR DESCRIPTION
…eness ConsistencyPolicy

Skip validation for BoundedStaleness specific ConsistencyPolicy while configuring
a geo replicated cosmosdb account with a non BoundedStaleness
ConsistencyPolicy

Fixes #4118 