### PR TITLE
[DO NOT MERGE] Adds Throughput to CosmosDB Resources

### DIFF
--- a/azurerm/resource_arm_cosmosdb_cassandra_keyspace.go
+++ b/azurerm/resource_arm_cosmosdb_cassandra_keyspace.go
@@ -17,8 +17,9 @@ import (
 
 func resourceArmCosmosDbCassandraKeyspace() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmCosmosDbCassandraKeyspaceCreate,
+		Create: resourceArmCosmosDbCassandraKeyspaceCreateUpdate,
 		Read:   resourceArmCosmosDbCassandraKeyspaceRead,
+		Update: resourceArmCosmosDbCassandraKeyspaceCreateUpdate,
 		Delete: resourceArmCosmosDbCassandraKeyspaceDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -52,7 +53,7 @@ func resourceArmCosmosDbCassandraKeyspace() *schema.Resource {
 	}
 }
 
-func resourceArmCosmosDbCassandraKeyspaceCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmCosmosDbCassandraKeyspaceCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Cosmos.DatabaseClient
 	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
 	defer cancel()

--- a/azurerm/resource_arm_cosmosdb_mongo_database.go
+++ b/azurerm/resource_arm_cosmosdb_mongo_database.go
@@ -17,8 +17,9 @@ import (
 
 func resourceArmCosmosDbMongoDatabase() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmCosmosDbMongoDatabaseCreate,
+		Create: resourceArmCosmosDbMongoDatabaseCreateUpdate,
 		Read:   resourceArmCosmosDbMongoDatabaseRead,
+		Update: resourceArmCosmosDbMongoDatabaseCreateUpdate,
 		Delete: resourceArmCosmosDbMongoDatabaseDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -52,7 +53,7 @@ func resourceArmCosmosDbMongoDatabase() *schema.Resource {
 	}
 }
 
-func resourceArmCosmosDbMongoDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmCosmosDbMongoDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Cosmos.DatabaseClient
 	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
 	defer cancel()

