### PR TITLE
`azurerm_frontdoor` update `custom_host` to be optional, add `redirect_configuration` to documentation

### DIFF
--- a/azurerm/resource_arm_front_door.go
+++ b/azurerm/resource_arm_front_door.go
@@ -1355,10 +1355,6 @@ func flattenArmFrontDoorRoutingRule(input *[]frontdoor.RoutingRule) []interface{
 								c["cache_use_dynamic_compression"] = true
 							}
 						}
-					} else {
-						// Set Defaults
-						c["cache_query_parameter_strip_directive"] = string(frontdoor.StripNone)
-						c["cache_use_dynamic_compression"] = false
 					}
 
 					rc = append(rc, c)

--- a/azurerm/resource_arm_front_door.go
+++ b/azurerm/resource_arm_front_door.go
@@ -121,7 +121,7 @@ func resourceArmFrontDoor() *schema.Resource {
 									},
 									"custom_host": {
 										Type:     schema.TypeString,
-										Required: true,
+										Optional: true,
 									},
 									"custom_path": {
 										Type:     schema.TypeString,
@@ -1018,6 +1018,9 @@ func expandArmFrontDoorRedirectConfiguration(input []interface{}) frontdoor.Redi
 
 	// The way the API works is if you don't include the attribute in the structure
 	// it is treated as Preserve instead of Replace...
+	if customHost != "" {
+		redirectConfiguration.CustomHost = utils.String(customHost)
+	}
 	if customPath != "" {
 		redirectConfiguration.CustomPath = utils.String(customPath)
 	}

--- a/website/docs/r/front_door.html.markdown
+++ b/website/docs/r/front_door.html.markdown
@@ -134,7 +134,7 @@ The `frontend_endpoint` block supports the following:
 
 * `session_affinity_ttl_seconds` - (Optional) The TTL to use in seconds for session affinity, if applicable. Defaults to `0`.
 
-* `enable_custom_https_provisioning` - (Required) Name of the Frontend Endpoint.
+* `custom_https_provisioning_enabled` - (Required) Name of the Frontend Endpoint.
 
 * `web_application_firewall_policy_link_id` - (Optional) Defines the Web Application Firewall policy `ID` for each host.
 
@@ -178,6 +178,8 @@ The `routing_rule` block supports the following:
 
 * `forwarding_configuration` - (Optional) A `forwarding_configuration` block as defined below.
 
+* `redirect_configuration`   - (Optional) A `redirect_configuration` block as defined below.
+
 ---
 
 The `forwarding_configuration` block supports the following:
@@ -191,6 +193,22 @@ The `forwarding_configuration` block supports the following:
 * `custom_forwarding_path` - (Optional) Path to use when constructing the request to forward to the backend. This functions as a URL Rewrite. Default behavior preserves the URL path.
 
 * `forwarding_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HTTPOnly`, `HTTPSOnly`, or `MatchRequest`. Defaults to `MatchRequest`.
+
+---
+
+The `redirect_configuration` block supports the following:
+
+* `custom_host` - (Optional)  Set this to change the URL for the redirection. 
+
+* `redirect_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HTTPOnly`, `HTTPSOnly`, `MatchRequest`. Defaults to `MatchRequest`
+
+* `redirect_type` - (Optional) Status code for the redirect. Valida options are `Moved`, `Found`, `TemporaryRedirect`, `PermanentRedirect`. Defaults to `Found`
+
+* `custom_fragment` - (Optional) The destination fragment in the portion of URL after '#'. Set this to add a fragment to the redirect URL.
+
+* `custom_path` - (Optional) The path to retain as per the incoming request, or update in the URL for the redirection.
+
+* `custom_query_string` - (Optional) Replace any existing query string from the incoming request URL.
 
 ---
 


### PR DESCRIPTION
As per the Azure FrontDoor console operations. CustomHost in the redirect configuration should be optional to preserve the host from the incoming request.

(fixes #4461)
(fixes #4562)