### PR TITLE
refactor: making more clients public

### DIFF
--- a/azurerm/automation_variable.go
+++ b/azurerm/automation_variable.go
@@ -122,7 +122,7 @@ func datasourceAutomationVariableCommonSchema(attType schema.ValueType) map[stri
 }
 
 func resourceAutomationVariableCreateUpdate(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automation.VariableClient
+	client := meta.(*ArmClient).Automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -190,7 +190,7 @@ func resourceAutomationVariableCreateUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automation.VariableClient
+	client := meta.(*ArmClient).Automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -237,7 +237,7 @@ func resourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, va
 }
 
 func datasourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automation.VariableClient
+	client := meta.(*ArmClient).Automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -281,7 +281,7 @@ func datasourceAutomationVariableRead(d *schema.ResourceData, meta interface{}, 
 }
 
 func resourceAutomationVariableDelete(d *schema.ResourceData, meta interface{}, varType string) error {
-	client := meta.(*ArmClient).automation.VariableClient
+	client := meta.(*ArmClient).Automation.VariableClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/automation_variable_test.go
+++ b/azurerm/automation_variable_test.go
@@ -90,7 +90,7 @@ func testCheckAzureRMAutomationVariableExists(resourceName string, varType strin
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		accountName := rs.Primary.Attributes["automation_account_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).automation.VariableClient
+		client := testAccProvider.Meta().(*ArmClient).Automation.VariableClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if resp, err := client.Get(ctx, resourceGroup, accountName, name); err != nil {
@@ -105,7 +105,7 @@ func testCheckAzureRMAutomationVariableExists(resourceName string, varType strin
 }
 
 func testCheckAzureRMAutomationVariableDestroy(s *terraform.State, varType string) error {
-	client := testAccProvider.Meta().(*ArmClient).automation.VariableClient
+	client := testAccProvider.Meta().(*ArmClient).Automation.VariableClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	resourceName := fmt.Sprintf("azurerm_automation_variable_%s", strings.ToLower(varType))

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -92,7 +92,7 @@ type ArmClient struct {
 	ApiManagement    *apimanagement.Client
 	AppInsights      *applicationinsights.Client
 	Automation       *automation.Client
-	authorization    *authorization.Client
+	Authorization    *authorization.Client
 	batch            *batch.Client
 	bot              *bot.Client
 	cdn              *cdn.Client
@@ -226,7 +226,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.ApiManagement = apimanagement.BuildClient(o)
 	client.AppInsights = applicationinsights.BuildClient(o)
 	client.Automation = automation.BuildClient(o)
-	client.authorization = authorization.BuildClient(o)
+	client.Authorization = authorization.BuildClient(o)
 	client.batch = batch.BuildClient(o)
 	client.bot = bot.BuildClient(o)
 	client.cdn = cdn.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -94,7 +94,7 @@ type ArmClient struct {
 	Automation       *automation.Client
 	Authorization    *authorization.Client
 	Batch            *batch.Client
-	bot              *bot.Client
+	Bot              *bot.Client
 	cdn              *cdn.Client
 	cognitive        *cognitive.Client
 	compute          *clients.ComputeClient
@@ -228,7 +228,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.Automation = automation.BuildClient(o)
 	client.Authorization = authorization.BuildClient(o)
 	client.Batch = batch.BuildClient(o)
-	client.bot = bot.BuildClient(o)
+	client.Bot = bot.BuildClient(o)
 	client.cdn = cdn.BuildClient(o)
 	client.cognitive = cognitive.BuildClient(o)
 	client.compute = clients.NewComputeClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -89,7 +89,7 @@ type ArmClient struct {
 	// Services
 	// NOTE: all new services should be Public as they're going to be relocated in the near-future
 	AnalysisServices *analysisservices.Client
-	apiManagement    *apimanagement.Client
+	ApiManagement    *apimanagement.Client
 	appInsights      *applicationinsights.Client
 	automation       *automation.Client
 	authorization    *authorization.Client
@@ -223,7 +223,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	}
 
 	client.AnalysisServices = analysisservices.BuildClient(o)
-	client.apiManagement = apimanagement.BuildClient(o)
+	client.ApiManagement = apimanagement.BuildClient(o)
 	client.appInsights = applicationinsights.BuildClient(o)
 	client.automation = automation.BuildClient(o)
 	client.authorization = authorization.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -93,7 +93,7 @@ type ArmClient struct {
 	AppInsights      *applicationinsights.Client
 	Automation       *automation.Client
 	Authorization    *authorization.Client
-	batch            *batch.Client
+	Batch            *batch.Client
 	bot              *bot.Client
 	cdn              *cdn.Client
 	cognitive        *cognitive.Client
@@ -227,7 +227,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.AppInsights = applicationinsights.BuildClient(o)
 	client.Automation = automation.BuildClient(o)
 	client.Authorization = authorization.BuildClient(o)
-	client.batch = batch.BuildClient(o)
+	client.Batch = batch.BuildClient(o)
 	client.bot = bot.BuildClient(o)
 	client.cdn = cdn.BuildClient(o)
 	client.cognitive = cognitive.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -90,7 +90,7 @@ type ArmClient struct {
 	// NOTE: all new services should be Public as they're going to be relocated in the near-future
 	AnalysisServices *analysisservices.Client
 	ApiManagement    *apimanagement.Client
-	appInsights      *applicationinsights.Client
+	AppInsights      *applicationinsights.Client
 	automation       *automation.Client
 	authorization    *authorization.Client
 	batch            *batch.Client
@@ -224,7 +224,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 
 	client.AnalysisServices = analysisservices.BuildClient(o)
 	client.ApiManagement = apimanagement.BuildClient(o)
-	client.appInsights = applicationinsights.BuildClient(o)
+	client.AppInsights = applicationinsights.BuildClient(o)
 	client.automation = automation.BuildClient(o)
 	client.authorization = authorization.BuildClient(o)
 	client.batch = batch.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -88,7 +88,7 @@ type ArmClient struct {
 
 	// Services
 	// NOTE: all new services should be Public as they're going to be relocated in the near-future
-	analysisservices *analysisservices.Client
+	AnalysisServices *analysisservices.Client
 	apiManagement    *apimanagement.Client
 	appInsights      *applicationinsights.Client
 	automation       *automation.Client
@@ -222,7 +222,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		Environment:                 *env,
 	}
 
-	client.analysisservices = analysisservices.BuildClient(o)
+	client.AnalysisServices = analysisservices.BuildClient(o)
 	client.apiManagement = apimanagement.BuildClient(o)
 	client.appInsights = applicationinsights.BuildClient(o)
 	client.automation = automation.BuildClient(o)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -91,7 +91,7 @@ type ArmClient struct {
 	AnalysisServices *analysisservices.Client
 	ApiManagement    *apimanagement.Client
 	AppInsights      *applicationinsights.Client
-	automation       *automation.Client
+	Automation       *automation.Client
 	authorization    *authorization.Client
 	batch            *batch.Client
 	bot              *bot.Client
@@ -225,7 +225,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 	client.AnalysisServices = analysisservices.BuildClient(o)
 	client.ApiManagement = apimanagement.BuildClient(o)
 	client.AppInsights = applicationinsights.BuildClient(o)
-	client.automation = automation.BuildClient(o)
+	client.Automation = automation.BuildClient(o)
 	client.authorization = authorization.BuildClient(o)
 	client.batch = batch.BuildClient(o)
 	client.bot = bot.BuildClient(o)

--- a/azurerm/data_source_api_management.go
+++ b/azurerm/data_source_api_management.go
@@ -159,7 +159,7 @@ func dataSourceApiManagementService() *schema.Resource {
 }
 
 func dataSourceApiManagementRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ServiceClient
+	client := meta.(*ArmClient).ApiManagement.ServiceClient
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_api_management_api.go
+++ b/azurerm/data_source_api_management_api.go
@@ -106,7 +106,7 @@ func dataSourceApiManagementApi() *schema.Resource {
 
 func dataSourceApiManagementApiRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).apiManagement.ApiClient
+	client := meta.(*ArmClient).ApiManagement.ApiClient
 
 	resourceGroup := d.Get("resource_group_name").(string)
 	serviceName := d.Get("api_management_name").(string)

--- a/azurerm/data_source_api_management_group.go
+++ b/azurerm/data_source_api_management_group.go
@@ -44,7 +44,7 @@ func dataSourceApiManagementGroup() *schema.Resource {
 }
 
 func dataSourceApiManagementGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.GroupClient
+	client := meta.(*ArmClient).ApiManagement.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_api_management_product.go
+++ b/azurerm/data_source_api_management_product.go
@@ -58,7 +58,7 @@ func dataSourceApiManagementProduct() *schema.Resource {
 	}
 }
 func dataSourceApiManagementProductRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductsClient
+	client := meta.(*ArmClient).ApiManagement.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_api_management_user.go
+++ b/azurerm/data_source_api_management_user.go
@@ -48,7 +48,7 @@ func dataSourceArmApiManagementUser() *schema.Resource {
 }
 
 func dataSourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.UsersClient
+	client := meta.(*ArmClient).ApiManagement.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_application_insights.go
+++ b/azurerm/data_source_application_insights.go
@@ -54,7 +54,7 @@ func dataSourceArmApplicationInsights() *schema.Resource {
 }
 
 func dataSourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.ComponentsClient
+	client := meta.(*ArmClient).AppInsights.ComponentsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_batch_account.go
+++ b/azurerm/data_source_batch_account.go
@@ -67,7 +67,7 @@ func dataSourceArmBatchAccount() *schema.Resource {
 }
 
 func dataSourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.AccountClient
+	client := meta.(*ArmClient).Batch.AccountClient
 
 	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)

--- a/azurerm/data_source_batch_certificate.go
+++ b/azurerm/data_source_batch_certificate.go
@@ -50,7 +50,7 @@ func dataSourceArmBatchCertificate() *schema.Resource {
 
 func dataSourceArmBatchCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).batch.CertificateClient
+	client := meta.(*ArmClient).Batch.CertificateClient
 
 	resourceGroupName := d.Get("resource_group_name").(string)
 	accountName := d.Get("account_name").(string)

--- a/azurerm/data_source_batch_pool.go
+++ b/azurerm/data_source_batch_pool.go
@@ -276,7 +276,7 @@ func dataSourceArmBatchPool() *schema.Resource {
 }
 
 func dataSourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.PoolClient
+	client := meta.(*ArmClient).Batch.PoolClient
 
 	name := d.Get("name").(string)
 	accountName := d.Get("account_name").(string)

--- a/azurerm/data_source_builtin_role_definition.go
+++ b/azurerm/data_source_builtin_role_definition.go
@@ -81,7 +81,7 @@ As such this Data Source will be removed in v2.0 of the AzureRM Provider.
 }
 
 func dataSourceArmBuiltInRoleDefinitionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).authorization.RoleDefinitionsClient
+	client := meta.(*ArmClient).Authorization.RoleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/data_source_role_definition.go
+++ b/azurerm/data_source_role_definition.go
@@ -100,7 +100,7 @@ func dataSourceArmRoleDefinition() *schema.Resource {
 }
 
 func dataSourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).authorization.RoleDefinitionsClient
+	client := meta.(*ArmClient).Authorization.RoleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)

--- a/azurerm/resource_arm_analysis_services_server.go
+++ b/azurerm/resource_arm_analysis_services_server.go
@@ -114,7 +114,7 @@ func resourceArmAnalysisServicesServer() *schema.Resource {
 }
 
 func resourceArmAnalysisServicesServerCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).analysisservices.ServerClient
+	client := meta.(*ArmClient).AnalysisServices.ServerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure ARM Analysis Services Server creation.")
@@ -174,7 +174,7 @@ func resourceArmAnalysisServicesServerCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmAnalysisServicesServerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).analysisservices.ServerClient
+	client := meta.(*ArmClient).AnalysisServices.ServerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -232,7 +232,7 @@ func resourceArmAnalysisServicesServerRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmAnalysisServicesServerUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).analysisservices.ServerClient
+	client := meta.(*ArmClient).AnalysisServices.ServerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure ARM Analysis Services Server creation.")
@@ -268,7 +268,7 @@ func resourceArmAnalysisServicesServerUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmAnalysisServicesServerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).analysisservices.ServerClient
+	client := meta.(*ArmClient).AnalysisServices.ServerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_analysis_services_server_test.go
+++ b/azurerm/resource_arm_analysis_services_server_test.go
@@ -467,7 +467,7 @@ resource "azurerm_analysis_services_server" "test" {
 }
 
 func testCheckAzureRMAnalysisServicesServerDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).analysisservices.ServerClient