--- a/azurerm/resource_arm_cosmosdb_mongo_database_test.go
+++ b/azurerm/resource_arm_cosmosdb_mongo_database_test.go
@@ -35,6 +35,43 @@ func TestAccAzureRMCosmosDbMongoDatabase_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbMongoDatabase_update(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+	resourceName := "azurerm_cosmosdb_mongo_database.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbMongoDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbMongoDatabase_complete(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "600"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAzureRMCosmosDbMongoDatabase_update(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "400"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbMongoDatabaseDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).Cosmos.DatabaseClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -99,6 +136,32 @@ resource "azurerm_cosmosdb_mongo_database" "test" {
   name                = "acctest-%[2]d"
   resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
   account_name        = "${azurerm_cosmosdb_account.test.name}"
+}
+`, testAccAzureRMCosmosDBAccount_mongoDB(rInt, location), rInt)
+}
+
+func testAccAzureRMCosmosDbMongoDatabase_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_mongo_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
+  account_name        = "${azurerm_cosmosdb_account.test.name}"
+  throughput          = 600
+}
+`, testAccAzureRMCosmosDBAccount_mongoDB(rInt, location), rInt)
+}
+
+func testAccAzureRMCosmosDbMongoDatabase_update(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_mongo_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
+  account_name        = "${azurerm_cosmosdb_account.test.name}"
+  throughput		  = 400
 }
 `, testAccAzureRMCosmosDBAccount_mongoDB(rInt, location), rInt)
 }

--- a/azurerm/resource_arm_cosmosdb_sql_container.go
+++ b/azurerm/resource_arm_cosmosdb_sql_container.go
@@ -17,8 +17,9 @@ import (
 
 func resourceArmCosmosDbSQLContainer() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmCosmosDbSQLContainerCreate,
+		Create: resourceArmCosmosDbSQLContainerCreateUpdate,
 		Read:   resourceArmCosmosDbSQLContainerRead,
+		Update: resourceArmCosmosDbSQLContainerCreateUpdate,
 		Delete: resourceArmCosmosDbSQLContainerDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -85,7 +86,7 @@ func resourceArmCosmosDbSQLContainer() *schema.Resource {
 	}
 }
 
-func resourceArmCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmCosmosDbSQLContainerCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Cosmos.DatabaseClient
 	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
 	defer cancel()

--- a/azurerm/resource_arm_cosmosdb_sql_container_test.go
+++ b/azurerm/resource_arm_cosmosdb_sql_container_test.go
@@ -72,16 +72,23 @@ func TestAccAzureRMCosmosDbSqlContainer_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccAzureRMCosmosDbSqlContainer_basic(ri, testLocation()),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testCheckAzureRMCosmosDbSqlContainerExists(resourceName),
-				),
-			},
-			{
-
 				Config: testAccAzureRMCosmosDbSqlContainer_complete(ri, testLocation()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testCheckAzureRMCosmosDbSqlContainerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "600"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_update(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "400"),
 				),
 			},
 			{
@@ -179,6 +186,26 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   unique_key {
 	paths = ["/definition/id1", "/definition/id2"]
   }
+  throughput = 600
+}
+
+`, testAccAzureRMCosmosDbSqlDatabase_basic(rInt, location), rInt)
+}
+
+func testAccAzureRMCosmosDbSqlContainer_update(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctest-CSQLC-%[2]d"
+  resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
+  account_name        = "${azurerm_cosmosdb_account.test.name}"
+  database_name       = "${azurerm_cosmosdb_sql_database.test.name}"
+  partition_key_path  = "/definition/id"
+  unique_key {
+	paths = ["/definition/id1", "/definition/id2"]
+  }
+  throughput = 400
 }
 
 `, testAccAzureRMCosmosDbSqlDatabase_basic(rInt, location), rInt)

--- a/azurerm/resource_arm_cosmosdb_sql_database.go
+++ b/azurerm/resource_arm_cosmosdb_sql_database.go
@@ -17,8 +17,9 @@ import (
 
 func resourceArmCosmosDbSQLDatabase() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmCosmosDbSQLDatabaseCreate,
+		Create: resourceArmCosmosDbSQLDatabaseCreateUpdate,
 		Read:   resourceArmCosmosDbSQLDatabaseRead,
+		Update: resourceArmCosmosDbSQLDatabaseCreateUpdate,
 		Delete: resourceArmCosmosDbSQLDatabaseDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -52,7 +53,7 @@ func resourceArmCosmosDbSQLDatabase() *schema.Resource {
 	}
 }
 
-func resourceArmCosmosDbSQLDatabaseCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmCosmosDbSQLDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Cosmos.DatabaseClient
 	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
 	defer cancel()

--- a/azurerm/resource_arm_cosmosdb_sql_database.go
+++ b/azurerm/resource_arm_cosmosdb_sql_database.go
@@ -41,6 +41,13 @@ func resourceArmCosmosDbSQLDatabase() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validate.CosmosAccountName,
 			},
+
+			"throughput": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      400,
+				ValidateFunc: validate.CosmosThroughput,
+			},
 		},
 	}
 }
@@ -53,6 +60,7 @@ func resourceArmCosmosDbSQLDatabaseCreate(d *schema.ResourceData, meta interface
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 	account := d.Get("account_name").(string)
+	throughput := d.Get("throughput").(int)
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.GetSQLDatabase(ctx, resourceGroup, account, name)
@@ -86,6 +94,23 @@ func resourceArmCosmosDbSQLDatabaseCreate(d *schema.ResourceData, meta interface
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting on create/update future for Cosmos SQL Database %s (Account %s): %+v", name, account, err)
+	}
+
+	throughputParameters := documentdb.ThroughputUpdateParameters{
+		ThroughputUpdateProperties: &documentdb.ThroughputUpdateProperties{
+			Resource: &documentdb.ThroughputResource{
+				Throughput: utils.Int32(int32(throughput)),
+			},
+		},
+	}
+
+	throughputFuture, err := client.UpdateSQLDatabaseThroughput(ctx, resourceGroup, account, name, throughputParameters)
+	if err != nil {
+		return fmt.Errorf("Error setting Throughput for Cosmos SQL Database %s (Account %s): %+v", name, account, err)
+	}
+
+	if err = throughputFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting on ThroughputUpdate future for Cosmos SQL Database %s (Account %s): %+v", name, account, err)
 	}
 
 	resp, err := client.GetSQLDatabase(ctx, resourceGroup, account, name)
@@ -127,6 +152,15 @@ func resourceArmCosmosDbSQLDatabaseRead(d *schema.ResourceData, meta interface{}
 	d.Set("account_name", id.Account)
 	if props := resp.SQLDatabaseProperties; props != nil {
 		d.Set("name", props.ID)
+	}
+
+	throughputResp, err := client.GetSQLDatabaseThroughput(ctx, id.ResourceGroup, id.Account, id.Database)
+	if err != nil {
+		return fmt.Errorf("Error reading Throughput on Cosmos SQL Database '%s' (Account %s) ID: %v", id.Database, id.Account, err)
+	}
+
+	if throughput := throughputResp.Throughput; throughput != nil {
+		d.Set("throughput", int(*throughput))
 	}
 
 	return nil

--- a/azurerm/resource_arm_cosmosdb_sql_database_test.go
+++ b/azurerm/resource_arm_cosmosdb_sql_database_test.go
@@ -36,6 +36,45 @@ func TestAccAzureRMCosmosDbSqlDatabase_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbSqlDatabase_update(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+	resourceName := "azurerm_cosmosdb_sql_database.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbSqlDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccAzureRMCosmosDbSqlDatabase_complete(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "600"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+
+				Config: testAccAzureRMCosmosDbSqlDatabase_update(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlDatabaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "400"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbSqlDatabaseDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).Cosmos.DatabaseClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -100,6 +139,32 @@ resource "azurerm_cosmosdb_sql_database" "test" {
   name                = "acctest-%[2]d"
   resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
   account_name        = "${azurerm_cosmosdb_account.test.name}"
+}
+`, testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.Eventual), "", ""), rInt)
+}
+
+func testAccAzureRMCosmosDbSqlDatabase_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
+  account_name        = "${azurerm_cosmosdb_account.test.name}"
+  throughput          = 600
+}
+`, testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.Eventual), "", ""), rInt)
+}
+
+func testAccAzureRMCosmosDbSqlDatabase_update(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
+  account_name        = "${azurerm_cosmosdb_account.test.name}"
+  throughput          = 400
 }
 `, testAccAzureRMCosmosDBAccount_basic(rInt, location, string(documentdb.Eventual), "", ""), rInt)
 }

