### PR TITLE
azurerm_kubernetes_cluster - allow disabling the `aci_connector_linux` by letting the subnet property be empty

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -295,7 +295,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 									},
 									"subnet_name": {
 										Type:         schema.TypeString,
-										Required:     true,
+										Optional:     true,
 										ValidateFunc: validate.NoEmptyStrings,
 									},
 								},
@@ -1022,7 +1022,7 @@ func expandKubernetesClusterAddonProfiles(d *schema.ResourceData) map[string]*co
 		config := make(map[string]*string)
 		enabled := value["enabled"].(bool)
 
-		if subnetName, ok := value["subnet_name"]; ok {
+		if subnetName, ok := value["subnet_name"]; ok && subnetName != "" {
 			config["SubnetName"] = utils.String(subnetName.(string))
 		}
 

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -363,6 +363,34 @@ func TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinux(t *testing.T)
 	})
 }
 
+func TestAccAzureRMKubernetesCluster_addonProfileAciConnectorLinuxDisabled(t *testing.T) {
+	resourceName := "azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	location := testLocation()
+	disablingConfig := testAccAzureRMKubernetesCluster_addonProfileAciConnectorLinuxDisabled(ri, clientId, clientSecret, location)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: disablingConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.http_application_routing.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "agent_pool_profile.0.count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.aci_connector_linux.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.aci_connector_linux.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "addon_profile.0.aci_connector_linux.0.subnet_name", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMKubernetesCluster_addonProfileOMS(t *testing.T) {
 	resourceName := "azurerm_kubernetes_cluster.test"
 	ri := tf.AccRandTimeInt()
@@ -1438,6 +1466,70 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, rInt, location, rInt, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
+}
+
+func testAccAzureRMKubernetesCluster_addonProfileAciConnectorLinuxDisabled(rInt int, clientId string, clientSecret string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+	name                = "acctestvirtnet%d"
+	address_space       = ["172.0.0.0/16"]
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+
+	tags = {
+	  environment = "Testing"
+	}
+  }
+
+  resource "azurerm_subnet" "test" {
+	name                 = "acctestsubnet%d"
+	resource_group_name  = "${azurerm_resource_group.test.name}"
+	virtual_network_name = "${azurerm_virtual_network.test.name}"
+	address_prefix       = "172.0.2.0/24"
+  }
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  agent_pool_profile {
+    name    		= "default"
+    count   		= "1"
+	vm_size 		= "Standard_DS2_v2"
+	vnet_subnet_id  = "${azurerm_subnet.test.id}"
+  }
+
+  service_principal {
+    client_id     = "%s"
+    client_secret = "%s"
+  }
+
+  addon_profile {
+    aci_connector_linux {
+      enabled = false
+    }
+  }
+
+  network_profile {
+    network_plugin = "azure"
+  }
+}
+`, rInt, location, rInt, rInt, rInt, rInt, rInt, clientId, clientSecret)
 }
 
 func testAccAzureRMKubernetesCluster_addonProfileOMS(rInt int, clientId string, clientSecret string, location string) string {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -87,7 +87,7 @@ A `aci_connector_linux` block supports the following:
 
 * `enabled` - (Required) Is the virtual node addon enabled?
 
-* `subnet_name` - (Required) The subnet name for the virtual nodes to run.
+* `subnet_name` - (Optional) The subnet name for the virtual nodes to run. This is required when `aci_connector_linux` `enabled` argument is set to `true`.
 
 -> **Note:** AKS will add a delegation to the subnet named here. To prevent further runs from failing you should make sure that the subnet you create for virtual nodes has a delegation, like so.
 


### PR DESCRIPTION
Allows to disable aci_connector_linux, similar to https://github.com/terraform-providers/terraform-provider-azurerm/pull/4513

Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/4540