+	client := testAccProvider.Meta().(*ArmClient).AnalysisServices.ServerClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_analysis_services_server" {
@@ -507,7 +507,7 @@ func testCheckAzureRMAnalysisServicesServerExists(resourceName string) resource.
 			return fmt.Errorf("Bad: no resource group found in state for Analysis Services Server: %s", analysisServicesServerName)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).analysisservices.ServerClient
+		client := testAccProvider.Meta().(*ArmClient).AnalysisServices.ServerClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.GetDetails(ctx, resourceGroup, analysisServicesServerName)
 		if err != nil {

--- a/azurerm/resource_arm_api_management.go
+++ b/azurerm/resource_arm_api_management.go
@@ -393,7 +393,7 @@ func resourceArmApiManagementService() *schema.Resource {
 }
 
 func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ServiceClient
+	client := meta.(*ArmClient).ApiManagement.ServiceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	// TODO: Remove in 2.0
@@ -480,19 +480,19 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 
 	signInSettingsRaw := d.Get("sign_in").([]interface{})
 	signInSettings := expandApiManagementSignInSettings(signInSettingsRaw)
-	signInClient := meta.(*ArmClient).apiManagement.SignInClient
+	signInClient := meta.(*ArmClient).ApiManagement.SignInClient
 	if _, err := signInClient.CreateOrUpdate(ctx, resourceGroup, name, signInSettings); err != nil {
 		return fmt.Errorf("Error setting Sign In settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	signUpSettingsRaw := d.Get("sign_up").([]interface{})
 	signUpSettings := expandApiManagementSignUpSettings(signUpSettingsRaw)
-	signUpClient := meta.(*ArmClient).apiManagement.SignUpClient
+	signUpClient := meta.(*ArmClient).ApiManagement.SignUpClient
 	if _, err := signUpClient.CreateOrUpdate(ctx, resourceGroup, name, signUpSettings); err != nil {
 		return fmt.Errorf("Error setting Sign Up settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	policyClient := meta.(*ArmClient).apiManagement.PolicyClient
+	policyClient := meta.(*ArmClient).ApiManagement.PolicyClient
 	policiesRaw := d.Get("policy").([]interface{})
 	policy, err := expandApiManagementPolicies(policiesRaw)
 	if err != nil {
@@ -519,7 +519,7 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ServiceClient
+	client := meta.(*ArmClient).ApiManagement.ServiceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -541,19 +541,19 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error making Read request on API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	signInClient := meta.(*ArmClient).apiManagement.SignInClient
+	signInClient := meta.(*ArmClient).ApiManagement.SignInClient
 	signInSettings, err := signInClient.Get(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Sign In Settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	signUpClient := meta.(*ArmClient).apiManagement.SignUpClient
+	signUpClient := meta.(*ArmClient).ApiManagement.SignUpClient
 	signUpSettings, err := signUpClient.Get(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Sign Up Settings for API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	policyClient := meta.(*ArmClient).apiManagement.PolicyClient
+	policyClient := meta.(*ArmClient).ApiManagement.PolicyClient
 	policy, err := policyClient.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(policy.Response) {
@@ -624,7 +624,7 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmApiManagementServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ServiceClient
+	client := meta.(*ArmClient).ApiManagement.ServiceClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api.go
+++ b/azurerm/resource_arm_api_management_api.go
@@ -181,7 +181,7 @@ func resourceArmApiManagementApi() *schema.Resource {
 }
 
 func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiClient
+	client := meta.(*ArmClient).ApiManagement.ApiClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -286,7 +286,7 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 
 func resourceArmApiManagementApiRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).apiManagement.ApiClient
+	client := meta.(*ArmClient).ApiManagement.ApiClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -344,7 +344,7 @@ func resourceArmApiManagementApiRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmApiManagementApiDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiClient
+	client := meta.(*ArmClient).ApiManagement.ApiClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_operation.go
+++ b/azurerm/resource_arm_api_management_api_operation.go
@@ -98,7 +98,7 @@ func resourceArmApiManagementApiOperation() *schema.Resource {
 }
 
 func resourceArmApiManagementApiOperationCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiOperationsClient
+	client := meta.(*ArmClient).ApiManagement.ApiOperationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -153,7 +153,7 @@ func resourceArmApiManagementApiOperationCreateUpdate(d *schema.ResourceData, me
 }
 
 func resourceArmApiManagementApiOperationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiOperationsClient
+	client := meta.(*ArmClient).ApiManagement.ApiOperationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -208,7 +208,7 @@ func resourceArmApiManagementApiOperationRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementApiOperationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiOperationsClient
+	client := meta.(*ArmClient).ApiManagement.ApiOperationsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_operation_policy.go
+++ b/azurerm/resource_arm_api_management_api_operation_policy.go
@@ -50,7 +50,7 @@ func resourceArmApiManagementApiOperationPolicy() *schema.Resource {
 }
 
 func resourceArmApiManagementAPIOperationPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiOperationPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ApiOperationPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -111,7 +111,7 @@ func resourceArmApiManagementAPIOperationPolicyCreateUpdate(d *schema.ResourceDa
 }
 
 func resourceArmApiManagementAPIOperationPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiOperationPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ApiOperationPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -149,7 +149,7 @@ func resourceArmApiManagementAPIOperationPolicyRead(d *schema.ResourceData, meta
 }
 
 func resourceArmApiManagementAPIOperationPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiOperationPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ApiOperationPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_operation_policy_test.go
+++ b/azurerm/resource_arm_api_management_api_operation_policy_test.go
@@ -111,7 +111,7 @@ func testCheckAzureRMApiManagementAPIOperationPolicyExists(resourceName string) 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		operationID := rs.Primary.Attributes["operation_id"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiOperationPoliciesClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiOperationPoliciesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName, operationID)
 		if err != nil {
@@ -127,7 +127,7 @@ func testCheckAzureRMApiManagementAPIOperationPolicyExists(resourceName string) 
 }
 
 func testCheckAzureRMApiManagementAPIOperationPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiOperationPoliciesClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiOperationPoliciesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api_operation_policy" {

--- a/azurerm/resource_arm_api_management_api_operation_test.go
+++ b/azurerm/resource_arm_api_management_api_operation_test.go
@@ -190,7 +190,7 @@ func TestAccAzureRMApiManagementApiOperation_representations(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiOperationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiOperationsClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiOperationsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -231,7 +231,7 @@ func testCheckAzureRMApiManagementApiOperationExists(name string) resource.TestC
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiOperationsClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiOperationsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName, operationId)

--- a/azurerm/resource_arm_api_management_api_policy.go
+++ b/azurerm/resource_arm_api_management_api_policy.go
@@ -48,7 +48,7 @@ func resourceArmApiManagementApiPolicy() *schema.Resource {
 }
 
 func resourceArmApiManagementAPIPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ApiPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -108,7 +108,7 @@ func resourceArmApiManagementAPIPolicyCreateUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceArmApiManagementAPIPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ApiPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -144,7 +144,7 @@ func resourceArmApiManagementAPIPolicyRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmApiManagementAPIPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ApiPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_policy_test.go
+++ b/azurerm/resource_arm_api_management_api_policy_test.go
@@ -110,7 +110,7 @@ func testCheckAzureRMApiManagementAPIPolicyExists(resourceName string) resource.
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiPoliciesClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiPoliciesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName)
 		if err != nil {
@@ -126,7 +126,7 @@ func testCheckAzureRMApiManagementAPIPolicyExists(resourceName string) resource.
 }
 
 func testCheckAzureRMApiManagementAPIPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiPoliciesClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiPoliciesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api_policy" {

--- a/azurerm/resource_arm_api_management_api_schema.go
+++ b/azurerm/resource_arm_api_management_api_schema.go
@@ -48,7 +48,7 @@ func resourceArmApiManagementApiSchema() *schema.Resource {
 }
 
 func resourceArmApiManagementApiSchemaCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiSchemasClient
+	client := meta.(*ArmClient).ApiManagement.ApiSchemasClient
 	ctx := meta.(*ArmClient).StopContext
 
 	schemaID := d.Get("schema_id").(string)
@@ -97,7 +97,7 @@ func resourceArmApiManagementApiSchemaCreateUpdate(d *schema.ResourceData, meta 
 }
 
 func resourceArmApiManagementApiSchemaRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiSchemasClient
+	client := meta.(*ArmClient).ApiManagement.ApiSchemasClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -136,7 +136,7 @@ func resourceArmApiManagementApiSchemaRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmApiManagementApiSchemaDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiSchemasClient
+	client := meta.(*ArmClient).ApiManagement.ApiSchemasClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_schema_test.go
+++ b/azurerm/resource_arm_api_management_api_schema_test.go
@@ -66,7 +66,7 @@ func TestAccAzureRMApiManagementApiSchema_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiSchemaDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiSchemasClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiSchemasClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -107,7 +107,7 @@ func testCheckAzureRMApiManagementApiSchemaExists(name string) resource.TestChec
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiSchemasClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiSchemasClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, apiName, schemaID)

--- a/azurerm/resource_arm_api_management_api_test.go
+++ b/azurerm/resource_arm_api_management_api_test.go
@@ -276,7 +276,7 @@ func TestAccAzureRMApiManagementApi_complete(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api" {
@@ -318,7 +318,7 @@ func testCheckAzureRMApiManagementApiExists(name string) resource.TestCheckFunc 
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		revision := rs.Primary.Attributes["revision"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ApiClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		apiId := fmt.Sprintf("%s;rev=%s", name, revision)

--- a/azurerm/resource_arm_api_management_api_version_set.go
+++ b/azurerm/resource_arm_api_management_api_version_set.go
@@ -72,7 +72,7 @@ func resourceArmApiManagementApiVersionSet() *schema.Resource {
 }
 
 func resourceArmApiManagementApiVersionSetCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiVersionSetClient
+	client := meta.(*ArmClient).ApiManagement.ApiVersionSetClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -154,7 +154,7 @@ func resourceArmApiManagementApiVersionSetCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmApiManagementApiVersionSetRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiVersionSetClient
+	client := meta.(*ArmClient).ApiManagement.ApiVersionSetClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -192,7 +192,7 @@ func resourceArmApiManagementApiVersionSetRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmApiManagementApiVersionSetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ApiVersionSetClient
+	client := meta.(*ArmClient).ApiManagement.ApiVersionSetClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_api_version_set_test.go
+++ b/azurerm/resource_arm_api_management_api_version_set_test.go
@@ -151,7 +151,7 @@ func TestAccAzureRMApiManagementApiVersionSet_update(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementApiVersionSetDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.ApiVersionSetClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiVersionSetClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_api_version_set" {
 			continue
@@ -186,7 +186,7 @@ func testCheckAzureRMApiManagementApiVersionSetExists(resourceName string) resou
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.ApiVersionSetClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.ApiVersionSetClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_authorization_server.go
+++ b/azurerm/resource_arm_api_management_authorization_server.go
@@ -176,7 +176,7 @@ func resourceArmApiManagementAuthorizationServer() *schema.Resource {
 }
 
 func resourceArmApiManagementAuthorizationServerCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.AuthorizationServersClient
+	client := meta.(*ArmClient).ApiManagement.AuthorizationServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -270,7 +270,7 @@ func resourceArmApiManagementAuthorizationServerCreateUpdate(d *schema.ResourceD
 
 func resourceArmApiManagementAuthorizationServerRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).apiManagement.AuthorizationServersClient
+	client := meta.(*ArmClient).ApiManagement.AuthorizationServersClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -334,7 +334,7 @@ func resourceArmApiManagementAuthorizationServerRead(d *schema.ResourceData, met
 }
 
 func resourceArmApiManagementAuthorizationServerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.AuthorizationServersClient
+	client := meta.(*ArmClient).ApiManagement.AuthorizationServersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_authorization_server_test.go
+++ b/azurerm/resource_arm_api_management_authorization_server_test.go
@@ -91,7 +91,7 @@ func TestAccAzureRMAPIManagementAuthorizationServer_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementAuthorizationServerDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.AuthorizationServersClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.AuthorizationServersClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_authorization_server" {
 			continue
@@ -126,7 +126,7 @@ func testCheckAzureRMAPIManagementAuthorizationServerExists(resourceName string)
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.AuthorizationServersClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.AuthorizationServersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_backend.go
+++ b/azurerm/resource_arm_api_management_backend.go
@@ -226,7 +226,7 @@ func resourceArmApiManagementBackend() *schema.Resource {
 }
 
 func resourceArmApiManagementBackendCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.BackendClient
+	client := meta.(*ArmClient).ApiManagement.BackendClient
 	ctx := meta.(*ArmClient).StopContext
 	resourceGroup := d.Get("resource_group_name").(string)
 	serviceName := d.Get("api_management_name").(string)
@@ -301,7 +301,7 @@ func resourceArmApiManagementBackendCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmApiManagementBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.BackendClient
+	client := meta.(*ArmClient).ApiManagement.BackendClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -354,7 +354,7 @@ func resourceArmApiManagementBackendRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmApiManagementBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.BackendClient
+	client := meta.(*ArmClient).ApiManagement.BackendClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_backend_test.go
+++ b/azurerm/resource_arm_api_management_backend_test.go
@@ -243,7 +243,7 @@ func TestAccAzureRMApiManagementBackend_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementBackendDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.BackendClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.BackendClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_backend" {
@@ -282,7 +282,7 @@ func testCheckAzureRMApiManagementBackendExists(name string) resource.TestCheckF
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.BackendClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.BackendClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, name)
@@ -313,7 +313,7 @@ func testCheckAzureRMApiManagementBackendDisappears(resourceName string) resourc
 			return fmt.Errorf("Bad: no resource group found in state for backend: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.BackendClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.BackendClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Delete(ctx, resourceGroup, serviceName, name, "")

--- a/azurerm/resource_arm_api_management_certificate.go
+++ b/azurerm/resource_arm_api_management_certificate.go
@@ -63,7 +63,7 @@ func resourceArmApiManagementCertificate() *schema.Resource {
 }
 
 func resourceArmApiManagementCertificateCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.CertificatesClient
+	client := meta.(*ArmClient).ApiManagement.CertificatesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -109,7 +109,7 @@ func resourceArmApiManagementCertificateCreateUpdate(d *schema.ResourceData, met
 }
 
 func resourceArmApiManagementCertificateRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.CertificatesClient
+	client := meta.(*ArmClient).ApiManagement.CertificatesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -149,7 +149,7 @@ func resourceArmApiManagementCertificateRead(d *schema.ResourceData, meta interf
 }
 
 func resourceArmApiManagementCertificateDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.CertificatesClient
+	client := meta.(*ArmClient).ApiManagement.CertificatesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_certificate_test.go
+++ b/azurerm/resource_arm_api_management_certificate_test.go
@@ -74,7 +74,7 @@ func TestAccAzureRMAPIManagementCertificate_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementCertificateDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.CertificatesClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.CertificatesClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_certificate" {
 			continue
@@ -109,7 +109,7 @@ func testCheckAzureRMAPIManagementCertificateExists(resourceName string) resourc
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.CertificatesClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.CertificatesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_group.go
+++ b/azurerm/resource_arm_api_management_group.go
@@ -63,7 +63,7 @@ func resourceArmApiManagementGroup() *schema.Resource {
 }
 
 func resourceArmApiManagementGroupCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.GroupClient
+	client := meta.(*ArmClient).ApiManagement.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -114,7 +114,7 @@ func resourceArmApiManagementGroupCreateUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceArmApiManagementGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.GroupClient
+	client := meta.(*ArmClient).ApiManagement.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -151,7 +151,7 @@ func resourceArmApiManagementGroupRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmApiManagementGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.GroupClient
+	client := meta.(*ArmClient).ApiManagement.GroupClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_group_test.go
+++ b/azurerm/resource_arm_api_management_group_test.go
@@ -140,7 +140,7 @@ func TestAccAzureRMAPIManagementGroup_descriptionDisplayNameUpdate(t *testing.T)
 }
 
 func testCheckAzureRMAPIManagementGroupDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.GroupClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.GroupClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_group" {
 			continue
@@ -175,7 +175,7 @@ func testCheckAzureRMAPIManagementGroupExists(resourceName string) resource.Test
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.GroupClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.GroupClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_group_user.go
+++ b/azurerm/resource_arm_api_management_group_user.go
@@ -33,7 +33,7 @@ func resourceArmApiManagementGroupUser() *schema.Resource {
 }
 
 func resourceArmApiManagementGroupUserCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.GroupUsersClient
+	client := meta.(*ArmClient).ApiManagement.GroupUsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -68,7 +68,7 @@ func resourceArmApiManagementGroupUserCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmApiManagementGroupUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.GroupUsersClient
+	client := meta.(*ArmClient).ApiManagement.GroupUsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -100,7 +100,7 @@ func resourceArmApiManagementGroupUserRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmApiManagementGroupUserDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.GroupUsersClient
+	client := meta.(*ArmClient).ApiManagement.GroupUsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_group_user_test.go
+++ b/azurerm/resource_arm_api_management_group_user_test.go
@@ -66,7 +66,7 @@ func TestAccAzureRMAPIManagementGroupUser_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementGroupUserDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.GroupUsersClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.GroupUsersClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_group_user" {
 			continue
@@ -102,7 +102,7 @@ func testCheckAzureRMAPIManagementGroupUserExists(resourceName string) resource.
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.GroupUsersClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.GroupUsersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.CheckEntityExists(ctx, resourceGroup, serviceName, groupName, userId)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_logger.go
+++ b/azurerm/resource_arm_api_management_logger.go
@@ -88,7 +88,7 @@ func resourceArmApiManagementLogger() *schema.Resource {
 }
 
 func resourceArmApiManagementLoggerCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.LoggerClient
+	client := meta.(*ArmClient).ApiManagement.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -147,7 +147,7 @@ func resourceArmApiManagementLoggerCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmApiManagementLoggerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.LoggerClient
+	client := meta.(*ArmClient).ApiManagement.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -184,7 +184,7 @@ func resourceArmApiManagementLoggerRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmApiManagementLoggerUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.LoggerClient
+	client := meta.(*ArmClient).ApiManagement.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -217,7 +217,7 @@ func resourceArmApiManagementLoggerUpdate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmApiManagementLoggerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.LoggerClient
+	client := meta.(*ArmClient).ApiManagement.LoggerClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_logger_test.go
+++ b/azurerm/resource_arm_api_management_logger_test.go
@@ -226,7 +226,7 @@ func testCheckAzureRMApiManagementLoggerExists(resourceName string) resource.Tes
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.LoggerClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.LoggerClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if resp, err := client.Get(ctx, resourceGroup, serviceName, name); err != nil {
@@ -241,7 +241,7 @@ func testCheckAzureRMApiManagementLoggerExists(resourceName string) resource.Tes
 }
 
 func testCheckAzureRMApiManagementLoggerDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.LoggerClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.LoggerClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_api_management_openid_connect_provider.go
+++ b/azurerm/resource_arm_api_management_openid_connect_provider.go
@@ -66,7 +66,7 @@ func resourceArmApiManagementOpenIDConnectProvider() *schema.Resource {
 }
 
 func resourceArmApiManagementOpenIDConnectProviderCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.OpenIdConnectClient
+	client := meta.(*ArmClient).ApiManagement.OpenIdConnectClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -113,7 +113,7 @@ func resourceArmApiManagementOpenIDConnectProviderCreateUpdate(d *schema.Resourc
 }
 
 func resourceArmApiManagementOpenIDConnectProviderRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.OpenIdConnectClient
+	client := meta.(*ArmClient).ApiManagement.OpenIdConnectClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -150,7 +150,7 @@ func resourceArmApiManagementOpenIDConnectProviderRead(d *schema.ResourceData, m
 }
 
 func resourceArmApiManagementOpenIDConnectProviderDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.OpenIdConnectClient
+	client := meta.(*ArmClient).ApiManagement.OpenIdConnectClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_openid_connect_provider_test.go
+++ b/azurerm/resource_arm_api_management_openid_connect_provider_test.go
@@ -107,7 +107,7 @@ func testCheckAzureRMApiManagementOpenIDConnectProviderExists(resourceName strin
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.OpenIdConnectClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.OpenIdConnectClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if resp, err := client.Get(ctx, resourceGroup, serviceName, name); err != nil {
@@ -122,7 +122,7 @@ func testCheckAzureRMApiManagementOpenIDConnectProviderExists(resourceName strin
 }
 
 func testCheckAzureRMApiManagementOpenIDConnectProviderDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.OpenIdConnectClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.OpenIdConnectClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_api_management_product.go
+++ b/azurerm/resource_arm_api_management_product.go
@@ -70,7 +70,7 @@ func resourceArmApiManagementProduct() *schema.Resource {
 }
 
 func resourceArmApiManagementProductCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductsClient
+	client := meta.(*ArmClient).ApiManagement.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for API Management Product creation.")
@@ -142,7 +142,7 @@ func resourceArmApiManagementProductCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmApiManagementProductRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductsClient
+	client := meta.(*ArmClient).ApiManagement.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -183,7 +183,7 @@ func resourceArmApiManagementProductRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmApiManagementProductDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductsClient
+	client := meta.(*ArmClient).ApiManagement.ProductsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_api.go
+++ b/azurerm/resource_arm_api_management_product_api.go
@@ -33,7 +33,7 @@ func resourceArmApiManagementProductApi() *schema.Resource {
 }
 
 func resourceArmApiManagementProductApiCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductApisClient
+	client := meta.(*ArmClient).ApiManagement.ProductApisClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -68,7 +68,7 @@ func resourceArmApiManagementProductApiCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementProductApiRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductApisClient
+	client := meta.(*ArmClient).ApiManagement.ProductApisClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -100,7 +100,7 @@ func resourceArmApiManagementProductApiRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmApiManagementProductApiDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductApisClient
+	client := meta.(*ArmClient).ApiManagement.ProductApisClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_api_test.go
+++ b/azurerm/resource_arm_api_management_product_api_test.go
@@ -66,7 +66,7 @@ func TestAccAzureRMAPIManagementProductApi_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementProductApiDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.ProductApisClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductApisClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product_api" {
 			continue
@@ -102,7 +102,7 @@ func testCheckAzureRMAPIManagementProductApiExists(resourceName string) resource
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.ProductApisClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductApisClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.CheckEntityExists(ctx, resourceGroup, serviceName, productId, apiName)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_product_group.go
+++ b/azurerm/resource_arm_api_management_product_group.go
@@ -33,7 +33,7 @@ func resourceArmApiManagementProductGroup() *schema.Resource {
 }
 
 func resourceArmApiManagementProductGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductGroupsClient
+	client := meta.(*ArmClient).ApiManagement.ProductGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -68,7 +68,7 @@ func resourceArmApiManagementProductGroupCreate(d *schema.ResourceData, meta int
 }
 
 func resourceArmApiManagementProductGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductGroupsClient
+	client := meta.(*ArmClient).ApiManagement.ProductGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -100,7 +100,7 @@ func resourceArmApiManagementProductGroupRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementProductGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductGroupsClient
+	client := meta.(*ArmClient).ApiManagement.ProductGroupsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_group_test.go
+++ b/azurerm/resource_arm_api_management_product_group_test.go
@@ -66,7 +66,7 @@ func TestAccAzureRMAPIManagementProductGroup_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementProductGroupDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.ProductGroupsClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductGroupsClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product_group" {
 			continue
@@ -102,7 +102,7 @@ func testCheckAzureRMAPIManagementProductGroupExists(resourceName string) resour
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.ProductGroupsClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductGroupsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.CheckEntityExists(ctx, resourceGroup, serviceName, productId, groupName)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_product_policy.go
+++ b/azurerm/resource_arm_api_management_product_policy.go
@@ -48,7 +48,7 @@ func resourceArmApiManagementProductPolicy() *schema.Resource {
 }
 
 func resourceArmApiManagementProductPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ProductPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -108,7 +108,7 @@ func resourceArmApiManagementProductPolicyCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmApiManagementProductPolicyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ProductPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -144,7 +144,7 @@ func resourceArmApiManagementProductPolicyRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmApiManagementProductPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.ProductPoliciesClient
+	client := meta.(*ArmClient).ApiManagement.ProductPoliciesClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_product_policy_test.go
+++ b/azurerm/resource_arm_api_management_product_policy_test.go
@@ -110,7 +110,7 @@ func testCheckAzureRMApiManagementProductPolicyExists(resourceName string) resou
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ProductPoliciesClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductPoliciesClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, productID)
 		if err != nil {
@@ -126,7 +126,7 @@ func testCheckAzureRMApiManagementProductPolicyExists(resourceName string) resou
 }
 
 func testCheckAzureRMApiManagementProductPolicyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ProductPoliciesClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductPoliciesClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product_policy" {

--- a/azurerm/resource_arm_api_management_product_test.go
+++ b/azurerm/resource_arm_api_management_product_test.go
@@ -74,7 +74,7 @@ func TestAccAzureRMApiManagementProduct_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementProductDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ProductsClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductsClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_product" {
@@ -255,7 +255,7 @@ func testCheckAzureRMApiManagementProductExists(resourceName string) resource.Te
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ProductsClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ProductsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, productId)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_property.go
+++ b/azurerm/resource_arm_api_management_property.go
@@ -60,7 +60,7 @@ func resourceArmApiManagementProperty() *schema.Resource {
 }
 
 func resourceArmApiManagementPropertyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.PropertyClient
+	client := meta.(*ArmClient).ApiManagement.PropertyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -109,7 +109,7 @@ func resourceArmApiManagementPropertyCreateUpdate(d *schema.ResourceData, meta i
 }
 
 func resourceArmApiManagementPropertyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.PropertyClient
+	client := meta.(*ArmClient).ApiManagement.PropertyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -146,7 +146,7 @@ func resourceArmApiManagementPropertyRead(d *schema.ResourceData, meta interface
 }
 
 func resourceArmApiManagementPropertyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.PropertyClient
+	client := meta.(*ArmClient).ApiManagement.PropertyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_property_test.go
+++ b/azurerm/resource_arm_api_management_property_test.go
@@ -81,7 +81,7 @@ func TestAccAzureRMAPIManagementProperty_update(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementPropertyDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.PropertyClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.PropertyClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_property" {
 			continue
@@ -116,7 +116,7 @@ func testCheckAzureRMAPIManagementPropertyExists(resourceName string) resource.T
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.PropertyClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.PropertyClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_subscription.go
+++ b/azurerm/resource_arm_api_management_subscription.go
@@ -80,7 +80,7 @@ func resourceArmApiManagementSubscription() *schema.Resource {
 }
 
 func resourceArmApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.SubscriptionsClient
+	client := meta.(*ArmClient).ApiManagement.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -142,7 +142,7 @@ func resourceArmApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, me
 }
 
 func resourceArmApiManagementSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.SubscriptionsClient
+	client := meta.(*ArmClient).ApiManagement.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -181,7 +181,7 @@ func resourceArmApiManagementSubscriptionRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.SubscriptionsClient
+	client := meta.(*ArmClient).ApiManagement.SubscriptionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_subscription_test.go
+++ b/azurerm/resource_arm_api_management_subscription_test.go
@@ -146,7 +146,7 @@ func TestAccAzureRMAPIManagementSubscription_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAPIManagementSubscriptionDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).apiManagement.SubscriptionsClient
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.SubscriptionsClient
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_subscription" {
 			continue
@@ -179,7 +179,7 @@ func testCheckAzureRMAPIManagementSubscriptionExists(resourceName string) resour
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		serviceName := rs.Primary.Attributes["api_management_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).apiManagement.SubscriptionsClient
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.SubscriptionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_test.go
+++ b/azurerm/resource_arm_api_management_test.go
@@ -247,7 +247,7 @@ func TestAccAzureRMApiManagement_policy(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.ServiceClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ServiceClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management" {
@@ -287,7 +287,7 @@ func testCheckAzureRMApiManagementExists(resourceName string) resource.TestCheck
 			return fmt.Errorf("Bad: no resource group found in state for Api Management: %s", apiMangementName)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.ServiceClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.ServiceClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, apiMangementName)
 		if err != nil {

--- a/azurerm/resource_arm_api_management_user.go
+++ b/azurerm/resource_arm_api_management_user.go
@@ -85,7 +85,7 @@ func resourceArmApiManagementUser() *schema.Resource {
 }
 
 func resourceArmApiManagementUserCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.UsersClient
+	client := meta.(*ArmClient).ApiManagement.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for API Management User creation.")
@@ -155,7 +155,7 @@ func resourceArmApiManagementUserCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.UsersClient
+	client := meta.(*ArmClient).ApiManagement.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -194,7 +194,7 @@ func resourceArmApiManagementUserRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmApiManagementUserDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).apiManagement.UsersClient
+	client := meta.(*ArmClient).ApiManagement.UsersClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_api_management_user_test.go
+++ b/azurerm/resource_arm_api_management_user_test.go
@@ -227,7 +227,7 @@ func TestAccAzureRMApiManagementUser_complete(t *testing.T) {
 }
 
 func testCheckAzureRMApiManagementUserDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).apiManagement.UsersClient
+	conn := testAccProvider.Meta().(*ArmClient).ApiManagement.UsersClient
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_user" {
@@ -265,7 +265,7 @@ func testCheckAzureRMApiManagementUserExists(resourceName string) resource.TestC
 		serviceName := rs.Primary.Attributes["api_management_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		conn := testAccProvider.Meta().(*ArmClient).apiManagement.UsersClient
+		conn := testAccProvider.Meta().(*ArmClient).ApiManagement.UsersClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := conn.Get(ctx, resourceGroup, serviceName, userId)
 		if err != nil {

--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -72,7 +72,7 @@ func resourceArmApplicationInsights() *schema.Resource {
 }
 
 func resourceArmApplicationInsightsCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.ComponentsClient
+	client := meta.(*ArmClient).AppInsights.ComponentsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Application Insights creation.")
@@ -134,7 +134,7 @@ func resourceArmApplicationInsightsCreateUpdate(d *schema.ResourceData, meta int
 }
 
 func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.ComponentsClient
+	client := meta.(*ArmClient).AppInsights.ComponentsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -172,7 +172,7 @@ func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmApplicationInsightsDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.ComponentsClient
+	client := meta.(*ArmClient).AppInsights.ComponentsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_application_insights_analytics_item.go
+++ b/azurerm/resource_arm_application_insights_analytics_item.go
@@ -93,7 +93,7 @@ func resourceArmApplicationInsightsAnalyticsItemUpdate(d *schema.ResourceData, m
 	return resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d, meta, true)
 }
 func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceData, meta interface{}, overwrite bool) error {
-	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
+	client := meta.(*ArmClient).AppInsights.AnalyticsItemsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	appInsightsID := d.Get("application_insights_id").(string)
@@ -154,7 +154,7 @@ func resourceArmApplicationInsightsAnalyticsItemCreateUpdate(d *schema.ResourceD
 }
 
 func resourceArmApplicationInsightsAnalyticsItemRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
+	client := meta.(*ArmClient).AppInsights.AnalyticsItemsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id := d.Id()
@@ -187,7 +187,7 @@ func resourceArmApplicationInsightsAnalyticsItemRead(d *schema.ResourceData, met
 }
 
 func resourceArmApplicationInsightsAnalyticsItemDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.AnalyticsItemsClient
+	client := meta.(*ArmClient).AppInsights.AnalyticsItemsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id := d.Id()

--- a/azurerm/resource_arm_application_insights_analytics_item_test.go
+++ b/azurerm/resource_arm_application_insights_analytics_item_test.go
@@ -184,7 +184,7 @@ func testCheckAzureRMApplicationInsightsAnalyticsItemExistsInternal(rs *terrafor
 		return false, fmt.Errorf("Failed to parse ID (id: %s): %+v", id, err)
 	}
 
-	conn := testAccProvider.Meta().(*ArmClient).appInsights.AnalyticsItemsClient
+	conn := testAccProvider.Meta().(*ArmClient).AppInsights.AnalyticsItemsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	response, err := conn.Get(ctx, resGroup, appInsightsName, itemScopePath, itemID, "")

--- a/azurerm/resource_arm_application_insights_api_key.go
+++ b/azurerm/resource_arm_application_insights_api_key.go
@@ -70,7 +70,7 @@ func resourceArmApplicationInsightsAPIKey() *schema.Resource {
 }
 
 func resourceArmApplicationInsightsAPIKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.APIKeyClient
+	client := meta.(*ArmClient).AppInsights.APIKeyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Application Insights API key creation.")
@@ -124,7 +124,7 @@ func resourceArmApplicationInsightsAPIKeyCreate(d *schema.ResourceData, meta int
 }
 
 func resourceArmApplicationInsightsAPIKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.APIKeyClient
+	client := meta.(*ArmClient).AppInsights.APIKeyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -164,7 +164,7 @@ func resourceArmApplicationInsightsAPIKeyRead(d *schema.ResourceData, meta inter
 }
 
 func resourceArmApplicationInsightsAPIKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.APIKeyClient
+	client := meta.(*ArmClient).AppInsights.APIKeyClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_application_insights_api_key_test.go
+++ b/azurerm/resource_arm_application_insights_api_key_test.go
@@ -182,7 +182,7 @@ func TestAccAzureRMApplicationInsightsAPIKey_full_permissions(t *testing.T) {
 }
 
 func testCheckAzureRMApplicationInsightsAPIKeyDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).appInsights.APIKeyClient
+	conn := testAccProvider.Meta().(*ArmClient).AppInsights.APIKeyClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -228,7 +228,7 @@ func testCheckAzureRMApplicationInsightsAPIKeyExists(resourceName string) resour
 		resGroup := id.ResourceGroup
 		appInsightsName := id.Path["components"]
 
-		conn := testAccProvider.Meta().(*ArmClient).appInsights.APIKeyClient
+		conn := testAccProvider.Meta().(*ArmClient).AppInsights.APIKeyClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resGroup, appInsightsName, keyID)

--- a/azurerm/resource_arm_application_insights_test.go
+++ b/azurerm/resource_arm_application_insights_test.go
@@ -224,7 +224,7 @@ func TestAccAzureRMApplicationInsights_basiciOS(t *testing.T) {
 }
 
 func testCheckAzureRMApplicationInsightsDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).appInsights.ComponentsClient
+	conn := testAccProvider.Meta().(*ArmClient).AppInsights.ComponentsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -263,7 +263,7 @@ func testCheckAzureRMApplicationInsightsExists(resourceName string) resource.Tes
 			return fmt.Errorf("Bad: no resource group found in state for App Insights: %s", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).appInsights.ComponentsClient
+		conn := testAccProvider.Meta().(*ArmClient).AppInsights.ComponentsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_application_insights_webtests.go
+++ b/azurerm/resource_arm_application_insights_webtests.go
@@ -119,7 +119,7 @@ func resourceArmApplicationInsightsWebTests() *schema.Resource {
 }
 
 func resourceArmApplicationInsightsWebTestsCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.WebTestsClient
+	client := meta.(*ArmClient).AppInsights.WebTestsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Application Insights WebTest creation.")
@@ -195,7 +195,7 @@ func resourceArmApplicationInsightsWebTestsCreateUpdate(d *schema.ResourceData, 
 }
 
 func resourceArmApplicationInsightsWebTestsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.WebTestsClient
+	client := meta.(*ArmClient).AppInsights.WebTestsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -254,7 +254,7 @@ func resourceArmApplicationInsightsWebTestsRead(d *schema.ResourceData, meta int
 }
 
 func resourceArmApplicationInsightsWebTestsDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).appInsights.WebTestsClient
+	client := meta.(*ArmClient).AppInsights.WebTestsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_application_insights_webtests_test.go
+++ b/azurerm/resource_arm_application_insights_webtests_test.go
@@ -132,7 +132,7 @@ func TestAccAzureRMApplicationInsightsWebTests_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMApplicationInsightsWebTestsDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).appInsights.WebTestsClient
+	conn := testAccProvider.Meta().(*ArmClient).AppInsights.WebTestsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -167,7 +167,7 @@ func testCheckAzureRMApplicationInsightsWebTestExists(resourceName string) resou
 
 		name := rs.Primary.Attributes["name"]
 		resGroup := rs.Primary.Attributes["resource_group_name"]
-		conn := testAccProvider.Meta().(*ArmClient).appInsights.WebTestsClient
+		conn := testAccProvider.Meta().(*ArmClient).AppInsights.WebTestsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resGroup, name)

--- a/azurerm/resource_arm_automation_account.go
+++ b/azurerm/resource_arm_automation_account.go
@@ -95,7 +95,7 @@ func resourceArmAutomationAccount() *schema.Resource {
 }
 
 func resourceArmAutomationAccountCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.AccountClient
+	client := meta.(*ArmClient).Automation.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	// Remove in 2.0
@@ -167,8 +167,8 @@ func resourceArmAutomationAccountCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmAutomationAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.AccountClient
-	registrationClient := meta.(*ArmClient).automation.AgentRegistrationInfoClient
+	client := meta.(*ArmClient).Automation.AccountClient
+	registrationClient := meta.(*ArmClient).Automation.AgentRegistrationInfoClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -233,7 +233,7 @@ func resourceArmAutomationAccountRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmAutomationAccountDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.AccountClient
+	client := meta.(*ArmClient).Automation.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_account_test.go
+++ b/azurerm/resource_arm_automation_account_test.go
@@ -142,7 +142,7 @@ func TestAccAzureRMAutomationAccount_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationAccountDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automation.AccountClient
+	conn := testAccProvider.Meta().(*ArmClient).Automation.AccountClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -183,7 +183,7 @@ func testCheckAzureRMAutomationAccountExists(resourceName string) resource.TestC
 			return fmt.Errorf("Bad: no resource group found in state for Automation Account: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automation.AccountClient
+		conn := testAccProvider.Meta().(*ArmClient).Automation.AccountClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -58,7 +58,7 @@ func resourceArmAutomationCredential() *schema.Resource {
 }
 
 func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.CredentialClient
+	client := meta.(*ArmClient).Automation.CredentialClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Credential creation.")
@@ -112,7 +112,7 @@ func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta in
 }
 
 func resourceArmAutomationCredentialRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.CredentialClient
+	client := meta.(*ArmClient).Automation.CredentialClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -145,7 +145,7 @@ func resourceArmAutomationCredentialRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceArmAutomationCredentialDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.CredentialClient
+	client := meta.(*ArmClient).Automation.CredentialClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_credential_test.go
+++ b/azurerm/resource_arm_automation_credential_test.go
@@ -94,7 +94,7 @@ func TestAccAzureRMAutomationCredential_complete(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationCredentialDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automation.CredentialClient
+	conn := testAccProvider.Meta().(*ArmClient).Automation.CredentialClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -142,7 +142,7 @@ func testCheckAzureRMAutomationCredentialExists(resourceName string) resource.Te
 			return fmt.Errorf("Bad: no resource group found in state for Automation Credential: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automation.CredentialClient
+		conn := testAccProvider.Meta().(*ArmClient).Automation.CredentialClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_dsc_configuration.go
+++ b/azurerm/resource_arm_automation_dsc_configuration.go
@@ -75,7 +75,7 @@ func resourceArmAutomationDscConfiguration() *schema.Resource {
 }
 
 func resourceArmAutomationDscConfigurationCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.DscConfigurationClient
+	client := meta.(*ArmClient).Automation.DscConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Dsc Configuration creation.")
@@ -133,7 +133,7 @@ func resourceArmAutomationDscConfigurationCreateUpdate(d *schema.ResourceData, m
 }
 
 func resourceArmAutomationDscConfigurationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.DscConfigurationClient
+	client := meta.(*ArmClient).Automation.DscConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -185,7 +185,7 @@ func resourceArmAutomationDscConfigurationRead(d *schema.ResourceData, meta inte
 }
 
 func resourceArmAutomationDscConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.DscConfigurationClient
+	client := meta.(*ArmClient).Automation.DscConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_dsc_configuration_test.go
+++ b/azurerm/resource_arm_automation_dsc_configuration_test.go
@@ -70,7 +70,7 @@ func TestAccAzureRMAutomationDscConfiguration_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationDscConfigurationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automation.DscConfigurationClient
+	conn := testAccProvider.Meta().(*ArmClient).Automation.DscConfigurationClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -118,7 +118,7 @@ func testCheckAzureRMAutomationDscConfigurationExists(resourceName string) resou
 			return fmt.Errorf("Bad: no resource group found in state for Automation Dsc Configuration: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automation.DscConfigurationClient
+		conn := testAccProvider.Meta().(*ArmClient).Automation.DscConfigurationClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
@@ -57,7 +57,7 @@ func resourceArmAutomationDscNodeConfiguration() *schema.Resource {
 }
 
 func resourceArmAutomationDscNodeConfigurationCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.DscNodeConfigurationClient
+	client := meta.(*ArmClient).Automation.DscNodeConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Dsc Node Configuration creation.")
@@ -116,7 +116,7 @@ func resourceArmAutomationDscNodeConfigurationCreateUpdate(d *schema.ResourceDat
 }
 
 func resourceArmAutomationDscNodeConfigurationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.DscNodeConfigurationClient
+	client := meta.(*ArmClient).Automation.DscNodeConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -148,7 +148,7 @@ func resourceArmAutomationDscNodeConfigurationRead(d *schema.ResourceData, meta 
 }
 
 func resourceArmAutomationDscNodeConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.DscNodeConfigurationClient
+	client := meta.(*ArmClient).Automation.DscNodeConfigurationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration_test.go
@@ -68,7 +68,7 @@ func TestAccAzureRMAutomationDscNodeConfiguration_requiresImport(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationDscNodeConfigurationDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automation.DscNodeConfigurationClient
+	conn := testAccProvider.Meta().(*ArmClient).Automation.DscNodeConfigurationClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -116,7 +116,7 @@ func testCheckAzureRMAutomationDscNodeConfigurationExists(resourceName string) r
 			return fmt.Errorf("Bad: no resource group found in state for Automation Dsc Node Configuration: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automation.DscNodeConfigurationClient
+		conn := testAccProvider.Meta().(*ArmClient).Automation.DscNodeConfigurationClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_module.go
+++ b/azurerm/resource_arm_automation_module.go
@@ -79,7 +79,7 @@ func resourceArmAutomationModule() *schema.Resource {
 }
 
 func resourceArmAutomationModuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.ModuleClient
+	client := meta.(*ArmClient).Automation.ModuleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Module creation.")
@@ -169,7 +169,7 @@ func resourceArmAutomationModuleCreateUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmAutomationModuleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.ModuleClient
+	client := meta.(*ArmClient).Automation.ModuleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -198,7 +198,7 @@ func resourceArmAutomationModuleRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmAutomationModuleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.ModuleClient
+	client := meta.(*ArmClient).Automation.ModuleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_module_test.go
+++ b/azurerm/resource_arm_automation_module_test.go
@@ -94,7 +94,7 @@ func TestAccAzureRMAutomationModule_multipleModules(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationModuleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automation.ModuleClient
+	conn := testAccProvider.Meta().(*ArmClient).Automation.ModuleClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -142,7 +142,7 @@ func testCheckAzureRMAutomationModuleExists(resourceName string) resource.TestCh
 			return fmt.Errorf("Bad: no resource group found in state for Automation Module: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automation.ModuleClient
+		conn := testAccProvider.Meta().(*ArmClient).Automation.ModuleClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -124,7 +124,7 @@ func resourceArmAutomationRunbook() *schema.Resource {
 }
 
 func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.RunbookClient
+	client := meta.(*ArmClient).Automation.RunbookClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Runbook creation.")
@@ -176,7 +176,7 @@ func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta inter
 	if v, ok := d.GetOk("content"); ok {
 		content := v.(string)
 		reader := ioutil.NopCloser(bytes.NewBufferString(content))
-		draftClient := meta.(*ArmClient).automation.RunbookDraftClient
+		draftClient := meta.(*ArmClient).Automation.RunbookDraftClient
 
 		if _, err := draftClient.ReplaceContent(ctx, resGroup, accName, name, reader); err != nil {
 			return fmt.Errorf("Error setting the draft Automation Runbook %q (Account %q / Resource Group %q): %+v", name, accName, resGroup, err)
@@ -202,7 +202,7 @@ func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmAutomationRunbookRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.RunbookClient
+	client := meta.(*ArmClient).Automation.RunbookClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -261,7 +261,7 @@ func resourceArmAutomationRunbookRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmAutomationRunbookDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.RunbookClient
+	client := meta.(*ArmClient).Automation.RunbookClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_runbook_test.go
+++ b/azurerm/resource_arm_automation_runbook_test.go
@@ -120,7 +120,7 @@ func TestAccAzureRMAutomationRunbook_PSWithContent(t *testing.T) {
 }
 
 func testCheckAzureRMAutomationRunbookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automation.RunbookClient
+	conn := testAccProvider.Meta().(*ArmClient).Automation.RunbookClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -168,7 +168,7 @@ func testCheckAzureRMAutomationRunbookExists(resourceName string) resource.TestC
 			return fmt.Errorf("Bad: no resource group found in state for Automation Runbook: '%s'", name)
 		}
 
-		conn := testAccProvider.Meta().(*ArmClient).automation.RunbookClient
+		conn := testAccProvider.Meta().(*ArmClient).Automation.RunbookClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := conn.Get(ctx, resourceGroup, accName, name)

--- a/azurerm/resource_arm_automation_schedule.go
+++ b/azurerm/resource_arm_automation_schedule.go
@@ -217,7 +217,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 }
 
 func resourceArmAutomationScheduleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.ScheduleClient
+	client := meta.(*ArmClient).Automation.ScheduleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for AzureRM Automation Schedule creation.")
@@ -310,7 +310,7 @@ func resourceArmAutomationScheduleCreateUpdate(d *schema.ResourceData, meta inte
 }
 
 func resourceArmAutomationScheduleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.ScheduleClient
+	client := meta.(*ArmClient).Automation.ScheduleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -370,7 +370,7 @@ func resourceArmAutomationScheduleRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmAutomationScheduleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).automation.ScheduleClient
+	client := meta.(*ArmClient).Automation.ScheduleClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_automation_schedule_test.go
+++ b/azurerm/resource_arm_automation_schedule_test.go
@@ -269,7 +269,7 @@ func TestAccAzureRMAutomationSchedule_monthly_advanced_by_week_day(t *testing.T)
 }
 
 func testCheckAzureRMAutomationScheduleDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).automation.ScheduleClient
+	conn := testAccProvider.Meta().(*ArmClient).Automation.ScheduleClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -303,7 +303,7 @@ func testCheckAzureRMAutomationScheduleDestroy(s *terraform.State) error {
 
 func testCheckAzureRMAutomationScheduleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := testAccProvider.Meta().(*ArmClient).automation.ScheduleClient
+		conn := testAccProvider.Meta().(*ArmClient).Automation.ScheduleClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		// Ensure we have enough information in state to look up in API

--- a/azurerm/resource_arm_batch_account.go
+++ b/azurerm/resource_arm_batch_account.go
@@ -95,7 +95,7 @@ func resourceArmBatchAccount() *schema.Resource {
 }
 
 func resourceArmBatchAccountCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.AccountClient
+	client := meta.(*ArmClient).Batch.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Batch account creation.")
@@ -173,7 +173,7 @@ func resourceArmBatchAccountCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.AccountClient
+	client := meta.(*ArmClient).Batch.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -223,7 +223,7 @@ func resourceArmBatchAccountRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceArmBatchAccountUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.AccountClient
+	client := meta.(*ArmClient).Batch.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Batch account update.")
@@ -266,7 +266,7 @@ func resourceArmBatchAccountUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmBatchAccountDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.AccountClient
+	client := meta.(*ArmClient).Batch.AccountClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_batch_account_test.go
+++ b/azurerm/resource_arm_batch_account_test.go
@@ -171,7 +171,7 @@ func testCheckAzureRMBatchAccountExists(resourceName string) resource.TestCheckF
 
 		// Ensure resource group exists in API
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		conn := testAccProvider.Meta().(*ArmClient).batch.AccountClient
+		conn := testAccProvider.Meta().(*ArmClient).Batch.AccountClient
 
 		resp, err := conn.Get(ctx, resourceGroup, batchAccount)
 		if err != nil {
@@ -187,7 +187,7 @@ func testCheckAzureRMBatchAccountExists(resourceName string) resource.TestCheckF
 }
 
 func testCheckAzureRMBatchAccountDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).batch.AccountClient
+	conn := testAccProvider.Meta().(*ArmClient).Batch.AccountClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_batch_application.go
+++ b/azurerm/resource_arm_batch_application.go
@@ -63,7 +63,7 @@ func resourceArmBatchApplication() *schema.Resource {
 }
 
 func resourceArmBatchApplicationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.ApplicationClient
+	client := meta.(*ArmClient).Batch.ApplicationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -111,7 +111,7 @@ func resourceArmBatchApplicationCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmBatchApplicationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.ApplicationClient
+	client := meta.(*ArmClient).Batch.ApplicationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -145,7 +145,7 @@ func resourceArmBatchApplicationRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmBatchApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.ApplicationClient
+	client := meta.(*ArmClient).Batch.ApplicationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -171,7 +171,7 @@ func resourceArmBatchApplicationUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmBatchApplicationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.ApplicationClient
+	client := meta.(*ArmClient).Batch.ApplicationClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_batch_application_test.go
+++ b/azurerm/resource_arm_batch_application_test.go
@@ -78,7 +78,7 @@ func testCheckAzureRMBatchApplicationExists(resourceName string) resource.TestCh
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		accountName := rs.Primary.Attributes["account_name"]
 
-		client := testAccProvider.Meta().(*ArmClient).batch.ApplicationClient
+		client := testAccProvider.Meta().(*ArmClient).Batch.ApplicationClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		if resp, err := client.Get(ctx, resourceGroup, accountName, name); err != nil {
@@ -93,7 +93,7 @@ func testCheckAzureRMBatchApplicationExists(resourceName string) resource.TestCh
 }
 
 func testCheckAzureRMBatchApplicationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).batch.ApplicationClient
+	client := testAccProvider.Meta().(*ArmClient).Batch.ApplicationClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_batch_certificate.go
+++ b/azurerm/resource_arm_batch_certificate.go
@@ -88,7 +88,7 @@ func resourceArmBatchCertificate() *schema.Resource {
 }
 
 func resourceArmBatchCertificateCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.CertificateClient
+	client := meta.(*ArmClient).Batch.CertificateClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Batch certificate creation.")
@@ -150,7 +150,7 @@ func resourceArmBatchCertificateCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmBatchCertificateRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.CertificateClient
+	client := meta.(*ArmClient).Batch.CertificateClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -186,7 +186,7 @@ func resourceArmBatchCertificateRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmBatchCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.CertificateClient
+	client := meta.(*ArmClient).Batch.CertificateClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Batch certificate update.")
@@ -237,7 +237,7 @@ func resourceArmBatchCertificateUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmBatchCertificateDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.CertificateClient
+	client := meta.(*ArmClient).Batch.CertificateClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_batch_certificate_test.go
+++ b/azurerm/resource_arm_batch_certificate_test.go
@@ -225,7 +225,7 @@ resource "azurerm_batch_certificate" "test" {
 }
 
 func testCheckAzureRMBatchCertificateDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*ArmClient).batch.CertificateClient
+	conn := testAccProvider.Meta().(*ArmClient).Batch.CertificateClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_batch_pool.go
+++ b/azurerm/resource_arm_batch_pool.go
@@ -370,7 +370,7 @@ func resourceArmBatchPool() *schema.Resource {
 }
 
 func resourceArmBatchPoolCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).batch.PoolClient
+	client := meta.(*ArmClient).Batch.PoolClient
 	ctx := meta.(*ArmClient).StopContext
 
 	log.Printf("[INFO] preparing arguments for Azure Batch pool creation.")
@@ -503,7 +503,7 @@ func resourceArmBatchPoolCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceArmBatchPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).batch.PoolClient
+	client := meta.(*ArmClient).Batch.PoolClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -591,7 +591,7 @@ func resourceArmBatchPoolUpdate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).batch.PoolClient
+	client := meta.(*ArmClient).Batch.PoolClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -652,7 +652,7 @@ func resourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceArmBatchPoolDelete(d *schema.ResourceData, meta interface{}) error {
 	ctx := meta.(*ArmClient).StopContext
-	client := meta.(*ArmClient).batch.PoolClient
+	client := meta.(*ArmClient).Batch.PoolClient
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_batch_pool_test.go
+++ b/azurerm/resource_arm_batch_pool_test.go
@@ -416,7 +416,7 @@ func testCheckAzureRMBatchPoolExists(name string) resource.TestCheckFunc {
 		accountName := rs.Primary.Attributes["account_name"]
 
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		conn := testAccProvider.Meta().(*ArmClient).batch.PoolClient
+		conn := testAccProvider.Meta().(*ArmClient).Batch.PoolClient
 
 		resp, err := conn.Get(ctx, resourceGroup, accountName, poolName)
 		if err != nil {
@@ -442,7 +442,7 @@ func testCheckAzureRMBatchPoolDestroy(s *terraform.State) error {
 		accountName := rs.Primary.Attributes["account_name"]
 
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
-		conn := testAccProvider.Meta().(*ArmClient).batch.PoolClient
+		conn := testAccProvider.Meta().(*ArmClient).Batch.PoolClient
 
 		resp, err := conn.Get(ctx, resourceGroup, accountName, poolName)
 		if err != nil {

--- a/azurerm/resource_arm_bot_channel_email.go
+++ b/azurerm/resource_arm_bot_channel_email.go
@@ -54,7 +54,7 @@ func resourceArmBotChannelEmail() *schema.Resource {
 }
 
 func resourceArmBotChannelEmailCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -104,7 +104,7 @@ func resourceArmBotChannelEmailCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmBotChannelEmailRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -140,7 +140,7 @@ func resourceArmBotChannelEmailRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmBotChannelEmailUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -182,7 +182,7 @@ func resourceArmBotChannelEmailUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmBotChannelEmailDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_bot_channel_email_test.go
+++ b/azurerm/resource_arm_bot_channel_email_test.go
@@ -107,7 +107,7 @@ func testCheckAzureRMBotChannelEmailExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Bad: no resource group found in state for Bot Channel Email")
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).bot.ChannelClient
+		client := testAccProvider.Meta().(*ArmClient).Bot.ChannelClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, botName, string(botservice.ChannelNameEmailChannel))
@@ -124,7 +124,7 @@ func testCheckAzureRMBotChannelEmailExists(name string) resource.TestCheckFunc {
 }
 
 func testCheckAzureRMBotChannelEmailDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).bot.ChannelClient
+	client := testAccProvider.Meta().(*ArmClient).Bot.ChannelClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_bot_channel_slack.go
+++ b/azurerm/resource_arm_bot_channel_slack.go
@@ -66,7 +66,7 @@ func resourceArmBotChannelSlack() *schema.Resource {
 }
 
 func resourceArmBotChannelSlackCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -119,7 +119,7 @@ func resourceArmBotChannelSlackCreate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmBotChannelSlackRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -155,7 +155,7 @@ func resourceArmBotChannelSlackRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmBotChannelSlackUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	botName := d.Get("bot_name").(string)
@@ -196,7 +196,7 @@ func resourceArmBotChannelSlackUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmBotChannelSlackDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ChannelClient
+	client := meta.(*ArmClient).Bot.ChannelClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_bot_channel_slack_test.go
+++ b/azurerm/resource_arm_bot_channel_slack_test.go
@@ -110,7 +110,7 @@ func testCheckAzureRMBotChannelSlackExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Bad: no resource group found in state for Bot Channel Slack")
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).bot.ChannelClient
+		client := testAccProvider.Meta().(*ArmClient).Bot.ChannelClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, botName, string(botservice.ChannelNameSlackChannel))
@@ -127,7 +127,7 @@ func testCheckAzureRMBotChannelSlackExists(name string) resource.TestCheckFunc {
 }
 
 func testCheckAzureRMBotChannelSlackDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).bot.ChannelClient
