### PR TITLE
Removed ForceNew for resource_arm_function_app for the app_service_plan_id

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -49,7 +49,6 @@ func resourceArmFunctionApp() *schema.Resource {
 			"app_service_plan_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"enabled": {

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Function App. Changing this forces a new resource to be created.
+* `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Function App.
 
 * `storage_connection_string` - (Required) The connection string of the backend storage account which will be used by this Function App (such as the dashboard, logs).
 


### PR DESCRIPTION
A function app should not have to be re-created when you re-associate it to another service plan. This PR will bring the `resource_arm_function_app` in line with its closely related `resource_arm_app_service` resource 