### PR TITLE
Add support for App Insights Analytics Items

### DIFF
--- a/azurerm/internal/services/applicationinsights/client.go
+++ b/azurerm/internal/services/applicationinsights/client.go
@@ -6,12 +6,17 @@ import (
 )
 
 type Client struct {
-	APIKeyClient     *insights.APIKeysClient
-	ComponentsClient *insights.ComponentsClient
-	WebTestsClient   *insights.WebTestsClient
+	AnalyticsItemsClient *insights.AnalyticsItemsClient
+	APIKeyClient         *insights.APIKeysClient
+	ComponentsClient     *insights.ComponentsClient
+	WebTestsClient       *insights.WebTestsClient
 }
 
 func BuildClient(o *common.ClientOptions) *Client {
+
+	AnalyticsItemsClient := insights.NewAnalyticsItemsClient(o.SubscriptionId)
+	o.ConfigureClient(&AnalyticsItemsClient.Client, o.ResourceManagerAuthorizer)
+
 	APIKeyClient := insights.NewAPIKeysClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&APIKeyClient.Client, o.ResourceManagerAuthorizer)
 
@@ -22,8 +27,9 @@ func BuildClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&WebTestsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		APIKeyClient:     &APIKeyClient,
-		ComponentsClient: &ComponentsClient,
-		WebTestsClient:   &WebTestsClient,
+		AnalyticsItemsClient: &AnalyticsItemsClient,
+		APIKeyClient:         &APIKeyClient,
+		ComponentsClient:     &ComponentsClient,
+		WebTestsClient:       &WebTestsClient,
 	}
 }

