### PR TITLE
Groundwork for Custom Timeouts

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -197,6 +197,8 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	// Key Vault Endpoints
 	keyVaultAuth := authConfig.BearerAuthorizerCallback(sender, oauthConfig)
 
+	timeout := 180 * time.Minute
+
 	o := &common.ClientOptions{
 		SubscriptionId:              authConfig.SubscriptionID,
 		TenantID:                    authConfig.TenantID,
@@ -208,7 +210,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		ResourceManagerAuthorizer:   auth,
 		ResourceManagerEndpoint:     endpoint,
 		StorageAuthorizer:           storageAuth,
-		PollingDuration:             180 * time.Minute,
+		PollingDuration:             &timeout,
 		SkipProviderReg:             skipProviderRegistration,
 		DisableCorrelationRequestID: disableCorrelationRequestID,
 		Environment:                 *env,

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -197,8 +197,6 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	// Key Vault Endpoints
 	keyVaultAuth := authConfig.BearerAuthorizerCallback(sender, oauthConfig)
 
-	timeout := 180 * time.Minute
-
 	o := &common.ClientOptions{
 		SubscriptionId:              authConfig.SubscriptionID,
 		TenantID:                    authConfig.TenantID,
@@ -210,7 +208,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		ResourceManagerAuthorizer:   auth,
 		ResourceManagerEndpoint:     endpoint,
 		StorageAuthorizer:           storageAuth,
-		PollingDuration:             &timeout,
+		PollingDuration:             180 * time.Minute,
 		SkipProviderReg:             skipProviderRegistration,
 		DisableCorrelationRequestID: disableCorrelationRequestID,
 		Environment:                 *env,

--- a/azurerm/internal/common/client_options.go
+++ b/azurerm/internal/common/client_options.go
@@ -32,7 +32,8 @@ type ClientOptions struct {
 	DisableCorrelationRequestID bool
 	Environment                 azure.Environment
 
-	PollingDuration *time.Duration
+	// TODO: remove me in 2.0
+	PollingDuration time.Duration
 }
 
 func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.Authorizer) {
@@ -47,8 +48,7 @@ func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.A
 
 	// TODO: remove in 2.0
 	if !features.SupportsCustomTimeouts() {
-		// this is intentionally de-referencing the timeout since this should be nil when timeouts are enabled by default
-		c.PollingDuration = *o.PollingDuration
+		c.PollingDuration = o.PollingDuration
 	}
 }
 

--- a/azurerm/internal/features/custom_timeouts.go
+++ b/azurerm/internal/features/custom_timeouts.go
@@ -1,0 +1,22 @@
+package features
+
+import (
+	"os"
+	"strings"
+)
+
+// SupportsCustomTimeouts returns whether Custom Timeouts are supported
+//
+// This feature allows Resources to define Custom Timeouts for Creation, Updating and Deletion
+// which helps work with Azure resources that take longer to provision/delete.
+// When this feature is disabled, all resources have a hard-coded timeout of 3 hours.
+//
+// This feature-toggle defaults to off in 1.x versions of the Azure Provider, however this will
+// become the default behaviour in version 2.0 of the Azure Provider. As outlined in the announcement
+// for v2.0 of the Azure Provider: https://github.com/terraform-providers/terraform-provider-azurerm/issues/2807
+//
+// Operators wishing to adopt this behaviour can opt-into this behaviour in 1.x versions of the
+// Azure Provider by setting the Environment Variable 'ARM_PROVIDER_CUSTOM_TIMEOUTS' to 'true'
+func SupportsCustomTimeouts() bool {
+	return strings.EqualFold(os.Getenv("ARM_PROVIDER_CUSTOM_TIMEOUTS"), "true")
+}

--- a/azurerm/internal/features/custom_timeouts_test.go
+++ b/azurerm/internal/features/custom_timeouts_test.go
@@ -1,0 +1,55 @@
+package features
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCustomTimeouts(t *testing.T) {
+	testData := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "unset",
+			value:    "",
+			expected: false,
+		},
+		{
+			name:     "disabled lower-case",
+			value:    "false",
+			expected: false,
+		},
+		{
+			name:     "disabled upper-case",
+			value:    "FALSE",
+			expected: false,
+		},
+		{
+			name:     "enabled lower-case",
+			value:    "true",
+			expected: true,
+		},
+		{
+			name:     "enabled upper-case",
+			value:    "TRUE",
+			expected: true,
+		},
+		{
+			name:     "invalid",
+			value:    "pandas",
+			expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Test %q..", v.name)
+
+		os.Setenv("ARM_PROVIDER_CUSTOM_TIMEOUTS", v.value)
+		actual := SupportsCustomTimeouts()
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/azurerm/internal/timeouts/determine.go
+++ b/azurerm/internal/timeouts/determine.go
@@ -18,6 +18,18 @@ func ForCreate(ctx context.Context, d *schema.ResourceData) (context.Context, co
 	return buildWithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
 }
 
+// ForCreateUpdate returns the context wrapped with the timeout for an combined Create/Update operation
+//
+// If the 'SupportsCustomTimeouts' feature toggle is enabled - this is wrapped with a context
+// Otherwise this returns the default context
+func ForCreateUpdate(ctx context.Context, d *schema.ResourceData) (context.Context, context.CancelFunc) {
+	if d.IsNewResource() {
+		return ForCreate(ctx, d)
+	}
+
+	return ForUpdate(ctx, d)
+}
+
 // ForDelete returns the context wrapped with the timeout for an Delete operation
 //
 // If the 'SupportsCustomTimeouts' feature toggle is enabled - this is wrapped with a context

--- a/azurerm/internal/timeouts/determine.go
+++ b/azurerm/internal/timeouts/determine.go
@@ -1,0 +1,54 @@
+package timeouts
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+// TODO: tests for this
+
+// ForCreate returns the context wrapped with the timeout for an Create operation
+//
+// If the 'SupportsCustomTimeouts' feature toggle is enabled - this is wrapped with a context
+// Otherwise this returns the default context
+func ForCreate(ctx context.Context, d *schema.ResourceData) (context.Context, context.CancelFunc) {
+	return buildWithTimeout(ctx, d.Timeout(schema.TimeoutCreate))
+}
+
+// ForDelete returns the context wrapped with the timeout for an Delete operation
+//
+// If the 'SupportsCustomTimeouts' feature toggle is enabled - this is wrapped with a context
+// Otherwise this returns the default context
+func ForDelete(ctx context.Context, d *schema.ResourceData) (context.Context, context.CancelFunc) {
+	return buildWithTimeout(ctx, d.Timeout(schema.TimeoutDelete))
+}
+
+// ForRead returns the context wrapped with the timeout for an Read operation
+//
+// If the 'SupportsCustomTimeouts' feature toggle is enabled - this is wrapped with a context
+// Otherwise this returns the default context
+func ForRead(ctx context.Context, d *schema.ResourceData) (context.Context, context.CancelFunc) {
+	return buildWithTimeout(ctx, d.Timeout(schema.TimeoutRead))
+}
+
+// ForUpdate returns the context wrapped with the timeout for an Update operation
+//
+// If the 'SupportsCustomTimeouts' feature toggle is enabled - this is wrapped with a context
+// Otherwise this returns the default context
+func ForUpdate(ctx context.Context, d *schema.ResourceData) (context.Context, context.CancelFunc) {
+	return buildWithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
+}
+
+func buildWithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if features.SupportsCustomTimeouts() {
+		return context.WithTimeout(ctx, timeout)
+	}
+
+	nullFunc := func() {
+		// do nothing on cancel since timeouts aren't enabled
+	}
+	return ctx, nullFunc
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -5,11 +5,13 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/common"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -473,6 +475,29 @@ func Provider() terraform.ResourceProvider {
 			}
 
 			resources[k] = v
+		}
+	}
+
+	// TODO: remove all of this in 2.0 once Custom Timeouts are supported
+	if features.SupportsCustomTimeouts() {
+		// default everything to 3 hours for now
+		for _, v := range resources {
+			if v.Timeouts == nil {
+				v.Timeouts = &schema.ResourceTimeout{
+					Create:  schema.DefaultTimeout(3 * time.Hour),
+					Update:  schema.DefaultTimeout(3 * time.Hour),
+					Delete:  schema.DefaultTimeout(3 * time.Hour),
+					Default: schema.DefaultTimeout(3 * time.Hour),
+
+					// Read is the only exception, since if it's taken more than 5 minutes something's seriously wrong
+					Read: schema.DefaultTimeout(5 * time.Minute),
+				}
+			}
+		}
+	} else {
+		// ensure any timeouts configured on the resources are removed until 2.0
+		for _, v := range resources {
+			v.Timeouts = nil
 		}
 	}
 

