### PR TITLE
clients: ensuring the user agent is set even if there's no partner id

### DIFF
--- a/azurerm/internal/common/client_options.go
+++ b/azurerm/internal/common/client_options.go
@@ -33,9 +33,7 @@ type ClientOptions struct {
 }
 
 func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.Authorizer) {
-	if o.PartnerId != "" {
-		setUserAgent(c, o.PartnerId)
-	}
+	setUserAgent(c, o.PartnerId)
 
 	c.Authorizer = authorizer
 	c.Sender = sender.BuildSender("AzureRM")


### PR DESCRIPTION
The check for `partner_id` happens within the setUserAgent function
so we can instead delegate to that and ensure this is always set

which means the user agent gets set again:

```
2019-09-30T16:41:01.792+0200 [DEBUG] plugin.terraform-provider-azurerm: User-Agent: Go/go1.13 (amd64-darwin) go-autorest/v13.0.0 Azure-SDK-For-Go/v33.2.0 resources/2016-02-01 Terraform/0.12.8 terraform-provider-azurerm/dev
```