--- a/azurerm/internal/services/applicationinsights/client.go
+++ b/azurerm/internal/services/applicationinsights/client.go
@@ -13,7 +13,6 @@ type Client struct {
 }
 
 func BuildClient(o *common.ClientOptions) *Client {
-
 	AnalyticsItemsClient := insights.NewAnalyticsItemsClient(o.SubscriptionId)
 	o.ConfigureClient(&AnalyticsItemsClient.Client, o.ResourceManagerAuthorizer)
 

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -175,6 +175,7 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_application_gateway":                                resourceArmApplicationGateway(),
 		"azurerm_application_insights_api_key":                       resourceArmApplicationInsightsAPIKey(),
 		"azurerm_application_insights":                               resourceArmApplicationInsights(),
+		"azurerm_application_insights_analytics_item":                resourceArmApplicationInsightsAnalyticsItem(),
 		"azurerm_application_insights_web_test":                      resourceArmApplicationInsightsWebTests(),
 		"azurerm_application_security_group":                         resourceArmApplicationSecurityGroup(),
 		"azurerm_automation_account":                                 resourceArmAutomationAccount(),

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -106,6 +106,7 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 
 	appInsightsName := id.Path["components"]
 
+	itemID := d.Id()
 	name := d.Get("name").(string)
 	content := d.Get("content").(string)
 	scopeName := d.Get("scope").(string)
@@ -115,6 +116,7 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 	itemType := insights.ItemType(typeName)
 	itemScope := insights.ItemScope(scopeName)
 	properties := insights.ApplicationInsightsComponentAnalyticsItem{
+		ID:      &itemID,
 		Name:    &name,
 		Type:    itemType,
 		Scope:   itemScope,

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -195,7 +195,7 @@ func resourceArmApplicationInsightsAnalyticsItemDelete(d *schema.ResourceData, m
 
 	_, err = client.Delete(ctx, resourceGroupName, appInsightsName, itemScopePath, itemID, "")
 	if err != nil {
-		return fmt.Errorf("Error Getting Application Insights Analytics Item %s (Resource Group %s, App Insights Name: %s): %s", itemID, resourceGroupName, appInsightsName, err)
+		return fmt.Errorf("Error Deleting Application Insights Analytics Item %s (Resource Group %s, App Insights Name: %s): %s", itemID, resourceGroupName, appInsightsName, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -106,13 +106,21 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 	scopeName := d.Get("scope").(string)
 	typeName := d.Get("type").(string)
 
+	itemType := insights.ItemType(typeName)
+	itemScope := insights.ItemScope(scopeName)
 	properties := insights.ApplicationInsightsComponentAnalyticsItem{
 		Name:    &name,
-		Type:    insights.ItemType(typeName),
-		Scope:   insights.ItemScope(scopeName),
+		Type:    itemType,
+		Scope:   itemScope,
 		Content: &content,
 	}
-	result, err := client.Put(ctx, resourceGroupName, appInsightsName, insights.AnalyticsItems, properties, &overwrite)
+	var itemScopePath insights.ItemScopePath
+	if itemScope == insights.ItemScopeUser {
+		itemScopePath = insights.MyanalyticsItems
+	} else {
+		itemScopePath = insights.AnalyticsItems
+	}
+	result, err := client.Put(ctx, resourceGroupName, appInsightsName, itemScopePath, properties, &overwrite)
 	if err != nil {
 		return fmt.Errorf("Error Putting Application Insights Analytics Item %s (Resource Group %s, App Insights Name: %s): %s", name, resourceGroupName, appInsightsName, err)
 	}

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -1,0 +1,105 @@
+package azurerm
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+
+	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+)
+
+func resourceArmApplicationInsightsAnalyticsItem() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApplicationInsightsAnalyticsItemCreate,
+		Read:   resourceArmApplicationInsightsAnalyticsItemRead,
+		Update: resourceArmApplicationInsightsAnalyticsItemUpdate,
+		Delete: resourceArmApplicationInsightsAnalyticsItemDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"application_insights_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"item_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"content": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(insights.ItemScopeShared),
+					string(insights.ItemScopeUser),
+				}, false),
+			},
+
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(insights.Query),
+					string(insights.Function),
+					string(insights.Folder),
+					string(insights.Recent),
+				}, false),
+			},
+
+			"time_created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"time_modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmApplicationInsightsAnalyticsItemCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d, meta, false)
+}
+func resourceArmApplicationInsightsAnalyticsItemUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d, meta, true)
+}
+func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceData, meta interface{}, overwrite bool) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func resourceArmApplicationInsightsAnalyticsItemRead(d *schema.ResourceData, meta interface{}) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func resourceArmApplicationInsightsAnalyticsItemDelete(d *schema.ResourceData, meta interface{}) error {
+	return fmt.Errorf("Not implemented")
+}

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -187,7 +187,6 @@ func resourceArmApplicationInsightsAnalyticsItemRead(d *schema.ResourceData, met
 }
 
 func resourceArmApplicationInsightsAnalyticsItemDelete(d *schema.ResourceData, meta interface{}) error {
-
 	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
 	ctx := meta.(*ArmClient).StopContext
 

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 
 	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -22,10 +23,10 @@ func resourceArmApplicationInsightsAnalyticsItem() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.NoEmptyStrings,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -25,6 +25,7 @@ func resourceArmApplicationInsightsAnalyticsItem() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: validation.NoEmptyStrings,
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -41,11 +41,6 @@ func resourceArmApplicationInsightsAnalyticsItem() *schema.Resource {
 				Computed: true,
 			},
 
-			"item_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"content": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -93,13 +88,106 @@ func resourceArmApplicationInsightsAnalyticsItemUpdate(d *schema.ResourceData, m
 	return resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d, meta, true)
 }
 func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceData, meta interface{}, overwrite bool) error {
-	return fmt.Errorf("Not implemented")
+	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	appInsightsID := d.Get("application_insights_id").(string)
+
+	id, err := azure.ParseAzureResourceID(appInsightsID)
+	if err != nil {
+		return fmt.Errorf("Error parsing resource ID: %s", err)
+	}
+
+	appInsightsName := id.Path["components"]
+
+	name := d.Get("name").(string)
+	content := d.Get("content").(string)
+	scopeName := d.Get("scope").(string)
+	typeName := d.Get("type").(string)
+
+	properties := insights.ApplicationInsightsComponentAnalyticsItem{
+		Name:    &name,
+		Type:    insights.ItemType(typeName),
+		Scope:   insights.ItemScope(scopeName),
+		Content: &content,
+	}
+	result, err := client.Put(ctx, resourceGroupName, appInsightsName, insights.AnalyticsItems, properties, &overwrite)
+	if err != nil {
+		return fmt.Errorf("Error Putting Application Insights Analytics Item %s (Resource Group %s, App Insights Name: %s): %s", name, resourceGroupName, appInsightsName, err)
+	}
+
+	d.SetId(*result.ID)
+
+	return resourceArmApplicationInsightsAnalyticsItemRead(d, meta)
 }
 
 func resourceArmApplicationInsightsAnalyticsItemRead(d *schema.ResourceData, meta interface{}) error {
-	return fmt.Errorf("Not implemented")
+	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	appInsightsID := d.Get("application_insights_id").(string)
+	scopeName := d.Get("scope").(string)
+	itemID := d.Id()
+
+	id, err := azure.ParseAzureResourceID(appInsightsID)
+	if err != nil {
+		return fmt.Errorf("Error parsing resource ID: %s", err)
+	}
+
+	appInsightsName := id.Path["components"]
+	name := d.Get("name").(string)
+
+	var scopePath insights.ItemScopePath
+	if scopeName == "user" {
+		scopePath = insights.MyanalyticsItems
+	} else {
+		scopePath = insights.AnalyticsItems
+	}
+	result, err := client.Get(ctx, resourceGroupName, appInsightsName, scopePath, itemID, name)
+	if err != nil {
+		return fmt.Errorf("Error Getting Application Insights Analytics Item %s (Resource Group %s, App Insights Name: %s): %s", name, resourceGroupName, appInsightsName, err)
+	}
+
+	d.Set("version", result.Version)
+	d.Set("content", result.Content)
+	d.Set("scope", string(result.Scope))
+	d.Set("type", string(result.Type))
+	d.Set("time_created", result.TimeCreated)
+	d.Set("time_modified", result.TimeModified)
+
+	return nil
 }
 
 func resourceArmApplicationInsightsAnalyticsItemDelete(d *schema.ResourceData, meta interface{}) error {
-	return fmt.Errorf("Not implemented")
+
+	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	resourceGroupName := d.Get("resource_group_name").(string)
+	appInsightsID := d.Get("application_insights_id").(string)
+	scopeName := d.Get("scope").(string)
+	itemID := d.Id()
+
+	id, err := azure.ParseAzureResourceID(appInsightsID)
+	if err != nil {
+		return fmt.Errorf("Error parsing resource ID: %s", err)
+	}
+
+	appInsightsName := id.Path["components"]
+	name := d.Get("name").(string)
+
+	var scopePath insights.ItemScopePath
+	if scopeName == "user" {
+		scopePath = insights.MyanalyticsItems
+	} else {
+		scopePath = insights.AnalyticsItems
+	}
+	_, err = client.Delete(ctx, resourceGroupName, appInsightsName, scopePath, itemID, name)
+	if err != nil {
+		return fmt.Errorf("Error Getting Application Insights Analytics Item %s (Resource Group %s, App Insights Name: %s): %s", name, resourceGroupName, appInsightsName, err)
+	}
+
+	return nil
 }

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -205,7 +205,7 @@ func resourceArmApplicationInsightsAnalyticsItemDelete(d *schema.ResourceData, m
 	name := d.Get("name").(string)
 
 	var scopePath insights.ItemScopePath
-	if scopeName == "user" {
+	if scopeName == string(insights.ItemScopeUser) {
 		scopePath = insights.MyanalyticsItems
 	} else {
 		scopePath = insights.AnalyticsItems

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -29,8 +29,6 @@ func resourceArmApplicationInsightsAnalyticsItem() *schema.Resource {
 				ValidateFunc: validate.NoEmptyStrings,
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
 			"application_insights_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -98,14 +96,13 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
 	ctx := meta.(*ArmClient).StopContext
 
-	resourceGroupName := d.Get("resource_group_name").(string)
 	appInsightsID := d.Get("application_insights_id").(string)
 
 	resourceID, err := azure.ParseAzureResourceID(appInsightsID)
 	if err != nil {
 		return fmt.Errorf("Error parsing resource ID: %s", err)
 	}
-
+	resourceGroupName := resourceID.ResourceGroup
 	appInsightsName := resourceID.Path["components"]
 
 	id := d.Id()
@@ -174,7 +171,6 @@ func resourceArmApplicationInsightsAnalyticsItemRead(d *schema.ResourceData, met
 	idSuffix := resourcesArmApplicationInsightsAnalyticsItemGenerateIDSuffix(result.Scope, itemID)
 	appInsightsID := id[0 : len(id)-len(idSuffix)]
 	d.Set("application_insights_id", appInsightsID)
-	d.Set("resource_group_name", resourceGroupName)
 	d.Set("name", result.Name)
 	d.Set("version", result.Version)
 	d.Set("content", result.Content)

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -110,6 +110,7 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 	content := d.Get("content").(string)
 	scopeName := d.Get("scope").(string)
 	typeName := d.Get("type").(string)
+	functionAlias := d.Get("function_alias").(string)
 
 	itemType := insights.ItemType(typeName)
 	itemScope := insights.ItemScope(scopeName)
@@ -119,6 +120,12 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 		Scope:   itemScope,
 		Content: &content,
 	}
+	if functionAlias != "" {
+		properties.Properties = &insights.ApplicationInsightsComponentAnalyticsItemProperties{
+			FunctionAlias: &functionAlias,
+		}
+	}
+
 	var itemScopePath insights.ItemScopePath
 	if itemScope == insights.ItemScopeUser {
 		itemScopePath = insights.MyanalyticsItems
@@ -169,6 +176,10 @@ func resourceArmApplicationInsightsAnalyticsItemRead(d *schema.ResourceData, met
 	d.Set("type", string(result.Type))
 	d.Set("time_created", result.TimeCreated)
 	d.Set("time_modified", result.TimeModified)
+
+	if result.Properties != nil {
+		d.Set("function_alias", result.Properties.FunctionAlias)
+	}
 
 	return nil
 }

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -101,14 +101,22 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 	resourceGroupName := d.Get("resource_group_name").(string)
 	appInsightsID := d.Get("application_insights_id").(string)
 
-	id, err := azure.ParseAzureResourceID(appInsightsID)
+	resourceID, err := azure.ParseAzureResourceID(appInsightsID)
 	if err != nil {
 		return fmt.Errorf("Error parsing resource ID: %s", err)
 	}
 
-	appInsightsName := id.Path["components"]
+	appInsightsName := resourceID.Path["components"]
 
-	itemID := d.Id()
+	id := d.Id()
+	itemID := ""
+	if id != "" {
+		_, _, _, itemID, err = resourcesArmApplicationInsightsAnalyticsItemParseID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Application Insights Analytics Item ID %s: %s", id, err)
+		}
+	}
+
 	name := d.Get("name").(string)
 	content := d.Get("content").(string)
 	scopeName := d.Get("scope").(string)

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -68,6 +68,11 @@ func resourceArmApplicationInsightsAnalyticsItem() *schema.Resource {
 				}, false),
 			},
 
+			"function_alias": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"time_created": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -40,6 +40,7 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basic(t *testing.T) {
 func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
 	resourceName1 := "azurerm_application_insights_analytics_item.test1"
 	resourceName2 := "azurerm_application_insights_analytics_item.test2"
+	resourceName3 := "azurerm_application_insights_analytics_item.test3"
 	ri := tf.AccRandTimeInt()
 	config := testAccAzureRMApplicationInsightsAnalyticsItem_multiple(ri, testLocation())
 
@@ -49,6 +50,7 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery1", insights.ItemScopeShared),
 			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery2", insights.ItemScopeUser),
+			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testfunction1", insights.ItemScopeShared),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -56,6 +58,7 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName1, "testquery1", insights.ItemScopeShared),
 					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName2, "testquery2", insights.ItemScopeUser),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName3, "testfunction1", insights.ItemScopeShared),
 					resource.TestCheckResourceAttr(resourceName1, "name", "testquery1"),
 					resource.TestCheckResourceAttr(resourceName1, "scope", "shared"),
 					resource.TestCheckResourceAttr(resourceName1, "type", "query"),
@@ -64,6 +67,11 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName2, "scope", "user"),
 					resource.TestCheckResourceAttr(resourceName2, "type", "query"),
 					resource.TestCheckResourceAttr(resourceName2, "content", "requests #test2"),