--- a/azurerm/resource_arm_cosmosdb_table.go
+++ b/azurerm/resource_arm_cosmosdb_table.go
@@ -17,8 +17,9 @@ import (
 
 func resourceArmCosmosDbTable() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmCosmosDbTableCreate,
+		Create: resourceArmCosmosDbTableCreateUpdate,
 		Read:   resourceArmCosmosDbTableRead,
+		Update: resourceArmCosmosDbTableCreateUpdate,
 		Delete: resourceArmCosmosDbTableDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -52,7 +53,7 @@ func resourceArmCosmosDbTable() *schema.Resource {
 	}
 }
 
-func resourceArmCosmosDbTableCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmCosmosDbTableCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Cosmos.DatabaseClient
 	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
 	defer cancel()

--- a/azurerm/resource_arm_cosmosdb_table_test.go
+++ b/azurerm/resource_arm_cosmosdb_table_test.go
@@ -35,6 +35,45 @@ func TestAccAzureRMCosmosDbTable_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbTable_update(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+	resourceName := "azurerm_cosmosdb_table.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccAzureRMCosmosDbTable_complete(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "600"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+
+				Config: testAccAzureRMCosmosDbTable_update(ri, testLocation()),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbTableExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "400"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbTableDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).Cosmos.DatabaseClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -99,6 +138,32 @@ resource "azurerm_cosmosdb_table" "test" {
   name                = "acctest-%[2]d"
   resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
   account_name        = "${azurerm_cosmosdb_account.test.name}"
+}
+`, testAccAzureRMCosmosDBAccount_capabilityTable(rInt, location), rInt)
+}
+
+func testAccAzureRMCosmosDbTable_complete(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_table" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
+  account_name        = "${azurerm_cosmosdb_account.test.name}"
+  throughput		  = 600
+}
+`, testAccAzureRMCosmosDBAccount_capabilityTable(rInt, location), rInt)
+}
+
+func testAccAzureRMCosmosDbTable_update(rInt int, location string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_table" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = "${azurerm_cosmosdb_account.test.resource_group_name}"
+  account_name        = "${azurerm_cosmosdb_account.test.name}"
+  throughput		  = 400
 }
 `, testAccAzureRMCosmosDBAccount_capabilityTable(rInt, location), rInt)
 }

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -22,6 +22,7 @@ resource "azurerm_cosmosdb_cassandra_keyspace" "example" {
   name                = "tfex-cosmos-cassandra-keyspace"
   resource_group_name = "${data.azurerm_cosmosdb_account.example.resource_group_name}"
   account_name        = "${data.azurerm_cosmosdb_account.example.name}"
+  throughput          = 400
 }
 ```
 