+	client := testAccProvider.Meta().(*ArmClient).Bot.ChannelClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_bot_channels_registration.go
+++ b/azurerm/resource_arm_bot_channels_registration.go
@@ -97,7 +97,7 @@ func resourceArmBotChannelsRegistration() *schema.Resource {
 }
 
 func resourceArmBotChannelsRegistrationCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -156,7 +156,7 @@ func resourceArmBotChannelsRegistrationCreate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmBotChannelsRegistrationRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -196,7 +196,7 @@ func resourceArmBotChannelsRegistrationRead(d *schema.ResourceData, meta interfa
 }
 
 func resourceArmBotChannelsRegistrationUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -243,7 +243,7 @@ func resourceArmBotChannelsRegistrationUpdate(d *schema.ResourceData, meta inter
 }
 
 func resourceArmBotChannelsRegistrationDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_bot_channels_registration_test.go
+++ b/azurerm/resource_arm_bot_channels_registration_test.go
@@ -153,7 +153,7 @@ func testCheckAzureRMBotChannelsRegistrationExists(name string) resource.TestChe
 			return fmt.Errorf("Bad: no resource group found in state for Bot Channels Registration: %s", name)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).bot.BotClient
+		client := testAccProvider.Meta().(*ArmClient).Bot.BotClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, name)
@@ -170,7 +170,7 @@ func testCheckAzureRMBotChannelsRegistrationExists(name string) resource.TestChe
 }
 
 func testCheckAzureRMBotChannelsRegistrationDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).bot.BotClient
