### PR TITLE
azurerm_function_app: Add support for user assigned identities 

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -820,9 +820,8 @@ func flattenFunctionAppIdentity(identity *web.ManagedServiceIdentity) interface{
 	if identity.TenantID != nil {
 		result["tenant_id"] = *identity.TenantID
 	}
-	if identity.UserAssignedIdentities != nil {
-		result["user_assigned_identity"] = flattenFunctionAppUserAssignedIdentities(identity.UserAssignedIdentities)
-	}
+
+	result["user_assigned_identity"] = flattenFunctionAppUserAssignedIdentities(identity.UserAssignedIdentities)
 
 	return []interface{}{result}
 }
@@ -874,8 +873,19 @@ func flattenFunctionAppUserAssignedIdentities(input map[string]*web.ManagedServi
 	for k, v := range input {
 		result := make(map[string]interface{})
 		result["id"] = k
-		result["principal_id"] = *v.PrincipalID
-		result["client_id"] = *v.ClientID
+
+		principalID := ""
+		if v.PrincipalID != nil {
+			principalID = *v.PrincipalID
+		}
+		result["principal_id"] = principalID
+
+		clientID := ""
+		if v.ClientID != nil {
+			clientID = *v.ClientID
+		}
+		result["client_id"] = clientID
+
 		results = append(results, result)
 	}
 

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -161,8 +161,9 @@ func resourceArmFunctionApp() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"id": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: azure.ValidateResourceID,
 									},
 									"principal_id": {
 										Type:     schema.TypeString,

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -863,7 +863,6 @@ func ExpandFunctionAppIdentity(input []interface{}) web.ManagedServiceIdentity {
 
 			managedServiceIdentity.UserAssignedIdentities = output
 		}
-
 	}
 
 	return managedServiceIdentity

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -143,6 +143,8 @@ func resourceArmFunctionApp() *schema.Resource {
 							DiffSuppressFunc: suppress.CaseDifference,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(web.ManagedServiceIdentityTypeSystemAssigned),
+								string(web.ManagedServiceIdentityTypeSystemAssignedUserAssigned),
+								string(web.ManagedServiceIdentityTypeUserAssigned),
 							}, true),
 						},
 						"principal_id": {
@@ -152,6 +154,26 @@ func resourceArmFunctionApp() *schema.Resource {
 						"tenant_id": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+						"user_assigned_identity": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"principal_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"client_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
 						},
 					},
 				},

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -1620,11 +1620,11 @@ resource "azurerm_function_app" "test" {
   storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
 
   identity {
-		type = "UserAssigned"
+    type = "UserAssigned"
 
-		user_assigned_identity {
-			id = "${azurerm_user_assigned_identity.testIdentity.id}"
-		}
+    user_assigned_identity {
+      id = "${azurerm_user_assigned_identity.testIdentity.id}"
+    }
   }
 }
 `, rInt, location, storage)
@@ -1681,15 +1681,15 @@ resource "azurerm_function_app" "test" {
   storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
 
   identity {
-		type = "UserAssigned"
+    type = "UserAssigned"
 
-		user_assigned_identity {
-			id = "${azurerm_user_assigned_identity.first.id}"
-		}
+    user_assigned_identity {
+      id = "${azurerm_user_assigned_identity.first.id}"
+    }
 
-		user_assigned_identity {
-			id = "${azurerm_user_assigned_identity.second.id}"
-		}
+    user_assigned_identity {
+      id = "${azurerm_user_assigned_identity.second.id}"
+    }
   }
 }
 `, rInt, location, storage)

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -160,7 +160,11 @@ A `cors` block supports the following:
 
 `identity` supports the following:
 
-* `type` - (Required) Specifies the identity type of the App Service. At this time the only allowed value is `SystemAssigned`.
+* `type` - (Required) Specifies the identity type of the App Service. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+
+~> **NOTE:** When `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned` at least one `user_assigned_identity` block must be defined.
+
+* `user_assigned_identity` - (Optional) A `user_assigned_identity` block as defined below.
 
 ---
 
@@ -236,6 +240,13 @@ A `microsoft` block supports the following:
 
 * `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. https://msdn.microsoft.com/en-us/library/dn631845.aspx
 
+---
+
+A `user_assigned_identity` block supports the following:
+
+* `id` - (Required) The ID of the user-assigned managed identity.
+
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -261,6 +272,13 @@ The following attributes are exported:
 * `principal_id` - The Principal ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
+
+
+`user_assigned_identity` exports the following:
+
+* `principal_id` - The Principal ID for the Service Principal associated with the Managed User Identity.
+
+* `client_id` - The Client ID for the Service Principal associated with the Managed User Identity.
 
 
 `site_credential` exports the following:

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -273,6 +273,7 @@ The following attributes are exported:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
+---
 
 `user_assigned_identity` exports the following:
 
@@ -280,6 +281,9 @@ The following attributes are exported:
 
 * `client_id` - The Client ID for the Service Principal associated with the Managed User Identity.
 
+-> You can access the Principal ID via `${azurerm_function_app.test.identity.0.user_assigned_identity.0.principal_id}` and the Client ID via `${azurerm_function_app.test.identity.0.user_assigned_identity.0.client_id}`
+
+---
 
 `site_credential` exports the following:
 


### PR DESCRIPTION
This PR fixes #4607  and allows users to add user assigned identities to the identities block.

User assigned identities are defined like so:

```hcl
identity {
   type = "UserAssigned"

   user_assigned_identity {
      id = "${azurerm_user_assigned_identity.this.id}"
   }
 }
```