### PR TITLE
azurerm/resource_arm_storage_blob.go: make sure storage blob is read after create/update to update all the computed properties

### DIFF
--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -259,7 +259,7 @@ func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) erro
 		log.Printf("[DEBUG] Updated MetaData for Blob %q (Container %q / Account %q).", id.BlobName, id.ContainerName, id.AccountName)
 	}
 
-	return nil
+	return resourceArmStorageBlobRead(d, meta)
 }
 
 func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
The previous behavior of the create was to read the resource like almost all others to make sure the computed properties like `url` are set.

but with the [change][1], it was changed to update to make sure create was done correctly, but update doesn't have a read call making the create failing to set the `url` property

[1]: https://github.com/terraform-providers/terraform-provider-azurerm/commit/cab451fb2db9ab0d4ca84fefb218770cb169eaf0#diff-8e833d66ec7540aaf7ec57fd375ba62aR177-R178