### PR TITLE
r/azurerm_servicebus_namespace - Allowed setting messaging units capacity to 8 for Premium SKU

### DIFF
--- a/azurerm/resource_arm_servicebus_namespace.go
+++ b/azurerm/resource_arm_servicebus_namespace.go
@@ -77,7 +77,7 @@ func resourceArmServiceBusNamespace() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      0,
-				ValidateFunc: validate.IntInSlice([]int{0, 1, 2, 4}),
+				ValidateFunc: validate.IntInSlice([]int{0, 1, 2, 4, 8}),
 			},
 
 			"default_primary_connection_string": {
@@ -155,7 +155,7 @@ func resourceArmServiceBusNamespaceCreateUpdate(d *schema.ResourceData, meta int
 			return fmt.Errorf("Service Bus SKU %q only supports `capacity` of 0", sku)
 		}
 		if strings.EqualFold(sku, string(servicebus.Premium)) && capacity.(int) == 0 {
-			return fmt.Errorf("Service Bus SKU %q only supports `capacity` of 1, 2 or 4", sku)
+			return fmt.Errorf("Service Bus SKU %q only supports `capacity` of 1, 2, 4 or 8", sku)
 		}
 		parameters.Sku.Capacity = utils.Int32(int32(capacity.(int)))
 	}

--- a/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/azurerm/resource_arm_servicebus_namespace_test.go
@@ -175,7 +175,7 @@ func TestAccAzureRMServiceBusNamespace_premiumCapacity(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile("Service Bus SKU \"Premium\" only supports `capacity` of 1, 2 or 4"),
+				ExpectError: regexp.MustCompile("Service Bus SKU \"Premium\" only supports `capacity` of 1, 2, 4 or 8"),
 			},
 		},
 	})

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `sku` - (Required) Defines which tier to use. Options are basic, standard or premium.
 
-* `capacity` - (Optional) Specifies the capacity. When `sku` is `Premium` can be `1`, `2` or `4`. When `sku` is `Basic` or `Standard` can be `0` only.
+* `capacity` - (Optional) Specifies the capacity. When `sku` is `Premium`, capacity can be `1`, `2`, `4` or `8`. When `sku` is `Basic` or `Standard`, capacity can be `0` only.
 
 * `zone_redundant` - (Optional) Whether or not this resource is zone redundant. `sku` needs to be `Premium`. Defaults to `false`.
 


### PR DESCRIPTION
Allowed the `azurerm_servicebus_namespace` resource to support the capacity of 8 for the number of messaging units to be set when using the Premium SKU.

Microsoft documentation and the Azure Portal show the ability to set the capacity of the messaging units to 8:

![Screenshot 2019-10-16 at 09 23 14](https://user-images.githubusercontent.com/264361/66905082-146d9100-effd-11e9-9e2e-069eff7d61a5.png)

https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-premium-messaging

```
Service Bus Premium Messaging provides resource isolation at the CPU and memory level so that each customer workload runs in isolation. This resource container is called a messaging unit. Each premium namespace is allocated at least one messaging unit. You can purchase 1, 2, 4 or 8 messaging units for each Service Bus Premium namespace. A single workload or entity can span multiple messaging units and the number of messaging units can be changed at will. The result is predictable and repeatable performance for your Service Bus-based solution.
```

But the provider fails with the following error when you attempt to set `capacity = 8`:

```
Error: module.mod_sbp.module.serviceBus.azurerm_servicebus_namespace.servicebusNameSpace: expected "capacity" to be one of [0 1 2 4], got 8
```

This change solves this limitation.

Example plan:

```
 + azurerm_servicebus_namespace.servicebusNameSpace
      id:                                      <computed>
      capacity:                                "8"
      default_primary_connection_string:       <computed>
      default_primary_key:                     <computed>
      default_secondary_connection_string:     <computed>
      default_secondary_key:                   <computed>
      location:                                "northeurope"
      name:                                    "testenv01sbp"
      resource_group_name:                     "testenv01sbp-rg"
      sku:                                     "premium"
      tags.%:                                  <computed>
```

Apply output:

```
azurerm_resource_group.resourceGroup: Creating...
  location:          "" => "northeurope"
  name:              "" => "testenv01sbp-rg"
  tags.%:            "" => "5"
  tags.client:       "" => "tst"
  tags.dc:           "" => "en1"
  tags.environment:  "" => "env01"
  tags.resource_cat: "" => "messaging"
  tags.tier:         "" => "messaging"
azurerm_resource_group.resourceGroup: Creation complete after 1s (ID: /subscriptions/00000000-0000-0000-0000-...000000/resourceGroups/testenv01sbp-rg)
azurerm_servicebus_namespace.servicebusNameSpace: Creating...
  capacity:                            "" => "8"
  default_primary_connection_string:   "<sensitive>" => "<sensitive>"
  default_primary_key:                 "<sensitive>" => "<sensitive>"
  default_secondary_connection_string: "<sensitive>" => "<sensitive>"
  default_secondary_key:               "<sensitive>" => "<sensitive>"
  location:                            "" => "northeurope"
  name:                                "" => "testenv01sbp"
  resource_group_name:                 "" => "testenv01sbp-rg"
  sku:                                 "" => "premium"
  tags.%:                              "" => "<computed>"
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (10s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (20s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (30s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (40s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (50s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (1m0s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (1m10s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (1m20s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (1m30s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (1m40s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (1m50s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Still creating... (2m0s elapsed)
azurerm_servicebus_namespace.servicebusNameSpace: Creation complete after 2m6s (ID: /subscriptions/00000000-0000-0000-0000-...ft.ServiceBus/namespaces/testenv01sbp)
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```