### PR TITLE
azurerm_kubernetes_cluster  - the `log_analytics_workspace_id` property is now optional

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -276,7 +276,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 									},
 									"log_analytics_workspace_id": {
 										Type:         schema.TypeString,
-										Required:     true,
+										Optional:     true,
 										ValidateFunc: azure.ValidateResourceID,
 									},
 								},
@@ -1006,7 +1006,7 @@ func expandKubernetesClusterAddonProfiles(d *schema.ResourceData) map[string]*co
 		config := make(map[string]*string)
 		enabled := value["enabled"].(bool)
 
-		if workspaceId, ok := value["log_analytics_workspace_id"]; ok {
+		if workspaceId, ok := value["log_analytics_workspace_id"]; ok && workspaceId != "" {
 			config["logAnalyticsWorkspaceResourceID"] = utils.String(workspaceId.(string))
 		}
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -241,7 +241,7 @@ A `oms_agent` block supports the following:
 
 * `enabled` - (Required) Is the OMS Agent Enabled?
 
-* `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace which the OMS Agent should send data to.
+* `log_analytics_workspace_id` - (Optional) The ID of the Log Analytics Workspace which the OMS Agent should send data to. Must be present if `enabled` is `true`.
 
 ---
 


### PR DESCRIPTION
This fixes #3239 where a kubernetes cluster that had first the OMS agent
profile addon enabled and then disabled not usable anymore by the
terraform provider. All subsequent update requests would return a bad
request response complaining that the `logAnalayticsWorkspaceId` needs
to be a fully qualified resource id.