+					resource.TestCheckResourceAttr(resourceName3, "name", "testfunction1"),
+					resource.TestCheckResourceAttr(resourceName3, "scope", "shared"),
+					resource.TestCheckResourceAttr(resourceName3, "type", "function"),
+					resource.TestCheckResourceAttr(resourceName3, "content", "requests #test3"),
+					resource.TestCheckResourceAttr(resourceName3, "function_alias", "myfunction"),
 				),
 			},
 		},
@@ -199,6 +207,16 @@ resource "azurerm_application_insights_analytics_item" "test2" {
   content                 = "requests #test2"
   scope                   = "user"
   type                    = "query"
+}
+
+resource "azurerm_application_insights_analytics_item" "test3" {
+  name                    = "testfunction1"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  application_insights_id = "${azurerm_application_insights.test.id}"
+  content                 = "requests #test3"
+  scope                   = "shared"
+  type                    = "function"
+  function_alias          = "myfunction"
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -158,7 +158,6 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string)
 }
 
 func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terraform.ResourceState) (bool, error) {
-	resGroup := rs.Primary.Attributes["resource_group_name"]
 	scopeName := rs.Primary.Attributes["scope"]
 	typeName := rs.Primary.Attributes["type"]
 	name := rs.Primary.Attributes["name"]
@@ -171,6 +170,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terrafor
 	if err != nil {
 		return false, fmt.Errorf("Error parsing resource ID: %s", err)
 	}
+	resGroup := id.ResourceGroup
 
 	appInsightsName := id.Path["components"]
 
@@ -210,7 +210,6 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_application_insights_analytics_item" "test" {
   name                    = "testquery"
-  resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
   content                 = "requests #test"
   scope                   = "shared"
@@ -235,7 +234,6 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_application_insights_analytics_item" "test" {
   name                    = "testquery"
-  resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
   content                 = "requests #updated"
   scope                   = "shared"
@@ -260,7 +258,6 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_application_insights_analytics_item" "test1" {
   name                    = "testquery1"
-  resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
   content                 = "requests #test1"
   scope                   = "shared"
@@ -269,7 +266,6 @@ resource "azurerm_application_insights_analytics_item" "test1" {
 
 resource "azurerm_application_insights_analytics_item" "test2" {
   name                    = "testquery2"
-  resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
   content                 = "requests #test2"
   scope                   = "user"
@@ -278,7 +274,6 @@ resource "azurerm_application_insights_analytics_item" "test2" {
 
 resource "azurerm_application_insights_analytics_item" "test3" {
   name                    = "testfunction1"
-  resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
   content                 = "requests #test3"
   scope                   = "shared"

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -33,6 +33,11 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "content", "requests #test"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -60,6 +60,11 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_update(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: config2,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName),
@@ -68,6 +73,11 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "query"),
 					resource.TestCheckResourceAttr(resourceName, "content", "requests #updated"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -105,6 +115,21 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName3, "content", "requests #test3"),
 					resource.TestCheckResourceAttr(resourceName3, "function_alias", "myfunction"),
 				),
+			},
+			{
+				ResourceName:      resourceName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceName3,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -21,12 +21,12 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery", insights.ItemScopeShared, insights.ItemTypeParameterQuery),
+		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName, "testquery", insights.ItemScopeShared, insights.ItemTypeParameterQuery),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "testquery"),
 					resource.TestCheckResourceAttr(resourceName, "scope", "shared"),
 					resource.TestCheckResourceAttr(resourceName, "type", "query"),
@@ -51,12 +51,12 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basicWithUpdate(t *testing.T
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery", insights.ItemScopeShared, insights.ItemTypeParameterQuery),
+		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: config1,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName, "testquery", insights.ItemScopeShared, insights.ItemTypeParameterQuery),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "testquery"),
 					resource.TestCheckResourceAttr(resourceName, "scope", "shared"),
 					resource.TestCheckResourceAttr(resourceName, "type", "query"),
