### PR TITLE
Removing lowercasing protocol to avoid changins at plans againsts loa…

### DIFF
--- a/azurerm/resource_arm_loadbalancer_probe.go
+++ b/azurerm/resource_arm_loadbalancer_probe.go
@@ -14,7 +14,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/state"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -59,7 +58,6 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 				Type:             schema.TypeString,
 				Computed:         true,
 				Optional:         true,
-				StateFunc:        state.IgnoreCase,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(network.ProbeProtocolHTTP),

--- a/azurerm/resource_arm_loadbalancer_rule.go
+++ b/azurerm/resource_arm_loadbalancer_rule.go
@@ -15,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/state"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -77,7 +76,6 @@ func resourceArmLoadBalancerRule() *schema.Resource {
 			"protocol": {
 				Type:             schema.TypeString,
 				Required:         true,
-				StateFunc:        state.IgnoreCase,
 				DiffSuppressFunc: suppress.CaseDifference,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(network.TransportProtocolAll),


### PR DESCRIPTION
Removing lowercasing protocol function to avoid changes at plans against load balancer rules and probes

This sorts out two diff issues:
resource_arm_loadbalancer_probe

```        Terraform Version: 0.11.14
    Resource ID: azurerm_lb_probe.probe.2
    Mismatch reason: attribute mismatch: protocol
    Diff One (usually from plan): *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{"protocol":*terraform.ResourceAttrDiff{Old:"Tcp", New:"tcp", NewComputed:false, NewRemoved:false, NewExtra:"tcp", RequiresNew:false, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}
    Diff Two (usually from apply): *terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff(nil), Destroy:false, DestroyDeposed:false, DestroyTainted:false, Meta:map[string]interface {}(nil)}

Also include as much context as you can about your config, state, and the steps you performed to trigger this error.
```

and 

resource_arm_loadbalancer_rule
```
  ~ azurerm_lb_probe.probe[2]
      protocol:                                                  "Tcp" => "tcp"
....
```