### PR TITLE
Adding data source 'azurerm_public_ip_prefix'

### DIFF
--- a/azurerm/data_source_public_ip_prefix.go
+++ b/azurerm/data_source_public_ip_prefix.go
@@ -1,0 +1,65 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmPublicIpPrefix() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmPublicIpPrefixRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"location": azure.SchemaLocationForDataSource(),
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"sku": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"prefix_length": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"ip_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"zones": azure.SchemaSingleZone(),
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func dataSourceArmPublicIpPrefixRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).network.PublicIPPrefixesClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	resp, err := client.Get(ctx, resGroup, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Public IP prefix %q was not found", name)
+		}
+		return err
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmPublicIpPrefixRead(d, meta)
+}

--- a/azurerm/data_source_public_ip_prefix_test.go
+++ b/azurerm/data_source_public_ip_prefix_test.go
@@ -1,0 +1,66 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccDataSourceAzureRMPublicIPPrefix_basic(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+	name := fmt.Sprintf("acctestpublicipprefix-%d", ri)
+	resourceGroupName := fmt.Sprintf("acctestRG-%d", ri)
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMPublicIPPrefixBasic(name, resourceGroupName, location),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.azurerm_public_ip_prefix.test", "name", name),
+					resource.TestCheckResourceAttr("data.azurerm_public_ip_prefix.test", "resource_group_name", resourceGroupName),
+					resource.TestCheckResourceAttr("data.azurerm_public_ip_prefix.test", "location", location),
+					resource.TestCheckResourceAttr("data.azurerm_public_ip_prefix.test", "sku", "Standard"),
+					resource.TestCheckResourceAttr("data.azurerm_public_ip_prefix.test", "prefix_length", "31"),
+					resource.TestCheckResourceAttrSet("data.azurerm_public_ip_prefix.test", "ip_prefix"),
+					resource.TestCheckResourceAttr("data.azurerm_public_ip_prefix.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.azurerm_public_ip_prefix.test", "tags.env", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMPublicIPPrefixBasic(name string, resourceGroupName string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "%s"
+  location = "%s"
+
+  tags = {
+    env = "test"
+  }
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  prefix_length       = 31
+
+  tags = {
+    env = "test"
+  }
+}
+
+data "azurerm_public_ip_prefix" "test" {
+  name                = azurerm_public_ip_prefix.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, resourceGroupName, location, name)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -111,6 +111,7 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_proximity_placement_group":               dataSourceArmProximityPlacementGroup(),
 		"azurerm_public_ip":                               dataSourceArmPublicIP(),
 		"azurerm_public_ips":                              dataSourceArmPublicIPs(),
+		"azurerm_public_ip_prefix":                        dataSourceArmPublicIpPrefix(),
 		"azurerm_recovery_services_vault":                 dataSourceArmRecoveryServicesVault(),
 		"azurerm_recovery_services_protection_policy_vm":  dataSourceArmRecoveryServicesProtectionPolicyVm(),
 		"azurerm_redis_cache":                             dataSourceArmRedisCache(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -275,6 +275,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/providers/azurerm/d/public_ip_prefix.html">azurerm_public_ip_prefix</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/public_ip.html">azurerm_public_ip</a>
                 </li>
 

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_public_ip_prefix"
+sidebar_current: "docs-azurerm-datasource-public-ip-prefix-x"
+description: |-
+  Gets information about an existing Public IP Prefix.
+
+---
+
+# Data Source: azurerm_public_ip_prefix
+
+Use this data source to access information about an existing Public IP Prefix.
+
+## Example Usage (reference an existing)
+
+```hcl
+data "azurerm_public_ip_prefix" "test" {
+  name                = "name_of_public_ip"
+  resource_group_name = "name_of_resource_group"
+}
+
+output "public_ip_prefix" {
+  value = "${data.azurerm_public_ip_prefix.test.ip_prefix}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Specifies the name of the public IP prefix.
+* `resource_group_name` - (Required) Specifies the name of the resource group.
+
+## Attributes Reference
+
+* `name` - The name of the Public IP prefix resource.
+* `resource_group_name` - The name of the resource group in which to create the public IP.
+* `location` - The supported Azure location where the resource exists.
+* `sku` - The SKU of the Public IP Prefix.
+* `prefix_length` - The number of bits of the prefix.
+* `tags` - A mapping of tags to assigned to the resource.


### PR DESCRIPTION
This PR is in response to #3748.

I still do not fully understand how everything works (although I would like to learn more), but I think this is all that is required to get this data source added and working.

### Acceptance Tests
The test runs successfully.
It creates a `public_ip_prefix` and also creates a data source of that resource that the test verifies against.
![image](https://user-images.githubusercontent.com/3960208/65009289-1b0fc800-d8da-11e9-860f-0d69b881f5ed.png).

### Website Documentation
I am pretty sure I got everything correct (but that is one of the main things I am not 100% sure about).

in the `Attributes Reference` section, I did not add `zones` as it is specific region only (that is what the resource object says).