@@ -66,7 +66,7 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basicWithUpdate(t *testing.T
 			{
 				Config: config2,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName, "testquery", insights.ItemScopeShared, insights.ItemTypeParameterQuery),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "testquery"),
 					resource.TestCheckResourceAttr(resourceName, "scope", "shared"),
 					resource.TestCheckResourceAttr(resourceName, "type", "query"),
@@ -85,20 +85,16 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
 	config := testAccAzureRMApplicationInsightsAnalyticsItem_multiple(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		CheckDestroy: resource.ComposeTestCheckFunc(
-			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery1", insights.ItemScopeShared, insights.ItemTypeParameterQuery),
-			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery2", insights.ItemScopeUser, insights.ItemTypeParameterQuery),
-			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testfunction1", insights.ItemScopeShared, insights.ItemTypeParameterFunction),
-		),
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName1, "testquery1", insights.ItemScopeShared, insights.ItemTypeParameterQuery),
-					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName2, "testquery2", insights.ItemScopeUser, insights.ItemTypeParameterQuery),
-					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName3, "testfunction1", insights.ItemScopeShared, insights.ItemTypeParameterFunction),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName1),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName2),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName3),
 					resource.TestCheckResourceAttr(resourceName1, "name", "testquery1"),
 					resource.TestCheckResourceAttr(resourceName1, "scope", "shared"),
 					resource.TestCheckResourceAttr(resourceName1, "type", "query"),
