### PR TITLE
Clarify DNS record resource_group_name usage in documentation.

### DIFF
--- a/website/docs/r/dns_a_record.html.markdown
+++ b/website/docs/r/dns_a_record.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS A Record.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_aaaa_record.html.markdown
+++ b/website/docs/r/dns_aaaa_record.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS AAAA Record.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_caa_record.html.markdown
+++ b/website/docs/r/dns_caa_record.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS CAA Record.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_cname_record.html.markdown
+++ b/website/docs/r/dns_cname_record.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS CNAME Record.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_mx_record.html.markdown
+++ b/website/docs/r/dns_mx_record.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 
-* `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `zone_name` - (Required) Specifies the DNS Zone where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 

--- a/website/docs/r/dns_ns_record.html.markdown
+++ b/website/docs/r/dns_ns_record.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 
-* `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `zone_name` - (Required) Specifies the DNS Zone where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 

--- a/website/docs/r/dns_ptr_record.html.markdown
+++ b/website/docs/r/dns_ptr_record.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 
-* `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `zone_name` - (Required) Specifies the DNS Zone where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 

--- a/website/docs/r/dns_srv_record.html.markdown
+++ b/website/docs/r/dns_srv_record.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 
-* `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `zone_name` - (Required) Specifies the DNS Zone where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 
-* `zone_name` - (Required) Specifies the DNS Zone where the resource exists. Changing this forces a new resource to be created.
+* `zone_name` - (Required) Specifies the DNS Zone where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 


### PR DESCRIPTION
For most resources, the resource_group_name attribute is used to specify the group
into which the new resource will be added. In the case of DNS records, the resource_group_name
specifies the group in which the parent can be found.

I had a DNS Zone in one resource group, and was attempting to create a CNAME record in a different resource group (as though that were possible). This wasn't working - 404 error indicated that the parent resource could not be found. When I realised that the resource_group_name attribute was used to locate the DNS Zone, rather than to select which group the new resources should be placed in, it all worked.

I wonder whether my proposed changes to the documentation might help others in future.
