### PR TITLE
refactor: making the clients public

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -127,7 +127,7 @@ type ArmClient struct {
 	redis            *redis.Client
 	relay            *relay.Client
 	resource         *resource.Client
-	scheduler        *scheduler.Client
+	Scheduler        *scheduler.Client
 	Search           *search.Client
 	SecurityCenter   *securitycenter.Client
 	ServiceBus       *servicebus.Client
@@ -259,7 +259,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.SecurityCenter = securitycenter.BuildClient(o)
 	client.ServiceBus = servicebus.BuildClient(o)
 	client.ServiceFabric = servicefabric.BuildClient(o)
-	client.scheduler = scheduler.BuildClient(o)
+	client.Scheduler = scheduler.BuildClient(o)
 	client.SignalR = signalr.BuildClient(o)
 	client.StreamAnalytics = streamanalytics.BuildClient(o)
 	client.Storage = storage.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -128,7 +128,7 @@ type ArmClient struct {
 	relay            *relay.Client
 	resource         *resource.Client
 	scheduler        *scheduler.Client
-	search           *search.Client
+	Search           *search.Client
 	SecurityCenter   *securitycenter.Client
 	ServiceBus       *servicebus.Client
 	ServiceFabric    *servicefabric.Client
@@ -255,7 +255,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.redis = redis.BuildClient(o)
 	client.relay = relay.BuildClient(o)
 	client.resource = resource.BuildClient(o)
-	client.search = search.BuildClient(o)
+	client.Search = search.BuildClient(o)
 	client.SecurityCenter = securitycenter.BuildClient(o)
 	client.ServiceBus = servicebus.BuildClient(o)
 	client.ServiceFabric = servicefabric.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -131,7 +131,7 @@ type ArmClient struct {
 	search           *search.Client
 	securityCenter   *securitycenter.Client
 	servicebus       *servicebus.Client
-	serviceFabric    *servicefabric.Client
+	ServiceFabric    *servicefabric.Client
 	SignalR          *signalr.Client
 	Storage          *storage.Client
 	streamanalytics  *streamanalytics.Client
@@ -258,7 +258,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.search = search.BuildClient(o)
 	client.securityCenter = securitycenter.BuildClient(o)
 	client.servicebus = servicebus.BuildClient(o)
-	client.serviceFabric = servicefabric.BuildClient(o)
+	client.ServiceFabric = servicefabric.BuildClient(o)
 	client.scheduler = scheduler.BuildClient(o)
 	client.SignalR = signalr.BuildClient(o)
 	client.streamanalytics = streamanalytics.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -135,7 +135,7 @@ type ArmClient struct {
 	signalr          *signalr.Client
 	storage          *storage.Client
 	streamanalytics  *streamanalytics.Client
-	subscription     *subscription.Client
+	Subscription     *subscription.Client
 	Sql              *sql.Client
 	TrafficManager   *trafficmanager.Client
 	web              *web.Client
@@ -263,7 +263,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.signalr = signalr.BuildClient(o)
 	client.streamanalytics = streamanalytics.BuildClient(o)
 	client.storage = storage.BuildClient(o)
-	client.subscription = subscription.BuildClient(o)
+	client.Subscription = subscription.BuildClient(o)
 	client.Sql = sql.BuildClient(o)
 	client.TrafficManager = trafficmanager.BuildClient(o)
 	client.web = web.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -133,7 +133,7 @@ type ArmClient struct {
 	servicebus       *servicebus.Client
 	serviceFabric    *servicefabric.Client
 	signalr          *signalr.Client
-	storage          *storage.Client
+	Storage          *storage.Client
 	streamanalytics  *streamanalytics.Client
 	Subscription     *subscription.Client
 	Sql              *sql.Client
@@ -262,7 +262,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.scheduler = scheduler.BuildClient(o)
 	client.signalr = signalr.BuildClient(o)
 	client.streamanalytics = streamanalytics.BuildClient(o)
-	client.storage = storage.BuildClient(o)
+	client.Storage = storage.BuildClient(o)
 	client.Subscription = subscription.BuildClient(o)
 	client.Sql = sql.BuildClient(o)
 	client.TrafficManager = trafficmanager.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -137,7 +137,7 @@ type ArmClient struct {
 	streamanalytics  *streamanalytics.Client
 	subscription     *subscription.Client
 	sql              *sql.Client
-	trafficManager   *trafficmanager.Client
+	TrafficManager   *trafficmanager.Client
 	web              *web.Client
 }
 
@@ -265,7 +265,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.storage = storage.BuildClient(o)
 	client.subscription = subscription.BuildClient(o)
 	client.sql = sql.BuildClient(o)
-	client.trafficManager = trafficmanager.BuildClient(o)
+	client.TrafficManager = trafficmanager.BuildClient(o)
 	client.web = web.BuildClient(o)
 
 	return &client, nil

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -82,6 +82,7 @@ type ArmClient struct {
 	skipProviderRegistration bool
 
 	// Services
+	// NOTE: all new services should be Public as they're going to be relocated in the near-future
 	analysisservices *analysisservices.Client
 	apiManagement    *apimanagement.Client
 	appInsights      *applicationinsights.Client

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -134,7 +134,7 @@ type ArmClient struct {
 	ServiceFabric    *servicefabric.Client
 	SignalR          *signalr.Client
 	Storage          *storage.Client
-	streamanalytics  *streamanalytics.Client
+	StreamAnalytics  *streamanalytics.Client
 	Subscription     *subscription.Client
 	Sql              *sql.Client
 	TrafficManager   *trafficmanager.Client
@@ -261,7 +261,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.ServiceFabric = servicefabric.BuildClient(o)
 	client.scheduler = scheduler.BuildClient(o)
 	client.SignalR = signalr.BuildClient(o)
-	client.streamanalytics = streamanalytics.BuildClient(o)
+	client.StreamAnalytics = streamanalytics.BuildClient(o)
 	client.Storage = storage.BuildClient(o)
 	client.Subscription = subscription.BuildClient(o)
 	client.Sql = sql.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -130,7 +130,7 @@ type ArmClient struct {
 	scheduler        *scheduler.Client
 	search           *search.Client
 	securityCenter   *securitycenter.Client
-	servicebus       *servicebus.Client
+	ServiceBus       *servicebus.Client
 	ServiceFabric    *servicefabric.Client
 	SignalR          *signalr.Client
 	Storage          *storage.Client
@@ -257,7 +257,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.resource = resource.BuildClient(o)
 	client.search = search.BuildClient(o)
 	client.securityCenter = securitycenter.BuildClient(o)
-	client.servicebus = servicebus.BuildClient(o)
+	client.ServiceBus = servicebus.BuildClient(o)
 	client.ServiceFabric = servicefabric.BuildClient(o)
 	client.scheduler = scheduler.BuildClient(o)
 	client.SignalR = signalr.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -136,7 +136,7 @@ type ArmClient struct {
 	storage          *storage.Client
 	streamanalytics  *streamanalytics.Client
 	subscription     *subscription.Client
-	sql              *sql.Client
+	Sql              *sql.Client
 	TrafficManager   *trafficmanager.Client
 	web              *web.Client
 }
@@ -264,7 +264,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.streamanalytics = streamanalytics.BuildClient(o)
 	client.storage = storage.BuildClient(o)
 	client.subscription = subscription.BuildClient(o)
-	client.sql = sql.BuildClient(o)
+	client.Sql = sql.BuildClient(o)
 	client.TrafficManager = trafficmanager.BuildClient(o)
 	client.web = web.BuildClient(o)
 

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -129,7 +129,7 @@ type ArmClient struct {
 	resource         *resource.Client
 	scheduler        *scheduler.Client
 	search           *search.Client
-	securityCenter   *securitycenter.Client
+	SecurityCenter   *securitycenter.Client
 	ServiceBus       *servicebus.Client
 	ServiceFabric    *servicefabric.Client
 	SignalR          *signalr.Client
@@ -256,7 +256,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.relay = relay.BuildClient(o)
 	client.resource = resource.BuildClient(o)
 	client.search = search.BuildClient(o)
-	client.securityCenter = securitycenter.BuildClient(o)
+	client.SecurityCenter = securitycenter.BuildClient(o)
 	client.ServiceBus = servicebus.BuildClient(o)
 	client.ServiceFabric = servicefabric.BuildClient(o)
 	client.scheduler = scheduler.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -132,7 +132,7 @@ type ArmClient struct {
 	securityCenter   *securitycenter.Client
 	servicebus       *servicebus.Client
 	serviceFabric    *servicefabric.Client
-	signalr          *signalr.Client
+	SignalR          *signalr.Client
 	Storage          *storage.Client
 	streamanalytics  *streamanalytics.Client
 	Subscription     *subscription.Client
@@ -260,7 +260,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.servicebus = servicebus.BuildClient(o)
 	client.serviceFabric = servicefabric.BuildClient(o)
 	client.scheduler = scheduler.BuildClient(o)
-	client.signalr = signalr.BuildClient(o)
+	client.SignalR = signalr.BuildClient(o)
 	client.streamanalytics = streamanalytics.BuildClient(o)
 	client.Storage = storage.BuildClient(o)
 	client.Subscription = subscription.BuildClient(o)

--- a/azurerm/data_source_management_group.go
+++ b/azurerm/data_source_management_group.go
@@ -98,7 +98,7 @@ func flattenArmManagementGroupDataSourceSubscriptionIds(input *[]managementgroup
 
 		id, err := parseManagementGroupSubscriptionID(*child.ID)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse child subscription ID %+v", err)
+			return nil, fmt.Errorf("Unable to parse child Subscription ID %+v", err)
 		}
 
 		if id != nil {

--- a/azurerm/data_source_scheduler_job_collection.go
+++ b/azurerm/data_source_scheduler_job_collection.go
@@ -75,7 +75,7 @@ func dataSourceArmSchedulerJobCollection() *schema.Resource {
 }
 
 func dataSourceArmSchedulerJobCollectionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).scheduler.JobCollectionsClient
+	client := meta.(*ArmClient).Scheduler.JobCollectionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_servicebus_namespace.go
+++ b/azurerm/data_source_servicebus_namespace.go
@@ -67,7 +67,7 @@ func dataSourceArmServiceBusNamespace() *schema.Resource {
 }
 
 func dataSourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_servicebus_namespace_authorization_rule.go
+++ b/azurerm/data_source_servicebus_namespace_authorization_rule.go
@@ -54,7 +54,7 @@ func dataSourceArmServiceBusNamespaceAuthorizationRule() *schema.Resource {
 }
 
 func dataSourceArmServiceBusNamespaceAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_sql_database.go
+++ b/azurerm/data_source_sql_database.go
@@ -68,7 +68,7 @@ func dataSourceSqlDatabase() *schema.Resource {
 }
 
 func dataSourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.DatabasesClient
+	client := meta.(*ArmClient).Sql.DatabasesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_sql_server.go
+++ b/azurerm/data_source_sql_server.go
@@ -47,7 +47,7 @@ func dataSourceSqlServer() *schema.Resource {
 }
 
 func dataSourceArmSqlServerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ServersClient
+	client := meta.(*ArmClient).Sql.ServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_storage_account.go
+++ b/azurerm/data_source_storage_account.go
@@ -259,7 +259,7 @@ func dataSourceArmStorageAccount() *schema.Resource {
 
 func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storage.AccountsClient
+	client := meta.(*ArmClient).Storage.AccountsClient
 	endpointSuffix := meta.(*ArmClient).environment.StorageEndpointSuffix
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_stream_analytics_job.go
+++ b/azurerm/data_source_stream_analytics_job.go
@@ -72,8 +72,8 @@ func dataSourceArmStreamAnalyticsJob() *schema.Resource {
 }
 
 func dataSourceArmStreamAnalyticsJobRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.JobsClient
-	transformationsClient := meta.(*ArmClient).streamanalytics.TransformationsClient
+	client := meta.(*ArmClient).StreamAnalytics.JobsClient
+	transformationsClient := meta.(*ArmClient).StreamAnalytics.TransformationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_subscription.go
+++ b/azurerm/data_source_subscription.go
@@ -17,7 +17,7 @@ func dataSourceArmSubscription() *schema.Resource {
 
 func dataSourceArmSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
-	groupClient := client.subscription.Client
+	groupClient := client.Subscription.Client
 	ctx := client.StopContext
 
 	subscriptionId := d.Get("subscription_id").(string)
@@ -31,7 +31,7 @@ func dataSourceArmSubscriptionRead(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error: Subscription %q was not found", subscriptionId)
 		}
 
-		return fmt.Errorf("Error reading subscription: %+v", err)
+		return fmt.Errorf("Error reading Subscription: %+v", err)
 	}
 
 	d.SetId(*resp.ID)

--- a/azurerm/data_source_subscriptions.go
+++ b/azurerm/data_source_subscriptions.go
@@ -34,7 +34,7 @@ func dataSourceArmSubscriptions() *schema.Resource {
 
 func dataSourceArmSubscriptionsRead(d *schema.ResourceData, meta interface{}) error {
 	armClient := meta.(*ArmClient)
-	subClient := armClient.subscription.Client
+	subClient := armClient.Subscription.Client
 	ctx := armClient.StopContext
 
 	displayNamePrefix := strings.ToLower(d.Get("display_name_prefix").(string))

--- a/azurerm/data_source_traffic_manager_geographical_location.go
+++ b/azurerm/data_source_traffic_manager_geographical_location.go
@@ -21,7 +21,7 @@ func dataSourceArmTrafficManagerGeographicalLocation() *schema.Resource {
 }
 
 func dataSourceArmTrafficManagerGeographicalLocationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).trafficManager.GeographialHierarchiesClient
+	client := meta.(*ArmClient).TrafficManager.GeographialHierarchiesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	results, err := client.GetDefault(ctx)

--- a/azurerm/resource_arm_container_registry_migrate.go
+++ b/azurerm/resource_arm_container_registry_migrate.go
@@ -92,7 +92,7 @@ func updateV1ToV2StorageAccountName(is *terraform.InstanceState, meta interface{
 
 func findAzureStorageAccountIdFromName(name string, meta interface{}) (string, error) {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storage.AccountsClient
+	client := meta.(*ArmClient).Storage.AccountsClient
 	accounts, err := client.List(ctx)
 	if err != nil {
 		return "", err

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -112,7 +112,7 @@ func createResourceGroup(ctx context.Context, client *ArmClient, resourceGroupNa
 }
 
 func createStorageAccount(client *ArmClient, resourceGroupName, storageAccountName, location string) (*storage.Account, error) {
-	storageClient := client.storage.AccountsClient
+	storageClient := client.Storage.AccountsClient
 	createParams := storage.AccountCreateParameters{
 		Location: &location,
 		Kind:     storage.Storage,
@@ -141,7 +141,7 @@ func createStorageAccount(client *ArmClient, resourceGroupName, storageAccountNa
 
 func destroyStorageAccountAndResourceGroup(client *ArmClient, resourceGroupName, storageAccountName string) {
 	ctx := client.StopContext
-	if _, err := client.storage.AccountsClient.Delete(ctx, resourceGroupName, storageAccountName); err != nil {
+	if _, err := client.Storage.AccountsClient.Delete(ctx, resourceGroupName, storageAccountName); err != nil {
 		log.Printf("[DEBUG] Error deleting Storage Account %q (Resource Group %q): %v", storageAccountName, resourceGroupName, err)
 	}
 	if _, err := client.resource.GroupsClient.Delete(ctx, resourceGroupName); err != nil {

--- a/azurerm/resource_arm_management_group.go
+++ b/azurerm/resource_arm_management_group.go
@@ -283,7 +283,7 @@ func flattenArmManagementGroupSubscriptionIds(input *[]managementgroups.ChildInf
 
 		id, err := parseManagementGroupSubscriptionID(*child.ID)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse child subscription ID %+v", err)
+			return nil, fmt.Errorf("Unable to parse child Subscription ID %+v", err)
 		}
 
 		if id != nil {

--- a/azurerm/resource_arm_scheduler_job.go
+++ b/azurerm/resource_arm_scheduler_job.go
@@ -464,7 +464,7 @@ func resourceArmSchedulerJobCustomizeDiff(diff *schema.ResourceDiff, _ interface
 }
 
 func resourceArmSchedulerJobCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).scheduler.JobsClient
+	client := meta.(*ArmClient).Scheduler.JobsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -521,7 +521,7 @@ func resourceArmSchedulerJobCreateUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmSchedulerJobRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).scheduler.JobsClient
+	client := meta.(*ArmClient).Scheduler.JobsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -615,7 +615,7 @@ func resourceArmSchedulerJobRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmSchedulerJobDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).scheduler.JobsClient
+	client := meta.(*ArmClient).Scheduler.JobsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_scheduler_job_collection.go
+++ b/azurerm/resource_arm_scheduler_job_collection.go
@@ -127,7 +127,7 @@ func resourceArmSchedulerJobCollection() *schema.Resource {
 }
 
 func resourceArmSchedulerJobCollectionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).scheduler.JobCollectionsClient
+	client := meta.(*ArmClient).Scheduler.JobCollectionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -183,7 +183,7 @@ func resourceArmSchedulerJobCollectionCreateUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceArmSchedulerJobCollectionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).scheduler.JobCollectionsClient
+	client := meta.(*ArmClient).Scheduler.JobCollectionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -229,7 +229,7 @@ func resourceArmSchedulerJobCollectionRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmSchedulerJobCollectionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).scheduler.JobCollectionsClient
+	client := meta.(*ArmClient).Scheduler.JobCollectionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_scheduler_job_collection_test.go
+++ b/azurerm/resource_arm_scheduler_job_collection_test.go
@@ -98,7 +98,7 @@ func testCheckAzureRMSchedulerJobCollectionDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).scheduler.JobCollectionsClient
+		client := testAccProvider.Meta().(*ArmClient).Scheduler.JobCollectionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, name)
@@ -131,7 +131,7 @@ func testCheckAzureRMSchedulerJobCollectionExists(resourceName string) resource.
 			return fmt.Errorf("Bad: no resource group found in state for Scheduler Job Collection: %q", name)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).scheduler.JobCollectionsClient
+		client := testAccProvider.Meta().(*ArmClient).Scheduler.JobCollectionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, name)
 

--- a/azurerm/resource_arm_scheduler_job_test.go
+++ b/azurerm/resource_arm_scheduler_job_test.go
@@ -515,7 +515,7 @@ func testCheckAzureRMSchedulerJobDestroy(s *terraform.State) error {
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		jobCollection := rs.Primary.Attributes["job_collection_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).scheduler.JobsClient
+		client := testAccProvider.Meta().(*ArmClient).Scheduler.JobsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, jobCollection, name)
@@ -549,7 +549,7 @@ func testCheckAzureRMSchedulerJobExists(resourceName string) resource.TestCheckF
 			return fmt.Errorf("Bad: no resource group found in state for Scheduler Job: %q", name)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).scheduler.JobsClient
+		client := testAccProvider.Meta().(*ArmClient).Scheduler.JobsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, jobCollection, name)

--- a/azurerm/resource_arm_search_service.go
+++ b/azurerm/resource_arm_search_service.go
@@ -79,7 +79,7 @@ func resourceArmSearchService() *schema.Resource {
 }
 
 func resourceArmSearchServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).search.ServicesClient
+	client := meta.(*ArmClient).Search.ServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -135,7 +135,7 @@ func resourceArmSearchServiceCreateUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmSearchServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).search.ServicesClient
+	client := meta.(*ArmClient).Search.ServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -176,7 +176,7 @@ func resourceArmSearchServiceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	adminKeysClient := meta.(*ArmClient).search.AdminKeysClient
+	adminKeysClient := meta.(*ArmClient).Search.AdminKeysClient
 	adminKeysResp, err := adminKeysClient.Get(ctx, resourceGroup, name, nil)
 	if err == nil {
 		d.Set("primary_key", adminKeysResp.PrimaryKey)
@@ -187,7 +187,7 @@ func resourceArmSearchServiceRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmSearchServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).search.ServicesClient
+	client := meta.(*ArmClient).Search.ServicesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_search_service_test.go
+++ b/azurerm/resource_arm_search_service_test.go
@@ -133,7 +133,7 @@ func testCheckAzureRMSearchServiceExists(resourceName string) resource.TestCheck
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		searchName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).search.ServicesClient
+		client := testAccProvider.Meta().(*ArmClient).Search.ServicesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, searchName, nil)
@@ -158,7 +158,7 @@ func testCheckAzureRMSearchServiceDestroy(s *terraform.State) error {
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		searchName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).search.ServicesClient
+		client := testAccProvider.Meta().(*ArmClient).Search.ServicesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, searchName, nil)

--- a/azurerm/resource_arm_security_center_contact.go
+++ b/azurerm/resource_arm_security_center_contact.go
@@ -57,7 +57,7 @@ func resourceArmSecurityCenterContact() *schema.Resource {
 }
 
 func resourceArmSecurityCenterContactCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).securityCenter.ContactsClient
+	client := meta.(*ArmClient).SecurityCenter.ContactsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := securityCenterContactName
@@ -119,7 +119,7 @@ func resourceArmSecurityCenterContactCreateUpdate(d *schema.ResourceData, meta i
 }
 
 func resourceArmSecurityCenterContactRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).securityCenter.ContactsClient
+	client := meta.(*ArmClient).SecurityCenter.ContactsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := securityCenterContactName
@@ -146,7 +146,7 @@ func resourceArmSecurityCenterContactRead(d *schema.ResourceData, meta interface
 }
 
 func resourceArmSecurityCenterContactDelete(_ *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).securityCenter.ContactsClient
+	client := meta.(*ArmClient).SecurityCenter.ContactsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := securityCenterContactName

--- a/azurerm/resource_arm_security_center_contact_test.go
+++ b/azurerm/resource_arm_security_center_contact_test.go
@@ -158,7 +158,7 @@ func testAccAzureRMSecurityCenterContact_phoneOptional(t *testing.T) {
 
 func testCheckAzureRMSecurityCenterContactExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*ArmClient).securityCenter.ContactsClient
+		client := testAccProvider.Meta().(*ArmClient).SecurityCenter.ContactsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -182,7 +182,7 @@ func testCheckAzureRMSecurityCenterContactExists(resourceName string) resource.T
 }
 
 func testCheckAzureRMSecurityCenterContactDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).securityCenter.ContactsClient
+	client := testAccProvider.Meta().(*ArmClient).SecurityCenter.ContactsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 	for _, res := range s.RootModule().Resources {
 		if res.Type != "azurerm_security_center_contact" {

--- a/azurerm/resource_arm_security_center_subscription_pricing.go
+++ b/azurerm/resource_arm_security_center_subscription_pricing.go
@@ -39,7 +39,7 @@ func resourceArmSecurityCenterSubscriptionPricing() *schema.Resource {
 }
 
 func resourceArmSecurityCenterSubscriptionPricingUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).securityCenter.PricingClient
+	client := meta.(*ArmClient).SecurityCenter.PricingClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := securityCenterSubscriptionPricingName
@@ -71,7 +71,7 @@ func resourceArmSecurityCenterSubscriptionPricingUpdate(d *schema.ResourceData, 
 }
 
 func resourceArmSecurityCenterSubscriptionPricingRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).securityCenter.PricingClient
+	client := meta.(*ArmClient).SecurityCenter.PricingClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resp, err := client.GetSubscriptionPricing(ctx, securityCenterSubscriptionPricingName)

--- a/azurerm/resource_arm_security_center_subscription_pricing_test.go
+++ b/azurerm/resource_arm_security_center_subscription_pricing_test.go
@@ -46,7 +46,7 @@ func testAccAzureRMSecurityCenterSubscriptionPricing_update(t *testing.T) {
 
 func testCheckAzureRMSecurityCenterSubscriptionPricingExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*ArmClient).securityCenter.PricingClient
+		client := testAccProvider.Meta().(*ArmClient).SecurityCenter.PricingClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/azurerm/resource_arm_security_center_workspace.go
+++ b/azurerm/resource_arm_security_center_workspace.go
@@ -47,8 +47,8 @@ func resourceArmSecurityCenterWorkspace() *schema.Resource {
 }
 
 func resourceArmSecurityCenterWorkspaceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	priceClient := meta.(*ArmClient).securityCenter.PricingClient
-	client := meta.(*ArmClient).securityCenter.WorkspaceClient
+	priceClient := meta.(*ArmClient).SecurityCenter.PricingClient
+	client := meta.(*ArmClient).SecurityCenter.WorkspaceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := securityCenterWorkspaceName
@@ -133,7 +133,7 @@ func resourceArmSecurityCenterWorkspaceCreateUpdate(d *schema.ResourceData, meta
 }
 
 func resourceArmSecurityCenterWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).securityCenter.WorkspaceClient
+	client := meta.(*ArmClient).SecurityCenter.WorkspaceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resp, err := client.Get(ctx, securityCenterWorkspaceName)
@@ -156,7 +156,7 @@ func resourceArmSecurityCenterWorkspaceRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmSecurityCenterWorkspaceDelete(_ *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).securityCenter.WorkspaceClient
+	client := meta.(*ArmClient).SecurityCenter.WorkspaceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resp, err := client.Delete(ctx, securityCenterWorkspaceName)

--- a/azurerm/resource_arm_security_center_workspace_test.go
+++ b/azurerm/resource_arm_security_center_workspace_test.go
@@ -117,7 +117,7 @@ func testAccAzureRMSecurityCenterWorkspace_update(t *testing.T) {
 
 func testCheckAzureRMSecurityCenterWorkspaceExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*ArmClient).securityCenter.WorkspaceClient
+		client := testAccProvider.Meta().(*ArmClient).SecurityCenter.WorkspaceClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -141,7 +141,7 @@ func testCheckAzureRMSecurityCenterWorkspaceExists(resourceName string) resource
 }
 
 func testCheckAzureRMSecurityCenterWorkspaceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).securityCenter.WorkspaceClient
