### PR TITLE
r/virtual_machine_data_disk_attachment: removing the identity block when making a delta update

### DIFF
--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment.go
@@ -162,6 +162,8 @@ func resourceArmVirtualMachineDataDiskAttachmentCreateUpdate(d *schema.ResourceD
 
 	virtualMachine.StorageProfile.DataDisks = &disks
 
+	// fixes #2485
+	virtualMachine.Identity = nil
 	// fixes #1600
 	virtualMachine.Resources = nil
 
@@ -273,6 +275,8 @@ func resourceArmVirtualMachineDataDiskAttachmentDelete(d *schema.ResourceData, m
 
 	virtualMachine.StorageProfile.DataDisks = &dataDisks
 
+	// fixes #2485
+	virtualMachine.Identity = nil
 	// fixes #1600
 	virtualMachine.Resources = nil
 

--- a/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
+++ b/azurerm/resource_arm_virtual_machine_data_disk_attachment_test.go
@@ -179,6 +179,35 @@ func TestAccAzureRMVirtualMachineDataDiskAttachment_updatingWriteAccelerator(t *
 	})
 }
 
+func TestAccAzureRMVirtualMachineDataDiskAttachment_managedServiceIdentity(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_data_disk_attachment.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	config := testAccAzureRMVirtualMachineDataDiskAttachment_managedServiceIdentity(ri, location)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDataDiskAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineDataDiskAttachmentExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "virtual_machine_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_disk_id"),
+					resource.TestCheckResourceAttr(resourceName, "lun", "0"),
+					resource.TestCheckResourceAttr(resourceName, "caching", "None"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineDataDiskAttachment_virtualMachineExtension(t *testing.T) {
 	resourceName := "azurerm_virtual_machine_data_disk_attachment.test"
 	ri := tf.AccRandTimeInt()
@@ -323,6 +352,93 @@ resource "azurerm_virtual_machine_data_disk_attachment" "import" {
   caching            = "${azurerm_virtual_machine_data_disk_attachment.test.caching}"
 }
 `, template)
+}
+
+func testAccAzureRMVirtualMachineDataDiskAttachment_managedServiceIdentity(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_virtual_machine" "test" {
+  name                  = "acctvm-%d"
+  location              = "${azurerm_resource_group.test.location}"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  network_interface_ids = ["${azurerm_network_interface.test.id}"]
+  vm_size               = "Standard_F2"
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name              = "myosdisk1"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  os_profile {
+    computer_name  = "hn%d"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "%d-disk1"
+  location             = "${azurerm_resource_group.test.location}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "test" {
+  managed_disk_id    = "${azurerm_managed_disk.test.id}"
+  virtual_machine_id = "${azurerm_virtual_machine.test.id}"
+  lun                = "0"
+  caching            = "None"
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
 func testAccAzureRMVirtualMachineDataDiskAttachment_multipleDisks(rInt int, location string) string {


### PR DESCRIPTION
This PR fixes #2485 by removing the "identity" block when doing a delta update with the body from a Get response (which is required when updating a VM)

Fixes #2485

