### PR TITLE
Check if new resource before import check

### DIFF
--- a/azurerm/automation_variable.go
+++ b/azurerm/automation_variable.go
@@ -132,7 +132,7 @@ func resourceAutomationVariableCreateUpdate(d *schema.ResourceData, meta interfa
 	accountName := d.Get("automation_account_name").(string)
 	varTypeLower := strings.ToLower(varType)
 
-	if features.ShouldResourcesBeImported() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		resp, err := client.Get(ctx, resourceGroup, accountName, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {

--- a/azurerm/resource_arm_api_management_certificate.go
+++ b/azurerm/resource_arm_api_management_certificate.go
@@ -81,7 +81,7 @@ func resourceArmApiManagementCertificateCreateUpdate(d *schema.ResourceData, met
 	data := d.Get("data").(string)
 	password := d.Get("password").(string)
 
-	if features.ShouldResourcesBeImported() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, serviceName, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_api_management_subscription.go
+++ b/azurerm/resource_arm_api_management_subscription.go
@@ -100,7 +100,7 @@ func resourceArmApiManagementSubscriptionCreateUpdate(d *schema.ResourceData, me
 		subscriptionId = uuid.NewV4().String()
 	}
 
-	if features.ShouldResourcesBeImported() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		resp, err := client.Get(ctx, resourceGroup, serviceName, subscriptionId)
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {

--- a/azurerm/resource_arm_front_door.go
+++ b/azurerm/resource_arm_front_door.go
@@ -453,7 +453,7 @@ func resourceArmFrontDoorCreateUpdate(d *schema.ResourceData, meta interface{}) 
 	resourceGroup := d.Get("resource_group_name").(string)
 	subscriptionId := meta.(*ArmClient).subscriptionId
 
-	if features.ShouldResourcesBeImported() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		resp, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {

--- a/azurerm/resource_arm_front_door_firewall_policy.go
+++ b/azurerm/resource_arm_front_door_firewall_policy.go
@@ -321,7 +321,7 @@ func resourceArmFrontDoorFirewallPolicyCreateUpdate(d *schema.ResourceData, meta
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	if features.ShouldResourcesBeImported() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_storage_table_entity.go
+++ b/azurerm/resource_arm_storage_table_entity.go
@@ -97,7 +97,7 @@ func resourceArmStorageTableEntityCreateUpdate(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error building Entity Client: %s", err)
 	}
 
-	if features.ShouldResourcesBeImported() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		input := entities.GetEntityInput{
 			PartitionKey:  partitionKey,
 			RowKey:        rowKey,


### PR DESCRIPTION
I've been testing the upcoming require imports change for 2.0 and found an issue when updating API management certificates - looking at the code there are a few resources that share a create/update method that weren't checking for `IsNewResource` before the import check