@@ -118,7 +114,7 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(queryName string, itemScope insights.ItemScope, itemType insights.ItemTypeParameter) resource.TestCheckFunc {
+func testCheckAzureRMApplicationInsightAnalyticsItemDestroy() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "azurerm_application_insights_analytics_item" {
@@ -127,7 +123,7 @@ func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(queryName string, it
 			name := rs.Primary.Attributes["name"]
 			resGroup := rs.Primary.Attributes["resource_group_name"]
 
-			exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs, queryName, itemScope, itemType)
+			exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs)
 			if err != nil {
 				return fmt.Errorf("Error checking if item has been destroyed: %s", err)
 			}
@@ -140,7 +136,7 @@ func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(queryName string, it
 	}
 }
 
-func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string, queryName string, itemScope insights.ItemScope, itemType insights.ItemTypeParameter) resource.TestCheckFunc {
+func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -149,7 +145,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string,
 		name := rs.Primary.Attributes["name"]
 		resGroup := rs.Primary.Attributes["resource_group_name"]
 
-		exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs, queryName, itemScope, itemType)
+		exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs)
 		if err != nil {
 			return fmt.Errorf("Error checking if item exists: %s", err)
 		}
@@ -161,8 +157,14 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string,
 	}
 }
 
-func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terraform.ResourceState, queryName string, itemScope insights.ItemScope, itemType insights.ItemTypeParameter) (bool, error) {
+func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terraform.ResourceState) (bool, error) {
 	resGroup := rs.Primary.Attributes["resource_group_name"]
+	scopeName := rs.Primary.Attributes["scope"]
+	typeName := rs.Primary.Attributes["type"]
+	name := rs.Primary.Attributes["name"]
+
+	itemScope := insights.ItemScope(scopeName)
+	itemType := insights.ItemTypeParameter(typeName)
 
 	appInsightsID := rs.Primary.Attributes["application_insights_id"]
 	id, err := azure.ParseAzureResourceID(appInsightsID)
@@ -184,7 +186,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terrafor
 		return false, fmt.Errorf("Bad: List on appInsightsAnalyticsItemsClient: %+v", err)
 	}
 	for _, item := range *resp.Value {
-		if *item.Name == queryName && item.Scope == itemScope {
+		if *item.Name == name && item.Scope == itemScope {
 			return true, nil
 		}
 	}

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -1,0 +1,112 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+
+	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights"
+)
+
+func TestAccAzureRMApplicationInsightsAnalyticsItem_basic(t *testing.T) {
+	resourceName := "azurerm_application_insights_analytics_item.test"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMApplicationInsightsAnalyticsItem_basic(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "scope", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "type", "query"),
+					resource.TestCheckResourceAttr(resourceName, "content", "requests #test"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).appInsights.AnalyticsItemsClient
+	ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_application_insights_analytics_item" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(ctx, resGroup, name, insights.AnalyticsItems, "", "testquery")
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Application Insights AnalyticsItem still exists:\n%#v", resp)
+		}
+	}
+
+	return nil
+}
+
+func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resGroup := rs.Primary.Attributes["resource_group_name"]
+		conn := testAccProvider.Meta().(*ArmClient).appInsights.AnalyticsItemsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := conn.Get(ctx, resGroup, name, insights.AnalyticsItems, "", "testquery")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on appInsightsAnalyticsItemsClient: %+v", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Application Insights AnalyticsItem '%q' (resource group: '%q') does not exist", name, resGroup)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApplicationInsightsAnalyticsItem_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_analytics_item" "test" {
+  name                    = "testquery"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  application_insights_id = "${azurerm_application_insights.test.id}"
+  content                 = "requests #test"
+	scope                   = "shared"
+	type                    = "query"
+}
+`, rInt, location, rInt)
+}

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -21,12 +21,12 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery"),
+		CheckDestroy: testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery", insights.ItemScopeShared),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName, "testquery"),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName, "testquery", insights.ItemScopeShared),
 					resource.TestCheckResourceAttr(resourceName, "name", "testquery"),
 					resource.TestCheckResourceAttr(resourceName, "scope", "shared"),
 					resource.TestCheckResourceAttr(resourceName, "type", "query"),
@@ -37,7 +37,40 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basic(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(queryName string) resource.TestCheckFunc {
+func TestAccAzureRMApplicationInsightsAnalyticsItem_multiple(t *testing.T) {
+	resourceName1 := "azurerm_application_insights_analytics_item.test1"
+	resourceName2 := "azurerm_application_insights_analytics_item.test2"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMApplicationInsightsAnalyticsItem_multiple(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery1", insights.ItemScopeShared),
+			testCheckAzureRMApplicationInsightAnalyticsItemDestroy("testquery2", insights.ItemScopeUser),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName1, "testquery1", insights.ItemScopeShared),
+					testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName2, "testquery2", insights.ItemScopeUser),
+					resource.TestCheckResourceAttr(resourceName1, "name", "testquery1"),
+					resource.TestCheckResourceAttr(resourceName1, "scope", "shared"),
+					resource.TestCheckResourceAttr(resourceName1, "type", "query"),
+					resource.TestCheckResourceAttr(resourceName1, "content", "requests #test1"),
+					resource.TestCheckResourceAttr(resourceName2, "name", "testquery2"),
+					resource.TestCheckResourceAttr(resourceName2, "scope", "user"),
+					resource.TestCheckResourceAttr(resourceName2, "type", "query"),
+					resource.TestCheckResourceAttr(resourceName2, "content", "requests #test2"),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(queryName string, itemScope insights.ItemScope) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "azurerm_application_insights_analytics_item" {
@@ -46,7 +79,7 @@ func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(queryName string) re
 			name := rs.Primary.Attributes["name"]
 			resGroup := rs.Primary.Attributes["resource_group_name"]
 
-			exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs, queryName)
+			exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs, queryName, itemScope)
 			if err != nil {
 				return fmt.Errorf("Error checking if item has been destroyed: %s", err)
 			}
@@ -59,7 +92,7 @@ func testCheckAzureRMApplicationInsightAnalyticsItemDestroy(queryName string) re
 	}
 }
 
-func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string, queryName string) resource.TestCheckFunc {
+func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string, queryName string, itemScope insights.ItemScope) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -68,7 +101,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string,
 		name := rs.Primary.Attributes["name"]
 		resGroup := rs.Primary.Attributes["resource_group_name"]
 
-		exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs, queryName)
+		exists, err := testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs, queryName, itemScope)
 		if err != nil {
 			return fmt.Errorf("Error checking if item exists: %s", err)
 		}
@@ -80,7 +113,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string,
 	}
 }
 
-func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terraform.ResourceState, queryName string) (bool, error) {
+func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terraform.ResourceState, queryName string, itemScope insights.ItemScope) (bool, error) {
 	resGroup := rs.Primary.Attributes["resource_group_name"]
 
 	appInsightsID := rs.Primary.Attributes["application_insights_id"]
@@ -95,7 +128,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terrafor
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	includeContent := false
-	resp, err := conn.List(ctx, resGroup, appInsightsName, insights.AnalyticsItems, insights.ItemScopeShared, insights.ItemTypeParameterQuery, &includeContent)
+	resp, err := conn.List(ctx, resGroup, appInsightsName, insights.AnalyticsItems, itemScope, insights.ItemTypeParameterQuery, &includeContent)
 	if resp.StatusCode == http.StatusNotFound {
 		return false, nil
 	}
@@ -103,7 +136,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terrafor
 		return false, fmt.Errorf("Bad: List on appInsightsAnalyticsItemsClient: %+v", err)
 	}
 	for _, item := range *resp.Value {
-		if *item.Name == queryName && item.Scope == insights.ItemScopeShared {
+		if *item.Name == queryName && item.Scope == itemScope {
 			return true, nil
 		}
 	}
@@ -130,8 +163,42 @@ resource "azurerm_application_insights_analytics_item" "test" {
   resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
   content                 = "requests #test"
-	scope                   = "shared"
-	type                    = "query"
+  scope                   = "shared"
+  type                    = "query"
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMApplicationInsightsAnalyticsItem_multiple(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_analytics_item" "test1" {
+  name                    = "testquery1"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  application_insights_id = "${azurerm_application_insights.test.id}"
+  content                 = "requests #test1"
+  scope                   = "shared"
+  type                    = "query"
+}
+
+resource "azurerm_application_insights_analytics_item" "test2" {
+  name                    = "testquery2"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  application_insights_id = "${azurerm_application_insights.test.id}"
+  content                 = "requests #test2"
+  scope                   = "user"
+  type                    = "query"
 }
 `, rInt, location, rInt)
 }

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -42,7 +42,7 @@ func TestAccAzureRMApplicationInsightsAnalyticsItem_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMApplicationInsightsAnalyticsItem_basicWithUpdate(t *testing.T) {
+func TestAccAzureRMApplicationInsightsAnalyticsItem_update(t *testing.T) {
 	resourceName := "azurerm_application_insights_analytics_item.test"
 	ri := tf.AccRandTimeInt()
 	config1 := testAccAzureRMApplicationInsightsAnalyticsItem_basic(ri, testLocation())

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -156,6 +156,9 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terrafor
 	id := rs.Primary.Attributes["id"]
 
 	resGroup, appInsightsName, itemScopePath, itemID, err := resourcesArmApplicationInsightsAnalyticsItemParseID(id)
+	if err != nil {
+		return false, fmt.Errorf("Failed to parse ID (id: %s): %+v", id, err)
+	}
 
 	conn := testAccProvider.Meta().(*ArmClient).appInsights.AnalyticsItemsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -177,7 +177,6 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExists(resourceName string)
 }
 
 func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terraform.ResourceState) (bool, error) {
-
 	id := rs.Primary.Attributes["id"]
 
 	resGroup, appInsightsName, itemScopePath, itemID, err := resourcesArmApplicationInsightsAnalyticsItemParseID(id)

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -539,6 +539,11 @@
                   <a href="/docs/providers/azurerm/r/application_insights_api_key.html">azurerm_application_insights_api_key</a>
                 </li>
 
+
+                <li>
+                  <a href="/docs/providers/azurerm/r/application_insights_analytics_item.html">azurerm_application_insights_analytics_item</a>
+                </li>
+
                 <li>
                   <a href="/docs/providers/azurerm/r/application_insights_web_tests.html">azurerm_application_insights_web_test</a>
                 </li>

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -35,8 +35,6 @@ resource "azurerm_application_insights_analytics_item" "test" {
 }
 ```
 
-*********************************************TODO!!
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -54,8 +52,6 @@ The following arguments are supported:
 * `content` - (Required) The content for the Analytics Item, for example the query text if `type` is `query`.
 
 * `function_alias` - (Optional) The alias to use for the function. Required when `type` is `function`.
-
-TODO!!
 
 ## Attributes Reference
 

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_application_insights_analytics_item"
+sidebar_current: "docs-azurerm-resource-application-insights-x"
+description: |-
+  Manages an Application Insights Analytics Item component.
+---
+
+# azurerm_application_insights_analytics_item
+
+Manages an Application Insights Analytics Item component.
+
+## Example Usage
+
+```terraform
+resource "azurerm_resource_group" "test" {
+  name     = "tf-test"
+  location = "West Europe"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "tf-test-appinsights"
+  location            = "West Europe"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_analytics_item" "test" {
+  name                    = "testquery"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  application_insights_id = "${azurerm_application_insights.test.id}"
+  content                 = "requests #simple example query"
+  scope                   = "shared"
+  type                    = "query"
+}
+```
+
+*********************************************TODO!!
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Application Insights Analytics Item. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the Application Insights component.
+
+* `application_insights_id` - (Required) The ID of the Application Insights component on which the Analytics Item exists. Changing this forces a new resource to be created.
+
+* `type` - (Required) The type of Analytics Item to create. Can be one of `query`, `function`, `folder`, `recent`. Changing this forces a new resource to be created.
+
+* `scope` - (Required) The scope for the Analytics Item. Can be `shared` or `user`. Changing this forces a new resource to be created.
+
+* `content` - (Required) The content for the Analytics Item, for example the query text if `type` is `query`.
+
+TODO!!
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Application Insights Analytics Item.
+
+* `time_created` - A string containing the time the Analytics Item was created.
+
+* `time_modified` - A string containing the time the Analytics Item was last modified.

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -62,3 +62,5 @@ The following attributes are exported:
 * `time_created` - A string containing the time the Analytics Item was created.
 
 * `time_modified` - A string containing the time the Analytics Item was last modified.
+
+* `version` - A string indicating the version of the query format

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `type` - (Required) The type of Analytics Item to create. Can be one of `query`, `function`, `folder`, `recent`. Changing this forces a new resource to be created.
 
-* `scope` - (Required) The scope for the Analytics Item. Can be `shared` or `user`. Changing this forces a new resource to be created. Must be `shared` for for functions.
+* `scope` - (Required) The scope for the Analytics Item. Can be `shared` or `user`. Changing this forces a new resource to be created. Must be `shared` for functions.
 
 * `content` - (Required) The content for the Analytics Item, for example the query text if `type` is `query`.
 

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -27,7 +27,6 @@ resource "azurerm_application_insights" "test" {
 
 resource "azurerm_application_insights_analytics_item" "test" {
   name                    = "testquery"
-  resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
   content                 = "requests //simple example query"
   scope                   = "shared"
@@ -40,8 +39,6 @@ resource "azurerm_application_insights_analytics_item" "test" {
 The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Application Insights Analytics Item. Changing this forces a new resource to be created.
-
-* `resource_group_name` - (Required) The name of the resource group in which to create the Application Insights component.
 
 * `application_insights_id` - (Required) The ID of the Application Insights component on which the Analytics Item exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `type` - (Required) The type of Analytics Item to create. Can be one of `query`, `function`, `folder`, `recent`. Changing this forces a new resource to be created.
 
-* `scope` - (Required) The scope for the Analytics Item. Can be `shared` or `user`. Changing this forces a new resource to be created.
+* `scope` - (Required) The scope for the Analytics Item. Can be `shared` or `user`. Changing this forces a new resource to be created. Must be `shared` for for functions.
 
 * `content` - (Required) The content for the Analytics Item, for example the query text if `type` is `query`.
 

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_application_insights_analytics_item" "test" {
   name                    = "testquery"
   resource_group_name     = "${azurerm_resource_group.test.name}"
   application_insights_id = "${azurerm_application_insights.test.id}"
-  content                 = "requests #simple example query"
+  content                 = "requests //simple example query"
   scope                   = "shared"
   type                    = "query"
 }

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -64,3 +64,19 @@ The following attributes are exported:
 * `time_modified` - A string containing the time the Analytics Item was last modified.
 
 * `version` - A string indicating the version of the query format
+
+## Import
+
+Application Insights Analytics Items can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_application_insights_analytics_item.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.insights/components/analyticsItems/11111111-1111-1111-1111-111111111111
+```
+
+-> **Please Note:** This is a Terraform Unique ID matching the format: `{appInsightsID}/analyticsItems/{itemId}` for items with `scope` set to `shared`, or  `{appInsightsID}/myanalyticsItems/{itemId}` for items with `scope` set to `user`
+
+To find the Analytics Item ID you can query the REST API using the [`az rest` CLI command](https://docs.microsoft.com/en-us/cli/azure/reference-index?view=azure-cli-latest#az-rest), e.g.
+
+```shell
+az rest --method GET --uri "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.insights/components/appinsightstest/analyticsItems?api-version=2015-05-01"
+```

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -53,6 +53,8 @@ The following arguments are supported:
 
 * `content` - (Required) The content for the Analytics Item, for example the query text if `type` is `query`.
 
+* `function_alias` - (Optional) The alias to use for the function. Required when `type` is `function`.
+
 TODO!!
 
 ## Attributes Reference


### PR DESCRIPTION
App Insights supports saved queries and functions (referred to as Analytics Items in the API/SDKs).

This PR adds a resource for App Insights Analytics Items.