--- a/azurerm/resource_arm_resource_group.go
+++ b/azurerm/resource_arm_resource_group.go
@@ -8,6 +8,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -37,7 +38,8 @@ func resourceArmResourceGroup() *schema.Resource {
 
 func resourceArmResourceGroupCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).resource.GroupsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	name := d.Get("name").(string)
 	location := azure.NormalizeLocation(d.Get("location").(string))
@@ -77,7 +79,8 @@ func resourceArmResourceGroupCreateUpdate(d *schema.ResourceData, meta interface
 
 func resourceArmResourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).resource.GroupsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -106,7 +109,8 @@ func resourceArmResourceGroupRead(d *schema.ResourceData, meta interface{}) erro
 
 func resourceArmResourceGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).resource.GroupsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_resource_group.go
+++ b/azurerm/resource_arm_resource_group.go
@@ -38,7 +38,7 @@ func resourceArmResourceGroup() *schema.Resource {
 
 func resourceArmResourceGroupCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).resource.GroupsClient
-	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
 	name := d.Get("name").(string)


### PR DESCRIPTION
This PR contains the necessary groundwork to support Custom Timeouts on both Resources and Data Sources

Whilst this functionality is controlled by a feature toggle (which is intentionally disabled by default) - in it's current form this functionality has no effect on existing resources, therefore it's intentionally not documented or recommended for use at this time.

