### PR TITLE
r/private_dns_zone: polling on the future instead of sleeping

### DIFF
--- a/azurerm/resource_arm_private_dns_zone.go
+++ b/azurerm/resource_arm_private_dns_zone.go
@@ -3,10 +3,7 @@ package azurerm
 import (
 	"fmt"
 
-	"time"
-
 	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
-	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
@@ -90,14 +87,12 @@ func resourceArmPrivateDnsZoneCreateUpdate(d *schema.ResourceData, meta interfac
 
 	etag := ""
 	ifNoneMatch := "" // set to empty to allow updates to records after creation
-
-	_, err := client.CreateOrUpdate(ctx, resGroup, name, parameters, etag, ifNoneMatch)
+	future, err := client.CreateOrUpdate(ctx, resGroup, name, parameters, etag, ifNoneMatch)
 	if err != nil {
 		return fmt.Errorf("error creating/updating Private DNS Zone %q (Resource Group %q): %s", name, resGroup, err)
 	}
 
-	time.Sleep(time.Second * 10) // resource is slow to create / update, retry covers the create, sleeping to make update more reliable
-	if err := resource.Retry(120*time.Second, retryPrivateDnsZonesClientGet(resGroup, name, meta)); err != nil {
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("error waiting for Private DNS Zone %q to become available: %+v", name, err)
 	}
 
@@ -113,19 +108,6 @@ func resourceArmPrivateDnsZoneCreateUpdate(d *schema.ResourceData, meta interfac
 	d.SetId(*resp.ID)
 
 	return resourceArmPrivateDnsZoneRead(d, meta)
-}
-
-func retryPrivateDnsZonesClientGet(resGroup string, name string, meta interface{}) func() *resource.RetryError {
-	return func() *resource.RetryError {
-		client := meta.(*ArmClient).privateDns.PrivateZonesClient
-		ctx := meta.(*ArmClient).StopContext
-
-		if _, err := client.Get(ctx, resGroup, name); err != nil {
-			return resource.RetryableError(err)
-		}
-
-		return nil
-	}
 }
 
 func resourceArmPrivateDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
@@ -151,10 +133,13 @@ func resourceArmPrivateDnsZoneRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resGroup)
-	d.Set("number_of_record_sets", resp.NumberOfRecordSets)
-	d.Set("max_number_of_record_sets", resp.MaxNumberOfRecordSets)
-	d.Set("max_number_of_virtual_network_links", resp.MaxNumberOfVirtualNetworkLinks)
-	d.Set("max_number_of_virtual_network_links_with_registration", resp.MaxNumberOfVirtualNetworkLinksWithRegistration)
+
+	if props := resp.PrivateZoneProperties; props != nil {
+		d.Set("number_of_record_sets", props.NumberOfRecordSets)
+		d.Set("max_number_of_record_sets", props.MaxNumberOfRecordSets)
+		d.Set("max_number_of_virtual_network_links", props.MaxNumberOfVirtualNetworkLinks)
+		d.Set("max_number_of_virtual_network_links_with_registration", props.MaxNumberOfVirtualNetworkLinksWithRegistration)
+	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }


### PR DESCRIPTION
This PR updates the Private DNS Zone resource to poll until the resource is created using the Future returned from the SDK, rather than sleeping for the specified time period. Also switches to reading properties from the `properties` block to match the API response.

Noticed whilst reviewing #3789