+	client := testAccProvider.Meta().(*ArmClient).SecurityCenter.WorkspaceClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, res := range s.RootModule().Resources {

--- a/azurerm/resource_arm_service_fabric_cluster.go
+++ b/azurerm/resource_arm_service_fabric_cluster.go
@@ -354,7 +354,7 @@ func resourceArmServiceFabricCluster() *schema.Resource {
 }
 
 func resourceArmServiceFabricClusterCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).serviceFabric.ClustersClient
+	client := meta.(*ArmClient).ServiceFabric.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Service Fabric Cluster creation.")
@@ -454,7 +454,7 @@ func resourceArmServiceFabricClusterCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmServiceFabricClusterRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).serviceFabric.ClustersClient
+	client := meta.(*ArmClient).ServiceFabric.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -540,7 +540,7 @@ func resourceArmServiceFabricClusterRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmServiceFabricClusterDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).serviceFabric.ClustersClient
+	client := meta.(*ArmClient).ServiceFabric.ClustersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/resource_arm_service_fabric_cluster_test.go
@@ -835,7 +835,7 @@ func TestAccAzureRMServiceFabricCluster_tags(t *testing.T) {
 }
 
 func testCheckAzureRMServiceFabricClusterDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).serviceFabric.ClustersClient
+	client := testAccProvider.Meta().(*ArmClient).ServiceFabric.ClustersClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -874,7 +874,7 @@ func testCheckAzureRMServiceFabricClusterExists(resourceName string) resource.Te
 			return fmt.Errorf("Bad: no resource group found in state for Service Fabric Cluster %q", clusterName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).serviceFabric.ClustersClient