When the context changes have been threaded through all of the resources, in a future 1.x release we'll document this behaviour so that users can opt into this - however at this time this functionality is unsupported.

Given this is feature toggled we should be able to add timeouts gradually to resources, internally if the feature toggle is disabled any timeouts defined on resources will be removed, leading to the same behaviour as today - for example:

Given the following configuration:

```
$ cat main.tf
resource "azurerm_resource_group" "test" {
  name = "tom-dev6666"
  location = "West Europe"

  timeouts {
    create = "2s"
    delete = "4s"
  }
}
```

Without the feature enabled:

```
$ terraform apply

Error: Unsupported block type

  on main.tf line 5, in resource "azurerm_resource_group" "test":
   5:   timeouts {

Blocks of type "timeouts" are not expected here.
```

With the feature enabled:

```
$ terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_resource_group.test will be created
  + resource "azurerm_resource_group" "test" {
      + id       = (known after apply)
      + location = "westeurope"
      + name     = "tom-dev6666"
      + tags     = (known after apply)

      + timeouts {
          + create = "2s"
          + delete = "4s"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_resource_group.test: Creating...

Error: Error creating resource group: resources.GroupsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: context deadline exceeded
```

(this obviously works with a more sane timeout configured, 2s/4s are an example)

The (acceptance) test suite itself intentionally _doesn't_ configure any timeouts in the Check Func's since we should continue polling until we have a conclusion

Longer term this unblocks #171 (and related issues like #1747) which forms a part of #2807 