### PR TITLE
Updating to release Microsoft.Security API 2019-08-01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,7 +521,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-* dependencies: downgrading the Security API to `2017-08-01-preview` to work around a breaking API change ([#3269](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3269))
+* dependencies: downgrading the Security API to `2019-08-01` to work around a breaking API change ([#3269](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3269))
 * `azurerm_app_service` - removing Computed from the `use_32_bit_worker_process` property in the `site_config` block ([#3219](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3219))
 * `azurerm_app_service_slot` - removing Computed from the `use_32_bit_worker_process` property in the `site_config` block ([#3219](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3219))
 * `azurerm_batch_account` - temporarily treating the Resource Group Name as case insensitive to work around an API bug ([#3260](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3260))

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1104,7 +1104,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		msg := err.Error()
 		if !strings.Contains(msg, "No registered resource provider found for location '") {
-			if !strings.Contains(msg, "' and API version '2017-08-01-preview' for type ") {
+			if !strings.Contains(msg, "' and API version '2019-08-01' for type ") {
 				return fmt.Errorf("Error reading the advanced threat protection settings of AzureRM Storage Account %q: %+v", name, err)
 			}
 		}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/advancedthreatprotection.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/advancedthreatprotection.go
@@ -83,7 +83,7 @@ func (client AdvancedThreatProtectionClient) CreatePreparer(ctx context.Context,
 		"settingName": autorest.Encode("path", "current"),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -160,7 +160,7 @@ func (client AdvancedThreatProtectionClient) GetPreparer(ctx context.Context, re
 		"settingName": autorest.Encode("path", "current"),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/autoprovisioningsettings.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/autoprovisioningsettings.go
@@ -90,7 +90,7 @@ func (client AutoProvisioningSettingsClient) CreatePreparer(ctx context.Context,
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -173,7 +173,7 @@ func (client AutoProvisioningSettingsClient) GetPreparer(ctx context.Context, se
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -252,7 +252,7 @@ func (client AutoProvisioningSettingsClient) ListPreparer(ctx context.Context) (
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/compliances.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/compliances.go
@@ -84,7 +84,7 @@ func (client CompliancesClient) GetPreparer(ctx context.Context, scope string, c
 		"scope":          autorest.Encode("path", scope),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -160,7 +160,7 @@ func (client CompliancesClient) ListPreparer(ctx context.Context, scope string) 
 		"scope": autorest.Encode("path", scope),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/contacts.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/contacts.go
@@ -93,7 +93,7 @@ func (client ContactsClient) CreatePreparer(ctx context.Context, securityContact
 		"subscriptionId":      autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -176,7 +176,7 @@ func (client ContactsClient) DeletePreparer(ctx context.Context, securityContact
 		"subscriptionId":      autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -256,7 +256,7 @@ func (client ContactsClient) GetPreparer(ctx context.Context, securityContactNam
 		"subscriptionId":      autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -335,7 +335,7 @@ func (client ContactsClient) ListPreparer(ctx context.Context) (*http.Request, e
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -454,7 +454,7 @@ func (client ContactsClient) UpdatePreparer(ctx context.Context, securityContact
 		"subscriptionId":      autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/devicesecuritygroups.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/devicesecuritygroups.go
@@ -84,7 +84,7 @@ func (client DeviceSecurityGroupsClient) CreateOrUpdatePreparer(ctx context.Cont
 		"resourceId":              autorest.Encode("path", resourceID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -162,7 +162,7 @@ func (client DeviceSecurityGroupsClient) DeletePreparer(ctx context.Context, res
 		"resourceId":              autorest.Encode("path", resourceID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -237,7 +237,7 @@ func (client DeviceSecurityGroupsClient) GetPreparer(ctx context.Context, resour
 		"resourceId":              autorest.Encode("path", resourceID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -312,7 +312,7 @@ func (client DeviceSecurityGroupsClient) ListPreparer(ctx context.Context, resou
 		"resourceId": autorest.Encode("path", resourceID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/informationprotectionpolicies.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/informationprotectionpolicies.go
@@ -85,7 +85,7 @@ func (client InformationProtectionPoliciesClient) CreateOrUpdatePreparer(ctx con
 		"scope":                           autorest.Encode("path", scope),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -162,7 +162,7 @@ func (client InformationProtectionPoliciesClient) GetPreparer(ctx context.Contex
 		"scope":                           autorest.Encode("path", scope),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -238,7 +238,7 @@ func (client InformationProtectionPoliciesClient) ListPreparer(ctx context.Conte
 		"scope": autorest.Encode("path", scope),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/pricings.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/pricings.go
@@ -97,7 +97,7 @@ func (client PricingsClient) CreateOrUpdateResourceGroupPricingPreparer(ctx cont
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -187,7 +187,7 @@ func (client PricingsClient) GetResourceGroupPricingPreparer(ctx context.Context
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -269,7 +269,7 @@ func (client PricingsClient) GetSubscriptionPricingPreparer(ctx context.Context,
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -348,7 +348,7 @@ func (client PricingsClient) ListPreparer(ctx context.Context) (*http.Request, e
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -472,7 +472,7 @@ func (client PricingsClient) ListByResourceGroupPreparer(ctx context.Context, re
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -591,7 +591,7 @@ func (client PricingsClient) UpdateSubscriptionPricingPreparer(ctx context.Conte
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/settings.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/settings.go
@@ -89,7 +89,7 @@ func (client SettingsClient) GetPreparer(ctx context.Context, settingName string
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -168,7 +168,7 @@ func (client SettingsClient) ListPreparer(ctx context.Context) (*http.Request, e
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -287,7 +287,7 @@ func (client SettingsClient) UpdatePreparer(ctx context.Context, settingName str
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/workspacesettings.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security/workspacesettings.go
@@ -95,7 +95,7 @@ func (client WorkspaceSettingsClient) CreatePreparer(ctx context.Context, worksp
 		"workspaceSettingName": autorest.Encode("path", workspaceSettingName),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -178,7 +178,7 @@ func (client WorkspaceSettingsClient) DeletePreparer(ctx context.Context, worksp
 		"workspaceSettingName": autorest.Encode("path", workspaceSettingName),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -259,7 +259,7 @@ func (client WorkspaceSettingsClient) GetPreparer(ctx context.Context, workspace
 		"workspaceSettingName": autorest.Encode("path", workspaceSettingName),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -339,7 +339,7 @@ func (client WorkspaceSettingsClient) ListPreparer(ctx context.Context) (*http.R
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -458,7 +458,7 @@ func (client WorkspaceSettingsClient) UpdatePreparer(ctx context.Context, worksp
 		"workspaceSettingName": autorest.Encode("path", workspaceSettingName),
 	}
 
-	const APIVersion = "2017-08-01-preview"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}


### PR DESCRIPTION
Upgrading reference to the Microsoft.Security REST from  API Version “api-version=2017-08-01-preview” to release 2019-08-01. 