+		client := testAccProvider.Meta().(*ArmClient).ServiceFabric.ClustersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, clusterName)

--- a/azurerm/resource_arm_servicebus_namespace.go
+++ b/azurerm/resource_arm_servicebus_namespace.go
@@ -102,7 +102,7 @@ func resourceArmServiceBusNamespace() *schema.Resource {
 }
 
 func resourceArmServiceBusNamespaceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM ServiceBus Namespace creation.")
@@ -169,7 +169,7 @@ func resourceArmServiceBusNamespaceCreateUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -213,7 +213,7 @@ func resourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmServiceBusNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_namespace_authorization_rule.go
+++ b/azurerm/resource_arm_servicebus_namespace_authorization_rule.go
@@ -48,7 +48,7 @@ func resourceArmServiceBusNamespaceAuthorizationRule() *schema.Resource {
 }
 
 func resourceArmServiceBusNamespaceAuthorizationRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM ServiceBus Namespace Authorization Rule creation.")
@@ -96,7 +96,7 @@ func resourceArmServiceBusNamespaceAuthorizationRuleCreateUpdate(d *schema.Resou
 }
 
 func resourceArmServiceBusNamespaceAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -142,7 +142,7 @@ func resourceArmServiceBusNamespaceAuthorizationRuleRead(d *schema.ResourceData,
 }
 
 func resourceArmServiceBusNamespaceAuthorizationRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.NamespacesClient
+	client := meta.(*ArmClient).ServiceBus.NamespacesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_authorization_rule_test.go
@@ -133,7 +133,7 @@ func TestAccAzureRMServiceBusNamespaceAuthorizationRule_requiresImport(t *testin
 }
 
 func testCheckAzureRMServiceBusNamespaceAuthorizationRuleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).servicebus.NamespacesClient
+	conn := testAccProvider.Meta().(*ArmClient).ServiceBus.NamespacesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -171,7 +171,7 @@ func testCheckAzureRMServiceBusNamespaceAuthorizationRuleExists(resourceName str
 			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Namespace: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).servicebus.NamespacesClient
+		conn := testAccProvider.Meta().(*ArmClient).ServiceBus.NamespacesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.GetAuthorizationRule(ctx, resourceGroup, namespaceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_test.go
@@ -182,7 +182,7 @@ func TestAccAzureRMServiceBusNamespace_premiumCapacity(t *testing.T) {
 }
 
 func testCheckAzureRMServiceBusNamespaceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).servicebus.NamespacesClient
+	client := testAccProvider.Meta().(*ArmClient).ServiceBus.NamespacesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -221,7 +221,7 @@ func testCheckAzureRMServiceBusNamespaceExists(resourceName string) resource.Tes
 			return fmt.Errorf("Bad: no resource group found in state for Service Bus Namespace: %s", namespaceName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).servicebus.NamespacesClient
+		client := testAccProvider.Meta().(*ArmClient).ServiceBus.NamespacesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, namespaceName)

--- a/azurerm/resource_arm_servicebus_queue.go
+++ b/azurerm/resource_arm_servicebus_queue.go
@@ -134,7 +134,7 @@ func resourceArmServiceBusQueue() *schema.Resource {
 }
 
 func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.QueuesClient
+	client := meta.(*ArmClient).ServiceBus.QueuesClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for AzureRM ServiceBus Queue creation/update.")
 
@@ -194,7 +194,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 
 	// We need to retrieve the namespace because Premium namespace works differently from Basic and Standard,
 	// so it needs different rules applied to it.
-	namespacesClient := meta.(*ArmClient).servicebus.NamespacesClient
+	namespacesClient := meta.(*ArmClient).ServiceBus.NamespacesClient
 	namespace, err := namespacesClient.Get(ctx, resourceGroup, namespaceName)
 	if err != nil {
 		return fmt.Errorf("Error retrieving ServiceBus Namespace %q (Resource Group %q): %+v", resourceGroup, namespaceName, err)
@@ -224,7 +224,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.QueuesClient
+	client := meta.(*ArmClient).ServiceBus.QueuesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -267,7 +267,7 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 			// If the queue is NOT in a premium namespace (ie. it is Basic or Standard) and partitioning is enabled
 			// then the max size returned by the API will be 16 times greater than the value set.
 			if *props.EnablePartitioning {
-				namespacesClient := meta.(*ArmClient).servicebus.NamespacesClient
+				namespacesClient := meta.(*ArmClient).ServiceBus.NamespacesClient
 				namespace, err := namespacesClient.Get(ctx, resourceGroup, namespaceName)
 				if err != nil {
 					return err
@@ -287,7 +287,7 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmServiceBusQueueDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.QueuesClient
+	client := meta.(*ArmClient).ServiceBus.QueuesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_queue_authorization_rule.go
+++ b/azurerm/resource_arm_servicebus_queue_authorization_rule.go
@@ -53,7 +53,7 @@ func resourceArmServiceBusQueueAuthorizationRule() *schema.Resource {
 }
 
 func resourceArmServiceBusQueueAuthorizationRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.QueuesClient
+	client := meta.(*ArmClient).ServiceBus.QueuesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM ServiceBus Queue Authorization Rule creation.")
@@ -102,7 +102,7 @@ func resourceArmServiceBusQueueAuthorizationRuleCreateUpdate(d *schema.ResourceD
 }
 
 func resourceArmServiceBusQueueAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.QueuesClient
+	client := meta.(*ArmClient).ServiceBus.QueuesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -151,7 +151,7 @@ func resourceArmServiceBusQueueAuthorizationRuleRead(d *schema.ResourceData, met
 }
 
 func resourceArmServiceBusQueueAuthorizationRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.QueuesClient
+	client := meta.(*ArmClient).ServiceBus.QueuesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_queue_authorization_rule_test.go
@@ -133,7 +133,7 @@ func TestAccAzureRMServiceBusQueueAuthorizationRule_requiresImport(t *testing.T)
 }
 
 func testCheckAzureRMServiceBusQueueAuthorizationRuleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).servicebus.QueuesClient
+	conn := testAccProvider.Meta().(*ArmClient).ServiceBus.QueuesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -173,7 +173,7 @@ func testCheckAzureRMServiceBusQueueAuthorizationRuleExists(resourceName string)
 			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Queue Authorization Rule: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).servicebus.QueuesClient