+	client := testAccProvider.Meta().(*ArmClient).Bot.BotClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_bot_connection.go
+++ b/azurerm/resource_arm_bot_connection.go
@@ -83,7 +83,7 @@ func resourceArmBotConnection() *schema.Resource {
 }
 
 func resourceArmBotConnectionCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ConnectionClient
+	client := meta.(*ArmClient).Bot.ConnectionClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -134,7 +134,7 @@ func resourceArmBotConnectionCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmBotConnectionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ConnectionClient
+	client := meta.(*ArmClient).Bot.ConnectionClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -173,7 +173,7 @@ func resourceArmBotConnectionRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmBotConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ConnectionClient
+	client := meta.(*ArmClient).Bot.ConnectionClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -212,7 +212,7 @@ func resourceArmBotConnectionUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceArmBotConnectionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.ConnectionClient
+	client := meta.(*ArmClient).Bot.ConnectionClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_bot_connection_test.go
+++ b/azurerm/resource_arm_bot_connection_test.go
@@ -100,7 +100,7 @@ func testCheckAzureRMBotConnectionExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Bad: no resource group found in state for Bot Channels Registration: %s", name)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).bot.ConnectionClient
+		client := testAccProvider.Meta().(*ArmClient).Bot.ConnectionClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, botName, name)
@@ -117,7 +117,7 @@ func testCheckAzureRMBotConnectionExists(name string) resource.TestCheckFunc {
 }
 
 func testCheckAzureRMBotConnectionDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).bot.ConnectionClient
