### PR TITLE
Create generic RFC3986 attribute validation rule

### DIFF
--- a/azurerm/helpers/validate/rfc3986.go
+++ b/azurerm/helpers/validate/rfc3986.go
@@ -1,0 +1,37 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// GenericRFC3986Compliance - This validation rule is to act as a general minimum bar that
+// all azure resource names should meet instead of falling back to just NoEmptyStrings
+// if they do not have any known validation rules.
+func GenericRFC3986Compliance(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return warnings, errors
+	}
+
+	// The minimum generic rules are:
+	// 1. Must not be empty.
+	// 2. Must be between 1 and 80 characters.
+	// 3. The attribute must:
+	//    a) begin with a letter or number
+	//    b) end with a letter, number or underscore
+	//    c) may contain only letters, numbers, underscores, periods, or hyphens.
+
+	if len(v) == 1 {
+		if matched := regexp.MustCompile(`^([a-zA-Z\d])`).Match([]byte(v)); !matched {
+			errors = append(errors, fmt.Errorf("%s must begin with a letter or number", k))
+		}
+	} else {
+		if matched := regexp.MustCompile(`^([a-zA-Z\d])([a-zA-Z\d-\_\.]{0,78})([a-zA-Z\d\_])$`).Match([]byte(v)); !matched {
+			errors = append(errors, fmt.Errorf("%s must be between 1 - 80 characters long, begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens", k))
+		}
+	}
+
+	return warnings, errors
+}

--- a/azurerm/helpers/validate/rfc3986_test.go
+++ b/azurerm/helpers/validate/rfc3986_test.go
@@ -1,0 +1,77 @@
+package validate
+
+import "testing"
+
+func TestValidateRFC3986Attribute(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected bool
+	}{
+		{
+			Input:    "",
+			Expected: false,
+		},
+		{
+			Input:    "_",
+			Expected: false,
+		},
+		{
+			Input:    "?#$~()*&^%[]/<>",
+			Expected: false,
+		},
+		{
+			Input:    "a",
+			Expected: true,
+		},
+		{
+			Input:    "A",
+			Expected: true,
+		},
+		{
+			Input:    "123-abc",
+			Expected: true,
+		},
+		{
+			Input:    "a-",
+			Expected: false,
+		},
+		{
+			Input:    "-",
+			Expected: false,
+		},
+		{
+			Input:    "a.-_",
+			Expected: true,
+		},
+		{
+			Input:    "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+			Expected: true,
+		},
+		{
+			Input:    "12345678901234567890123456789012345678901234567890123456789012345678901234567890_",
+			Expected: false,
+		},
+		{
+			Input:    "aA_-.1",
+			Expected: true,
+		},
+		{
+			Input:    "a _",
+			Expected: false,
+		},
+	}
+
+	for _, v := range testCases {
+		t.Logf("[DEBUG] Test Input %q", v.Input)
+
+		warnings, errors := GenericRFC3986Compliance(v.Input, "RFC3986Attribute")
+		if len(warnings) != 0 {
+			t.Fatalf("Expected no warnings but got %d", len(warnings))
+		}
+
+		result := len(errors) == 0
+		if result != v.Expected {
+			t.Fatalf("Expected the result to be %t but got %t (and %d errors)", v.Expected, result, len(errors))
+		}
+	}
+}


### PR DESCRIPTION
Address lack of validation for many Azure attributes. This validation rule is to act as a general/generic minimum bar that all azure resource names/attributes should meet instead of falling back to just `NoEmptyStrings` if they do not have any known validation rules.