+		conn := testAccProvider.Meta().(*ArmClient).ServiceBus.QueuesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.GetAuthorizationRule(ctx, resourceGroup, namespaceName, queueName, name)

--- a/azurerm/resource_arm_servicebus_queue_test.go
+++ b/azurerm/resource_arm_servicebus_queue_test.go
@@ -355,7 +355,7 @@ func TestAccAzureRMServiceBusQueue_maxDeliveryCount(t *testing.T) {
 }
 
 func testCheckAzureRMServiceBusQueueDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).servicebus.QueuesClient
+	client := testAccProvider.Meta().(*ArmClient).ServiceBus.QueuesClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -398,7 +398,7 @@ func testCheckAzureRMServiceBusQueueExists(resourceName string) resource.TestChe
 			return fmt.Errorf("Bad: no resource group found in state for queue: %s", queueName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).servicebus.QueuesClient
+		client := testAccProvider.Meta().(*ArmClient).ServiceBus.QueuesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, namespaceName, queueName)

--- a/azurerm/resource_arm_servicebus_subscription.go
+++ b/azurerm/resource_arm_servicebus_subscription.go
@@ -104,7 +104,7 @@ func resourceArmServiceBusSubscription() *schema.Resource {
 }
 
 func resourceArmServiceBusSubscriptionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.SubscriptionsClient
+	client := meta.(*ArmClient).ServiceBus.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for Azure ARM ServiceBus Subscription creation.")
 
@@ -174,7 +174,7 @@ func resourceArmServiceBusSubscriptionCreateUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.SubscriptionsClient
+	client := meta.(*ArmClient).ServiceBus.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -218,7 +218,7 @@ func resourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmServiceBusSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.SubscriptionsClient
+	client := meta.(*ArmClient).ServiceBus.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_subscription_rule.go
+++ b/azurerm/resource_arm_servicebus_subscription_rule.go
@@ -123,7 +123,7 @@ func resourceArmServiceBusSubscriptionRule() *schema.Resource {
 }
 
 func resourceArmServiceBusSubscriptionRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.SubscriptionRulesClient
+	client := meta.(*ArmClient).ServiceBus.SubscriptionRulesClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for Azure Service Bus Subscription Rule creation.")
 
@@ -193,7 +193,7 @@ func resourceArmServiceBusSubscriptionRuleCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmServiceBusSubscriptionRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.SubscriptionRulesClient
+	client := meta.(*ArmClient).ServiceBus.SubscriptionRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -242,7 +242,7 @@ func resourceArmServiceBusSubscriptionRuleRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmServiceBusSubscriptionRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.SubscriptionRulesClient
+	client := meta.(*ArmClient).ServiceBus.SubscriptionRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_subscription_rule_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_rule_test.go
@@ -219,7 +219,7 @@ func testCheckAzureRMServiceBusSubscriptionRuleExists(resourceName string) resou
 			return fmt.Errorf("Bad: no resource group found in state for Subscription Rule: %q", ruleName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).servicebus.SubscriptionRulesClient
+		client := testAccProvider.Meta().(*ArmClient).ServiceBus.SubscriptionRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, namespaceName, topicName, subscriptionName, ruleName)

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -191,7 +191,7 @@ func TestAccAzureRMServiceBusSubscription_updateForwardTo(t *testing.T) {
 }
 
 func testCheckAzureRMServiceBusSubscriptionDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).servicebus.SubscriptionsClient
+	client := testAccProvider.Meta().(*ArmClient).ServiceBus.SubscriptionsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -236,7 +236,7 @@ func testCheckAzureRMServiceBusSubscriptionExists(resourceName string) resource.
 			return fmt.Errorf("Bad: no resource group found in state for Subscription: %q", topicName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).servicebus.SubscriptionsClient
+		client := testAccProvider.Meta().(*ArmClient).ServiceBus.SubscriptionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, namespaceName, topicName, subscriptionName)

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -233,7 +233,7 @@ func testCheckAzureRMServiceBusSubscriptionExists(resourceName string) resource.
 		namespaceName := rs.Primary.Attributes["namespace_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for subscription: %q", topicName)
+			return fmt.Errorf("Bad: no resource group found in state for Subscription: %q", topicName)
 		}
 
 		client := testAccProvider.Meta().(*ArmClient).servicebus.SubscriptionsClient

--- a/azurerm/resource_arm_servicebus_topic.go
+++ b/azurerm/resource_arm_servicebus_topic.go
@@ -121,7 +121,7 @@ func resourceArmServiceBusTopic() *schema.Resource {
 }
 
 func resourceArmServiceBusTopicCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.TopicsClient
+	client := meta.(*ArmClient).ServiceBus.TopicsClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for Azure ServiceBus Topic creation.")
 
@@ -193,7 +193,7 @@ func resourceArmServiceBusTopicCreateUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmServiceBusTopicRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.TopicsClient
+	client := meta.(*ArmClient).ServiceBus.TopicsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -238,7 +238,7 @@ func resourceArmServiceBusTopicRead(d *schema.ResourceData, meta interface{}) er
 			// if the topic is in a premium namespace and partitioning is enabled then the
 			// max size returned by the API will be 16 times greater than the value set
 			if partitioning := props.EnablePartitioning; partitioning != nil && *partitioning {
-				namespacesClient := meta.(*ArmClient).servicebus.NamespacesClient
+				namespacesClient := meta.(*ArmClient).ServiceBus.NamespacesClient
 				namespace, err := namespacesClient.Get(ctx, resourceGroup, namespaceName)
 				if err != nil {
 					return err
@@ -258,7 +258,7 @@ func resourceArmServiceBusTopicRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmServiceBusTopicDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.TopicsClient
+	client := meta.(*ArmClient).ServiceBus.TopicsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_topic_authorization_rule.go
+++ b/azurerm/resource_arm_servicebus_topic_authorization_rule.go
@@ -54,7 +54,7 @@ func resourceArmServiceBusTopicAuthorizationRule() *schema.Resource {
 }
 
 func resourceArmServiceBusTopicAuthorizationRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.TopicsClient
+	client := meta.(*ArmClient).ServiceBus.TopicsClient
 	ctx := meta.(*ArmClient).StopContext
 	log.Printf("[INFO] preparing arguments for AzureRM ServiceBus Topic Authorization Rule creation.")
 
@@ -102,7 +102,7 @@ func resourceArmServiceBusTopicAuthorizationRuleCreateUpdate(d *schema.ResourceD
 }
 
 func resourceArmServiceBusTopicAuthorizationRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.TopicsClient
+	client := meta.(*ArmClient).ServiceBus.TopicsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -150,7 +150,7 @@ func resourceArmServiceBusTopicAuthorizationRuleRead(d *schema.ResourceData, met
 }
 
 func resourceArmServiceBusTopicAuthorizationRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).servicebus.TopicsClient
+	client := meta.(*ArmClient).ServiceBus.TopicsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
+++ b/azurerm/resource_arm_servicebus_topic_authorization_rule_test.go
@@ -133,7 +133,7 @@ func TestAccAzureRMServiceBusTopicAuthorizationRule_rightsUpdate(t *testing.T) {
 }
 
 func testCheckAzureRMServiceBusTopicAuthorizationRuleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).servicebus.TopicsClient
+	conn := testAccProvider.Meta().(*ArmClient).ServiceBus.TopicsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -173,7 +173,7 @@ func testCheckAzureRMServiceBusTopicAuthorizationRuleExists(resourceName string)
 			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Topic: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).servicebus.TopicsClient
+		conn := testAccProvider.Meta().(*ArmClient).ServiceBus.TopicsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.GetAuthorizationRule(ctx, resourceGroup, namespaceName, topicName, name)
 		if err != nil {

--- a/azurerm/resource_arm_servicebus_topic_test.go
+++ b/azurerm/resource_arm_servicebus_topic_test.go
@@ -281,7 +281,7 @@ func TestAccAzureRMServiceBusTopic_isoTimeSpanAttributes(t *testing.T) {
 }
 
 func testCheckAzureRMServiceBusTopicDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).servicebus.TopicsClient
+	client := testAccProvider.Meta().(*ArmClient).ServiceBus.TopicsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -324,7 +324,7 @@ func testCheckAzureRMServiceBusTopicExists(resourceName string) resource.TestChe
 			return fmt.Errorf("Bad: no resource group found in state for topic: %s", topicName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).servicebus.TopicsClient
+		client := testAccProvider.Meta().(*ArmClient).ServiceBus.TopicsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, namespaceName, topicName)

--- a/azurerm/resource_arm_signalr_service.go
+++ b/azurerm/resource_arm_signalr_service.go
@@ -113,7 +113,7 @@ func resourceArmSignalRService() *schema.Resource {
 }
 
 func resourceArmSignalRServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).signalr.Client
+	client := meta.(*ArmClient).SignalR.Client
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -164,7 +164,7 @@ func resourceArmSignalRServiceCreateUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmSignalRServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).signalr.Client
+	client := meta.(*ArmClient).SignalR.Client
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -215,7 +215,7 @@ func resourceArmSignalRServiceRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmSignalRServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).signalr.Client
+	client := meta.(*ArmClient).SignalR.Client
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -399,7 +399,7 @@ resource "azurerm_signalr_service" "test" {
 }
 
 func testCheckAzureRMSignalRServiceDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).signalr.Client
