### PR TITLE
Add support for adding node's public IP in agent_pool_profile

### DIFF
--- a/azurerm/data_source_kubernetes_cluster.go
+++ b/azurerm/data_source_kubernetes_cluster.go
@@ -180,6 +180,11 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+
+						"enable_node_public_ip": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -717,6 +722,10 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 
 		if profile.NodeTaints != nil {
 			agentPoolProfile["node_taints"] = *profile.NodeTaints
+		}
+
+		if profile.EnableNodePublicIP != nil {
+			agentPoolProfile["enable_node_public_ip"] = *profile.EnableNodePublicIP
 		}
 
 		agentPoolProfiles = append(agentPoolProfiles, agentPoolProfile)

--- a/azurerm/data_source_kubernetes_cluster_test.go
+++ b/azurerm/data_source_kubernetes_cluster_test.go
@@ -549,6 +549,30 @@ func TestAccDataSourceAzureRMKubernetesCluster_nodeTaints(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMKubernetesCluster_enableNodePublicIP(t *testing.T) {
+	dataSourceName := "data.azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+
+	config := testAccDataSourceAzureRMKubernetesCluster_enableNodePublicIP(ri, clientId, clientSecret, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "agent_pool_profile.0.enable_node_public_ip", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAzureRMKubernetesCluster_basic(rInt int, clientId string, clientSecret string, location string) string {
 	r := testAccAzureRMKubernetesCluster_basic(rInt, clientId, clientSecret, location)
 	return fmt.Sprintf(`
@@ -767,6 +791,18 @@ data "azurerm_kubernetes_cluster" "test" {
 
 func testAccDataSourceAzureRMKubernetesCluster_nodeTaints(rInt int, clientId string, clientSecret string, location string) string {
 	r := testAccAzureRMKubernetesCluster_nodeTaints(rInt, clientId, clientSecret, location)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_kubernetes_cluster" "test" {
+  name                = "${azurerm_kubernetes_cluster.test.name}"
+  resource_group_name = "${azurerm_kubernetes_cluster.test.resource_group_name}"
+}
+`, r)
+}
+
+func testAccDataSourceAzureRMKubernetesCluster_enableNodePublicIP(rInt int, clientId string, clientSecret string, location string) string {
+	r := testAccAzureRMKubernetesCluster_enableNodePublicIP(rInt, clientId, clientSecret, location)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -219,6 +219,11 @@ func resourceArmKubernetesCluster() *schema.Resource {
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+
+						"enable_node_public_ip": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -1240,6 +1245,10 @@ func expandKubernetesClusterAgentPoolProfiles(d *schema.ResourceData) ([]contain
 			profile.NodeTaints = nodeTaints
 		}
 
+		if enableNodePublicIP := config["enable_node_public_ip"]; enableNodePublicIP != nil {
+			profile.EnableNodePublicIP = utils.Bool(enableNodePublicIP.(bool))
+		}
+
 		profiles = append(profiles, profile)
 	}
 
@@ -1300,20 +1309,26 @@ func flattenKubernetesClusterAgentPoolProfiles(profiles *[]containerservice.Mana
 			subnetId = *profile.VnetSubnetID
 		}
 
+		enableNodePublicIP := false
+		if profile.EnableAutoScaling != nil {
+			enableNodePublicIP = *profile.EnableNodePublicIP
+		}
+
 		agentPoolProfile := map[string]interface{}{
-			"availability_zones":  utils.FlattenStringSlice(profile.AvailabilityZones),
-			"count":               count,
-			"enable_auto_scaling": enableAutoScaling,
-			"max_count":           maxCount,
-			"max_pods":            maxPods,
-			"min_count":           minCount,
-			"name":                name,
-			"node_taints":         utils.FlattenStringSlice(profile.NodeTaints),
-			"os_disk_size_gb":     osDiskSizeGB,
-			"os_type":             string(profile.OsType),
-			"type":                string(profile.Type),
-			"vm_size":             string(profile.VMSize),
-			"vnet_subnet_id":      subnetId,
+			"availability_zones":    utils.FlattenStringSlice(profile.AvailabilityZones),
+			"count":                 count,
+			"enable_auto_scaling":   enableAutoScaling,
+			"max_count":             maxCount,
+			"max_pods":              maxPods,
+			"min_count":             minCount,
+			"name":                  name,
+			"node_taints":           utils.FlattenStringSlice(profile.NodeTaints),
+			"os_disk_size_gb":       osDiskSizeGB,
+			"os_type":               string(profile.OsType),
+			"type":                  string(profile.Type),
+			"vm_size":               string(profile.VMSize),
+			"vnet_subnet_id":        subnetId,
+			"enable_node_public_ip": enableNodePublicIP,
 
 			// TODO: remove in 2.0
 			"fqdn": fqdnVal,

--- a/azurerm/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/resource_arm_kubernetes_cluster_test.go
@@ -1086,6 +1086,29 @@ func testCheckAzureRMKubernetesClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
+func TestAccAzureRMKubernetesCluster_enableNodePublicIP(t *testing.T) {
+	resourceName := "azurerm_kubernetes_cluster.test"
+	ri := tf.AccRandTimeInt()
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	config := testAccAzureRMKubernetesCluster_enableNodePublicIP(ri, clientId, clientSecret, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "agent_pool_profile.0.enable_node_public_ip", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAzureRMKubernetesCluster_basic(rInt int, clientId string, clientSecret string, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -2529,6 +2552,35 @@ resource "azurerm_kubernetes_cluster" "test" {
     name    = "default"
     count   = "1"
     vm_size = "Standard_DS2_v2"
+  }
+
+  service_principal {
+    client_id     = "%s"
+    client_secret = "%s"
+  }
+}
+`, rInt, location, rInt, rInt, clientId, clientSecret)
+}
+
+func testAccAzureRMKubernetesCluster_enableNodePublicIP(rInt int, clientId string, clientSecret string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_prefix          = "acctestaks%d"
+
+  agent_pool_profile {
+    name                  = "default"
+    count                 = "1"
+    type                  = "VirtualMachineScaleSets"
+    vm_size               = "Standard_DS2_v2"
+    enable_node_public_ip = true
   }
 
   service_principal {


### PR DESCRIPTION
Adds support for enabling node's public IP in agent_pool_profile with simple boolean flag as requested by #4581.

For example:

``` HCL
agent_pool_profile {
    name                  = "default"
    count                 = 1
    vm_size               = "Standard_D2_v2"
    os_type               = "Linux"
    os_disk_size_gb       = 30
    type                  = "VirtualMachineScaleSets"
    enable_node_public_ip = true
  }
```

Things to notice: Since this is update that is only available in AKS preview so you need to enable following feature `Microsoft.ContainerService/NodePublicIPPreview`.