### PR TITLE
azurerm_network_profile  - inaccurate docs container_network_interface_configuration 

### DIFF
--- a/website/docs/r/network_profile.html.markdown
+++ b/website/docs/r/network_profile.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_network_profile" "example" {
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
 
-  container_network_interface_configuration {
+  container_network_interface {
     name = "examplecnic"
 
     ip_configuration {
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource. Changing this forces a new resource to be created.
 
-* `container_network_interface_configuration` - (Required) A `container_network_interface_configuration` block as documented below.
+* `container_network_interface` - (Required) A `container_network_interface` block as documented below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
container_network_interface_configuration results on error: Unsupported block type...

based on https://github.com/terraform-providers/terraform-provider-azurerm/pull/3716#issue-290836818, changed to container_network_interface and worked!