### PR TITLE
Fix #4560: Removes ForceNew on agent_pool_profile

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -112,14 +112,12 @@ func resourceArmKubernetesCluster() *schema.Resource {
 						"name": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validate.KubernetesAgentPoolName,
 						},
 
 						"type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 							Default:  string(containerservice.AvailabilitySet),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(containerservice.AvailabilitySet),
@@ -175,7 +173,6 @@ func resourceArmKubernetesCluster() *schema.Resource {
 						"vm_size": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ForceNew:         true,
 							DiffSuppressFunc: suppress.CaseDifference,
 							ValidateFunc:     validate.NoEmptyStrings,
 						},
@@ -183,7 +180,6 @@ func resourceArmKubernetesCluster() *schema.Resource {
 						"os_disk_size_gb": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ForceNew:     true,
 							Computed:     true,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
@@ -191,14 +187,12 @@ func resourceArmKubernetesCluster() *schema.Resource {
 						"vnet_subnet_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
 							ValidateFunc: azure.ValidateResourceID,
 						},
 
 						"os_type": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 							Default:  string(containerservice.Linux),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(containerservice.Linux),
@@ -211,7 +205,6 @@ func resourceArmKubernetesCluster() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
-							ForceNew: true,
 						},
 
 						"node_taints": {


### PR DESCRIPTION
With this change, if you add a new "agent_pool_profile" block, it successfully creates the new "agent_pool_profile" without force creating a new cluster.

It's important to note, by removing the `ForceNew` elements from the "agent_pool_profile" schema, a new behavior is introduced.

Given a configuration that looks like this:
```hcl
variable "agent_pools" {
  type = list(object({
    count           = number,
    name            = string,
    os_disk_size_gb = number,
    os_type         = string,
    vm_size         = string,
  }))
  default = [
    {
      count           = 1,
      name            = "nodepool1",
      os_disk_size_gb = 30,
      os_type         = "Linux",
      vm_size         = "Standard_B2s",
    },
    {
        count           = 1
        name            = "nodepool2"
        os_disk_size_gb = 30
        os_type         = "Linux"
        vm_size         = "Standard_F2",
    },
  ]
}

resource "azurerm_kubernetes_cluster" "cluster" {

  // Other required fields skipped for brevity

  dynamic "agent_pool_profile" {
    for_each = var.agent_pools
    content {
      count           = agent_pool_profile.value.count
      name            = agent_pool_profile.value.name
      vm_size         = agent_pool_profile.value.vm_size # az vm list-sizes --location centralus
      os_type         = agent_pool_profile.value.os_type
      os_disk_size_gb = agent_pool_profile.value.os_disk_size_gb
    }
  }
}
```

The `terraform apply` is successful, but if you choose to swap your list around such that `nodepool2` comes before `nodepool1`:
```hcl
variable "agent_pools" {
  type = list(object({
    count           = number,
    name            = string,
    os_disk_size_gb = number,
    os_type         = string,
    vm_size         = string,
  }))
  default = [
    {
        count           = 1
        name            = "nodepool2"
        os_disk_size_gb = 30
        os_type         = "Linux"
        vm_size         = "Standard_F2",
    },
    {
      count           = 1,
      name            = "nodepool1",
      os_disk_size_gb = 30,
      os_type         = "Linux",
      vm_size         = "Standard_B2s",
    },
  ]
}
```

Subsequent `terraform plan`s work as expected, but you can't `terraform apply`, because the request that is sent to the Azure RM is to update the agent pool profile with a name that already exists. All agent pool profile names *must* be unique.

```hcl
      ~ agent_pool_profile {
            availability_zones  = []
            count               = 1
            enable_auto_scaling = false
            max_count           = 0
            max_pods            = 110
            min_count           = 0
          ~ name                = "nodepool1" -> "nodepool2"
            node_taints         = []
            os_disk_size_gb     = 30
            os_type             = "Linux"
            type                = "AvailabilitySet"
            vm_size             = "Standard_B2s"
        }
      ~ agent_pool_profile {
            availability_zones  = []
            count               = 1
            enable_auto_scaling = false
            max_count           = 0
            max_pods            = 110
            min_count           = 0
          ~ name                = "nodepool2" -> "nodepool1"
            node_taints         = []
            os_disk_size_gb     = 30
            os_type             = "Linux"
            type                = "AvailabilitySet"
            vm_size             = "Standard_B2s"
        }
```

For my use case, it's far more practical to deal with this behavior than it is to create a new cluster every time a new agent pool profile is added to my config. This said, if someone knows an obvious fix, I'm happy to implement it.

Thank you for your review 🙏