### PR TITLE
[azurerm_key_vault_certificate] - switches the `emails`, `dns_names `, `upns` of the `subject_alternative_names` property to use `TypeSet`

### DIFF
--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -281,7 +281,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"emails": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													ForceNew: true,
 													Elem: &schema.Schema{
@@ -289,7 +289,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 													},
 												},
 												"dns_names": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													ForceNew: true,
 													Elem: &schema.Schema{
@@ -297,7 +297,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 													},
 												},
 												"upns": {
-													Type:     schema.TypeList,
+													Type:     schema.TypeSet,
 													Optional: true,
 													ForceNew: true,
 													Elem: &schema.Schema{

--- a/azurerm/resource_arm_key_vault_certificate.go
+++ b/azurerm/resource_arm_key_vault_certificate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/set"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
@@ -287,6 +288,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 													Elem: &schema.Schema{
 														Type: schema.TypeString,
 													},
+													Set: schema.HashString,
 												},
 												"dns_names": {
 													Type:     schema.TypeSet,
@@ -295,6 +297,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 													Elem: &schema.Schema{
 														Type: schema.TypeString,
 													},
+													Set: schema.HashString,
 												},
 												"upns": {
 													Type:     schema.TypeSet,
@@ -303,6 +306,7 @@ func resourceArmKeyVaultCertificate() *schema.Resource {
 													Elem: &schema.Schema{
 														Type: schema.TypeString,
 													},
+													Set: schema.HashString,
 												},
 											},
 										},
@@ -639,17 +643,17 @@ func expandKeyVaultCertificatePolicy(d *schema.ResourceData) keyvault.Certificat
 				if sans[0] != nil {
 					san := sans[0].(map[string]interface{})
 
-					emails := san["emails"].([]interface{})
+					emails := san["emails"].(*schema.Set).List()
 					if len(emails) > 0 {
 						subjectAlternativeNames.Emails = utils.ExpandStringSlice(emails)
 					}
 
-					dnsNames := san["dns_names"].([]interface{})
+					dnsNames := san["dns_names"].(*schema.Set).List()
 					if len(dnsNames) > 0 {
 						subjectAlternativeNames.DNSNames = utils.ExpandStringSlice(dnsNames)
 					}
 
-					upns := san["upns"].([]interface{})
+					upns := san["upns"].(*schema.Set).List()
 					if len(upns) > 0 {
 						subjectAlternativeNames.Upns = utils.ExpandStringSlice(upns)
 					}
@@ -737,10 +741,15 @@ func flattenKeyVaultCertificatePolicy(input *keyvault.CertificatePolicy) []inter
 		sanOutputs := make([]interface{}, 0)
 		if san := props.SubjectAlternativeNames; san != nil {
 			sanOutput := make(map[string]interface{})
-
-			sanOutput["emails"] = utils.FlattenStringSlice(san.Emails)
-			sanOutput["dns_names"] = utils.FlattenStringSlice(san.DNSNames)
-			sanOutput["upns"] = utils.FlattenStringSlice(san.Upns)
+			if emails := san.Emails; emails != nil {
+				sanOutput["emails"] = set.FromStringSlice(*emails)
+			}
+			if dnsNames := san.DNSNames; dnsNames != nil {
+				sanOutput["dns_names"] = set.FromStringSlice(*dnsNames)
+			}
+			if upns := san.Upns; upns != nil {
+				sanOutput["upns"] = set.FromStringSlice(*upns)
+			}
 
 			sanOutputs = append(sanOutputs, sanOutput)
 		}

--- a/azurerm/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/resource_arm_key_vault_certificate_test.go
@@ -183,9 +183,9 @@ func TestAccAzureRMKeyVaultCertificate_basicGenerateSans(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKeyVaultCertificateExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_data"),
-					resource.TestCheckResourceAttr(resourceName, "certificate_policy.0.x509_certificate_properties.0.subject_alternative_names.0.emails.0", "mary@stu.co.uk"),
-					resource.TestCheckResourceAttr(resourceName, "certificate_policy.0.x509_certificate_properties.0.subject_alternative_names.0.dns_names.0", "internal.contoso.com"),
-					resource.TestCheckResourceAttr(resourceName, "certificate_policy.0.x509_certificate_properties.0.subject_alternative_names.0.upns.0", "john@doe.com"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_policy.0.x509_certificate_properties.0.subject_alternative_names.0.emails.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_policy.0.x509_certificate_properties.0.subject_alternative_names.0.dns_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "certificate_policy.0.x509_certificate_properties.0.subject_alternative_names.0.upns.#", "1"),
 				),
 			},
 		},


### PR DESCRIPTION
I noticed when importing an existing certificate these properties did not come back in the same order as the configuration, so Terraform wanted to recreate the certificate.