### PR TITLE
Kubernetes agent pool profile add orchestrator version

### DIFF
--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -161,6 +161,11 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+
+						"orchestrator_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -683,6 +688,10 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 
 		if profile.NodeTaints != nil {
 			agentPoolProfile["node_taints"] = *profile.NodeTaints
+		}
+
+		if profile.OrchestratorVersion != nil {
+			agentPoolProfile["orchestrator_version"] = *profile.OrchestratorVersion
 		}
 
 		agentPoolProfiles = append(agentPoolProfiles, agentPoolProfile)

--- a/azurerm/data_source_kubernetes_cluster_test.go
+++ b/azurerm/data_source_kubernetes_cluster_test.go
@@ -525,6 +525,30 @@ func TestAccDataSourceAzureRMKubernetesCluster_nodeTaints(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMKubernetesCluster_orchestratorVersion(t *testing.T) {
+	dataSourceName := "data.azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+
+	config := testAccDataSourceAzureRMKubernetesCluster_orchestratorVersion(ri, clientId, clientSecret, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "agent_pool_profile.0.orchestrator_version", "1.14.6"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAzureRMKubernetesCluster_basic(rInt int, clientId string, clientSecret string, location string) string {
 	r := testAccAzureRMKubernetesCluster_basic(rInt, clientId, clientSecret, location)
 	return fmt.Sprintf(`
@@ -731,6 +755,18 @@ data "azurerm_kubernetes_cluster" "test" {
 
 func testAccDataSourceAzureRMKubernetesCluster_nodeTaints(rInt int, clientId string, clientSecret string, location string) string {
 	r := testAccAzureRMKubernetesCluster_nodeTaints(rInt, clientId, clientSecret, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = "${azurerm_kubernetes_cluster.test.name}"
+  resource_group_name = "${azurerm_kubernetes_cluster.test.resource_group_name}"
+}
+`, r)
+}
+
+func testAccDataSourceAzureRMKubernetesCluster_orchestratorVersion(rInt int, clientId string, clientSecret string, location string) string {
+	r := testAccAzureRMKubernetesCluster_orchestratorVersion(rInt, clientId, clientSecret, location)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -1249,6 +1249,11 @@ func flattenKubernetesClusterAgentPoolProfiles(profiles *[]containerservice.Mana
 			name = *profile.Name
 		}
 
+		orchestratorVersion := ""
+		if profile.OrchestratorVersion != nil {
+			orchestratorVersion = *profile.OrchestratorVersion
+		}
+
 		osDiskSizeGB := 0
 		if profile.OsDiskSizeGB != nil {
 			osDiskSizeGB = int(*profile.OsDiskSizeGB)
@@ -1260,26 +1265,23 @@ func flattenKubernetesClusterAgentPoolProfiles(profiles *[]containerservice.Mana
 		}
 
 		agentPoolProfile := map[string]interface{}{
-			"availability_zones":  utils.FlattenStringSlice(profile.AvailabilityZones),
-			"count":               count,
-			"enable_auto_scaling": enableAutoScaling,
-			"max_count":           maxCount,
-			"max_pods":            maxPods,
-			"min_count":           minCount,
-			"name":                name,
-			"node_taints":         utils.FlattenStringSlice(profile.NodeTaints),
-			"os_disk_size_gb":     osDiskSizeGB,
-			"os_type":             string(profile.OsType),
-			"type":                string(profile.Type),
-			"vm_size":             string(profile.VMSize),
-			"vnet_subnet_id":      subnetId,
+			"availability_zones":   utils.FlattenStringSlice(profile.AvailabilityZones),
+			"count":                count,
+			"enable_auto_scaling":  enableAutoScaling,
+			"max_count":            maxCount,
+			"max_pods":             maxPods,
+			"min_count":            minCount,
+			"name":                 name,
+			"node_taints":          utils.FlattenStringSlice(profile.NodeTaints),
+			"orchestrator_version": orchestratorVersion,
+			"os_disk_size_gb":      osDiskSizeGB,
+			"os_type":              string(profile.OsType),
+			"type":                 string(profile.Type),
+			"vm_size":              string(profile.VMSize),
+			"vnet_subnet_id":       subnetId,
 
 			// TODO: remove in 2.0
 			"fqdn": fqdnVal,
-		}
-
-		if profile.OrchestratorVersion != nil {
-			agentPoolProfile["orchestrator_version"] = *profile.OrchestratorVersion
 		}
 
 		agentPoolProfiles = append(agentPoolProfiles, agentPoolProfile)

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -210,6 +210,13 @@ func resourceArmKubernetesCluster() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+
+						"orchestrator_version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validate.NoEmptyStrings,
+						},
 					},
 				},
 			},
@@ -1188,6 +1195,10 @@ func expandKubernetesClusterAgentPoolProfiles(d *schema.ResourceData) ([]contain
 			profile.NodeTaints = nodeTaints
 		}
 
+		if orchestratorVersion, ok := config["orchestrator_version"]; ok {
+			profile.OrchestratorVersion = utils.String(orchestratorVersion.(string))
+		}
+
 		profiles = append(profiles, profile)
 	}
 
@@ -1265,6 +1276,10 @@ func flattenKubernetesClusterAgentPoolProfiles(profiles *[]containerservice.Mana
 
 			// TODO: remove in 2.0
 			"fqdn": fqdnVal,
+		}
+
+		if profile.OrchestratorVersion != nil {
+			agentPoolProfile["orchestrator_version"] = *profile.OrchestratorVersion
 		}
 
 		agentPoolProfiles = append(agentPoolProfiles, agentPoolProfile)

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -110,6 +110,8 @@ A `agent_pool_profile` block exports the following:
 
 * `node_taints` - The list of Kubernetes taints which are applied to nodes in the agent pool
 
+* `orchestrator_version` - (Optional) Kubernetes version for the worker nodes (e.g. `1.14.6`)
+
 ---
 
 A `azure_active_directory` block exports the following:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -141,8 +141,11 @@ resource "azurerm_subnet" "virtual" {
 A `addon_profile` block supports the following:
 
 * `aci_connector_linux` - (Optional) A `aci_connector_linux` block. For more details, please visit [Create and configure an AKS cluster to use virtual nodes](https://docs.microsoft.com/en-us/azure/aks/virtual-nodes-portal).
+
 * `http_application_routing` - (Optional) A `http_application_routing` block.
+
 * `oms_agent` - (Optional) A `oms_agent` block. For more details, please visit [How to onboard Azure Monitor for containers](https://docs.microsoft.com/en-us/azure/monitoring/monitoring-container-insights-onboard).
+
 * `kube_dashboard` - (Optional) A `kube_dashboard` block.
 
 ---
@@ -176,6 +179,8 @@ A `agent_pool_profile` block supports the following:
 ~> **NOTE:** A route table should be configured on this Subnet.
 
 * `node_taints` - (Optional) A list of Kubernetes taints which should be applied to nodes in the agent pool (e.g `key=value:NoSchedule`)
+
+* `orchestrator_version` - (Optional) Kubernetes version for the worker nodes (e.g. `1.14.6`)
 
 ---
 


### PR DESCRIPTION
Requested here: https://github.com/terraform-providers/terraform-provider-azurerm/issues/4327

Added tests which fail but even the basic test for AKS resource fails locally so there might be a different problem.

Fixes #4327