### PR TITLE
subnet resource: remove "Deprecated" attribute on "network_security_group_id" and "route_table_id"

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -48,15 +48,13 @@ func resourceArmSubnet() *schema.Resource {
 			},
 
 			"network_security_group_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Deprecated: "Use the `azurerm_subnet_network_security_group_association` resource instead.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"route_table_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Deprecated: "Use the `azurerm_subnet_route_table_association` resource instead.",
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"ip_configurations": {


### PR DESCRIPTION
subnet resource: removed the "Deprecated" attribute on "network_security_group_id" and "route_table_id", as they are still required to be used ([see issue 3077](https://github.com/terraform-providers/terraform-provider-azurerm/issues/3077)), causing "deprecated" warnings. They can't be deprecated and have to be used at the same time.