### PR TITLE
New Resource: `azurerm_virtual_machine_scale_set_extension`

### DIFF
--- a/azurerm/internal/clients/compute.go
+++ b/azurerm/internal/clients/compute.go
@@ -20,6 +20,7 @@ type ComputeClient struct {
 	VMExtensionImageClient         *compute.VirtualMachineExtensionImagesClient
 	VMExtensionClient              *compute.VirtualMachineExtensionsClient
 	VMScaleSetClient               *compute.VirtualMachineScaleSetsClient
+	VMScaleSetExtensionsClient     *compute.VirtualMachineScaleSetExtensionsClient
 	VMScaleSetVMsClient            *compute.VirtualMachineScaleSetVMsClient
 	VMClient                       *compute.VirtualMachinesClient
 	VMImageClient                  *compute.VirtualMachineImagesClient
@@ -68,6 +69,9 @@ func NewComputeClient(o *common.ClientOptions) *ComputeClient {
 	vmScaleSetClient := compute.NewVirtualMachineScaleSetsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vmScaleSetClient.Client, o.ResourceManagerAuthorizer)
 
+	vmScaleSetExtensionsClient := compute.NewVirtualMachineScaleSetExtensionsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&vmScaleSetExtensionsClient.Client, o.ResourceManagerAuthorizer)
+
 	vmScaleSetVMsClient := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vmScaleSetVMsClient.Client, o.ResourceManagerAuthorizer)
 
