### PR TITLE
alpha numeric characters only are allowed

### DIFF
--- a/examples/container-registry/main.tf
+++ b/examples/container-registry/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_container_registry" "example" {
-  name                = "${var.prefix}"
+  name                = "${var.prefix}registry"
   resource_group_name = "${azurerm_resource_group.example.name}"
   location            = "${azurerm_resource_group.example.location}"
   sku                 = "Standard"

--- a/examples/container-registry/main.tf
+++ b/examples/container-registry/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_container_registry" "example" {
-  name                = "${var.prefix}-registry"
+  name                = "${var.prefix}"
   resource_group_name = "${azurerm_resource_group.example.name}"
   location            = "${azurerm_resource_group.example.location}"
   sku                 = "Standard"


### PR DESCRIPTION
I've got an error running this example:

```
Error: alpha numeric characters only are allowed in "name": "ttiqtm-registry"

  on main.tf line 6, in resource "azurerm_container_registry" "example":
  6: resource "azurerm_container_registry" "example" {
```