### PR TITLE
Fix terraform state in case of deployment error

### DIFF
--- a/azurerm/resource_arm_template_deployment.go
+++ b/azurerm/resource_arm_template_deployment.go
@@ -154,6 +154,7 @@ func resourceArmTemplateDeploymentCreateUpdate(d *schema.ResourceData, meta inte
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, deployment)
 	if err != nil {
+		d.SetId("")
 		return fmt.Errorf("Error creating deployment: %+v", err)
 	}
 


### PR DESCRIPTION
This solves the problem when you are trying to deploy a template and encounter an error related to validation;
The state in terraform is persisted with new  values provided and subsequent runs will not detect a change


Signed-off-by: Octavian Ionescu <itavyg@gmail.com>