+	client := testAccProvider.Meta().(*ArmClient).Bot.ConnectionClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_bot_web_app.go
+++ b/azurerm/resource_arm_bot_web_app.go
@@ -113,7 +113,7 @@ func resourceArmBotWebApp() *schema.Resource {
 }
 
 func resourceArmBotWebAppCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -174,7 +174,7 @@ func resourceArmBotWebAppCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceArmBotWebAppRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -215,7 +215,7 @@ func resourceArmBotWebAppRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArmBotWebAppUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -263,7 +263,7 @@ func resourceArmBotWebAppUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceArmBotWebAppDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).bot.BotClient
+	client := meta.(*ArmClient).Bot.BotClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := azure.ParseAzureResourceID(d.Id())

--- a/azurerm/resource_arm_bot_web_app_test.go
+++ b/azurerm/resource_arm_bot_web_app_test.go
@@ -116,7 +116,7 @@ func testCheckAzureRMBotWebAppExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Bad: no resource group found in state for Bot Web App: %s", name)
 		}
 
-		client := testAccProvider.Meta().(*ArmClient).bot.BotClient
+		client := testAccProvider.Meta().(*ArmClient).Bot.BotClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup, name)
@@ -133,7 +133,7 @@ func testCheckAzureRMBotWebAppExists(name string) resource.TestCheckFunc {
 }
 
 func testCheckAzureRMBotWebAppDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*ArmClient).bot.BotClient