+	conn := testAccProvider.Meta().(*ArmClient).SignalR.Client
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_signalr_service" {
@@ -434,7 +434,7 @@ func testCheckAzureRMSignalRServiceExists(resourceName string) resource.TestChec
 			return fmt.Errorf("Bad: no resource group found in state for SignalR service: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).signalr.Client
+		conn := testAccProvider.Meta().(*ArmClient).SignalR.Client
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_sql_administrator.go
+++ b/azurerm/resource_arm_sql_administrator.go
@@ -54,7 +54,7 @@ func resourceArmSqlAdministrator() *schema.Resource {
 }
 
 func resourceArmSqlActiveDirectoryAdministratorCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ServerAzureADAdministratorsClient
+	client := meta.(*ArmClient).Sql.ServerAzureADAdministratorsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	serverName := d.Get("server_name").(string)
@@ -105,7 +105,7 @@ func resourceArmSqlActiveDirectoryAdministratorCreateUpdate(d *schema.ResourceDa
 }
 
 func resourceArmSqlActiveDirectoryAdministratorRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ServerAzureADAdministratorsClient
+	client := meta.(*ArmClient).Sql.ServerAzureADAdministratorsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -137,7 +137,7 @@ func resourceArmSqlActiveDirectoryAdministratorRead(d *schema.ResourceData, meta
 }
 
 func resourceArmSqlActiveDirectoryAdministratorDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ServerAzureADAdministratorsClient
+	client := meta.(*ArmClient).Sql.ServerAzureADAdministratorsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_sql_administrator_test.go
+++ b/azurerm/resource_arm_sql_administrator_test.go
@@ -102,7 +102,7 @@ func testCheckAzureRMSqlAdministratorExists(resourceName string) resource.TestCh
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serverName := rs.Primary.Attributes["server_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.ServerAzureADAdministratorsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.ServerAzureADAdministratorsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		_, err := client.Get(ctx, resourceGroup, serverName)
@@ -120,7 +120,7 @@ func testCheckAzureRMSqlAdministratorDisappears(resourceName string) resource.Te
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serverName := rs.Primary.Attributes["server_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.ServerAzureADAdministratorsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.ServerAzureADAdministratorsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if _, err := client.Delete(ctx, resourceGroup, serverName); err != nil {
@@ -140,7 +140,7 @@ func testCheckAzureRMSqlAdministratorDestroy(s *terraform.State) error {
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serverName := rs.Primary.Attributes["server_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.ServerAzureADAdministratorsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.ServerAzureADAdministratorsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName)

--- a/azurerm/resource_arm_sql_database.go
+++ b/azurerm/resource_arm_sql_database.go
@@ -335,7 +335,7 @@ func resourceArmSqlDatabase() *schema.Resource {
 }
 
 func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.DatabasesClient
+	client := meta.(*ArmClient).Sql.DatabasesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -484,7 +484,7 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 
 	d.SetId(*resp.ID)
 
-	threatDetectionClient := meta.(*ArmClient).sql.DatabaseThreatDetectionPoliciesClient
+	threatDetectionClient := meta.(*ArmClient).Sql.DatabaseThreatDetectionPoliciesClient
 	if _, err = threatDetectionClient.CreateOrUpdate(ctx, resourceGroup, serverName, name, *threatDetection); err != nil {
 		return fmt.Errorf("Error setting database threat detection policy: %+v", err)
 	}
@@ -493,7 +493,7 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.DatabasesClient
+	client := meta.(*ArmClient).Sql.DatabasesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -516,7 +516,7 @@ func resourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error making Read request on Sql Database %s: %+v", name, err)
 	}
 
-	threatDetectionClient := meta.(*ArmClient).sql.DatabaseThreatDetectionPoliciesClient
+	threatDetectionClient := meta.(*ArmClient).Sql.DatabaseThreatDetectionPoliciesClient
 	threatDetection, err := threatDetectionClient.Get(ctx, resourceGroup, serverName, name)
 	if err == nil {
 		flattenedThreatDetection := flattenArmSqlServerThreatDetectionPolicy(d, threatDetection)
@@ -574,7 +574,7 @@ func resourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceArmSqlDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.DatabasesClient
+	client := meta.(*ArmClient).Sql.DatabasesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_sql_database_test.go
+++ b/azurerm/resource_arm_sql_database_test.go
@@ -341,7 +341,7 @@ func testCheckAzureRMSqlDatabaseExists(resourceName string) resource.TestCheckFu
 		serverName := rs.Primary.Attributes["server_name"]
 		databaseName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.DatabasesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.DatabasesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, databaseName, "")
@@ -367,7 +367,7 @@ func testCheckAzureRMSqlDatabaseDestroy(s *terraform.State) error {
 		serverName := rs.Primary.Attributes["server_name"]
 		databaseName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.DatabasesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.DatabasesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, databaseName, "")
@@ -397,7 +397,7 @@ func testCheckAzureRMSqlDatabaseDisappears(resourceName string) resource.TestChe
 		serverName := rs.Primary.Attributes["server_name"]
 		databaseName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.DatabasesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.DatabasesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if _, err := client.Delete(ctx, resourceGroup, serverName, databaseName); err != nil {

--- a/azurerm/resource_arm_sql_elasticpool.go
+++ b/azurerm/resource_arm_sql_elasticpool.go
@@ -86,7 +86,7 @@ func resourceArmSqlElasticPool() *schema.Resource {
 }
 
 func resourceArmSqlElasticPoolCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ElasticPoolsClient
+	client := meta.(*ArmClient).Sql.ElasticPoolsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for SQL ElasticPool creation.")
@@ -140,7 +140,7 @@ func resourceArmSqlElasticPoolCreateUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmSqlElasticPoolRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ElasticPoolsClient
+	client := meta.(*ArmClient).Sql.ElasticPoolsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resGroup, serverName, name, err := parseArmSqlElasticPoolId(d.Id())
@@ -180,7 +180,7 @@ func resourceArmSqlElasticPoolRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmSqlElasticPoolDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ElasticPoolsClient
+	client := meta.(*ArmClient).Sql.ElasticPoolsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resGroup, serverName, name, err := parseArmSqlElasticPoolId(d.Id())

--- a/azurerm/resource_arm_sql_elasticpool_test.go
+++ b/azurerm/resource_arm_sql_elasticpool_test.go
@@ -125,7 +125,7 @@ func testCheckAzureRMSqlElasticPoolExists(resourceName string) resource.TestChec
 		serverName := rs.Primary.Attributes["server_name"]
 		poolName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.ElasticPoolsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.ElasticPoolsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, poolName)
@@ -142,7 +142,7 @@ func testCheckAzureRMSqlElasticPoolExists(resourceName string) resource.TestChec
 }
 
 func testCheckAzureRMSqlElasticPoolDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).sql.ElasticPoolsClient
+	client := testAccProvider.Meta().(*ArmClient).Sql.ElasticPoolsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -180,7 +180,7 @@ func testCheckAzureRMSqlElasticPoolDisappears(resourceName string) resource.Test
 		serverName := rs.Primary.Attributes["server_name"]
 		poolName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.ElasticPoolsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.ElasticPoolsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if _, err := client.Delete(ctx, resourceGroup, serverName, poolName); err != nil {

--- a/azurerm/resource_arm_sql_failover_group.go
+++ b/azurerm/resource_arm_sql_failover_group.go
@@ -128,7 +128,7 @@ func resourceArmSqlFailoverGroup() *schema.Resource {
 }
 
 func resourceArmSqlFailoverGroupCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.FailoverGroupsClient
+	client := meta.(*ArmClient).Sql.FailoverGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -189,7 +189,7 @@ func resourceArmSqlFailoverGroupCreateUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmSqlFailoverGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.FailoverGroupsClient
+	client := meta.(*ArmClient).Sql.FailoverGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -241,7 +241,7 @@ func resourceArmSqlFailoverGroupRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmSqlFailoverGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.FailoverGroupsClient
+	client := meta.(*ArmClient).Sql.FailoverGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_sql_failover_group_test.go
+++ b/azurerm/resource_arm_sql_failover_group_test.go
@@ -124,7 +124,7 @@ func testCheckAzureRMSqlFailoverGroupExists(resourceName string) resource.TestCh
 		serverName := rs.Primary.Attributes["server_name"]
 		name := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.FailoverGroupsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.FailoverGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, name)
@@ -152,7 +152,7 @@ func testCheckAzureRMSqlFailoverGroupDisappears(resourceName string) resource.Te
 		serverName := rs.Primary.Attributes["server_name"]
 		name := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.FailoverGroupsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.FailoverGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		future, err := client.Delete(ctx, resourceGroup, serverName, name)
@@ -178,7 +178,7 @@ func testCheckAzureRMSqlFailoverGroupDestroy(s *terraform.State) error {
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serverName := rs.Primary.Attributes["server_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.FailoverGroupsClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.FailoverGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, name)

--- a/azurerm/resource_arm_sql_firewall_rule.go
+++ b/azurerm/resource_arm_sql_firewall_rule.go
@@ -56,7 +56,7 @@ func resourceArmSqlFirewallRule() *schema.Resource {
 }
 
 func resourceArmSqlFirewallRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.FirewallRulesClient
+	client := meta.(*ArmClient).Sql.FirewallRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -100,7 +100,7 @@ func resourceArmSqlFirewallRuleCreateUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmSqlFirewallRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.FirewallRulesClient
+	client := meta.(*ArmClient).Sql.FirewallRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -133,7 +133,7 @@ func resourceArmSqlFirewallRuleRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmSqlFirewallRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.FirewallRulesClient
+	client := meta.(*ArmClient).Sql.FirewallRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_sql_firewall_rule_test.go
+++ b/azurerm/resource_arm_sql_firewall_rule_test.go
@@ -105,7 +105,7 @@ func testCheckAzureRMSqlFirewallRuleExists(resourceName string) resource.TestChe
 		serverName := rs.Primary.Attributes["server_name"]
 		ruleName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.FirewallRulesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.FirewallRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, ruleName)
@@ -131,7 +131,7 @@ func testCheckAzureRMSqlFirewallRuleDestroy(s *terraform.State) error {
 		serverName := rs.Primary.Attributes["server_name"]
 		ruleName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.FirewallRulesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.FirewallRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, ruleName)
@@ -161,7 +161,7 @@ func testCheckAzureRMSqlFirewallRuleDisappears(resourceName string) resource.Tes
 		serverName := rs.Primary.Attributes["server_name"]
 		ruleName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.FirewallRulesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.FirewallRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Delete(ctx, resourceGroup, serverName, ruleName)

--- a/azurerm/resource_arm_sql_server.go
+++ b/azurerm/resource_arm_sql_server.go
@@ -71,7 +71,7 @@ func resourceArmSqlServer() *schema.Resource {
 }
 
 func resourceArmSqlServerCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ServersClient
+	client := meta.(*ArmClient).Sql.ServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -134,7 +134,7 @@ func resourceArmSqlServerCreateUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmSqlServerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ServersClient
+	client := meta.(*ArmClient).Sql.ServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -172,7 +172,7 @@ func resourceArmSqlServerRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArmSqlServerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.ServersClient
+	client := meta.(*ArmClient).Sql.ServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_sql_server_test.go
+++ b/azurerm/resource_arm_sql_server_test.go
@@ -134,7 +134,7 @@ func testCheckAzureRMSqlServerExists(resourceName string) resource.TestCheckFunc
 			return fmt.Errorf("Bad: no resource group found in state for SQL Server: %s", sqlServerName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).sql.ServersClient
+		conn := testAccProvider.Meta().(*ArmClient).Sql.ServersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, sqlServerName)
 		if err != nil {
@@ -149,7 +149,7 @@ func testCheckAzureRMSqlServerExists(resourceName string) resource.TestCheckFunc
 }
 
 func testCheckAzureRMSqlServerDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).sql.ServersClient
+	conn := testAccProvider.Meta().(*ArmClient).Sql.ServersClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -188,7 +188,7 @@ func testCheckAzureRMSqlServerDisappears(resourceName string) resource.TestCheck
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serverName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.ServersClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.ServersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		future, err := client.Delete(ctx, resourceGroup, serverName)

--- a/azurerm/resource_arm_sql_virtual_network_rule.go
+++ b/azurerm/resource_arm_sql_virtual_network_rule.go
@@ -61,7 +61,7 @@ func resourceArmSqlVirtualNetworkRule() *schema.Resource {
 }
 
 func resourceArmSqlVirtualNetworkRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.VirtualNetworkRulesClient
+	client := meta.(*ArmClient).Sql.VirtualNetworkRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -120,7 +120,7 @@ func resourceArmSqlVirtualNetworkRuleCreateUpdate(d *schema.ResourceData, meta i
 }
 
 func resourceArmSqlVirtualNetworkRuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.VirtualNetworkRulesClient
+	client := meta.(*ArmClient).Sql.VirtualNetworkRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -156,7 +156,7 @@ func resourceArmSqlVirtualNetworkRuleRead(d *schema.ResourceData, meta interface
 }
 
 func resourceArmSqlVirtualNetworkRuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).sql.VirtualNetworkRulesClient
