### PR TITLE
Update key vault data source docs for deprecated vault_uri

### DIFF
--- a/examples/virtual-machines/provisioners/windows/2-certificates.tf
+++ b/examples/virtual-machines/provisioners/windows/2-certificates.tf
@@ -30,8 +30,8 @@ resource "azurerm_key_vault" "example" {
 }
 
 resource "azurerm_key_vault_certificate" "example" {
-  name      = "${local.virtual_machine_name}-cert"
-  vault_uri = "${azurerm_key_vault.example.vault_uri}"
+  name         = "${local.virtual_machine_name}-cert"
+  key_vault_id = "${azurerm_key_vault.example.id}"
 
   certificate_policy {
     issuer_parameters {

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -33,7 +33,9 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Key.
 
-* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
+* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. 
+
+**NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -18,8 +18,8 @@ Use this data source to access information about an existing Key Vault Key.
 
 ```hcl
 data "azurerm_key_vault_key" "test" {
-  name      = "secret-sauce"
-  vault_uri = "https://rickslab.vault.azure.net/"
+  name         = "secret-sauce"
+  key_vault_id = "${data.azurerm_key_vault.existing.id}"
 }
 
 output "key_type" {
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Key.
 
-* `vault_uri` - (Required) Specifies the ID of the Key Vault Key Vault instance where the Key resides, available on the `azurerm_key_vault` Data Source / Resource.
+* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -33,7 +33,9 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Secret.
 
-* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
+* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. 
+
+**NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -33,8 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Secret.
 
-* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
-
+* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Replace the `vault_uri` attribute with `key_vault_id` for `key_vault_key`
- Add a note that the key vault must be in the same subscription as the
configured provider. See #2396 for discussion
- Update example that uses the deprecated `vault_uri`

Fixes #3029