### PR TITLE
storage_account: Ignore Advanced Threat Protection read errors in Azure Germany

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1103,9 +1103,11 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 	atp, err := advancedThreatProtectionClient.Get(ctx, d.Id())
 	if err != nil {
 		msg := err.Error()
-		if !strings.Contains(msg, "No registered resource provider found for location '") {
-			if !strings.Contains(msg, "' and API version '2017-08-01-preview' for type ") {
-				return fmt.Errorf("Error reading the advanced threat protection settings of AzureRM Storage Account %q: %+v", name, err)
+		if msg != "The resource namespace 'Microsoft.Security' is invalid." {
+			if !strings.Contains(msg, "No registered resource provider found for location '") {
+				if !strings.Contains(msg, "' and API version '2017-08-01-preview' for type ") {
+					return fmt.Errorf("Error reading the advanced threat protection settings of AzureRM Storage Account %q: %+v", name, err)
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
The Azure Germany Cloud returns `HTTP/2.0 404 Not Found` when requesting the ATP details. In particular,

```
Code="InvalidResourceNamespace"
Message="The resource namespace 'Microsoft.Security' is invalid."
```

As we are simply ignoring the error on Azure Government based on #3920, we can apply the same logic for Azure Germany.

Closes #4563.