+	client := meta.(*ArmClient).Sql.VirtualNetworkRulesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_sql_virtual_network_rule_test.go
+++ b/azurerm/resource_arm_sql_virtual_network_rule_test.go
@@ -359,7 +359,7 @@ func testCheckAzureRMSqlVirtualNetworkRuleExists(resourceName string) resource.T
 		serverName := rs.Primary.Attributes["server_name"]
 		ruleName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.VirtualNetworkRulesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.VirtualNetworkRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, ruleName)
@@ -388,7 +388,7 @@ func testCheckAzureRMSqlVirtualNetworkRuleDestroy(s *terraform.State) error {
 		serverName := rs.Primary.Attributes["server_name"]
 		ruleName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.VirtualNetworkRulesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.VirtualNetworkRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, serverName, ruleName)
@@ -421,7 +421,7 @@ func testCheckAzureRMSqlVirtualNetworkRuleDisappears(resourceName string) resour
 		serverName := rs.Primary.Attributes["server_name"]
 		ruleName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).sql.VirtualNetworkRulesClient
+		client := testAccProvider.Meta().(*ArmClient).Sql.VirtualNetworkRulesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		future, err := client.Delete(ctx, resourceGroup, serverName, ruleName)

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -607,7 +607,7 @@ func validateAzureRMStorageAccountTags(v interface{}, _ string) (warnings []stri
 func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
 	client := meta.(*ArmClient).Storage.AccountsClient
-	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
+	advancedThreatProtectionClient := meta.(*ArmClient).SecurityCenter.AdvancedThreatProtectionClient
 
 	storageAccountName := d.Get("name").(string)
 	resourceGroupName := d.Get("resource_group_name").(string)
@@ -762,7 +762,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
 	client := meta.(*ArmClient).Storage.AccountsClient
-	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
+	advancedThreatProtectionClient := meta.(*ArmClient).SecurityCenter.AdvancedThreatProtectionClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -956,7 +956,7 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
 	client := meta.(*ArmClient).Storage.AccountsClient
-	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
+	advancedThreatProtectionClient := meta.(*ArmClient).SecurityCenter.AdvancedThreatProtectionClient
 	endpointSuffix := meta.(*ArmClient).environment.StorageEndpointSuffix
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -606,7 +606,7 @@ func validateAzureRMStorageAccountTags(v interface{}, _ string) (warnings []stri
 
 func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storage.AccountsClient
+	client := meta.(*ArmClient).Storage.AccountsClient
 	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
 
 	storageAccountName := d.Get("name").(string)
@@ -738,7 +738,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if val, ok := d.GetOk("queue_properties"); ok {
-		queueClient, err := meta.(*ArmClient).storage.QueuesClient(ctx, resourceGroupName, storageAccountName)
+		queueClient, err := meta.(*ArmClient).Storage.QueuesClient(ctx, resourceGroupName, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("Error building Queues Client: %s", err)
 		}
@@ -761,7 +761,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 // available requires a call to Update per parameter...
 func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storage.AccountsClient
+	client := meta.(*ArmClient).Storage.AccountsClient
 	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -932,7 +932,7 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("queue_properties") {
-		queueClient, err := meta.(*ArmClient).storage.QueuesClient(ctx, resourceGroupName, storageAccountName)
+		queueClient, err := meta.(*ArmClient).Storage.QueuesClient(ctx, resourceGroupName, storageAccountName)
 		if err != nil {
 			return fmt.Errorf("Error building Queues Client: %s", err)
 		}
@@ -955,7 +955,7 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).storage.AccountsClient
+	client := meta.(*ArmClient).Storage.AccountsClient
 	advancedThreatProtectionClient := meta.(*ArmClient).securityCenter.AdvancedThreatProtectionClient
 	endpointSuffix := meta.(*ArmClient).environment.StorageEndpointSuffix
 
@@ -1112,7 +1112,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	queueClient, err := meta.(*ArmClient).storage.QueuesClient(ctx, resGroup, name)
+	queueClient, err := meta.(*ArmClient).Storage.QueuesClient(ctx, resGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error building Queues Client: %s", err)
 	}
@@ -1133,7 +1133,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	client := storageClient.AccountsClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_storage_account_test.go
+++ b/azurerm/resource_arm_storage_account_test.go
@@ -800,7 +800,7 @@ func testCheckAzureRMStorageAccountExists(resourceName string) resource.TestChec
 
 		// Ensure resource group exists in API
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		conn := testAccProvider.Meta().(*ArmClient).storage.AccountsClient
+		conn := testAccProvider.Meta().(*ArmClient).Storage.AccountsClient
 
 		resp, err := conn.GetProperties(ctx, resourceGroup, storageAccount, "")
 		if err != nil {
@@ -828,7 +828,7 @@ func testCheckAzureRMStorageAccountDisappears(resourceName string) resource.Test
 
 		// Ensure resource group exists in API
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		conn := testAccProvider.Meta().(*ArmClient).storage.AccountsClient
+		conn := testAccProvider.Meta().(*ArmClient).Storage.AccountsClient
 
 		if _, err := conn.Delete(ctx, resourceGroup, storageAccount); err != nil {
 			return fmt.Errorf("Bad: Delete on storageServiceClient: %+v", err)
@@ -840,7 +840,7 @@ func testCheckAzureRMStorageAccountDisappears(resourceName string) resource.Test
 
 func testCheckAzureRMStorageAccountDestroy(s *terraform.State) error {
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
-	conn := testAccProvider.Meta().(*ArmClient).storage.AccountsClient
+	conn := testAccProvider.Meta().(*ArmClient).Storage.AccountsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_storage_account" {

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -141,7 +141,7 @@ func resourceArmStorageBlob() *schema.Resource {
 }
 
 func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	accountName := d.Get("storage_account_name").(string)
@@ -203,7 +203,7 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := blobs.ParseResourceID(d.Id())
@@ -263,7 +263,7 @@ func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := blobs.ParseResourceID(d.Id())
@@ -322,7 +322,7 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceArmStorageBlobDelete(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := blobs.ParseResourceID(d.Id())

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -623,7 +623,7 @@ func testCheckAzureRMStorageBlobExists(resourceName string) resource.TestCheckFu
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		name := rs.Primary.Attributes["name"]
@@ -665,7 +665,7 @@ func testCheckAzureRMStorageBlobDisappears(resourceName string) resource.TestChe
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		name := rs.Primary.Attributes["name"]
@@ -703,7 +703,7 @@ func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind blobs.Blob
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		name := rs.Primary.Attributes["name"]
@@ -763,7 +763,7 @@ func testCheckAzureRMStorageBlobDestroy(s *terraform.State) error {
 			continue
 		}
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		name := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_storage_container.go
+++ b/azurerm/resource_arm_storage_container.go
@@ -77,7 +77,7 @@ func resourceArmStorageContainer() *schema.Resource {
 }
 
 func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	containerName := d.Get("name").(string)
@@ -130,7 +130,7 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 
 func resourceArmStorageContainerUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := containers.ParseResourceID(d.Id())
 	if err != nil {
@@ -179,7 +179,7 @@ func resourceArmStorageContainerUpdate(d *schema.ResourceData, meta interface{})
 
 func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := containers.ParseResourceID(d.Id())
 	if err != nil {
@@ -234,7 +234,7 @@ func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := containers.ParseResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -242,7 +242,7 @@ func testCheckAzureRMStorageContainerExists(resourceName string) resource.TestCh
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		containerName := rs.Primary.Attributes["name"]
@@ -281,7 +281,7 @@ func testAccARMStorageContainerDisappears(resourceName string) resource.TestChec
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		containerName := rs.Primary.Attributes["name"]
@@ -314,7 +314,7 @@ func testCheckAzureRMStorageContainerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		containerName := rs.Primary.Attributes["name"]

--- a/azurerm/resource_arm_storage_queue.go
+++ b/azurerm/resource_arm_storage_queue.go
@@ -78,7 +78,7 @@ func validateArmStorageQueueName(v interface{}, k string) (warnings []string, er
 }
 
 func resourceArmStorageQueueCreate(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	queueName := d.Get("name").(string)
@@ -124,7 +124,7 @@ func resourceArmStorageQueueCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmStorageQueueUpdate(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := queues.ParseResourceID(d.Id())
@@ -156,7 +156,7 @@ func resourceArmStorageQueueUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmStorageQueueRead(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := queues.ParseResourceID(d.Id())
@@ -202,7 +202,7 @@ func resourceArmStorageQueueRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmStorageQueueDelete(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := queues.ParseResourceID(d.Id())

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -158,7 +158,7 @@ func testCheckAzureRMStorageQueueExists(resourceName string) resource.TestCheckF
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
 		if err != nil {
@@ -196,7 +196,7 @@ func testCheckAzureRMStorageQueueDestroy(s *terraform.State) error {
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
 		if err != nil {

--- a/azurerm/resource_arm_storage_share.go
+++ b/azurerm/resource_arm_storage_share.go
@@ -111,7 +111,7 @@ func resourceArmStorageShare() *schema.Resource {
 }
 func resourceArmStorageShareCreate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	accountName := d.Get("storage_account_name").(string)
 	shareName := d.Get("name").(string)
@@ -170,7 +170,7 @@ func resourceArmStorageShareCreate(d *schema.ResourceData, meta interface{}) err
 
 func resourceArmStorageShareRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := shares.ParseResourceID(d.Id())
 	if err != nil {
@@ -229,7 +229,7 @@ func resourceArmStorageShareRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceArmStorageShareUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := shares.ParseResourceID(d.Id())
 	if err != nil {
@@ -292,7 +292,7 @@ func resourceArmStorageShareUpdate(d *schema.ResourceData, meta interface{}) err
 
 func resourceArmStorageShareDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := shares.ParseResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_storage_share_directory.go
+++ b/azurerm/resource_arm_storage_share_directory.go
@@ -54,7 +54,7 @@ func resourceArmStorageShareDirectory() *schema.Resource {
 
 func resourceArmStorageShareDirectoryCreate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	accountName := d.Get("storage_account_name").(string)
 	shareName := d.Get("share_name").(string)
@@ -117,7 +117,7 @@ func resourceArmStorageShareDirectoryCreate(d *schema.ResourceData, meta interfa
 
 func resourceArmStorageShareDirectoryUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := directories.ParseResourceID(d.Id())
 	if err != nil {
@@ -151,7 +151,7 @@ func resourceArmStorageShareDirectoryUpdate(d *schema.ResourceData, meta interfa
 
 func resourceArmStorageShareDirectoryRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := directories.ParseResourceID(d.Id())
 	if err != nil {
@@ -191,7 +191,7 @@ func resourceArmStorageShareDirectoryRead(d *schema.ResourceData, meta interface
 
 func resourceArmStorageShareDirectoryDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := directories.ParseResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_storage_share_directory_test.go
+++ b/azurerm/resource_arm_storage_share_directory_test.go
@@ -190,7 +190,7 @@ func testCheckAzureRMStorageShareDirectoryExists(resourceName string) resource.T
 		shareName := rs.Primary.Attributes["share_name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
@@ -229,7 +229,7 @@ func testCheckAzureRMStorageShareDirectoryDestroy(s *terraform.State) error {
 		shareName := rs.Primary.Attributes["share_name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -203,7 +203,7 @@ func testCheckAzureRMStorageShareExists(resourceName string) resource.TestCheckF
 		shareName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
@@ -237,7 +237,7 @@ func testCheckAzureRMStorageShareDisappears(resourceName string) resource.TestCh
 		shareName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
@@ -270,7 +270,7 @@ func testCheckAzureRMStorageShareDestroy(s *terraform.State) error {
 		shareName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)

--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -99,7 +99,7 @@ func resourceArmStorageTable() *schema.Resource {
 
 func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	tableName := d.Get("name").(string)
 	accountName := d.Get("storage_account_name").(string)
@@ -147,7 +147,7 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := tables.ParseResourceID(d.Id())
@@ -199,7 +199,7 @@ func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := tables.ParseResourceID(d.Id())
@@ -231,7 +231,7 @@ func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmStorageTableUpdate(d *schema.ResourceData, meta interface{}) error {
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := tables.ParseResourceID(d.Id())

--- a/azurerm/resource_arm_storage_table_entity.go
+++ b/azurerm/resource_arm_storage_table_entity.go
@@ -60,7 +60,7 @@ func resourceArmStorageTableEntity() *schema.Resource {
 
 func resourceArmStorageTableEntityCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	accountName := d.Get("storage_account_name").(string)
 	tableName := d.Get("table_name").(string)
@@ -124,7 +124,7 @@ func resourceArmStorageTableEntityCreateUpdate(d *schema.ResourceData, meta inte
 
 func resourceArmStorageTableEntityRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := entities.ParseResourceID(d.Id())
 	if err != nil {
@@ -170,7 +170,7 @@ func resourceArmStorageTableEntityRead(d *schema.ResourceData, meta interface{})
 
 func resourceArmStorageTableEntityDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	storageClient := meta.(*ArmClient).storage
+	storageClient := meta.(*ArmClient).Storage
 
 	id, err := entities.ParseResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_storage_table_entity_test.go
+++ b/azurerm/resource_arm_storage_table_entity_test.go
@@ -120,7 +120,7 @@ func testCheckAzureRMTableEntityExists(resourceName string) resource.TestCheckFu
 		partitionKey := rs.Primary.Attributes["partition_key"]
 		rowKey := rs.Primary.Attributes["row_key"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
@@ -165,7 +165,7 @@ func testCheckAzureRMTableEntityDestroy(s *terraform.State) error {
 		partitionKey := rs.Primary.Attributes["parititon_key"]
 		rowKey := rs.Primary.Attributes["row_key"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -141,7 +141,7 @@ func testCheckAzureRMStorageTableExists(resourceName string) resource.TestCheckF
 		tableName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
@@ -180,7 +180,7 @@ func testAccARMStorageTableDisappears(resourceName string) resource.TestCheckFun
 		tableName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
@@ -222,7 +222,7 @@ func testCheckAzureRMStorageTableDestroy(s *terraform.State) error {
 		tableName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		storageClient := testAccProvider.Meta().(*ArmClient).storage
+		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)

--- a/azurerm/resource_arm_stream_analytics_function_javascript_udf.go
+++ b/azurerm/resource_arm_stream_analytics_function_javascript_udf.go
@@ -101,7 +101,7 @@ func resourceArmStreamAnalyticsFunctionUDF() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsFunctionUDFCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.FunctionsClient
+	client := meta.(*ArmClient).StreamAnalytics.FunctionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Function Javascript UDF creation.")
@@ -169,7 +169,7 @@ func resourceArmStreamAnalyticsFunctionUDFCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmStreamAnalyticsFunctionUDFRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.FunctionsClient
+	client := meta.(*ArmClient).StreamAnalytics.FunctionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -223,7 +223,7 @@ func resourceArmStreamAnalyticsFunctionUDFRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmStreamAnalyticsFunctionUDFDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.FunctionsClient
+	client := meta.(*ArmClient).StreamAnalytics.FunctionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_function_javascript_udf_test.go
+++ b/azurerm/resource_arm_stream_analytics_function_javascript_udf_test.go
@@ -113,7 +113,7 @@ func testCheckAzureRMStreamAnalyticsFunctionJavaScriptUDFExists(resourceName str
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.FunctionsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.FunctionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -129,7 +129,7 @@ func testCheckAzureRMStreamAnalyticsFunctionJavaScriptUDFExists(resourceName str
 }
 
 func testCheckAzureRMStreamAnalyticsFunctionJavaScriptUDFDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_function_javascript_udf" {

--- a/azurerm/resource_arm_stream_analytics_job.go
+++ b/azurerm/resource_arm_stream_analytics_job.go
@@ -120,8 +120,8 @@ func resourceArmStreamAnalyticsJob() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsJobCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.JobsClient
-	transformationsClient := meta.(*ArmClient).streamanalytics.TransformationsClient
+	client := meta.(*ArmClient).StreamAnalytics.JobsClient
+	transformationsClient := meta.(*ArmClient).StreamAnalytics.TransformationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Job creation.")
@@ -216,8 +216,8 @@ func resourceArmStreamAnalyticsJobCreateUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceArmStreamAnalyticsJobRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.JobsClient
-	transformationsClient := meta.(*ArmClient).streamanalytics.TransformationsClient
+	client := meta.(*ArmClient).StreamAnalytics.JobsClient
+	transformationsClient := meta.(*ArmClient).StreamAnalytics.TransformationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -283,7 +283,7 @@ func resourceArmStreamAnalyticsJobRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmStreamAnalyticsJobDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.JobsClient
+	client := meta.(*ArmClient).StreamAnalytics.JobsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_job_test.go
+++ b/azurerm/resource_arm_stream_analytics_job_test.go
@@ -136,7 +136,7 @@ func testCheckAzureRMStreamAnalyticsJobExists(resourceName string) resource.Test
 		name := rs.Primary.Attributes["name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.JobsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.JobsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, name, "")
 		if err != nil {
@@ -152,7 +152,7 @@ func testCheckAzureRMStreamAnalyticsJobExists(resourceName string) resource.Test
 }
 
 func testCheckAzureRMStreamAnalyticsJobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.JobsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.JobsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_job" {

--- a/azurerm/resource_arm_stream_analytics_output_blob.go
+++ b/azurerm/resource_arm_stream_analytics_output_blob.go
@@ -83,7 +83,7 @@ func resourceArmStreamAnalyticsOutputBlob() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsOutputBlobCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Output Blob creation.")
@@ -163,7 +163,7 @@ func resourceArmStreamAnalyticsOutputBlobCreateUpdate(d *schema.ResourceData, me
 }
 
 func resourceArmStreamAnalyticsOutputBlobRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -214,7 +214,7 @@ func resourceArmStreamAnalyticsOutputBlobRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmStreamAnalyticsOutputBlobDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_output_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_blob_test.go
@@ -181,7 +181,7 @@ func testCheckAzureRMStreamAnalyticsOutputBlobExists(resourceName string) resour
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -197,7 +197,7 @@ func testCheckAzureRMStreamAnalyticsOutputBlobExists(resourceName string) resour
 }
 
 func testCheckAzureRMStreamAnalyticsOutputBlobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_output_blob" {

--- a/azurerm/resource_arm_stream_analytics_output_eventhub.go
+++ b/azurerm/resource_arm_stream_analytics_output_eventhub.go
@@ -72,7 +72,7 @@ func resourceArmStreamAnalyticsOutputEventHub() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsOutputEventHubCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Output EventHub creation.")
@@ -144,7 +144,7 @@ func resourceArmStreamAnalyticsOutputEventHubCreateUpdate(d *schema.ResourceData
 }
 
 func resourceArmStreamAnalyticsOutputEventHubRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -189,7 +189,7 @@ func resourceArmStreamAnalyticsOutputEventHubRead(d *schema.ResourceData, meta i
 }
 
 func resourceArmStreamAnalyticsOutputEventHubDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_output_eventhub_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_eventhub_test.go
@@ -212,7 +212,7 @@ func testCheckAzureRMStreamAnalyticsOutputEventHubExists(resourceName string) re
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -228,7 +228,7 @@ func testCheckAzureRMStreamAnalyticsOutputEventHubExists(resourceName string) re
 }
 
 func testCheckAzureRMStreamAnalyticsOutputEventHubDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_output_eventhub" {

--- a/azurerm/resource_arm_stream_analytics_output_mssql.go
+++ b/azurerm/resource_arm_stream_analytics_output_mssql.go
@@ -85,7 +85,7 @@ func resourceArmStreamAnalyticsOutputSql() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsOutputSqlCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] Preparing arguments for Azure Stream Analytics SQL Output creation.")
@@ -150,7 +150,7 @@ func resourceArmStreamAnalyticsOutputSqlCreateUpdate(d *schema.ResourceData, met
 }
 
 func resourceArmStreamAnalyticsOutputSqlRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -193,7 +193,7 @@ func resourceArmStreamAnalyticsOutputSqlRead(d *schema.ResourceData, meta interf
 }
 
 func resourceArmStreamAnalyticsOutputSqlDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_output_mssql_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_mssql_test.go
@@ -121,7 +121,7 @@ func testCheckAzureRMStreamAnalyticsOutputSqlExists(resourceName string) resourc
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -137,7 +137,7 @@ func testCheckAzureRMStreamAnalyticsOutputSqlExists(resourceName string) resourc
 }
 
 func testCheckAzureRMStreamAnalyticsOutputSqlDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_output_mssql" {

--- a/azurerm/resource_arm_stream_analytics_output_servicebus_queue.go
+++ b/azurerm/resource_arm_stream_analytics_output_servicebus_queue.go
@@ -72,7 +72,7 @@ func resourceArmStreamAnalyticsOutputServiceBusQueue() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsOutputServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Output ServiceBus Queue creation.")
@@ -144,7 +144,7 @@ func resourceArmStreamAnalyticsOutputServiceBusQueueCreateUpdate(d *schema.Resou
 }
 
 func resourceArmStreamAnalyticsOutputServiceBusQueueRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -189,7 +189,7 @@ func resourceArmStreamAnalyticsOutputServiceBusQueueRead(d *schema.ResourceData,
 }
 
 func resourceArmStreamAnalyticsOutputServiceBusQueueDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_output_servicebus_queue_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_servicebus_queue_test.go
@@ -174,7 +174,7 @@ func testCheckAzureRMStreamAnalyticsOutputServiceBusQueueExists(resourceName str
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -190,7 +190,7 @@ func testCheckAzureRMStreamAnalyticsOutputServiceBusQueueExists(resourceName str
 }
 
 func testCheckAzureRMStreamAnalyticsOutputServiceBusQueueDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_output_servicebus_queue" {

--- a/azurerm/resource_arm_stream_analytics_output_servicebus_topic.go
+++ b/azurerm/resource_arm_stream_analytics_output_servicebus_topic.go
@@ -72,7 +72,7 @@ func resourceArmStreamAnalyticsOutputServiceBusTopic() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsOutputServiceBusTopicCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Output ServiceBus Topic creation.")
@@ -144,7 +144,7 @@ func resourceArmStreamAnalyticsOutputServiceBusTopicCreateUpdate(d *schema.Resou
 }
 
 func resourceArmStreamAnalyticsOutputServiceBusTopicRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -189,7 +189,7 @@ func resourceArmStreamAnalyticsOutputServiceBusTopicRead(d *schema.ResourceData,
 }
 
 func resourceArmStreamAnalyticsOutputServiceBusTopicDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.OutputsClient
+	client := meta.(*ArmClient).StreamAnalytics.OutputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_output_servicebus_topic_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_servicebus_topic_test.go
@@ -174,7 +174,7 @@ func testCheckAzureRMStreamAnalyticsOutputServiceBusTopicExists(resourceName str
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -190,7 +190,7 @@ func testCheckAzureRMStreamAnalyticsOutputServiceBusTopicExists(resourceName str
 }
 
 func testCheckAzureRMStreamAnalyticsOutputServiceBusTopicDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.OutputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.OutputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_output_servicebus_topic" {

--- a/azurerm/resource_arm_stream_analytics_stream_input_blob.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_blob.go
@@ -86,7 +86,7 @@ func resourceArmStreamAnalyticsStreamInputBlob() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsStreamInputBlobCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Stream Input Blob creation.")
@@ -167,7 +167,7 @@ func resourceArmStreamAnalyticsStreamInputBlobCreateUpdate(d *schema.ResourceDat
 }
 
 func resourceArmStreamAnalyticsStreamInputBlobRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -223,7 +223,7 @@ func resourceArmStreamAnalyticsStreamInputBlobRead(d *schema.ResourceData, meta 
 }
 
 func resourceArmStreamAnalyticsStreamInputBlobDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_stream_input_blob_test.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_blob_test.go
@@ -181,7 +181,7 @@ func testCheckAzureRMStreamAnalyticsStreamInputBlobExists(resourceName string) r
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.InputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -197,7 +197,7 @@ func testCheckAzureRMStreamAnalyticsStreamInputBlobExists(resourceName string) r
 }
 
 func testCheckAzureRMStreamAnalyticsStreamInputBlobDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.InputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_stream_input_eventhub" {

--- a/azurerm/resource_arm_stream_analytics_stream_input_eventhub.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_eventhub.go
@@ -81,7 +81,7 @@ func resourceArmStreamAnalyticsStreamInputEventHub() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsStreamInputEventHubCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Stream Input EventHub creation.")
@@ -156,7 +156,7 @@ func resourceArmStreamAnalyticsStreamInputEventHubCreateUpdate(d *schema.Resourc
 }
 
 func resourceArmStreamAnalyticsStreamInputEventHubRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -207,7 +207,7 @@ func resourceArmStreamAnalyticsStreamInputEventHubRead(d *schema.ResourceData, m
 }
 
 func resourceArmStreamAnalyticsStreamInputEventHubDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_stream_input_eventhub_test.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_eventhub_test.go
@@ -174,7 +174,7 @@ func testCheckAzureRMStreamAnalyticsStreamInputEventHubExists(resourceName strin
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.InputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -190,7 +190,7 @@ func testCheckAzureRMStreamAnalyticsStreamInputEventHubExists(resourceName strin
 }
 
 func testCheckAzureRMStreamAnalyticsStreamInputEventHubDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.InputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_stream_input_eventhub" {

--- a/azurerm/resource_arm_stream_analytics_stream_input_iothub.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_iothub.go
@@ -82,7 +82,7 @@ func resourceArmStreamAnalyticsStreamInputIoTHub() *schema.Resource {
 }
 
 func resourceArmStreamAnalyticsStreamInputIoTHubCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Stream Analytics Stream Input IoTHub creation.")
@@ -157,7 +157,7 @@ func resourceArmStreamAnalyticsStreamInputIoTHubCreateUpdate(d *schema.ResourceD
 }
 
 func resourceArmStreamAnalyticsStreamInputIoTHubRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -208,7 +208,7 @@ func resourceArmStreamAnalyticsStreamInputIoTHubRead(d *schema.ResourceData, met
 }
 
 func resourceArmStreamAnalyticsStreamInputIoTHubDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).streamanalytics.InputsClient
+	client := meta.(*ArmClient).StreamAnalytics.InputsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_stream_analytics_stream_input_iothub_test.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_iothub_test.go
@@ -174,7 +174,7 @@ func testCheckAzureRMStreamAnalyticsStreamInputIoTHubExists(resourceName string)
 		jobName := rs.Primary.Attributes["stream_analytics_job_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).streamanalytics.InputsClient
+		conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, jobName, name)
 		if err != nil {
@@ -190,7 +190,7 @@ func testCheckAzureRMStreamAnalyticsStreamInputIoTHubExists(resourceName string)
 }
 
 func testCheckAzureRMStreamAnalyticsStreamInputIoTHubDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).streamanalytics.InputsClient
+	conn := testAccProvider.Meta().(*ArmClient).StreamAnalytics.InputsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_stream_analytics_stream_input_iothub" {

--- a/azurerm/resource_arm_traffic_manager_endpoint.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint.go
@@ -163,7 +163,7 @@ func resourceArmTrafficManagerEndpoint() *schema.Resource {
 }
 
 func resourceArmTrafficManagerEndpointCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).trafficManager.EndpointsClient
+	client := meta.(*ArmClient).TrafficManager.EndpointsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for TrafficManager Endpoint creation.")
@@ -211,7 +211,7 @@ func resourceArmTrafficManagerEndpointCreateUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceArmTrafficManagerEndpointRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).trafficManager.EndpointsClient
+	client := meta.(*ArmClient).TrafficManager.EndpointsClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -305,7 +305,7 @@ func flattenAzureRMTrafficManagerEndpointCustomHeaderConfig(input *[]trafficmana
 }
 
 func resourceArmTrafficManagerEndpointDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).trafficManager.EndpointsClient
+	client := meta.(*ArmClient).TrafficManager.EndpointsClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_traffic_manager_endpoint_test.go
+++ b/azurerm/resource_arm_traffic_manager_endpoint_test.go
@@ -387,7 +387,7 @@ func testCheckAzureRMTrafficManagerEndpointExists(resourceName string) resource.
 		}
 
 		// Ensure resource group/virtual network combination exists in API
-		conn := testAccProvider.Meta().(*ArmClient).trafficManager.EndpointsClient
+		conn := testAccProvider.Meta().(*ArmClient).TrafficManager.EndpointsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, profileName, path.Base(endpointType), name)
 		if err != nil {
@@ -419,7 +419,7 @@ func testCheckAzureRMTrafficManagerEndpointDisappears(resourceName string) resou
 		}
 
 		// Ensure resource group/virtual network combination exists in API
-		conn := testAccProvider.Meta().(*ArmClient).trafficManager.EndpointsClient
+		conn := testAccProvider.Meta().(*ArmClient).TrafficManager.EndpointsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if _, err := conn.Delete(ctx, resourceGroup, profileName, path.Base(endpointType), name); err != nil {
@@ -432,7 +432,7 @@ func testCheckAzureRMTrafficManagerEndpointDisappears(resourceName string) resou
 
 func testCheckAzureRMTrafficManagerEndpointDestroy(s *terraform.State) error {
 
-	conn := testAccProvider.Meta().(*ArmClient).trafficManager.EndpointsClient
+	conn := testAccProvider.Meta().(*ArmClient).TrafficManager.EndpointsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_traffic_manager_endpoint" {

--- a/azurerm/resource_arm_traffic_manager_profile.go
+++ b/azurerm/resource_arm_traffic_manager_profile.go
@@ -140,7 +140,7 @@ func resourceArmTrafficManagerProfile() *schema.Resource {
 }
 
 func resourceArmTrafficManagerProfileCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).trafficManager.ProfilesClient
+	client := meta.(*ArmClient).TrafficManager.ProfilesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for TrafficManager Profile creation.")
@@ -195,7 +195,7 @@ func resourceArmTrafficManagerProfileCreateUpdate(d *schema.ResourceData, meta i
 }
 
 func resourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).trafficManager.ProfilesClient
+	client := meta.(*ArmClient).TrafficManager.ProfilesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -235,7 +235,7 @@ func resourceArmTrafficManagerProfileRead(d *schema.ResourceData, meta interface
 }
 
 func resourceArmTrafficManagerProfileDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).trafficManager.ProfilesClient
+	client := meta.(*ArmClient).TrafficManager.ProfilesClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -380,7 +380,7 @@ func testCheckAzureRMTrafficManagerProfileExists(resourceName string) resource.T
 		}
 
 		// Ensure resource group/virtual network combination exists in API
-		conn := testAccProvider.Meta().(*ArmClient).trafficManager.ProfilesClient
+		conn := testAccProvider.Meta().(*ArmClient).TrafficManager.ProfilesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, name)
 		if err != nil {
@@ -396,7 +396,7 @@ func testCheckAzureRMTrafficManagerProfileExists(resourceName string) resource.T
 }
 
 func testCheckAzureRMTrafficManagerProfileDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).trafficManager.ProfilesClient
+	conn := testAccProvider.Meta().(*ArmClient).TrafficManager.ProfilesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_traffic_manager_profile" {

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -935,7 +935,7 @@ func resourceArmVirtualMachineDelete(d *schema.ResourceData, meta interface{}) e
 	deleteDataDisks := d.Get("delete_data_disks_on_termination").(bool)
 
 	if deleteOsDisk || deleteDataDisks {
-		storageClient := meta.(*ArmClient).storage
+		storageClient := meta.(*ArmClient).Storage
 
 		props := virtualMachine.VirtualMachineProperties
 		if props == nil {

--- a/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
@@ -3023,7 +3023,7 @@ func testCheckAzureRMVirtualMachineVHDExistence(blobName string, shouldExist boo
 			accountName := rs.Primary.Attributes["storage_account_name"]
 			containerName := rs.Primary.Attributes["name"]
 
-			storageClient := testAccProvider.Meta().(*ArmClient).storage
+			storageClient := testAccProvider.Meta().(*ArmClient).Storage
 			ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 			client, err := storageClient.BlobsClient(ctx, resourceGroup, accountName)


### PR DESCRIPTION
This PR makes the Service Clients public to ease the migration away from the `ArmClient` struct.

I've intentionally started at the bottom and skipped the `web` client since there's a couple of open PR's for this I've tried to avoid conflicting with. This PR also adds a NOTE explaining all new fields should be public