### PR TITLE
azurerm_media_service - fix test resource group names

### DIFF
--- a/azurerm/resource_arm_media_services_account_test.go
+++ b/azurerm/resource_arm_media_services_account_test.go
@@ -254,7 +254,7 @@ resource "azurerm_media_services_account" "test" {
 func testAccAzureRMMediaServicesAccount_template(rInt int, rString, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "%d"
+  name     = "acctestRG-media-%d"
   location = "%s"
 }
 


### PR DESCRIPTION
noticed a bunch of RGs in our subscription without the `acctest` prefix. This should fix that.