@@ -88,6 +92,7 @@ func NewComputeClient(o *common.ClientOptions) *ComputeClient {
 		VMExtensionImageClient:         &vmExtensionImageClient,
 		VMExtensionClient:              &vmExtensionClient,
 		VMScaleSetClient:               &vmScaleSetClient,
+		VMScaleSetExtensionsClient:     &vmScaleSetExtensionsClient,
 		VMScaleSetVMsClient:            &vmScaleSetVMsClient,
 		VMClient:                       &vmClient,
 		VMImageClient:                  &vmImageClient,

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -14,6 +14,27 @@ func ValidateWindowsName(i interface{}, k string) (warnings []string, errors []e
 	return validateName(16)(i, k)
 }
 
+func ValidateScaleSetResourceID(i interface{}, k string) (s []string, es []error) {
+	v, ok := i.(string)
+	if !ok {
+		es = append(es, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	id, err := ParseVirtualMachineScaleSetResourceID(v)
+	if err != nil {
+		es = append(es, fmt.Errorf("Error parsing %q as a VM Scale Set Resource ID: %s", v, err))
+		return
+	}
+
+	if id.Name == "" {
+		es = append(es, fmt.Errorf("Error parsing %q as a VM Scale Set Resource ID: `virtualMachineScaleSets` segment was empty", v))
+		return
+	}
+
+	return
+}
+
 func validateName(maxLength int) func(i interface{}, k string) (warnings []string, errors []error) {
 	return func(i interface{}, k string) (warnings []string, errors []error) {
 		v, ok := i.(string)

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -23,16 +23,16 @@ func ParseVirtualMachineScaleSetResourceID(input string) (*VirtualMachineScaleSe
 		return nil, fmt.Errorf("[ERROR] Unable to parse Virtual Machine Scale Set ID %q: %+v", input, err)
 	}
 
-	networkSecurityGroup := VirtualMachineScaleSetResourceID{
+	vmScaleSet := VirtualMachineScaleSetResourceID{
 		Base: *id,
 		Name: id.Path["virtualMachineScaleSets"],
 	}
 
-	if networkSecurityGroup.Name == "" {
+	if vmScaleSet.Name == "" {
 		return nil, fmt.Errorf("ID was missing the `virtualMachineScaleSets` element")
 	}
 
-	return &networkSecurityGroup, nil
+	return &vmScaleSet, nil
 }
 
 func VirtualMachineScaleSetAdditionalCapabilitiesSchema() *schema.Schema {

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_extension.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_extension.go
@@ -1,0 +1,37 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type VirtualMachineScaleSetExtensionResourceID struct {
+	Base azure.ResourceID
+
+	VirtualMachineName string
+	Name               string
+}
+
+func ParseVirtualMachineScaleSetExtensionResourceID(input string) (*VirtualMachineScaleSetExtensionResourceID, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Virtual Machine Scale Set Extension ID %q: %+v", input, err)
+	}
+
+	extension := VirtualMachineScaleSetExtensionResourceID{
+		Base:               *id,
+		VirtualMachineName: id.Path["virtualMachineScaleSets"],
+		Name:               id.Path["extensions"],
+	}
+
+	if extension.VirtualMachineName == "" {
+		return nil, fmt.Errorf("ID was missing the `virtualMachineScaleSets` element")
+	}
+
+	if extension.Name == "" {
+		return nil, fmt.Errorf("ID was missing the `extensions` element")
+	}
+
+	return &extension, nil
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -462,6 +462,7 @@ func Provider() terraform.ResourceProvider {
 	// 2.0 resources
 	if features.SupportsTwoPointZeroResources() {
 		resources["azurerm_linux_virtual_machine_scale_set"] = resourceArmLinuxVirtualMachineScaleSet()
+		resources["azurerm_virtual_machine_scale_set_extension"] = resourceArmVirtualMachineScaleSetExtension()
 		resources["azurerm_windows_virtual_machine_scale_set"] = resourceArmWindowsVirtualMachineScaleSet()
 	}
 

--- a/azurerm/resource_arm_virtual_machine_extension.go
+++ b/azurerm/resource_arm_virtual_machine_extension.go
@@ -40,10 +40,9 @@ func resourceArmVirtualMachineExtensions() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": azure.SchemaLocation(),
-
+			// TODO: deprecate these 2/3 in favour of pulling it from the VMSS
+			"location":            azure.SchemaLocation(),
 			"resource_group_name": azure.SchemaResourceGroupName(),
-
 			"virtual_machine_name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/azurerm/resource_arm_virtual_machine_scale_set_extension.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_extension.go
@@ -1,0 +1,357 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	computeSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+// NOTE (also in the docs): this is not intended to be used with the `azurerm_virtual_machine_scale_set` resource
+
+func resourceArmVirtualMachineScaleSetExtension() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmVirtualMachineScaleSetExtensionCreate,
+		Read:   resourceArmVirtualMachineScaleSetExtensionRead,
+		Update: resourceArmVirtualMachineScaleSetExtensionUpdate,
+		Delete: resourceArmVirtualMachineScaleSetExtensionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"virtual_machine_scale_set_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: computeSvc.ValidateScaleSetResourceID,
+			},
+
+			"publisher": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"type_handler_version": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"auto_upgrade_minor_version": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"force_update_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"protected_settings": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Sensitive:        true,
+				ValidateFunc:     validation.ValidateJsonString,
+				DiffSuppressFunc: structure.SuppressJsonDiff,
+			},
+
+			"provision_after_extensions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"settings": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.ValidateJsonString,
+				DiffSuppressFunc: structure.SuppressJsonDiff,
+			},
+		},
+	}
+}
+
+func resourceArmVirtualMachineScaleSetExtensionCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).Compute.VMScaleSetExtensionsClient
+	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Get("virtual_machine_scale_set_id").(string))
+	if err != nil {
+		return err
+	}
+	resourceGroup := virtualMachineScaleSetId.Base.ResourceGroup
+	vmssName := virtualMachineScaleSetId.Name
+
+	if features.ShouldResourcesBeImported() {
+		resp, err := client.Get(ctx, resourceGroup, vmssName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Error checking for existing Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", name, vmssName, resourceGroup, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return tf.ImportAsExistsError("azurerm_linux_virtual_machine_scale_set", *resp.ID)
+		}
+	}
+
+	settings := map[string]interface{}{}
+	if settingsString := d.Get("settings").(string); settingsString != "" {
+		s, err := structure.ExpandJsonFromString(settingsString)
+		if err != nil {
+			return fmt.Errorf("unable to parse `settings`: %s", err)
+		}
+		settings = s
+	}
+
+	provisionAfterExtensionsRaw := d.Get("provision_after_extensions").([]interface{})
+	provisionAfterExtensions := utils.ExpandStringSlice(provisionAfterExtensionsRaw)
+
+	protectedSettings := map[string]interface{}{}
+	if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
+		ps, err := structure.ExpandJsonFromString(protectedSettingsString)
+		if err != nil {
+			return fmt.Errorf("unable to parse `protected_settings`: %s", err)
+		}
+		protectedSettings = ps
+	}
+
+	props := compute.VirtualMachineScaleSetExtension{
+		Name: utils.String(name),
+		VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
+			Publisher:                utils.String(d.Get("publisher").(string)),
+			Type:                     utils.String(d.Get("type").(string)),
+			TypeHandlerVersion:       utils.String(d.Get("type_handler_version").(string)),
+			AutoUpgradeMinorVersion:  utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
+			ProtectedSettings:        protectedSettings,
+			ProvisionAfterExtensions: provisionAfterExtensions,
+			Settings:                 settings,
+		},
+	}
+	if v, ok := d.GetOk("force_update_tag"); ok {
+		props.VirtualMachineScaleSetExtensionProperties.ForceUpdateTag = utils.String(v.(string))
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, vmssName, name, props)
+	if err != nil {
+		return fmt.Errorf("Error creating Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", name, vmssName, resourceGroup, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for creation of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", name, vmssName, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, vmssName, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", name, vmssName, resourceGroup, err)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmVirtualMachineScaleSetExtensionRead(d, meta)
+}
+
+func resourceArmVirtualMachineScaleSetExtensionUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).Compute.VMScaleSetExtensionsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	props := compute.VirtualMachineScaleSetExtensionProperties{
+		// if this isn't specified it defaults to false
+		AutoUpgradeMinorVersion: utils.Bool(d.Get("auto_upgrade_minor_version").(bool)),
+	}
+
+	if d.HasChange("force_update_tag") {
+		props.ForceUpdateTag = utils.String(d.Get("force_update_tag").(string))
+	}
+
+	if d.HasChange("protected_settings") {
+		protectedSettings := map[string]interface{}{}
+		if protectedSettingsString := d.Get("protected_settings").(string); protectedSettingsString != "" {
+			ps, err := structure.ExpandJsonFromString(protectedSettingsString)
+			if err != nil {
+				return fmt.Errorf("unable to parse `protected_settings`: %s", err)
+			}
+			protectedSettings = ps
+		}
+
+		props.ProtectedSettings = protectedSettings
+	}
+
+	if d.HasChange("provision_after_extensions") {
+		provisionAfterExtensionsRaw := d.Get("provision_after_extensions").([]interface{})
+		props.ProvisionAfterExtensions = utils.ExpandStringSlice(provisionAfterExtensionsRaw)
+	}
+
+	if d.HasChange("publisher") {
+		props.Publisher = utils.String(d.Get("publisher").(string))
+	}
+
+	if d.HasChange("settings") {
+		settings := map[string]interface{}{}
+
+		if settingsString := d.Get("settings").(string); settingsString != "" {
+			s, err := structure.ExpandJsonFromString(settingsString)
+			if err != nil {
+				return fmt.Errorf("unable to parse `settings`: %s", err)
+			}
+			settings = s
+		}
+
+		props.Settings = settings
+	}
+
+	if d.HasChange("type") {
+		props.Type = utils.String(d.Get("type").(string))
+	}
+
+	if d.HasChange("type_handler_version") {
+		props.TypeHandlerVersion = utils.String(d.Get("type_handler_version").(string))
+	}
+
+	extension := compute.VirtualMachineScaleSetExtension{
+		Name: utils.String(id.Name),
+		VirtualMachineScaleSetExtensionProperties: &props,
+	}
+	future, err := client.CreateOrUpdate(ctx, id.Base.ResourceGroup, id.VirtualMachineName, id.Name, extension)
+	if err != nil {
+		return fmt.Errorf("Error updating Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for update of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+	}
+
+	return resourceArmVirtualMachineScaleSetExtensionRead(d, meta)
+}
+
+func resourceArmVirtualMachineScaleSetExtensionRead(d *schema.ResourceData, meta interface{}) error {
+	vmssClient := meta.(*ArmClient).Compute.VMScaleSetClient
+	client := meta.(*ArmClient).Compute.VMScaleSetExtensionsClient
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	vmss, err := vmssClient.Get(ctx, id.Base.ResourceGroup, id.VirtualMachineName)
+	if err != nil {
+		if utils.ResponseWasNotFound(vmss.Response) {
+			log.Printf("Virtual Machine Scale Set %q was not found in Resource Group %q - removing Extension from state!", id.VirtualMachineName, id.Base.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Virtual Machine Scale Set %q (Resource Group %q): %+v", id.VirtualMachineName, id.Base.ResourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, id.Base.ResourceGroup, id.VirtualMachineName, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("Extension %q (Virtual Machine Scale Set %q / Resource Group %q) was not found - removing from state!", id.Name, id.VirtualMachineName, id.Base.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("virtual_machine_scale_set_id", vmss.ID)
+
+	if props := resp.VirtualMachineScaleSetExtensionProperties; props != nil {
+		d.Set("auto_upgrade_minor_version", props.AutoUpgradeMinorVersion)
+		d.Set("force_update_tag", props.ForceUpdateTag)
+		d.Set("provision_after_extensions", utils.FlattenStringSlice(props.ProvisionAfterExtensions))
+		d.Set("publisher", props.Publisher)
+		d.Set("type", props.Type)
+		d.Set("type_handler_version", props.TypeHandlerVersion)
+
+		settings := ""
+		if props.Settings != nil {
+			settingsVal, ok := props.Settings.(map[string]interface{})
+			if ok {
+				settingsJson, err := structure.FlattenJsonToString(settingsVal)
+				if err != nil {
+					return fmt.Errorf("unable to parse settings from response: %s", err)
+				}
+				settings = settingsJson
+			}
+		}
+		d.Set("settings", settings)
+	}
+
+	return nil
+}
+
+func resourceArmVirtualMachineScaleSetExtensionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).Compute.VMScaleSetExtensionsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	future, err := client.Delete(ctx, id.Base.ResourceGroup, id.VirtualMachineName, id.Name)
+	if err != nil {
+		if response.WasNotFound(future.Response()) {
+			return nil
+		}
+
+		return fmt.Errorf("Error deleting Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for deletion of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_virtual_machine_scale_set_extension_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_extension_test.go
@@ -1,0 +1,619 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	computeSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute"
+)
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_basicLinux(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_basicLinux(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_basicWindows(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(4)
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_basicWindows(ri, rs, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_basicLinux(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMVirtualMachineScaleSetExtension_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_virtual_machine_scale_set_extension"),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_autoUpgradeDisabled(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_autoUpgradeDisabled(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_extensionChaining(t *testing.T) {
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_extensionChaining(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists("azurerm_virtual_machine_scale_set_extension.first"),
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists("azurerm_virtual_machine_scale_set_extension.second"),
+				),
+			},
+			{
+				ResourceName:      "azurerm_virtual_machine_scale_set_extension.first",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "azurerm_virtual_machine_scale_set_extension.second",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_forceUpdateTag(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_forceUpdateTag(ri, location, "first"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_forceUpdateTag(ri, location, "second"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_protectedSettings(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_protectedSettings(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"protected_settings"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_protectedSettingsOnly(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_protectedSettingsOnly(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"protected_settings"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSetExtension_updateVersion(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set_extension.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				// old version
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_updateVersion(ri, location, "1.2"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAzureRMVirtualMachineScaleSetExtension_updateVersion(ri, location, "1.3"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		client := testAccProvider.Meta().(*ArmClient).Compute.VMScaleSetExtensionsClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		name := rs.Primary.Attributes["name"]
+		virtualMachineScaleSetIdRaw := rs.Primary.Attributes["virtual_machine_scale_set_id"]
+		virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetResourceID(virtualMachineScaleSetIdRaw)
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Get(ctx, virtualMachineScaleSetId.Base.ResourceGroup, virtualMachineScaleSetId.Name, name, "")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on vmScaleSetClient: %+v", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Extension %q (VirtualMachineScaleSet %q / Resource Group: %q) does not exist", name, virtualMachineScaleSetId.Name, virtualMachineScaleSetId.Base.ResourceGroup)
+		}
+
+		return err
+	}
+}
+
+func testCheckAzureRMVirtualMachineScaleSetExtensionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ArmClient).Compute.VMScaleSetExtensionsClient
+	ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_virtual_machine_scale_set_extension" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		virtualMachineScaleSetIdRaw := rs.Primary.Attributes["virtual_machine_scale_set_id"]
+		virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetResourceID(virtualMachineScaleSetIdRaw)
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Get(ctx, virtualMachineScaleSetId.Base.ResourceGroup, virtualMachineScaleSetId.Name, name, "")
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Virtual Machine Scale Set Extension still exists:\n%#v", resp.VirtualMachineScaleSetExtensionProperties)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_basicLinux(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  settings                     = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME"
+  })
+}
+`, template, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_basicWindows(rInt int, rString, location string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateWindows(rInt, rString, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%d"
+  virtual_machine_scale_set_id = azurerm_windows_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  settings                     = jsonencode({
+    "commandToExecute" = "Write-Host \"Hello\""
+  })
+}
+`, template, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_autoUpgradeDisabled(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  auto_upgrade_minor_version   = false
+  settings                     = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME"
+  })
+}
+`, template, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_extensionChaining(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "first" {
+  name                         = "acctestExt1-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "DockerExtension"
+  type_handler_version         = "1.0"
+}
+
+resource "azurerm_virtual_machine_scale_set_extension" "second" {
+  name                         = "acctestExt2-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  settings                     = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME"
+  })
+  provision_after_extensions = [ azurerm_virtual_machine_scale_set_extension.first.name ]
+}
+`, template, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_forceUpdateTag(rInt int, location, tag string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  force_update_tag             = %q
+  settings                     = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME"
+  })
+}
+`, template, rInt, tag)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_updateVersion(rInt int, location, version string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.OSTCExtensions"
+  type                         = "CustomScriptForLinux"
+  type_handler_version         = %q
+  settings                     = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME"
+  })
+}
+`, template, rInt, version)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_protectedSettings(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  settings                     = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME"
+  })
+  protected_settings           = jsonencode({
+    "secretValue" = "P@55W0rd1234!"
+  })
+}
+`, template, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_protectedSettingsOnly(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "test" {
+  name                         = "acctestExt-%d"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.test.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  protected_settings           = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME",
+    "secretValue"      = "P@55W0rd1234!"
+  })
+}
+`, template, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMVirtualMachineScaleSetExtension_basicLinux(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_virtual_machine_scale_set_extension" "import" {
+  name                         = azurerm_virtual_machine_scale_set_extension.test.name
+  virtual_machine_scale_set_id = azurerm_virtual_machine_scale_set_extension.test.virtual_machine_scale_set_id
+  publisher                    = azurerm_virtual_machine_scale_set_extension.test.publisher
+  type                         = azurerm_virtual_machine_scale_set_extension.test.type
+  type_handler_version         = azurerm_virtual_machine_scale_set_extension.test.type_handler_version
+  settings                     = azurerm_virtual_machine_scale_set_extension.test.settings
+}
+`, template)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_templateLinux(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+}
+`, rInt, location, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSetExtension_templateWindows(rInt int, rString, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                 = "acctestvm%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  sku                  = "Standard_F2"
+  instances            = 1
+  admin_username       = "adminuser"
+  admin_password       = "P@ssword1234!"
+  computer_name_prefix = "acctestvm"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+}
+`, rInt, location, rInt, rString)
+}

--- a/website/docs/r/virtual_machine_scale_set_extension.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_extension.html.markdown
@@ -1,0 +1,80 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_virtual_machine_scale_set_extension"
+sidebar_current: "docs-azurerm-resource-virtual-machine-scale-set-extension"
+description: |-
+  Manages an Extension for a Virtual Machine Scale Set.
+---
+
+# azurerm_virtual_machine_scale_set_extension
+
+~> **NOTE:** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
+
+Manages an Extension for a Virtual Machine Scale Set.
+
+~> **NOTE:** This resource is not intended to be used with the `azurerm_virtual_machine_scale_set` resource - instead it's intended for this to be used with the `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources.
+
+## Example Usage
+
+```hcl
+resource "azurerm_linux_virtual_machine_scale_set" "example" {
+  ...
+}
+
+resource "azurerm_virtual_machine_scale_set_extension" "example" {
+  name                         = "example"
+  virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.example.id
+  publisher                    = "Microsoft.Azure.Extensions"
+  type                         = "CustomScript"
+  type_handler_version         = "2.0"
+  settings                     = jsonencode({
+    "commandToExecute" = "echo $HOSTNAME"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name for the Virtual Machine Scale Set Extension. Changing this forces a new resource to be created.
+
+* `virtual_machine_scale_set_id` - (Required) The ID of the Virtual Machine Scale Set. Changing this forces a new resource to be created.
+
+-> **NOTE:** This should be the ID from the `azurerm_linux_virtual_machine_scale_set` or `azurerm_windows_virtual_machine_scale_set` resource - when using the older `azurerm_virtual_machine_scale_set` resource extensions should instead be defined inline.
+
+* `publisher` - (Required) Specifies the Publisher of the Extension. Changing this forces a new resource to be created.
+
+* `type` - (Required) Specifies the Type of the Extension. Changing this forces a new resource to be created.
+
+* `type_handler_version` - (Required) Specifies the version of the Script Handler which should be used.
+
+---
+
+* `auto_upgrade_minor_version` - (Optional) Should the latest version of the Extension be used at Deployment Time, if one is available? This won't auto-update the extension on existing installation. Defaults to `true`.
+
+* `force_update_tag` - (Optional) A value which, when different to the previous value can be used to force-run the Extension even if the Extension Configuration hasn't changed.
+
+* `protected_settings` - (Optional) A JSON String which specifies Sensitive Settings (such as Passwords) for the Extension.
+
+~> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+* `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
+
+* `settings` - (Optional) A JSON String which specifies Settings for the Extension.
+
+~> **NOTE:** Keys within the `settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Virtual Machine Scale Set Extension.
+
+## Import
+
+Virtual Machine Scale Set Extensions can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_virtual_machine_scale_set_extension.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleSet1/extensions/extension1
+```


### PR DESCRIPTION
This PR introduces a new resource `azurerm_virtual_machine_scale_set_extension` which is coming in 2.0 which we've previously outlined in #2807.

Since this resource uses the separate VM Scale Set Extension API's - this won't work with the existing `azurerm_virtual_machine_scale_set` resource (which is intentional, and documented to this effect) - instead this only works with the newer `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources.

Like the other 2.0 resources - for the moment these are all feature-toggled off, but will be feature-toggled on (and documented in the sidebar) when all of the new resources are completed & available, so that users are able to Beta test them in a 1.x release prior to them becoming Generally Available in 2.0.

Fixes #2709
Fixes #4695