+	client := testAccProvider.Meta().(*ArmClient).Bot.BotClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 	for _, rs := range s.RootModule().Resources {

--- a/azurerm/resource_arm_role_assignment.go
+++ b/azurerm/resource_arm_role_assignment.go
@@ -81,8 +81,8 @@ func resourceArmRoleAssignment() *schema.Resource {
 }
 
 func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) error {
-	roleAssignmentsClient := meta.(*ArmClient).authorization.RoleAssignmentsClient
-	roleDefinitionsClient := meta.(*ArmClient).authorization.RoleDefinitionsClient
+	roleAssignmentsClient := meta.(*ArmClient).Authorization.RoleAssignmentsClient
+	roleDefinitionsClient := meta.(*ArmClient).Authorization.RoleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	name := d.Get("name").(string)
@@ -160,8 +160,8 @@ func resourceArmRoleAssignmentCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmRoleAssignmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).authorization.RoleAssignmentsClient
-	roleDefinitionsClient := meta.(*ArmClient).authorization.RoleDefinitionsClient
+	client := meta.(*ArmClient).Authorization.RoleAssignmentsClient
+	roleDefinitionsClient := meta.(*ArmClient).Authorization.RoleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resp, err := client.GetByID(ctx, d.Id())
@@ -200,7 +200,7 @@ func resourceArmRoleAssignmentRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmRoleAssignmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).authorization.RoleAssignmentsClient
+	client := meta.(*ArmClient).Authorization.RoleAssignmentsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseRoleAssignmentId(d.Id())
@@ -232,7 +232,7 @@ func validateRoleDefinitionName(i interface{}, k string) ([]string, []error) {
 
 func retryRoleAssignmentsClient(scope string, name string, properties authorization.RoleAssignmentCreateParameters, meta interface{}) func() *resource.RetryError {
 	return func() *resource.RetryError {
-		roleAssignmentsClient := meta.(*ArmClient).authorization.RoleAssignmentsClient
+		roleAssignmentsClient := meta.(*ArmClient).Authorization.RoleAssignmentsClient
 		ctx := meta.(*ArmClient).StopContext
 
 		resp, err := roleAssignmentsClient.Create(ctx, scope, name, properties)

--- a/azurerm/resource_arm_role_assignment_test.go
+++ b/azurerm/resource_arm_role_assignment_test.go
@@ -286,7 +286,7 @@ func testCheckAzureRMRoleAssignmentExists(resourceName string) resource.TestChec
 		scope := rs.Primary.Attributes["scope"]
 		roleAssignmentName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).authorization.RoleAssignmentsClient
+		client := testAccProvider.Meta().(*ArmClient).Authorization.RoleAssignmentsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, scope, roleAssignmentName)
 
@@ -310,7 +310,7 @@ func testCheckAzureRMRoleAssignmentDestroy(s *terraform.State) error {
 		scope := rs.Primary.Attributes["scope"]
 		roleAssignmentName := rs.Primary.Attributes["name"]
 
-		client := testAccProvider.Meta().(*ArmClient).authorization.RoleAssignmentsClient
+		client := testAccProvider.Meta().(*ArmClient).Authorization.RoleAssignmentsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, scope, roleAssignmentName)
 

--- a/azurerm/resource_arm_role_definition.go
+++ b/azurerm/resource_arm_role_definition.go
@@ -99,7 +99,7 @@ func resourceArmRoleDefinition() *schema.Resource {
 }
 
 func resourceArmRoleDefinitionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).authorization.RoleDefinitionsClient
