### PR TITLE
provider: Use real Terraform version

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -146,7 +146,7 @@ type ArmClient struct {
 
 // getArmClient is a helper method which returns a fully instantiated
 // *ArmClient based on the Config's current settings.
-func getArmClient(authConfig *authentication.Config, skipProviderRegistration bool, partnerId string, disableCorrelationRequestID bool) (*ArmClient, error) {
+func getArmClient(authConfig *authentication.Config, skipProviderRegistration bool, tfVersion, partnerId string, disableCorrelationRequestID bool) (*ArmClient, error) {
 	env, err := authentication.DetermineEnvironment(authConfig.Environment)
 	if err != nil {
 		return nil, err
@@ -201,6 +201,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		SubscriptionId:              authConfig.SubscriptionID,
 		TenantID:                    authConfig.TenantID,
 		PartnerId:                   partnerId,
+		TerraformVersion:            tfVersion,
 		GraphAuthorizer:             graphAuth,
 		GraphEndpoint:               graphEndpoint,
 		KeyVaultAuthorizer:          keyVaultAuth,

--- a/azurerm/internal/common/client_options.go
+++ b/azurerm/internal/common/client_options.go
@@ -15,9 +15,10 @@ import (
 )
 
 type ClientOptions struct {
-	SubscriptionId string
-	TenantID       string
-	PartnerId      string
+	SubscriptionId   string
+	TenantID         string
+	PartnerId        string
+	TerraformVersion string
 
 	GraphAuthorizer           autorest.Authorizer
 	GraphEndpoint             string
@@ -33,7 +34,7 @@ type ClientOptions struct {
 }
 
 func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.Authorizer) {
-	setUserAgent(c, o.PartnerId)
+	setUserAgent(c, o.TerraformVersion, o.PartnerId)
 
 	c.Authorizer = authorizer
 	c.Sender = sender.BuildSender("AzureRM")
@@ -44,8 +45,8 @@ func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.A
 	}
 }
 
-func setUserAgent(client *autorest.Client, partnerID string) {
-	tfUserAgent := httpclient.UserAgentString()
+func setUserAgent(client *autorest.Client, tfVersion, partnerID string) {
+	tfUserAgent := httpclient.TerraformUserAgent(tfVersion)
 
 	providerUserAgent := fmt.Sprintf("%s terraform-provider-azurerm/%s", tfUserAgent, version.ProviderVersion)
 	client.UserAgent = strings.TrimSpace(fmt.Sprintf("%s %s", client.UserAgent, providerUserAgent))

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -638,7 +638,14 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		skipProviderRegistration := d.Get("skip_provider_registration").(bool)
 		disableCorrelationRequestID := d.Get("disable_correlation_request_id").(bool)
 
-		client, err := getArmClient(config, skipProviderRegistration, partnerId, disableCorrelationRequestID)
+		terraformVersion := p.TerraformVersion
+		if terraformVersion == "" {
+			// Terraform 0.12 introduced this field to the protocol
+			// We can therefore assume that if it's missing it's 0.10 or 0.11
+			terraformVersion = "0.11+compatible"
+		}
+
+		client, err := getArmClient(config, skipProviderRegistration, terraformVersion, partnerId, disableCorrelationRequestID)
 		if err != nil {
 			return nil, err
 		}

--- a/azurerm/required_resource_providers_test.go
+++ b/azurerm/required_resource_providers_test.go
@@ -14,7 +14,7 @@ func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 	}
 
 	// this test intentionally checks all the RP's are registered - so this is intentional
-	armClient, err := getArmClient(config, true, "", true)
+	armClient, err := getArmClient(config, true, "0.0.0", "", true)
 	if err != nil {
 		t.Fatalf("Error building ARM Client: %+v", err)
 	}

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -21,7 +21,7 @@ func TestAccAzureRMContainerRegistryMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_data_lake_store_file_migration_test.go
+++ b/azurerm/resource_arm_data_lake_store_file_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMDataLakeStoreFileMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_queue_migration_test.go
+++ b/azurerm/resource_arm_storage_queue_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMStorageQueueMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return


### PR DESCRIPTION
Depends on https://github.com/terraform-providers/terraform-provider-azurerm/pull/4463

----

This makes the provider ready for migration to the standalone SDK.

I ran one acceptance test and I can see that the PR doesn't break anything and it's changing the UA header as expected.
