### PR TITLE
`azurerm_image`: add option to set the hyper_v_generation for the image

### DIFF
--- a/azurerm/resource_arm_image.go
+++ b/azurerm/resource_arm_image.go
@@ -45,6 +45,17 @@ func resourceArmImage() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"hyper_v_generation": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(compute.HyperVGenerationTypesV1),
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.HyperVGenerationTypesV1),
+					string(compute.HyperVGenerationTypesV2),
+				}, false),
+			},
+
 			"source_virtual_machine_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -177,6 +188,7 @@ func resourceArmImageCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	zoneResilient := d.Get("zone_resilient").(bool)
+	hyperVGeneration := d.Get("hyper_v_generation").(string)
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name, "")
@@ -194,7 +206,9 @@ func resourceArmImageCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	expandedTags := tags.Expand(d.Get("tags").(map[string]interface{}))
 
-	properties := compute.ImageProperties{}
+	properties := compute.ImageProperties{
+		HyperVGeneration: compute.HyperVGenerationTypes(hyperVGeneration),
+	}
 
 	osDisk, err := expandAzureRmImageOsDisk(d)
 	if err != nil {
@@ -227,14 +241,10 @@ func resourceArmImageCreateUpdate(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("[ERROR] Cannot create image when both source VM and storage profile are empty")
 		}
 
-		properties = compute.ImageProperties{
-			StorageProfile: &storageProfile,
-		}
+		properties.StorageProfile = &storageProfile
 	} else {
 		//creating an image from source VM
-		properties = compute.ImageProperties{
-			SourceVirtualMachine: &sourceVM,
-		}
+		properties.SourceVirtualMachine = &sourceVM
 	}
 
 	createImage := compute.Image{
@@ -309,6 +319,7 @@ func resourceArmImageRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		d.Set("zone_resilient", resp.StorageProfile.ZoneResilient)
 	}
+	d.Set("hyper_v_generation", string(resp.HyperVGeneration))
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -171,7 +171,7 @@ func testAccAzureRMSharedImageVersion_setup(rInt int, location, username, passwo
 }
 
 func testAccAzureRMSharedImageVersion_provision(rInt int, location, username, password, hostname string) string {
-	template := testAccAzureRMImage_standaloneImage_provision(rInt, username, password, hostname, location, "LRS")
+	template := testAccAzureRMImage_standaloneImage_provision(rInt, username, password, hostname, location, "LRS", "")
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `data_disk` - (Optional) One or more `data_disk` elements as defined below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `zone_resilient` - (Optional) Is zone resiliency enabled?  Defaults to `false`.  Changing this forces a new resource to be created.
+* `hyper_v_generation` - (Optional) The HyperVGenerationType of the VirtualMachine created from the image as `V1`, `V2`. The default is `V1`.
 
 ~> **Note**: `zone_resilient` can only be set to `true` if the image is stored in a region that supports availability zones.
 


### PR DESCRIPTION
The new clients require this information see [properties.hyperVGeneration][1] and it supports 2 values `V1` and `V2` [2]

the default is `V1` in azure cli `--hyper-v-generation` [3], so it should be safe to keep that as default.

[1]: https://docs.microsoft.com/en-us/rest/api/compute/images/createorupdate#image
[2]: https://docs.microsoft.com/en-us/rest/api/compute/images/createorupdate#hypervgenerationtypes
[3]: https://docs.microsoft.com/en-us/cli/azure/image?view=azure-cli-latest#optional-parameters

Fixes: https://github.com/terraform-providers/terraform-provider-azurerm/issues/4361