### PR TITLE
Fix large case of validate_certificate_name

### DIFF
--- a/website/docs/r/api_management_backend.html.markdown
+++ b/website/docs/r/api_management_backend.html.markdown
@@ -129,6 +129,7 @@ A `tls` block supports the following:
 * `validate_certificate_chain` - (Optional) Flag indicating whether SSL certificate chain validation should be done when using self-signed certificates for the backend host.
 
 * `validate_certificate_name` - (Optional) Flag indicating whether SSL certificate name validation should be done when using self-signed certificates for the backend host.
+
 ---
 
 ## Attributes Reference


### PR DESCRIPTION
On https://www.terraform.io/docs/providers/azurerm/r/api_management_backend.html the `validate_certificate_name` section was rendered as-is. The only difference I could find is the item list item not having an explicit enter beneath is in the source. Hopefully this fixes the problem.