### PR TITLE
Adding default_site_hostname attribute

### DIFF
--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -53,6 +53,8 @@ output "app_service_id" {
 
 * `tags` - A mapping of tags to assign to the resource.
 
+* `default_site_hostname` - The Default Hostname associated with the App Service - such as `mysite.azurewebsites.net`
+
 * `outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12`
 
 * `possible_outbound_ip_addresses` - A comma separated list of outbound IP addresses - such as `52.23.25.3,52.143.43.12,52.143.43.17` - not all of which are necessarily in use. Superset of `outbound_ip_addresses`.


### PR DESCRIPTION
This fixes #4373 by adding the default_site_hostname attribute to the list of attributes.