### PR TITLE
Adds throughput support for Cosmos DB Mongo Collection

### DIFF
--- a/azurerm/helpers/validate/cosmos.go
+++ b/azurerm/helpers/validate/cosmos.go
@@ -27,7 +27,7 @@ func CosmosEntityName(v interface{}, k string) (warnings []string, errors []erro
 	return warnings, errors
 }
 
-func Throughput(v interface{}, k string) (warnings []string, errors []error) {
+func CosmosThroughput(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(int)
 
 	if value < 400 {

--- a/azurerm/helpers/validate/cosmos.go
+++ b/azurerm/helpers/validate/cosmos.go
@@ -26,3 +26,19 @@ func CosmosEntityName(v interface{}, k string) (warnings []string, errors []erro
 
 	return warnings, errors
 }
+
+func Throughput(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(int)
+
+	if value < 400 {
+		errors = append(errors, fmt.Errorf(
+			"%s must be a minimum of 400", k))
+	}
+
+	if value%100 != 0 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be set in increments of 100", k))
+	}
+
+	return warnings, errors
+}

--- a/azurerm/helpers/validate/cosmos_test.go
+++ b/azurerm/helpers/validate/cosmos_test.go
@@ -36,7 +36,7 @@ func TestCosmosAccountName(t *testing.T) {
 	for _, tc := range cases {
 		_, errors := CosmosAccountName(tc.Value, "throughput")
 		if len(errors) != tc.Errors {
-			t.Fatalf("Expected DatabaseCollation to trigger '%d' errors for '%s' - got '%d'", tc.Errors, tc.Value, len(errors))
+			t.Fatalf("Expected CosmosAccountName to trigger '%d' errors for '%s' - got '%d'", tc.Errors, tc.Value, len(errors))
 		}
 	}
 }
@@ -63,7 +63,7 @@ func TestCosmosEntityName(t *testing.T) {
 	for _, tc := range cases {
 		_, errors := CosmosEntityName(tc.Value, "throughput")
 		if len(errors) != tc.Errors {
-			t.Fatalf("Expected DatabaseCollation to trigger '%d' errors for '%s' - got '%d'", tc.Errors, tc.Value, len(errors))
+			t.Fatalf("Expected CosmosEntityName to trigger '%d' errors for '%s' - got '%d'", tc.Errors, tc.Value, len(errors))
 		}
 	}
 }
@@ -94,7 +94,7 @@ func TestCosmosThroughput(t *testing.T) {
 	for _, tc := range cases {
 		_, errors := CosmosThroughput(tc.Value, "throughput")
 		if len(errors) != tc.Errors {
-			t.Fatalf("Expected DatabaseCollation to trigger '%d' errors for '%d' - got '%d'", tc.Errors, tc.Value, len(errors))
+			t.Fatalf("Expected CosmosThroughput to trigger '%d' errors for '%d' - got '%d'", tc.Errors, tc.Value, len(errors))
 		}
 	}
 }

--- a/azurerm/helpers/validate/cosmos_test.go
+++ b/azurerm/helpers/validate/cosmos_test.go
@@ -68,7 +68,7 @@ func TestCosmosEntityName(t *testing.T) {
 	}
 }
 
-func TestThroughput(t *testing.T) {
+func TestCosmosThroughput(t *testing.T) {
 	cases := []struct {
 		Value  int
 		Errors int
@@ -92,7 +92,7 @@ func TestThroughput(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, errors := Throughput(tc.Value, "throughput")
+		_, errors := CosmosThroughput(tc.Value, "throughput")
 		if len(errors) != tc.Errors {
 			t.Fatalf("Expected DatabaseCollation to trigger '%d' errors for '%d' - got '%d'", tc.Errors, tc.Value, len(errors))
 		}

--- a/azurerm/helpers/validate/cosmos_test.go
+++ b/azurerm/helpers/validate/cosmos_test.go
@@ -1,0 +1,100 @@
+package validate
+
+import "testing"
+
+func TestCosmosAccountName(t *testing.T) {
+	cases := []struct {
+		Value  string
+		Errors int
+	}{
+		{
+			Value:  "foo-bar",
+			Errors: 0,
+		},
+		{
+			Value:  "foo",
+			Errors: 0,
+		},
+		{
+			Value:  "fu",
+			Errors: 1,
+		},
+		{
+			Value:  "foo_bar",
+			Errors: 1,
+		},
+		{
+			Value:  "fooB@r",
+			Errors: 1,
+		},
+		{
+			Value:  "foo-bar-foo-bar-foo-bar-foo-bar-foo-bar-foo-bar-foo-bar",
+			Errors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := CosmosAccountName(tc.Value, "throughput")
+		if len(errors) != tc.Errors {
+			t.Fatalf("Expected DatabaseCollation to trigger '%d' errors for '%s' - got '%d'", tc.Errors, tc.Value, len(errors))
+		}
+	}
+}
+
+func TestCosmosEntityName(t *testing.T) {
+	cases := []struct {
+		Value  string
+		Errors int
+	}{
+		{
+			Value:  "",
+			Errors: 1,
+		},
+		{
+			Value:  "someEntityName",
+			Errors: 0,
+		},
+		{
+			Value:  "someEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityNamesomeEntityName",
+			Errors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := CosmosEntityName(tc.Value, "throughput")
+		if len(errors) != tc.Errors {
+			t.Fatalf("Expected DatabaseCollation to trigger '%d' errors for '%s' - got '%d'", tc.Errors, tc.Value, len(errors))
+		}
+	}
+}
+
+func TestThroughput(t *testing.T) {
+	cases := []struct {
+		Value  int
+		Errors int
+	}{
+		{
+			Value:  400,
+			Errors: 0,
+		},
+		{
+			Value:  300,
+			Errors: 1,
+		},
+		{
+			Value:  450,
+			Errors: 1,
+		},
+		{
+			Value:  10000,
+			Errors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := Throughput(tc.Value, "throughput")
+		if len(errors) != tc.Errors {
+			t.Fatalf("Expected DatabaseCollation to trigger '%d' errors for '%d' - got '%d'", tc.Errors, tc.Value, len(errors))
+		}
+	}
+}

--- a/azurerm/resource_arm_cosmosdb_mongo_collection.go
+++ b/azurerm/resource_arm_cosmosdb_mongo_collection.go
@@ -70,7 +70,7 @@ func resourceArmCosmosDbMongoCollection() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      400,
-				ValidateFunc: validate.Throughput,
+				ValidateFunc: validate.CosmosThroughput,
 			},
 
 			"indexes": {

--- a/azurerm/resource_arm_cosmosdb_mongo_collection.go
+++ b/azurerm/resource_arm_cosmosdb_mongo_collection.go
@@ -70,7 +70,7 @@ func resourceArmCosmosDbMongoCollection() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      400,
-				ValidateFunc: validation.IntAtLeast(400),
+				ValidateFunc: validate.Throughput,
 			},
 
 			"indexes": {

--- a/azurerm/resource_arm_cosmosdb_mongo_collection.go
+++ b/azurerm/resource_arm_cosmosdb_mongo_collection.go
@@ -66,6 +66,13 @@ func resourceArmCosmosDbMongoCollection() *schema.Resource {
 				ValidateFunc: validation.IntAtLeast(-1),
 			},
 
+			"throughput": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      400,
+				ValidateFunc: validation.IntAtLeast(400),
+			},
+
 			"indexes": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -100,6 +107,7 @@ func resourceArmCosmosDbMongoCollectionCreateUpdate(d *schema.ResourceData, meta
 	resourceGroup := d.Get("resource_group_name").(string)
 	account := d.Get("account_name").(string)
 	database := d.Get("database_name").(string)
+	throughput := d.Get("throughput").(int)
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.GetMongoDBCollection(ctx, resourceGroup, account, database, name)
@@ -145,6 +153,23 @@ func resourceArmCosmosDbMongoCollectionCreateUpdate(d *schema.ResourceData, meta
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting on create/update future for Cosmos Mongo Collection %s (Account %s, Database %s): %+v", name, account, database, err)
+	}
+
+	throughputParameters := documentdb.ThroughputUpdateParameters{
+		ThroughputUpdateProperties: &documentdb.ThroughputUpdateProperties{
+			Resource: &documentdb.ThroughputResource{
+				Throughput: utils.Int32(int32(throughput)),
+			},
+		},
+	}
+
+	throughputFuture, err := client.UpdateMongoDBCollectionThroughput(ctx, resourceGroup, account, database, name, throughputParameters)
+	if err != nil {
+		return fmt.Errorf("Error setting Throughput for Cosmos MongoDB Collection %s (Account %s, Database %s): %+v", name, account, database, err)
+	}
+
+	if err = throughputFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting on ThroughputUpdate future for Cosmos Mongo Collection %s (Account %s, Database %s): %+v", name, account, database, err)
 	}
 
 	resp, err := client.GetMongoDBCollection(ctx, resourceGroup, account, database, name)
@@ -203,6 +228,15 @@ func resourceArmCosmosDbMongoCollectionRead(d *schema.ResourceData, meta interfa
 				return fmt.Errorf("Error setting `indexes`: %+v", err)
 			}
 		}
+	}
+
+	throughputResp, err := client.GetMongoDBCollectionThroughput(ctx, id.ResourceGroup, id.Account, id.Database, id.Collection)
+	if err != nil {
+		return fmt.Errorf("Error reading Throughput on Cosmos Mongo Collection %s (Account %s, Database %s): %+v", id.Collection, id.Account, id.Database, err)
+	}
+
+	if throughput := throughputResp.Throughput; throughput != nil {
+		d.Set("throughput", int(*throughput))
 	}
 
 	return nil

--- a/azurerm/resource_arm_cosmosdb_mongo_collection_test.go
+++ b/azurerm/resource_arm_cosmosdb_mongo_collection_test.go
@@ -51,6 +51,7 @@ func TestAccAzureRMCosmosDbMongoCollection_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "shard_key", "day"),
 					resource.TestCheckResourceAttr(resourceName, "default_ttl_seconds", "707"),
 					resource.TestCheckResourceAttr(resourceName, "indexes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "600"),
 				),
 			},
 			{
@@ -84,6 +85,7 @@ func TestAccAzureRMCosmosDbMongoCollection_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "shard_key", "day"),
 					resource.TestCheckResourceAttr(resourceName, "default_ttl_seconds", "707"),
 					resource.TestCheckResourceAttr(resourceName, "indexes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "600"),
 				),
 			},
 			{
@@ -97,6 +99,7 @@ func TestAccAzureRMCosmosDbMongoCollection_update(t *testing.T) {
 					testCheckAzureRMCosmosDbMongoCollectionExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "default_ttl_seconds", "70707"),
 					resource.TestCheckResourceAttr(resourceName, "indexes.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "400"),
 				),
 			},
 			{
@@ -191,6 +194,7 @@ resource "azurerm_cosmosdb_mongo_collection" "test" {
 
   default_ttl_seconds = 707
   shard_key           = "day"
+  throughput          = 600
 
   indexes {
     key    = "seven"
@@ -216,6 +220,7 @@ resource "azurerm_cosmosdb_mongo_collection" "test" {
   database_name       = "${azurerm_cosmosdb_mongo_database.test.name}"
 
   default_ttl_seconds = 70707
+  throughput          = 400
 
   indexes {
     key    = "seven"

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `database_name` - (Required) The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `default_ttl_seconds` - (Required) The default Time To Live in seconds. If the value is `-1` items are not automatically expired.
 * `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys.
-* `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of 100. The default and minimum value is 400.
+* `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The default and minimum value is `400`.
 * `indexes` - (Optional) One or more `indexes` blocks as defined below.
 
 ---

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `database_name` - (Required) The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `default_ttl_seconds` - (Required) The default Time To Live in seconds. If the value is `-1` items are not automatically expired.
 * `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys.
-* `throughput` - (Optional) The throughput of MongoDB collection (RU/s). Must be set in increments of 100. Default value is 400.
+* `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of 100. The default and minimum value is 400.
 * `indexes` - (Optional) One or more `indexes` blocks as defined below.
 
 ---

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -32,6 +32,7 @@ resource "azurerm_cosmosdb_mongo_collection" "example" {
 
   default_ttl_seconds = "777"
   shard_key           = "uniqueKey"
+  throughput          = 400
 
   indexes {
     key    = "aKey"
@@ -53,7 +54,8 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `database_name` - (Required) The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `default_ttl_seconds` - (Required) The default Time To Live in seconds. If the value is `-1` items are not automatically expired.
-* `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys. 
+* `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys.
+* `throughput` - (Optional) The throughput of MongoDB collection (RU/s). Must be set in increments of 100. Default value is 400.
 * `indexes` - (Optional) One or more `indexes` blocks as defined below.
 
 ---


### PR DESCRIPTION
This would resolve #3586 and allow setting the `throughput` property on the collection.

There are several places where support should be added for `throughput` on the Cosmos DB resources. If this ok, I can add in the others.