### PR TITLE
New Resource: `azurerm_app_service_source_control`

### DIFF
--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -148,6 +148,7 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_app_service_custom_hostname_binding":                resourceArmAppServiceCustomHostnameBinding(),
 		"azurerm_app_service_plan":                                   resourceArmAppServicePlan(),
 		"azurerm_app_service_slot":                                   resourceArmAppServiceSlot(),
+		"azurerm_app_service_source_control":                         resourceArmAppServiceSourceControl(),
 		"azurerm_app_service_source_control_token":                   resourceArmAppServiceSourceControlToken(),
 		"azurerm_app_service":                                        resourceArmAppService(),
 		"azurerm_application_gateway":                                resourceArmApplicationGateway(),

--- a/azurerm/resource_arm_app_service_source_control.go
+++ b/azurerm/resource_arm_app_service_source_control.go
@@ -1,0 +1,270 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+var appServiceSourceControlResourceName = "azurerm_app_service_source_control"
+
+func resourceArmAppServiceSourceControl() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAppServiceSourceControlCreateUpdate,
+		Read:   resourceArmAppServiceSourceControlRead,
+		Update: resourceArmAppServiceSourceControlCreateUpdate,
+		Delete: resourceArmAppServiceSourceControlDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"app_service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(web.ScmTypeBitbucketGit),
+					// Bitbucket Mercurial support will be removed June 2020
+					// https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket
+					string(web.ScmTypeBitbucketHg),
+					// CodePlex was shut down December 2017
+					// https://devblogs.microsoft.com/bharry/shutting-down-codeplex/
+					// string(web.ScmTypeCodePlexGit),
+					// string(web.ScmTypeCodePlexHg),
+					string(web.ScmTypeDropbox),
+					string(web.ScmTypeExternalGit),
+					string(web.ScmTypeExternalHg),
+					string(web.ScmTypeGitHub),
+					string(web.ScmTypeLocalGit),
+					string(web.ScmTypeOneDrive),
+					string(web.ScmTypeTfs),
+					string(web.ScmTypeVSO),
+					// Not in the specs, but is set by Azure Pipelines
+					// https://github.com/Microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureRmWebAppDeploymentV4/operations/AzureAppServiceUtility.ts#L19
+					// upstream issue: https://github.com/Azure/azure-rest-api-specs/issues/5345
+					"VSTSRM",
+				}, false),
+			},
+
+			"repo_url": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"branch": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"deployment_rollback_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"is_manual_integration": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"is_mercurial": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"local_repo_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmAppServiceSourceControlCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).web.AppServicesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	log.Printf("[INFO] preparing arguments for App Service Source Control creation.")
+
+	appServiceId := d.Get("app_service_id").(string)
+	id, err := azure.ParseAzureResourceID(appServiceId)
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+	scmType := d.Get("type").(string)
+	repoUrl := d.Get("repo_url").(string)
+	branch := d.Get("branch").(string)
+	deploymentRollbackEnabled := d.Get("deployment_rollback_enabled").(bool)
+
+	locks.ByName(appServiceName, appServiceSourceControlResourceName)
+	defer locks.UnlockByName(appServiceName, appServiceSourceControlResourceName)
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.GetSourceControl(ctx, resourceGroup, appServiceName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing App Service Source Control (App Service %q / Resource Group %q): %s", appServiceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError(appServiceSourceControlResourceName, *existing.ID)
+		}
+	}
+
+	if repoUrl != "" {
+		sourceControl := web.SiteSourceControl{
+			SiteSourceControlProperties: &web.SiteSourceControlProperties{
+				RepoURL: utils.String(repoUrl),
+				Branch:  utils.String(branch),
+				DeploymentRollbackEnabled: utils.Bool(deploymentRollbackEnabled),
+			},
+		}
+
+		if web.ScmType(scmType) == web.ScmTypeExternalGit || web.ScmType(scmType) == web.ScmTypeExternalHg {
+			sourceControl.SiteSourceControlProperties.IsManualIntegration = utils.Bool(true)
+		}
+
+		if web.ScmType(scmType) == web.ScmTypeBitbucketHg || web.ScmType(scmType) == web.ScmTypeCodePlexHg || web.ScmType(scmType) == web.ScmTypeExternalHg {
+			sourceControl.SiteSourceControlProperties.IsMercurial = utils.Bool(true)
+		}
+
+		if _, err := client.CreateOrUpdateSourceControl(ctx, resourceGroup, appServiceName, sourceControl); err != nil {
+			return fmt.Errorf("Error updating App Service Source Control (App Service %q / Resource Group %q): %s", appServiceName, resourceGroup, err)
+		}
+	}
+
+	sitePatchResource := web.SitePatchResource{
+		SitePatchResourceProperties: &web.SitePatchResourceProperties{
+			SiteConfig: &web.SiteConfig{
+				ScmType: web.ScmType(scmType),
+			},
+		},
+	}
+
+	if _, err := client.Update(ctx, resourceGroup, appServiceName, sitePatchResource); err != nil {
+		return fmt.Errorf("Error updating App Service Configuration (App Service %q / Resource Group %q): %+v", appServiceName, resourceGroup, err)
+	}
+
+	read, err := client.GetSourceControl(ctx, resourceGroup, appServiceName)
+	if err != nil {
+		return fmt.Errorf("Error retrieving App Service Source Control (App Service %q / Resource Group %q): %s", appServiceName, resourceGroup, err)
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read App Service Source Control (App Service %q / Resource Group %q) ID", appServiceName, resourceGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmAppServiceSourceControlRead(d, meta)
+}
+
+func resourceArmAppServiceSourceControlRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).web.AppServicesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+
+	siteConfigResp, err := client.GetConfiguration(ctx, resourceGroup, appServiceName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(siteConfigResp.Response) {
+			return fmt.Errorf("Error checking for presence of existing App Service Configuration (App Service %q / Resource Group %q): %s", appServiceName, resourceGroup, err)
+		}
+	}
+
+	siteConfigProps := siteConfigResp.SiteConfig
+	if siteConfigProps != nil {
+		d.Set("type", siteConfigProps.ScmType)
+	}
+
+	resp, err := client.GetSourceControl(ctx, resourceGroup, appServiceName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] App Service Source Control (App Service %q / Resource Group %q) was not found - removing from state", appServiceName, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on App Service Source Control (App Service %q / Resource Group %q): %+v", appServiceName, resourceGroup, err)
+	}
+
+	if props := resp.SiteSourceControlProperties; props != nil {
+		if web.ScmType(siteConfigProps.ScmType) == web.ScmTypeLocalGit {
+			d.Set("local_repo_url", props.RepoURL)
+		} else {
+			d.Set("repo_url", props.RepoURL)
+		}
+		d.Set("branch", props.Branch)
+		d.Set("deployment_rollback_enabled", props.DeploymentRollbackEnabled)
+		d.Set("is_manual_integration", props.IsManualIntegration)
+		d.Set("is_mercurial", props.IsMercurial)
+	}
+
+	return nil
+}
+
+func resourceArmAppServiceSourceControlDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).web.AppServicesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	appServiceName := id.Path["sites"]
+
+	locks.ByName(appServiceName, appServiceSourceControlResourceName)
+	defer locks.UnlockByName(appServiceName, appServiceSourceControlResourceName)
+
+	log.Printf("[DEBUG] Deleting App Service Source Control (App Service %q / Resource Group %q)", appServiceName, resourceGroup)
+
+	resp, err := client.DeleteSourceControl(ctx, resourceGroup, appServiceName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error deleting App Service Source Control (App Service %q / Resource Group %q): %s)", appServiceName, resourceGroup, err)
+		}
+	}
+
+	sitePatchResource := web.SitePatchResource{
+		SitePatchResourceProperties: &web.SitePatchResourceProperties{
+			SiteConfig: &web.SiteConfig{
+				ScmType: web.ScmType(web.ScmTypeNone),
+			},
+		},
+	}
+
+	if _, err := client.Update(ctx, resourceGroup, appServiceName, sitePatchResource); err != nil {
+		return fmt.Errorf("Error updating App Service Configuration (App Service %q / Resource Group %q): %+v", appServiceName, resourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_app_service_source_control.go
+++ b/azurerm/resource_arm_app_service_source_control.go
@@ -107,7 +107,7 @@ func resourceArmAppServiceSourceControlCreate(d *schema.ResourceData, meta inter
 
 	sourceControl := web.SiteSourceControl{
 		SiteSourceControlProperties: &web.SiteSourceControlProperties{
-			RepoURL: 				   utils.String(repoUrl),
+			RepoURL:                   utils.String(repoUrl),
 			Branch:                    utils.String(branch),
 			DeploymentRollbackEnabled: utils.Bool(deploymentRollbackEnabled),
 			IsManualIntegration:       utils.Bool(manualIntegrationEnabled),

--- a/azurerm/resource_arm_app_service_source_control.go
+++ b/azurerm/resource_arm_app_service_source_control.go
@@ -107,8 +107,8 @@ func resourceArmAppServiceSourceControlCreate(d *schema.ResourceData, meta inter
 
 	sourceControl := web.SiteSourceControl{
 		SiteSourceControlProperties: &web.SiteSourceControlProperties{
-			RepoURL: utils.String(repoUrl),
-			Branch:  utils.String(branch),
+			RepoURL: 				   utils.String(repoUrl),
+			Branch:                    utils.String(branch),
 			DeploymentRollbackEnabled: utils.Bool(deploymentRollbackEnabled),
 			IsManualIntegration:       utils.Bool(manualIntegrationEnabled),
 		},

--- a/azurerm/resource_arm_app_service_source_control.go
+++ b/azurerm/resource_arm_app_service_source_control.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web"
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
@@ -19,9 +18,8 @@ var appServiceSourceControlResourceName = "azurerm_app_service_source_control"
 
 func resourceArmAppServiceSourceControl() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmAppServiceSourceControlCreateUpdate,
+		Create: resourceArmAppServiceSourceControlCreate,
 		Read:   resourceArmAppServiceSourceControlRead,
-		Update: resourceArmAppServiceSourceControlCreateUpdate,
 		Delete: resourceArmAppServiceSourceControlDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -34,38 +32,9 @@ func resourceArmAppServiceSourceControl() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(web.ScmTypeBitbucketGit),
-					// Bitbucket Mercurial support will be removed June 2020
-					// https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket
-					string(web.ScmTypeBitbucketHg),
-					// CodePlex was shut down December 2017
-					// https://devblogs.microsoft.com/bharry/shutting-down-codeplex/
-					// string(web.ScmTypeCodePlexGit),
-					// string(web.ScmTypeCodePlexHg),
-					string(web.ScmTypeDropbox),
-					string(web.ScmTypeExternalGit),
-					string(web.ScmTypeExternalHg),
-					string(web.ScmTypeGitHub),
-					string(web.ScmTypeLocalGit),
-					string(web.ScmTypeOneDrive),
-					// Setting this to `Tfs` will result in 500 InternalServerError from the API
-					// string(web.ScmTypeTfs),
-					string(web.ScmTypeVSO),
-					// Not in the specs, but is set by Azure Pipelines
-					// https://github.com/Microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureRmWebAppDeploymentV4/operations/AzureAppServiceUtility.ts#L19
-					// upstream issue: https://github.com/Azure/azure-rest-api-specs/issues/5345
-					"VSTSRM",
-				}, false),
-			},
-
 			"repo_url": {
 				Type:         schema.TypeString,
-				Optional:     true,
+				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validate.NoEmptyStrings,
 			},
@@ -80,47 +49,45 @@ func resourceArmAppServiceSourceControl() *schema.Resource {
 			"deployment_rollback_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 				Default:  false,
 			},
 
-			"is_manual_integration": {
+			"manual_integration_enabled": {
 				Type:     schema.TypeBool,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 
 			"is_mercurial": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-
-			// If `type` is set to `LocalGit`, then
-			// this returns the URL of the Kudu service.
-			// Is this really needful?
-			"local_repo_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
 
-func resourceArmAppServiceSourceControlCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmAppServiceSourceControlCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).web.AppServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for App Service Source Control creation.")
 
 	appServiceId := d.Get("app_service_id").(string)
+
 	id, err := azure.ParseAzureResourceID(appServiceId)
 	if err != nil {
 		return err
 	}
+
 	resourceGroup := id.ResourceGroup
 	appServiceName := id.Path["sites"]
-	scmType := d.Get("type").(string)
+
 	repoUrl := d.Get("repo_url").(string)
 	branch := d.Get("branch").(string)
 	deploymentRollbackEnabled := d.Get("deployment_rollback_enabled").(bool)
+	manualIntegrationEnabled := d.Get("manual_integration_enabled").(bool)
 
 	locks.ByName(appServiceName, appServiceSourceControlResourceName)
 	defer locks.UnlockByName(appServiceName, appServiceSourceControlResourceName)
@@ -138,39 +105,17 @@ func resourceArmAppServiceSourceControlCreateUpdate(d *schema.ResourceData, meta
 		}
 	}
 
-	if repoUrl != "" {
-		sourceControl := web.SiteSourceControl{
-			SiteSourceControlProperties: &web.SiteSourceControlProperties{
-				RepoURL:                   utils.String(repoUrl),
-				Branch:                    utils.String(branch),
-				DeploymentRollbackEnabled: utils.Bool(deploymentRollbackEnabled),
-			},
-		}
-
-		if web.ScmType(scmType) == web.ScmTypeExternalGit || web.ScmType(scmType) == web.ScmTypeExternalHg {
-			sourceControl.SiteSourceControlProperties.IsManualIntegration = utils.Bool(true)
-		}
-
-		if web.ScmType(scmType) == web.ScmTypeBitbucketHg || web.ScmType(scmType) == web.ScmTypeCodePlexHg || web.ScmType(scmType) == web.ScmTypeExternalHg {
-			sourceControl.SiteSourceControlProperties.IsMercurial = utils.Bool(true)
-		}
-
-		if _, err := client.CreateOrUpdateSourceControl(ctx, resourceGroup, appServiceName, sourceControl); err != nil {
-			return fmt.Errorf("Error updating App Service Source Control (App Service %q / Resource Group %q): %s", appServiceName, resourceGroup, err)
-		}
-	}
-
-	// This is normally only needed if ScmType is `LocalGit` or `None`
-	sitePatchResource := web.SitePatchResource{
-		SitePatchResourceProperties: &web.SitePatchResourceProperties{
-			SiteConfig: &web.SiteConfig{
-				ScmType: web.ScmType(scmType),
-			},
+	sourceControl := web.SiteSourceControl{
+		SiteSourceControlProperties: &web.SiteSourceControlProperties{
+			RepoURL: utils.String(repoUrl),
+			Branch:  utils.String(branch),
+			DeploymentRollbackEnabled: utils.Bool(deploymentRollbackEnabled),
+			IsManualIntegration:       utils.Bool(manualIntegrationEnabled),
 		},
 	}
 
-	if _, err := client.Update(ctx, resourceGroup, appServiceName, sitePatchResource); err != nil {
-		return fmt.Errorf("Error updating App Service Configuration (App Service %q / Resource Group %q): %+v", appServiceName, resourceGroup, err)
+	if _, err := client.CreateOrUpdateSourceControl(ctx, resourceGroup, appServiceName, sourceControl); err != nil {
+		return fmt.Errorf("Error updating App Service Source Control (App Service %q / Resource Group %q): %s", appServiceName, resourceGroup, err)
 	}
 
 	read, err := client.GetSourceControl(ctx, resourceGroup, appServiceName)
@@ -198,18 +143,6 @@ func resourceArmAppServiceSourceControlRead(d *schema.ResourceData, meta interfa
 	resourceGroup := id.ResourceGroup
 	appServiceName := id.Path["sites"]
 
-	siteConfigResp, err := client.GetConfiguration(ctx, resourceGroup, appServiceName)
-	if err != nil {
-		if !utils.ResponseWasNotFound(siteConfigResp.Response) {
-			return fmt.Errorf("Error checking for presence of existing App Service Configuration (App Service %q / Resource Group %q): %s", appServiceName, resourceGroup, err)
-		}
-	}
-
-	siteConfigProps := siteConfigResp.SiteConfig
-	if siteConfigProps != nil {
-		d.Set("type", siteConfigProps.ScmType)
-	}
-
 	resp, err := client.GetSourceControl(ctx, resourceGroup, appServiceName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
@@ -221,17 +154,10 @@ func resourceArmAppServiceSourceControlRead(d *schema.ResourceData, meta interfa
 	}
 
 	if props := resp.SiteSourceControlProperties; props != nil {
-		if siteConfigProps.ScmType == web.ScmTypeLocalGit {
-			// If `type` is set to `LocalGit`, then
-			// this returns the URL of the Kudu service.
-			// Is this really needful?
-			d.Set("local_repo_url", props.RepoURL)
-		} else {
-			d.Set("repo_url", props.RepoURL)
-		}
+		d.Set("repo_url", props.RepoURL)
 		d.Set("branch", props.Branch)
 		d.Set("deployment_rollback_enabled", props.DeploymentRollbackEnabled)
-		d.Set("is_manual_integration", props.IsManualIntegration)
+		d.Set("manual_integration_enabled", props.IsManualIntegration)
 		d.Set("is_mercurial", props.IsMercurial)
 	}
 
@@ -260,18 +186,6 @@ func resourceArmAppServiceSourceControlDelete(d *schema.ResourceData, meta inter
 		if !utils.ResponseWasNotFound(resp) {
 			return fmt.Errorf("Error deleting App Service Source Control (App Service %q / Resource Group %q): %s)", appServiceName, resourceGroup, err)
 		}
-	}
-
-	sitePatchResource := web.SitePatchResource{
-		SitePatchResourceProperties: &web.SitePatchResourceProperties{
-			SiteConfig: &web.SiteConfig{
-				ScmType: web.ScmTypeNone,
-			},
-		},
-	}
-
-	if _, err := client.Update(ctx, resourceGroup, appServiceName, sitePatchResource); err != nil {
-		return fmt.Errorf("Error updating App Service Configuration (App Service %q / Resource Group %q): %+v", appServiceName, resourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_app_service_source_control_test.go
+++ b/azurerm/resource_arm_app_service_source_control_test.go
@@ -1,0 +1,110 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMAppServiceSourceControl_ExternalGit(t *testing.T) {
+	resourceName := "azurerm_app_service_source_control.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	repoUrl := "https://github.com/Azure-Samples/app-service-web-html-get-started"
+
+	config := testAccAzureRMAppServiceSourceControlExternalGit(ri, location, repoUrl)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSourceControlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "repo_url", repoUrl),
+					resource.TestCheckResourceAttr(resourceName, "type", "ExternalGit"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_service_id"},
+			},
+		},
+	})
+}
+
+func testAccAzureRMAppServiceSourceControlExternalGit(rInt int, location, repoUrl string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctest%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctest%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+
+  lifecycle {
+    ignore_changes = [site_config.0.scm_type]
+  }
+}
+
+resource "azurerm_app_service_source_control" "test" {
+  app_service_id = "${azurerm_app_service.test.id}"
+  type           = "ExternalGit"
+  repo_url       = "%s"
+  branch         = "master"
+}
+`, rInt, location, rInt, rInt, repoUrl)
+}
+
+func testCheckAzureRMAppServiceSourceControlDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).web.AppServicesClient
+	ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_app_service_source_control" {
+			continue
+		}
+
+		id, err := azure.ParseAzureResourceID(rs.Primary.Attributes["id"])
+		if err != nil {
+			return err
+		}
+
+		resourceGroup := id.ResourceGroup
+		name := id.Path["sites"]
+
+		resp, err := conn.GetSourceControl(ctx, resourceGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_app_service_source_control_test.go
+++ b/azurerm/resource_arm_app_service_source_control_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAppServiceSourceControl_ExternalGit(t *testing.T) {
+func TestAccAzureRMAppServiceSourceControl_ManualIntegration(t *testing.T) {
 	resourceName := "azurerm_app_service_source_control.test"
 	ri := tf.AccRandTimeInt()
 	location := testLocation()
 	repoUrl := "https://github.com/Azure-Samples/app-service-web-html-get-started"
 
-	config := testAccAzureRMAppServiceSourceControlExternalGit(ri, location, repoUrl)
+	config := testAccAzureRMAppServiceSourceControlManualIntegration(ri, location, repoUrl)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -28,7 +28,6 @@ func TestAccAzureRMAppServiceSourceControl_ExternalGit(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "repo_url", repoUrl),
-					resource.TestCheckResourceAttr(resourceName, "type", "ExternalGit"),
 				),
 			},
 			{
@@ -41,7 +40,7 @@ func TestAccAzureRMAppServiceSourceControl_ExternalGit(t *testing.T) {
 	})
 }
 
-func testAccAzureRMAppServiceSourceControlExternalGit(rInt int, location, repoUrl string) string {
+func testAccAzureRMAppServiceSourceControlManualIntegration(rInt int, location, repoUrl string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctest%d"
@@ -71,10 +70,10 @@ resource "azurerm_app_service" "test" {
 }
 
 resource "azurerm_app_service_source_control" "test" {
-  app_service_id = "${azurerm_app_service.test.id}"
-  type           = "ExternalGit"
-  repo_url       = "%s"
-  branch         = "master"
+  app_service_id             = "${azurerm_app_service.test.id}"
+  repo_url                   = "%s"
+  branch                     = "master"
+  manual_integration_enabled = true
 }
 `, rInt, location, rInt, rInt, repoUrl)
 }

--- a/azurerm/resource_arm_app_service_source_control_token.go
+++ b/azurerm/resource_arm_app_service_source_control_token.go
@@ -29,7 +29,7 @@ func resourceArmAppServiceSourceControlToken() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"BitBucket",
+					"Bitbucket",
 					"Dropbox",
 					"GitHub",
 					"OneDrive",

--- a/examples/app-service/source-control-continuous-deployment/README.md
+++ b/examples/app-service/source-control-continuous-deployment/README.md
@@ -1,0 +1,3 @@
+# Example: App Service with Source Control to enable continuous deployment
+
+This example creates an App Service with Source Control to enable continuous deployment (which configures webhooks into online repos like GitHub).

--- a/examples/app-service/source-control-continuous-deployment/main.tf
+++ b/examples/app-service/source-control-continuous-deployment/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_app_service" "example" {
 # not on each App Service - as such this can only be configured Subscription-wide.
 resource "azurerm_app_service_source_control_token" "example" {
   type  = "GitHub"
-  token = "insert-personal-access-token-here"
+  token = "${var.github_token}"
 }
 
 resource "azurerm_app_service_source_control" "example" {

--- a/examples/app-service/source-control-continuous-deployment/main.tf
+++ b/examples/app-service/source-control-continuous-deployment/main.tf
@@ -1,0 +1,39 @@
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "example" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.example.id}"
+
+  lifecycle {
+    ignore_changes = [site_config.0.scm_type]
+  }
+}
+
+# NOTE: Source Control Token's are configured at the subscription level, 
+# not on each App Service - as such this can only be configured Subscription-wide.
+resource "azurerm_app_service_source_control_token" "example" {
+  type  = "GitHub"
+  token = "insert-personal-access-token-here"
+}
+
+resource "azurerm_app_service_source_control" "example" {
+  app_service_id = "${azurerm_app_service.example.id}"
+  repo_url       = "https://github.com/example-user/example-repo"
+  branch         = "master"
+}

--- a/examples/app-service/source-control-continuous-deployment/outputs.tf
+++ b/examples/app-service/source-control-continuous-deployment/outputs.tf
@@ -1,0 +1,7 @@
+output "app_service_name" {
+  value = "${azurerm_app_service.example.name}"
+}
+
+output "app_service_default_hostname" {
+  value = "https://${azurerm_app_service.example.default_site_hostname}"
+}

--- a/examples/app-service/source-control-continuous-deployment/variables.tf
+++ b/examples/app-service/source-control-continuous-deployment/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}

--- a/examples/app-service/source-control-continuous-deployment/variables.tf
+++ b/examples/app-service/source-control-continuous-deployment/variables.tf
@@ -5,3 +5,7 @@ variable "prefix" {
 variable "location" {
   description = "The Azure location where all resources in this example should be created"
 }
+
+variable "github_token" {
+  description = "A personal access token"
+}

--- a/examples/app-service/source-control-token-github/README.md
+++ b/examples/app-service/source-control-token-github/README.md
@@ -1,6 +1,6 @@
 # Example: App Service Source Control Token for GitHub
 
-This example configures App Service source control token for GitHub.
+This example configures App Service Source Control Token for GitHub.
 
 > **NOTE:** Source Control Token's are configured at the subscription level, not on each App Service - as such this can only be configured Subscription-wide.
 
@@ -10,11 +10,4 @@ This example configures App Service source control token for GitHub.
 
 2. Give your token a descriptive name, select the **repo** and **admin:repo hook** scopes, and then click **Generate token**.
 
-3. Copy the personal access token into the `token` field, for example:
-
-```hcl
-resource "azurerm_app_service_source_control_token" "example" {
-  type  = "GitHub"
-  token = "5e43648fe7a59bc89f7348aa729d07659428c758"
-}
-```
+3. Copy the personal access token and use it to set the `github_token` variable.

--- a/examples/app-service/source-control-token-github/README.md
+++ b/examples/app-service/source-control-token-github/README.md
@@ -1,0 +1,20 @@
+# Example: App Service Source Control Token for GitHub
+
+This example configures App Service source control token for GitHub.
+
+> **NOTE:** Source Control Token's are configured at the subscription level, not on each App Service - as such this can only be configured Subscription-wide.
+
+## Create a Personal Access Token
+
+1. Sign in to GitHub, browse to [https://github.com/settings/tokens](https://github.com/settings/tokens), and then click **Generate new token**.
+
+2. Give your token a descriptive name, select the **repo** and **admin:repo hook** scopes, and then click **Generate token**.
+
+3. Copy the personal access token into the `token` field, for example:
+
+```hcl
+resource "azurerm_app_service_source_control_token" "example" {
+  type  = "GitHub"
+  token = "5e43648fe7a59bc89f7348aa729d07659428c758"
+}
+```

--- a/examples/app-service/source-control-token-github/main.tf
+++ b/examples/app-service/source-control-token-github/main.tf
@@ -1,0 +1,4 @@
+resource "azurerm_app_service_source_control_token" "example" {
+  type  = "GitHub"
+  token = "insert-personal-access-token-here"
+}

--- a/examples/app-service/source-control-token-github/main.tf
+++ b/examples/app-service/source-control-token-github/main.tf
@@ -1,4 +1,4 @@
 resource "azurerm_app_service_source_control_token" "example" {
   type  = "GitHub"
-  token = "insert-personal-access-token-here"
+  token = "${var.github_token}"
 }

--- a/examples/app-service/source-control-token-github/variables.tf
+++ b/examples/app-service/source-control-token-github/variables.tf
@@ -1,0 +1,3 @@
+variable "github_token" {
+  description = "A personal access token"
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -511,6 +511,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/app_service_source_control.html">azurerm_app_service_source_control</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service_source_control_token.html">azurerm_app_service_source_control_token</a>
                 </li>
 

--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -1,0 +1,80 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_source_control"
+sidebar_current: "docs-azurerm-resource-app-service-source-control"
+description: |-
+  Manages source control for an App Service.
+
+---
+
+# azurerm_app_service_source_control
+
+Manages source control for an App Service.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "example-app-service-plan"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "example" {
+  name                = "example-app-service"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.example.id}"
+
+  lifecycle {
+    ignore_changes = [site_config.0.scm_type]
+  }
+}
+
+resource "azurerm_app_service_source_control" "example" {
+  app_service_id = "${azurerm_app_service.example.id}"
+  type           = "ExternalGit"
+  repo_url       = "https://github.com/Azure-Samples/app-service-web-html-get-started"
+  branch         = "master"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `type` - (Required) The source control type. Possible values are: `BitbucketGit`, `BitbucketHg`, `Dropbox`, `ExternalGit`, `ExternalHg`, `GitHub`, `LocalGit`, `OneDrive`, `Tfs`, `VSO` and `VSTSRM`.
+
+* `repo_url` - (Optional) The repository or source control URL.
+
+* `branch` - (Optional) The name of branch to use for deployment.
+
+* `deployment_rollback_enabled` - (Optional) Should deployment rollback be enabled?
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the App Service Source Control.
+
+* `is_mercurial` - Whether the repository is Mercurial.
+
+* `is_manual_integration` - Whether manual integration is enabled, rather than continuous integration (which configures webhooks into online repos like GitHub).
+
+## Import
+
+App Service source control can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_app_service_source_control.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-group/providers/Microsoft.Web/sites/test-app/sourcecontrols/web
+```

--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -42,10 +42,10 @@ resource "azurerm_app_service" "example" {
 }
 
 resource "azurerm_app_service_source_control" "example" {
-  app_service_id = "${azurerm_app_service.example.id}"
-  type           = "ExternalGit"
-  repo_url       = "https://github.com/Azure-Samples/app-service-web-html-get-started"
-  branch         = "master"
+  app_service_id             = "${azurerm_app_service.example.id}"
+  repo_url                   = "https://github.com/Azure-Samples/app-service-web-html-get-started"
+  branch                     = "master"
+  manual_integration_enabled = true
 }
 ```
 
@@ -53,13 +53,13 @@ resource "azurerm_app_service_source_control" "example" {
 
 The following arguments are supported:
 
-* `type` - (Required) The source control type. Possible values are: `BitbucketGit`, `BitbucketHg`, `Dropbox`, `ExternalGit`, `ExternalHg`, `GitHub`, `LocalGit`, `OneDrive`, `Tfs`, `VSO` and `VSTSRM`.
+* `repo_url` - (Required) The repository or source control URL. Changing this forces a new resource to be created.
 
-* `repo_url` - (Optional) The repository or source control URL.
+* `branch` - (Optional) The name of branch to use for deployment. Changing this forces a new resource to be created.
 
-* `branch` - (Optional) The name of branch to use for deployment.
+* `deployment_rollback_enabled` - (Optional) Should deployment rollback be enabled? Defaults to `false`. Changing this forces a new resource to be created.
 
-* `deployment_rollback_enabled` - (Optional) Should deployment rollback be enabled?
+* `manual_integration_enabled` - (Optional) Should manual integration be enabled, rather than continuous integration (which configures webhooks into online repos like GitHub)? Defaults to `false`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
@@ -67,9 +67,7 @@ The following attributes are exported:
 
 * `id` - The ID of the App Service Source Control.
 
-* `is_mercurial` - Whether the repository is Mercurial.
-
-* `is_manual_integration` - Whether manual integration is enabled, rather than continuous integration (which configures webhooks into online repos like GitHub).
+* `is_mercurial` - Whether the repository is Mercurial, rather than Git.
 
 ## Import
 

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -26,7 +26,7 @@ resource "azurerm_app_service_source_control_token" "test" {
 
 The following arguments are supported:
 
-* `type` - (Required) The source control type. Possible values are `BitBucket`, `Dropbox`, `GitHub` and `OneDrive`.
+* `type` - (Required) The source control type. Possible values are `Bitbucket`, `Dropbox`, `GitHub` and `OneDrive`.
 
 * `token` - (Required) The OAuth access token.
 


### PR DESCRIPTION
Reference to https://github.com/terraform-providers/terraform-provider-azurerm/issues/3696#issuecomment-529224458 and #4246

This is attempt to add support for managing source control for an App Service without causing breaking changes. More can be done later to improve this :)

It would be nice to have your blessing for this new resource ~~before adding all the examples and their READMEs, because it's quite extensive (configuring OAuth App/Personal Access Token in Butbucket and GitHub, configuring source control for manual integration, and source control tokens for continuous integration)~~, have added very basic examples.

TODO:
- [x] Add examples to examples folder