### PR TITLE
azurerm_sql_database - fix #4196 by ensuring `read_scale` is always set during initial creation

### DIFF
--- a/azurerm/resource_arm_sql_database.go
+++ b/azurerm/resource_arm_sql_database.go
@@ -433,13 +433,11 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if v, ok := d.GetOk("read_scale"); ok {
-		readScale := v.(bool)
-		if readScale {
-			properties.DatabaseProperties.ReadScale = sql.ReadScaleEnabled
-		} else {
-			properties.DatabaseProperties.ReadScale = sql.ReadScaleDisabled
-		}
+	readScale := d.Get("read_scale").(bool)
+	if readScale {
+		properties.DatabaseProperties.ReadScale = sql.ReadScaleEnabled
+	} else {
+		properties.DatabaseProperties.ReadScale = sql.ReadScaleDisabled
 	}
 
 	// The requested Service Objective Name does not match the requested Service Objective Id.


### PR DESCRIPTION
The GetOk method always return not ok when the target property is a bool, which cause the `read_scale` property not works as expected as #4196 explained. Using Get method instead to fix the issue.