### PR TITLE
keyvault_certificate: Store raw data as hex

### DIFF
--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -494,7 +494,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 	d.Set("secret_id", cert.Sid)
 
 	if contents := cert.Cer; contents != nil {
-		d.Set("certificate_data", string(*contents))
+		d.Set("certificate_data", strings.ToUpper(hex.EncodeToString(*contents)))
 	}
 
 	if v := cert.X509Thumbprint; v != nil {

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -323,8 +323,8 @@ The following attributes are exported:
 * `id` - The Key Vault Certificate ID.
 * `secret_id` - The ID of the associated Key Vault Secret.
 * `version` - The current version of the Key Vault Certificate.
-* `certificate_data` - The raw Key Vault Certificate.
-* `thumbprint` - The X509 Thumbprint of the Key Vault Certificate returned as hex string.
+* `certificate_data` - The raw Key Vault Certificate data represented as a hexadecimal string.
+* `thumbprint` - The X509 Thumbprint of the Key Vault Certificate represented as a hexadecimal string.
 
 
 ## Import


### PR DESCRIPTION
This commit changes the `certificate_data` field of an `azurerm_keyvault_certificate` to a hexadecimal representation, in common with the `thumbprint`. This is a better approach than calling `string(x)` directly on a byte array, since certificate data usually contains invalid UTF-8, and therefore cannot be processed by a wide array of tools downstream.

Documentation is updated to reflect the new format, but since this is a computed value, no state migration function is supplied.