@@ -34,6 +35,8 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB Cassandra KeySpace is created. Changing this forces a new resource to be created.
 
 * `account_name` - (Required) The name of the Cosmos DB Cassandra KeySpace to create the table within. Changing this forces a new resource to be created.
+
+* `throughput` - (Optional) The throughput of Cassandra keyspace (RU/s). Must be set in increments of `100`. The default and minimum value is `400`.
 
 
 ## Attributes Reference

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -22,6 +22,7 @@ resource "azurerm_cosmosdb_mongo_database" "example" {
   name                = "tfex-cosmos-mongo-db"
   resource_group_name = "${data.azurerm_cosmosdb_account.example.resource_group_name}"
   account_name        = "${data.azurerm_cosmosdb_account.example.name}"
+  throughput          = 400
 }
 ```
 
@@ -34,6 +35,8 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB Mongo Database is created. Changing this forces a new resource to be created.
 
 * `account_name` - (Required) The name of the Cosmos DB Mongo Database to create the table within. Changing this forces a new resource to be created.
+
+* `throughput` - (Optional) The throughput of MongoDB database (RU/s). Must be set in increments of `100`. The default and minimum value is `400`.
 
 
 ## Attributes Reference

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -20,6 +20,7 @@ resource "azurerm_cosmosdb_sql_container" "example" {
   account_name        = "${azurerm_cosmosdb_account.example.name}"
   database_name       = "${azurerm_cosmosdb_sql_database.example.name}"
   partition_key_path  = "/definition/id"
+  throughput          = 400
  
   unique_key {
     paths = ["/definition/idlong", "/definition/idshort"]
@@ -43,6 +44,8 @@ The following arguments are supported:
 * `partition_key_path` - (Optional) Define a partition key. Changing this forces a new resource to be created.
 
 * `unique_key` - (Optional) One or more `unique_key` blocks as defined below. Changing this forces a new resource to be created.
+
+* `throughput` - (Optional) The throughput of SQL container (RU/s). Must be set in increments of `100`. The default and minimum value is `400`.
 
 ---
 A `unique_key` block supports the following:

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -22,6 +22,7 @@ resource "azurerm_cosmosdb_sql_database" "example" {
   name                = "tfex-cosmos-mongo-db"
   resource_group_name = "${data.azurerm_cosmosdb_account.example.resource_group_name}"
   account_name        = "${data.azurerm_cosmosdb_account.example.name}"
+  throughput          = 400
 }
 ```
 
@@ -34,6 +35,8 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB SQL Database is created. Changing this forces a new resource to be created.
 
 * `account_name` - (Required) The name of the Cosmos DB SQL Database to create the table within. Changing this forces a new resource to be created.
+
+* `throughput` - (Optional) The throughput of SQL database (RU/s). Must be set in increments of `100`. The default and minimum value is `400`.
 
 
 ## Attributes Reference

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -22,6 +22,7 @@ resource "azurerm_cosmosdb_table" "example" {
   name                = "tfex-cosmos-table"
   resource_group_name = "${data.azurerm_cosmosdb_account.example.resource_group_name}"
   account_name        = "${data.azurerm_cosmosdb_account.example.name}"
+  throughput          = 400
 }
 ```
 
@@ -34,6 +35,8 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB Table is created. Changing this forces a new resource to be created.
 
 * `account_name` - (Required) The name of the Cosmos DB Table to create the table within. Changing this forces a new resource to be created.
+
+* `throughput` - (Optional) The throughput of Table (RU/s). Must be set in increments of `100`. The default and minimum value is `400`.
 
 
 ## Attributes Reference


### PR DESCRIPTION
As a follow up to #4467, this would add the ability to specify `throughput` on the remaining, supported CosmosDB resources. This would resolve #3623. 