### PR TITLE
linting only the provider code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - go: tip
   include:
     - name: "make lint"
-      script: GOGC=10 make lint
+      script: GOGC=15 make lint
     - name: "make tflint"
       script: make tflint
     - name: "make test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - go: tip
   include:
     - name: "make lint"
-      script: GOGC=20 make lint
+      script: GOGC=10 make lint
     - name: "make tflint"
       script: make tflint
     - name: "make test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     - go: tip
   include:
     - name: "make lint"
-      script: GOGC=15 make lint
+      script: GOGC=25 make lint
     - name: "make tflint"
       script: make tflint
     - name: "make test"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,6 +15,8 @@ tools:
 	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
 	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	GO111MODULE=off go get -u github.com/bflad/tfproviderlint/cmd/tfproviderlint
+	@echo "==> pinning golangci-lint version..."
+	@sh "$(CURDIR)/scripts/pin-golangci-lint.sh"
 
 build: fmtcheck
 	go install

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ goimports:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	golangci-lint run ./...
+	golangci-lint run ./$(PKG_NAME)/
 
 tflint:
 	@echo "==> Checking source code against terraform provider linters..."

--- a/scripts/pin-golangci-lint.sh
+++ b/scripts/pin-golangci-lint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cd $GOPATH/src/github.com/golangci/golangci-lint
-git checkout v1.18.0 &> /dev/null
+git checkout v1.17.0 &> /dev/null

--- a/scripts/pin-golangci-lint.sh
+++ b/scripts/pin-golangci-lint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cd $GOPATH/src/github.com/golangci/golangci-lint
-git checkout v1.17.0 &> /dev/null
+git checkout v1.18.0 &> /dev/null

--- a/scripts/pin-golangci-lint.sh
+++ b/scripts/pin-golangci-lint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd $GOPATH/src/github.com/golangci/golangci-lint
+git checkout v1.18.0 &> /dev/null


### PR DESCRIPTION
Linting the `./azurerm` directory, rather than the vendor directory too

Should reduce the memory footprint within Travis