### PR TITLE
`azurerm_role_assignment` -  changing the `skip_service_principal_aad_check` property no longer forces a new resource

### DIFF
--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -74,8 +74,7 @@ func resourceArmRoleAssignment() *schema.Resource {
 			"skip_service_principal_aad_check": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
-				Default:  false,
+				Computed: true,
 			},
 		},
 	}


### PR DESCRIPTION
(fixes #4393 )