### PR TITLE
azurerm_kubernetes_cluster - prevent possible nil crashes when flattening the `service_principal_profile` property.

### DIFF
--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -1641,7 +1641,7 @@ func flattenAzureRmKubernetesClusterServicePrincipalProfile(profile *containerse
 			val = v.List()
 		}
 
-		if len(val) > 0 {
+		if len(val) > 0 && val[0] != nil {
 			raw := val[0].(map[string]interface{})
 			clientSecret = raw["client_secret"].(string)
 		}


### PR DESCRIPTION
This should fix the following `panic`.

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
```
Should fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/4519.