### PR TITLE
`azurerm_app_service_certificate` - Added note to documentation about magic Resource Principal

### DIFF
--- a/website/docs/r/app_service_certificate.html.markdown
+++ b/website/docs/r/app_service_certificate.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `key_vault_secret_id` - (Optional) The ID of the Key Vault secret. Changing this forces a new resource to be created.
 
+-> **NOTE:** If using `key_vault_secret_id`, the magic Resource Principal with id of `abfa0a7c-a6b6-4736-8310-5855508787cd` must have 'Secret -> get' and 'Certificate -> get' permissions on the Key Vault containing the certificate.  (Source: [App Service Blog](https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html))
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Updated documentation to reflect that magic Resource Principal must be given appropriate Key Vault rights for this to work.  It is not officially documented anywhere, however [a post from 2016](https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html) in the App Service Blog explains that it is necessary.