### PR TITLE
network: reverting the locking changes from #3673

### DIFF
--- a/azurerm/internal/services/network/network_security_group.go
+++ b/azurerm/internal/services/network/network_security_group.go
@@ -1,0 +1,31 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type NetworkSecurityGroupResourceID struct {
+	Base azure.ResourceID
+
+	Name string
+}
+
+func ParseNetworkSecurityGroupResourceID(input string) (*NetworkSecurityGroupResourceID, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Network Security Group ID %q: %+v", input, err)
+	}
+
+	networkSecurityGroup := NetworkSecurityGroupResourceID{
+		Base: *id,
+		Name: id.Path["networkSecurityGroups"],
+	}
+
+	if networkSecurityGroup.Name == "" {
+		return nil, fmt.Errorf("ID was missing the `networkSecurityGroups` element")
+	}
+
+	return &networkSecurityGroup, nil
+}

--- a/azurerm/internal/services/network/network_security_group_test.go
+++ b/azurerm/internal/services/network/network_security_group_test.go
@@ -1,0 +1,62 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+func TestParseNetworkSecurityGroup(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *RouteTableResourceID
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Network Security Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo",
+			Expected: nil,
+		},
+		{
+			Name:     "No Network Security Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/networkSecurityGroups/",
+			Expected: nil,
+		},
+		{
+			Name:  "Completed",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/networkSecurityGroups/example",
+			Expected: &RouteTableResourceID{
+				Name: "example",
+				Base: azure.ResourceID{
+					ResourceGroup: "foo",
+				},
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ParseNetworkSecurityGroupResourceID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/network/route_table.go
+++ b/azurerm/internal/services/network/route_table.go
@@ -1,0 +1,34 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+// NOTE: there's some nice things we can do with this around validation
+// since these top level objects exist
+
+type RouteTableResourceID struct {
+	Base azure.ResourceID
+
+	Name string
+}
+
+func ParseRouteTableResourceID(input string) (*RouteTableResourceID, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Route Table ID %q: %+v", input, err)
+	}
+
+	routeTable := RouteTableResourceID{
+		Base: *id,
+		Name: id.Path["routeTables"],
+	}
+
+	if routeTable.Name == "" {
+		return nil, fmt.Errorf("ID was missing the `routeTables` element")
+	}
+
+	return &routeTable, nil
+}

--- a/azurerm/internal/services/network/route_table_test.go
+++ b/azurerm/internal/services/network/route_table_test.go
@@ -1,0 +1,62 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+func TestParseRouteTable(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *RouteTableResourceID
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Route Table Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo",
+			Expected: nil,
+		},
+		{
+			Name:     "No Route Table Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/routeTables/",
+			Expected: nil,
+		},
+		{
+			Name:  "Completed",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/routeTables/example",
+			Expected: &RouteTableResourceID{
+				Name: "example",
+				Base: azure.ResourceID{
+					ResourceGroup: "foo",
+				},
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ParseRouteTableResourceID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/resource_arm_subnet_route_table_association.go
+++ b/azurerm/resource_arm_subnet_route_table_association.go
@@ -10,6 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	networkSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -54,12 +55,20 @@ func resourceArmSubnetRouteTableAssociationCreate(d *schema.ResourceData, meta i
 		return err
 	}
 
+	parsedRouteTableId, err := networkSvc.ParseRouteTableResourceID(routeTableId)
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(parsedRouteTableId.Name, routeTableResourceName)
+	defer locks.UnlockByName(parsedRouteTableId.Name, routeTableResourceName)
+
 	subnetName := parsedSubnetId.Path["subnets"]
 	virtualNetworkName := parsedSubnetId.Path["virtualNetworks"]
 	resourceGroup := parsedSubnetId.ResourceGroup
 
-	locks.ByName(subnetName, subnetResourceName)
-	defer locks.UnlockByName(subnetName, subnetResourceName)
+	locks.ByName(virtualNetworkName, virtualNetworkResourceName)
+	defer locks.UnlockByName(virtualNetworkName, virtualNetworkResourceName)
 
 	subnet, err := client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")
 	if err != nil {
@@ -178,8 +187,17 @@ func resourceArmSubnetRouteTableAssociationDelete(d *schema.ResourceData, meta i
 		return nil
 	}
 
-	locks.ByName(subnetName, subnetResourceName)
-	defer locks.UnlockByName(subnetName, subnetResourceName)
+	// once we have the route table id to lock on, lock on that
+	parsedRouteTableId, err := networkSvc.ParseRouteTableResourceID(*props.RouteTable.ID)
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(parsedRouteTableId.Name, routeTableResourceName)
+	defer locks.UnlockByName(parsedRouteTableId.Name, routeTableResourceName)
+
+	locks.ByName(virtualNetworkName, virtualNetworkResourceName)
+	defer locks.UnlockByName(virtualNetworkName, virtualNetworkResourceName)
 
 	// then re-retrieve it to ensure we've got the latest state
 	read, err = client.Get(ctx, resourceGroup, virtualNetworkName, subnetName, "")


### PR DESCRIPTION
This PR reverts the locking changes introduces in #3673 since this requires further amendments to confirm this works as expected - which should fix the newer issues identified in #3780 (which should remain open, since the original bug isn't fixed) and #2758

Rather than reintroducing methods to the top level, I've added them to the `network` service package and now return a struct - which has the added benefit of being able to return more granular validation (and allows us to build better validation functions in the future)