+	client := meta.(*ArmClient).Authorization.RoleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	roleDefinitionId := d.Get("role_definition_id").(string)
@@ -159,7 +159,7 @@ func resourceArmRoleDefinitionCreateUpdate(d *schema.ResourceData, meta interfac
 }
 
 func resourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).authorization.RoleDefinitionsClient
+	client := meta.(*ArmClient).Authorization.RoleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	resp, err := client.GetByID(ctx, d.Id())
@@ -202,7 +202,7 @@ func resourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmRoleDefinitionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*ArmClient).authorization.RoleDefinitionsClient
+	client := meta.(*ArmClient).Authorization.RoleDefinitionsClient
 	ctx := meta.(*ArmClient).StopContext
 
 	id, err := parseRoleDefinitionId(d.Id())

--- a/azurerm/resource_arm_role_definition_test.go
+++ b/azurerm/resource_arm_role_definition_test.go
@@ -191,7 +191,7 @@ func testCheckAzureRMRoleDefinitionExists(resourceName string) resource.TestChec
 		scope := rs.Primary.Attributes["scope"]
 		roleDefinitionId := rs.Primary.Attributes["role_definition_id"]
 
-		client := testAccProvider.Meta().(*ArmClient).authorization.RoleDefinitionsClient
+		client := testAccProvider.Meta().(*ArmClient).Authorization.RoleDefinitionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, scope, roleDefinitionId)
 
@@ -215,7 +215,7 @@ func testCheckAzureRMRoleDefinitionDestroy(s *terraform.State) error {
 		scope := rs.Primary.Attributes["scope"]
 		roleDefinitionId := rs.Primary.Attributes["role_definition_id"]
 
-		client := testAccProvider.Meta().(*ArmClient).authorization.RoleDefinitionsClient
+		client := testAccProvider.Meta().(*ArmClient).Authorization.RoleDefinitionsClient
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		resp, err := client.Get(ctx, scope, roleDefinitionId)
 


### PR DESCRIPTION
As part of the continued work on 2.0 this PR makes some more of the clients Public so we can move them gradually, rather than doing it in a big-bang and introducing conflicts everywhere