### PR TITLE
Updated policy section to clarify usage

### DIFF
--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -26,6 +26,17 @@ resource "azurerm_api_management" "test" {
   publisher_email     = "company@terraform.io"
 
   sku_name = "Developer_1"
+   
+  policy {
+    xml_content = <<XML
+    <policies>
+      <inbound />
+      <backend />
+      <outbound />
+      <on-error />
+    </policies>
+XML
+  }
 }
 ```
 
@@ -126,18 +137,6 @@ A `management`, `portal` and `scm` block supports the following:
 
 A `policy` block supports the following:
 
-```hcl
-  policy {
-  xml_content = <<XML
-  <policies>
-    <inbound />
-    <backend />
-    <outbound />
-    <on-error />
-  </policies>
-XML
-  }
-```
 * `xml_content` - (Optional) The XML Content for this Policy.
 
 * `xml_link` - (Optional) A link to an API Management Policy XML Document, which must be publicly available.

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -126,6 +126,18 @@ A `management`, `portal` and `scm` block supports the following:
 
 A `policy` block supports the following:
 
+```hcl
+  policy {
+  xml_content = <<XML
+  <policies>
+    <inbound />
+    <backend />
+    <outbound />
+    <on-error />
+  </policies>
+XML
+  }
+```
 * `xml_content` - (Optional) The XML Content for this Policy.
 
 * `xml_link` - (Optional) A link to an API Management Policy XML Document, which must be publicly available.


### PR DESCRIPTION
In the previous version there was a reference to the Policy block, but nowhere was to be found how to add this to the API Management resource itself. The update shows an example so users don't need to go through the code to find out how to use it.