### PR TITLE
storage: caching all of the account information

### DIFF
--- a/azurerm/internal/services/storage/client.go
+++ b/azurerm/internal/services/storage/client.go
@@ -47,85 +47,85 @@ func BuildClient(options *common.ClientOptions) *Client {
 	}
 }
 
-func (client Client) BlobsClient(ctx context.Context, resourceGroup, accountName string) (*blobs.Client, error) {
-	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+func (client Client) BlobsClient(ctx context.Context, account accountDetails) (*blobs.Client, error) {
+	accountKey, err := account.AccountKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(account.name, *accountKey)
 	blobsClient := blobs.NewWithEnvironment(client.environment)
 	blobsClient.Client.Authorizer = storageAuth
 	return &blobsClient, nil
 }
 
-func (client Client) ContainersClient(ctx context.Context, resourceGroup, accountName string) (*containers.Client, error) {
-	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+func (client Client) ContainersClient(ctx context.Context, account accountDetails) (*containers.Client, error) {
+	accountKey, err := account.AccountKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyAuthorizer(account.name, *accountKey)
 	containersClient := containers.NewWithEnvironment(client.environment)
 	containersClient.Client.Authorizer = storageAuth
 	return &containersClient, nil
 }
 
-func (client Client) FileShareDirectoriesClient(ctx context.Context, resourceGroup, accountName string) (*directories.Client, error) {
-	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+func (client Client) FileShareDirectoriesClient(ctx context.Context, account accountDetails) (*directories.Client, error) {
+	accountKey, err := account.AccountKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(account.name, *accountKey)
 	directoriesClient := directories.NewWithEnvironment(client.environment)
 	directoriesClient.Client.Authorizer = storageAuth
 	return &directoriesClient, nil
 }
 
-func (client Client) FileSharesClient(ctx context.Context, resourceGroup, accountName string) (*shares.Client, error) {
-	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+func (client Client) FileSharesClient(ctx context.Context, account accountDetails) (*shares.Client, error) {
+	accountKey, err := account.AccountKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(account.name, *accountKey)
 	directoriesClient := shares.NewWithEnvironment(client.environment)
 	directoriesClient.Client.Authorizer = storageAuth
 	return &directoriesClient, nil
 }
 
-func (client Client) QueuesClient(ctx context.Context, resourceGroup, accountName string) (*queues.Client, error) {
-	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+func (client Client) QueuesClient(ctx context.Context, account accountDetails) (*queues.Client, error) {
+	accountKey, err := account.AccountKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteAuthorizer(account.name, *accountKey)
 	queuesClient := queues.NewWithEnvironment(client.environment)
 	queuesClient.Client.Authorizer = storageAuth
 	return &queuesClient, nil
 }
 
-func (client Client) TableEntityClient(ctx context.Context, resourceGroup, accountName string) (*entities.Client, error) {
-	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+func (client Client) TableEntityClient(ctx context.Context, account accountDetails) (*entities.Client, error) {
+	accountKey, err := account.AccountKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteTableAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteTableAuthorizer(account.name, *accountKey)
 	entitiesClient := entities.NewWithEnvironment(client.environment)
 	entitiesClient.Client.Authorizer = storageAuth
 	return &entitiesClient, nil
 }
 
-func (client Client) TablesClient(ctx context.Context, resourceGroup, accountName string) (*tables.Client, error) {
-	accountKey, err := client.findAccountKey(ctx, resourceGroup, accountName)
+func (client Client) TablesClient(ctx context.Context, account accountDetails) (*tables.Client, error) {
+	accountKey, err := account.AccountKey(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving Account Key: %s", err)
 	}
 
-	storageAuth := authorizers.NewSharedKeyLiteTableAuthorizer(accountName, *accountKey)
+	storageAuth := authorizers.NewSharedKeyLiteTableAuthorizer(account.name, *accountKey)
 	tablesClient := tables.NewWithEnvironment(client.environment)
 	tablesClient.Client.Authorizer = storageAuth
 	return &tablesClient, nil

--- a/azurerm/internal/services/storage/helpers.go
+++ b/azurerm/internal/services/storage/helpers.go
@@ -4,97 +4,122 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 )
 
 var (
-	accountKeysCache        = map[string]string{}
-	resourceGroupNamesCache = map[string]string{}
-	writeLock               = sync.RWMutex{}
+	storageAccountsCache = map[string]accountDetails{}
+
+	accountsLock    = sync.RWMutex{}
+	credentialsLock = sync.RWMutex{}
 )
 
-func (client Client) ClearFromCache(resourceGroup, accountName string) {
-	writeLock.Lock()
+type accountDetails struct {
+	ID            string
+	ResourceGroup string
+	Properties    *storage.AccountProperties
 
-	log.Printf("[DEBUG] Removing Account %q (Resource Group %q) from the cache", accountName, resourceGroup)
-	accountCacheKey := fmt.Sprintf("%s-%s", resourceGroup, accountName)
-	delete(accountKeysCache, accountCacheKey)
-
-	resourceGroupsCacheKey := accountName
-	delete(resourceGroupNamesCache, resourceGroupsCacheKey)
-
-	log.Printf("[DEBUG] Removed Account %q (Resource Group %q) from the cache", accountName, resourceGroup)
-	writeLock.Unlock()
+	accountKey *string
+	name       string
 }
 
-func (client Client) FindResourceGroup(ctx context.Context, accountName string) (*string, error) {
-	cacheKey := accountName
-	if v, ok := resourceGroupNamesCache[cacheKey]; ok {
-		return &v, nil
+func (ad *accountDetails) AccountKey(ctx context.Context, client Client) (*string, error) {
+	credentialsLock.Lock()
+	defer credentialsLock.Unlock()
+
+	if ad.accountKey != nil {
+		return ad.accountKey, nil
 	}
 
-	log.Printf("[DEBUG] Cache Miss - looking up the resource group for storage account %q..", accountName)
-	writeLock.Lock()
-	accounts, err := client.AccountsClient.List(ctx)
+	log.Printf("[DEBUG] Cache Miss - looking up the account key for storage account %q..", ad.name)
+	props, err := client.AccountsClient.ListKeys(ctx, ad.ResourceGroup, ad.name)
 	if err != nil {
-		return nil, fmt.Errorf("Error listing Storage Accounts (to find Resource Group for %q): %s", accountName, err)
+		return nil, fmt.Errorf("Error Listing Keys for Storage Account %q (Resource Group %q): %+v", ad.name, ad.ResourceGroup, err)
 	}
 
-	if accounts.Values() == nil {
-		return nil, nil
-	}
-
-	var resourceGroup *string
-	for _, account := range accounts.Values() {
-		if account.Name == nil || account.ID == nil {
-			continue
-		}
-
-		if strings.EqualFold(accountName, *account.Name) {
-			id, err := azure.ParseAzureResourceID(*account.ID)
-			if err != nil {
-				return nil, fmt.Errorf("Error parsing ID for Storage Account %q: %s", accountName, err)
-			}
-
-			resourceGroup = &id.ResourceGroup
-			break
-		}
-	}
-
-	if resourceGroup != nil {
-		resourceGroupNamesCache[cacheKey] = *resourceGroup
-	}
-
-	writeLock.Unlock()
-
-	return resourceGroup, nil
-}
-
-func (client Client) findAccountKey(ctx context.Context, resourceGroup, accountName string) (*string, error) {
-	cacheKey := fmt.Sprintf("%s-%s", resourceGroup, accountName)
-	if v, ok := accountKeysCache[cacheKey]; ok {
-		return &v, nil
-	}
-
-	writeLock.Lock()
-	log.Printf("[DEBUG] Cache Miss - looking up the account key for storage account %q..", accountName)
-	props, err := client.AccountsClient.ListKeys(ctx, resourceGroup, accountName)
-	if err != nil {
-		return nil, fmt.Errorf("Error Listing Keys for Storage Account %q (Resource Group %q): %+v", accountName, resourceGroup, err)
-	}
-
-	if props.Keys == nil || len(*props.Keys) == 0 {
-		return nil, fmt.Errorf("Keys were nil for Storage Account %q (Resource Group %q): %+v", accountName, resourceGroup, err)
+	if props.Keys == nil || len(*props.Keys) == 0 || (*props.Keys)[0].Value == nil {
+		return nil, fmt.Errorf("Keys were nil for Storage Account %q (Resource Group %q): %+v", ad.name, ad.ResourceGroup, err)
 	}
 
 	keys := *props.Keys
-	firstKey := keys[0].Value
+	ad.accountKey = keys[0].Value
 
-	accountKeysCache[cacheKey] = *firstKey
-	writeLock.Unlock()
+	// force-cache this
+	storageAccountsCache[ad.name] = *ad
 
-	return firstKey, nil
+	return ad.accountKey, nil
+}
+
+func (client Client) AddToCache(accountName string, props storage.Account) error {
+	accountsLock.Lock()
+	defer accountsLock.Unlock()
+
+	account, err := client.populateAccountDetails(accountName, props)
+	if err != nil {
+		return err
+	}
+
+	storageAccountsCache[accountName] = *account
+
+	return nil
+}
+
+func (client Client) RemoveAccountFromCache(accountName string) {
+	accountsLock.Lock()
+	delete(storageAccountsCache, accountName)
+	accountsLock.Unlock()
+}
+
+func (client Client) FindAccount(ctx context.Context, accountName string) (*accountDetails, error) {
+	accountsLock.Lock()
+	defer accountsLock.Unlock()
+
+	if existing, ok := storageAccountsCache[accountName]; ok {
+		return &existing, nil
+	}
+
+	accounts, err := client.AccountsClient.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving storage accounts: %+v", err)
+	}
+
+	for _, v := range accounts.Values() {
+		if v.Name == nil {
+			continue
+		}
+
+		account, err := client.populateAccountDetails(*v.Name, v)
+		if err != nil {
+			return nil, err
+		}
+
+		storageAccountsCache[*v.Name] = *account
+	}
+
+	if existing, ok := storageAccountsCache[accountName]; ok {
+		return &existing, nil
+	}
+
+	return nil, nil
+}
+
+func (client Client) populateAccountDetails(accountName string, props storage.Account) (*accountDetails, error) {
+	if props.ID == nil {
+		return nil, fmt.Errorf("`id` was nil for Account %q", accountName)
+	}
+
+	accountId := *props.ID
+	id, err := ParseAccountID(accountId)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing %q as a Resource ID: %+v", accountId, err)
+	}
+
+	return &accountDetails{
+		name:          accountName,
+		ID:            accountId,
+		ResourceGroup: id.ResourceGroup,
+		Properties:    props.AccountProperties,
+	}, nil
 }

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -735,6 +735,7 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[INFO] storage account %q ID: %q", storageAccountName, *account.ID)
 	d.SetId(*account.ID)
 
+	// TODO: deprecate & split this out into it's own resource in 2.0
 	// as this is not available in all regions, and presumably off by default
 	// lets only try to set this value when true
 	// TODO in 2.0 switch to guarding this with d.GetOkExists() ?
@@ -751,7 +752,16 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if val, ok := d.GetOk("queue_properties"); ok {
-		queueClient, err := meta.(*ArmClient).Storage.QueuesClient(ctx, resourceGroupName, storageAccountName)
+		storageClient := meta.(*ArmClient).Storage
+		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		if err != nil {
+			return fmt.Errorf("Error retrieving Account %q: %s", storageAccountName, err)
+		}
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", storageAccountName)
+		}
+
+		queueClient, err := storageClient.QueuesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Queues Client: %s", err)
 		}
@@ -945,7 +955,16 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("queue_properties") {
-		queueClient, err := meta.(*ArmClient).Storage.QueuesClient(ctx, resourceGroupName, storageAccountName)
+		storageClient := meta.(*ArmClient).Storage
+		account, err := storageClient.FindAccount(ctx, storageAccountName)
+		if err != nil {
+			return fmt.Errorf("Error retrieving Account %q: %s", storageAccountName, err)
+		}
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", storageAccountName)
+		}
+
+		queueClient, err := storageClient.QueuesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Queues Client: %s", err)
 		}
@@ -1128,7 +1147,16 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	queueClient, err := meta.(*ArmClient).Storage.QueuesClient(ctx, resGroup, name)
+	storageClient := meta.(*ArmClient).Storage
+	account, err := storageClient.FindAccount(ctx, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Account %q: %s", name, err)
+	}
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", name)
+	}
+
+	queueClient, err := storageClient.QueuesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Queues Client: %s", err)
 	}
@@ -1202,7 +1230,7 @@ func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// remove this from the cache
-	storageClient.ClearFromCache(resourceGroup, name)
+	storageClient.RemoveAccountFromCache(name)
 
 	return nil
 }

--- a/azurerm/resource_arm_storage_blob.go
+++ b/azurerm/resource_arm_storage_blob.go
@@ -158,15 +158,15 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 	containerName := d.Get("storage_container_name").(string)
 	name := d.Get("name").(string)
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, accountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Account %q: %s", accountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", accountName, name, containerName, err)
 	}
-	if resourceGroup == nil {
-		return fmt.Errorf("Unable to locate Resource Group for Blob %q (Container %q / Account %q)", name, containerName, accountName)
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 	}
 
-	blobsClient, err := storageClient.BlobsClient(ctx, *resourceGroup, accountName)
+	blobsClient, err := storageClient.BlobsClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Blobs Client: %s", err)
 	}
@@ -177,7 +177,7 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 		props, err := blobsClient.GetProperties(ctx, accountName, containerName, name, input)
 		if err != nil {
 			if !utils.ResponseWasNotFound(props.Response) {
-				return fmt.Errorf("Error checking if Blob %q exists (Container %q / Account %q / Resource Group %q): %s", name, containerName, accountName, *resourceGroup, err)
+				return fmt.Errorf("Error checking if Blob %q exists (Container %q / Account %q / Resource Group %q): %s", name, containerName, accountName, account.ResourceGroup, err)
 			}
 		}
 		if !utils.ResponseWasNotFound(props.Response) {
@@ -222,15 +222,15 @@ func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error parsing %q: %s", d.Id(), err)
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Account %q: %s", id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", id.AccountName, id.BlobName, id.ContainerName, err)
 	}
-	if resourceGroup == nil {
-		return fmt.Errorf("Unable to locate Resource Group for Blob %q (Container %q / Account %q)", id.BlobName, id.ContainerName, id.AccountName)
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	blobsClient, err := storageClient.BlobsClient(ctx, *resourceGroup, id.AccountName)
+	blobsClient, err := storageClient.BlobsClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Blobs Client: %s", err)
 	}
@@ -283,17 +283,17 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error parsing %q: %s", d.Id(), err)
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Account %q: %s", id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", id.AccountName, id.BlobName, id.ContainerName, err)
 	}
-	if resourceGroup == nil {
-		log.Printf("[DEBUG] Unable to locate Resource Group for Blob %q (Container %q / Account %q) - assuming removed & removing from state!", id.BlobName, id.ContainerName, id.AccountName)
+	if account == nil {
+		log.Printf("[DEBUG] Unable to locate Account %q for Blob %q (Container %q) - assuming removed & removing from state!", id.AccountName, id.BlobName, id.ContainerName)
 		d.SetId("")
 		return nil
 	}
 
-	blobsClient, err := storageClient.BlobsClient(ctx, *resourceGroup, id.AccountName)
+	blobsClient, err := storageClient.BlobsClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Blobs Client: %s", err)
 	}
@@ -314,7 +314,7 @@ func resourceArmStorageBlobRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", id.BlobName)
 	d.Set("storage_container_name", id.ContainerName)
 	d.Set("storage_account_name", id.AccountName)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("resource_group_name", account.ResourceGroup)
 
 	d.Set("access_tier", string(props.AccessTier))
 	d.Set("content_type", props.ContentType)
@@ -343,15 +343,15 @@ func resourceArmStorageBlobDelete(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error parsing %q: %s", d.Id(), err)
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Account %q: %s", id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", id.AccountName, id.BlobName, id.ContainerName, err)
 	}
-	if resourceGroup == nil {
-		return fmt.Errorf("Unable to locate Resource Group for Storage Account %q!", id.AccountName)
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	blobsClient, err := storageClient.BlobsClient(ctx, *resourceGroup, id.AccountName)
+	blobsClient, err := storageClient.BlobsClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Blobs Client: %s", err)
 	}

--- a/azurerm/resource_arm_storage_blob_test.go
+++ b/azurerm/resource_arm_storage_blob_test.go
@@ -629,15 +629,15 @@ func testCheckAzureRMStorageBlobExists(resourceName string) resource.TestCheckFu
 		containerName := rs.Primary.Attributes["storage_container_name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Blob %q (Container %q / Account %q): %s", name, containerName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", accountName, name, containerName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Blob %q (Container %q / Account %q) - assuming removed & removing from state", name, containerName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.BlobsClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.BlobsClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Blobs Client: %s", err)
 		}
@@ -646,7 +646,7 @@ func testCheckAzureRMStorageBlobExists(resourceName string) resource.TestCheckFu
 		resp, err := client.GetProperties(ctx, accountName, containerName, name, input)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Blob %q (Container %q / Account %q / Resource Group %q) does not exist", name, containerName, accountName, *resourceGroup)
+				return fmt.Errorf("Bad: Blob %q (Container %q / Account %q / Resource Group %q) does not exist", name, containerName, accountName, account.ResourceGroup)
 			}
 
 			return fmt.Errorf("Bad: Get on BlobsClient: %+v", err)
@@ -670,15 +670,15 @@ func testCheckAzureRMStorageBlobDisappears(resourceName string) resource.TestChe
 		containerName := rs.Primary.Attributes["storage_container_name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Blob %q (Container %q / Account %q): %s", name, containerName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", accountName, name, containerName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Blob %q (Container %q / Account %q) - assuming removed & removing from state", name, containerName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.BlobsClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.BlobsClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Blobs Client: %s", err)
 		}
@@ -687,7 +687,7 @@ func testCheckAzureRMStorageBlobDisappears(resourceName string) resource.TestChe
 			DeleteSnapshots: false,
 		}
 		if _, err := client.Delete(ctx, accountName, containerName, name, input); err != nil {
-			return fmt.Errorf("Error deleting Blob %q (Container %q / Account %q / Resource Group %q): %s", name, containerName, accountName, *resourceGroup, err)
+			return fmt.Errorf("Error deleting Blob %q (Container %q / Account %q / Resource Group %q): %s", name, containerName, accountName, account.ResourceGroup, err)
 		}
 
 		return nil
@@ -708,15 +708,15 @@ func testCheckAzureRMStorageBlobMatchesFile(resourceName string, kind blobs.Blob
 		containerName := rs.Primary.Attributes["storage_container_name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Blob %q (Container %q / Account %q): %s", name, containerName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", accountName, name, containerName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Blob %q (Container %q / Account %q) - assuming removed & removing from state", name, containerName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.BlobsClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.BlobsClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Blobs Client: %s", err)
 		}
@@ -768,15 +768,15 @@ func testCheckAzureRMStorageBlobDestroy(s *terraform.State) error {
 		containerName := rs.Primary.Attributes["storage_container_name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Blob %q (Container %q / Account %q): %s", name, containerName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", accountName, name, containerName, err)
 		}
-		if resourceGroup == nil {
+		if account == nil {
 			return nil
 		}
 
-		client, err := storageClient.BlobsClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.BlobsClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Blobs Client: %s", err)
 		}

--- a/azurerm/resource_arm_storage_container_test.go
+++ b/azurerm/resource_arm_storage_container_test.go
@@ -247,15 +247,15 @@ func testCheckAzureRMStorageContainerExists(resourceName string) resource.TestCh
 		containerName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Container %q (Account %s): %s", containerName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Container %q: %s", accountName, containerName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Container %q (Account %s) - assuming removed & removing from state", containerName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.ContainersClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.ContainersClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Containers Client: %s", err)
 		}
@@ -263,7 +263,7 @@ func testCheckAzureRMStorageContainerExists(resourceName string) resource.TestCh
 		resp, err := client.GetProperties(ctx, accountName, containerName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Container %q (Account %q / Resource Group %q) does not exist", containerName, accountName, *resourceGroup)
+				return fmt.Errorf("Bad: Container %q (Account %q / Resource Group %q) does not exist", containerName, accountName, account.ResourceGroup)
 			}
 
 			return fmt.Errorf("Bad: Get on ContainersClient: %+v", err)
@@ -286,15 +286,15 @@ func testAccARMStorageContainerDisappears(resourceName string) resource.TestChec
 		containerName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Container %q (Account %s): %s", containerName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Container %q: %s", accountName, containerName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Container %q (Account %s) - assuming removed & removing from state", containerName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.ContainersClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.ContainersClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Containers Client: %s", err)
 		}
@@ -319,16 +319,15 @@ func testCheckAzureRMStorageContainerDestroy(s *terraform.State) error {
 		containerName := rs.Primary.Attributes["name"]
 		accountName := rs.Primary.Attributes["storage_account_name"]
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Container %q (Account %s): %s", containerName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Container %q: %s", accountName, containerName, err)
 		}
-
-		if resourceGroup == nil {
+		if account == nil {
 			return nil
 		}
 
-		client, err := storageClient.ContainersClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.ContainersClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Containers Client: %s", err)
 		}

--- a/azurerm/resource_arm_storage_data_lake_gen2_filesystem.go
+++ b/azurerm/resource_arm_storage_data_lake_gen2_filesystem.go
@@ -32,20 +32,13 @@ func resourceArmStorageDataLakeGen2FileSystem() *schema.Resource {
 					return []*schema.ResourceData{d}, fmt.Errorf("Error parsing ID %q for import of Data Lake Gen2 File System: %v", d.Id(), err)
 				}
 
-				// we then need to look up the Storage Account ID - so first find the resource group
-				resourceGroup, err := storageClients.FindResourceGroup(ctx, id.AccountName)
+				// we then need to look up the Storage Account ID
+				account, err := storageClients.FindAccount(ctx, id.AccountName)
 				if err != nil {
-					return []*schema.ResourceData{d}, fmt.Errorf("Error locating Resource Group for Storage Account %q to import Data Lake Gen2 File System %q: %v", id.AccountName, d.Id(), err)
+					return []*schema.ResourceData{d}, fmt.Errorf("Error retrieving Account %q for Data Lake Gen2 File System %q: %s", id.AccountName, id.DirectoryName, err)
 				}
-
-				if resourceGroup == nil {
-					return []*schema.ResourceData{d}, fmt.Errorf("Unable to locate Resource Group for Storage Account %q to import Data Lake Gen2 File System %q", id.AccountName, d.Id())
-				}
-
-				// then pull the storage account itself
-				account, err := storageClients.AccountsClient.GetProperties(ctx, *resourceGroup, id.AccountName, "")
-				if err != nil {
-					return []*schema.ResourceData{d}, fmt.Errorf("Error retrieving Storage Account %q to import Data Lake Gen2 File System %q: %+v", id.AccountName, d.Id(), err)
+				if account == nil {
+					return []*schema.ResourceData{d}, fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 				}
 
 				d.Set("storage_account_id", account.ID)

--- a/azurerm/resource_arm_storage_queue.go
+++ b/azurerm/resource_arm_storage_queue.go
@@ -97,15 +97,15 @@ func resourceArmStorageQueueCreate(d *schema.ResourceData, meta interface{}) err
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := storage.ExpandMetaData(metaDataRaw)
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, accountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Queue %q (Account %s): %s", queueName, accountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Queue %q: %s", accountName, queueName, err)
 	}
-	if resourceGroup == nil {
-		return fmt.Errorf("Unable to locate Resource Group for Storage Queue %q (Account %s)", queueName, accountName)
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 	}
 
-	queueClient, err := storageClient.QueuesClient(ctx, *resourceGroup, accountName)
+	queueClient, err := storageClient.QueuesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Queues Client: %s", err)
 	}
@@ -146,15 +146,15 @@ func resourceArmStorageQueueUpdate(d *schema.ResourceData, meta interface{}) err
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
 	metaData := storage.ExpandMetaData(metaDataRaw)
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Queue %q (Account %s): %s", id.QueueName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Queue %q: %s", id.AccountName, id.QueueName, err)
 	}
-	if resourceGroup == nil {
-		return fmt.Errorf("Unable to locate Resource Group for Storage Queue %q (Account %s)", id.QueueName, id.AccountName)
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	queuesClient, err := storageClient.QueuesClient(ctx, *resourceGroup, id.AccountName)
+	queuesClient, err := storageClient.QueuesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Queues Client: %s", err)
 	}
@@ -176,17 +176,17 @@ func resourceArmStorageQueueRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Queue Container %q (Account %s): %s", id.QueueName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Queue %q: %s", id.AccountName, id.QueueName, err)
 	}
-	if resourceGroup == nil {
+	if account == nil {
 		log.Printf("[WARN] Unable to determine Resource Group for Storage Queue %q (Account %s) - assuming removed & removing from state", id.QueueName, id.AccountName)
 		d.SetId("")
 		return nil
 	}
 
-	queuesClient, err := storageClient.QueuesClient(ctx, *resourceGroup, id.AccountName)
+	queuesClient, err := storageClient.QueuesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Queues Client: %s", err)
 	}
@@ -204,7 +204,7 @@ func resourceArmStorageQueueRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("name", id.QueueName)
 	d.Set("storage_account_name", id.AccountName)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("resource_group_name", account.ResourceGroup)
 
 	if err := d.Set("metadata", storage.FlattenMetaData(metaData.MetaData)); err != nil {
 		return fmt.Errorf("Error setting `metadata`: %s", err)
@@ -223,17 +223,17 @@ func resourceArmStorageQueueDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Queue %q (Account %s): %s", id.QueueName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Queue %q: %s", id.AccountName, id.QueueName, err)
 	}
-	if resourceGroup == nil {
+	if account == nil {
 		log.Printf("[WARN] Unable to determine Resource Group for Storage Queue %q (Account %s) - assuming removed & removing from state", id.QueueName, id.AccountName)
 		d.SetId("")
 		return nil
 	}
 
-	queuesClient, err := storageClient.QueuesClient(ctx, *resourceGroup, id.AccountName)
+	queuesClient, err := storageClient.QueuesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Queues Client: %s", err)
 	}

--- a/azurerm/resource_arm_storage_queue_test.go
+++ b/azurerm/resource_arm_storage_queue_test.go
@@ -159,20 +159,20 @@ func testCheckAzureRMStorageQueueExists(resourceName string) resource.TestCheckF
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Queue %q (Account %s): %s", name, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Queue %q: %s", accountName, name, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Queue %q (Account %s) - assuming removed", name, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		queueClient, err := storageClient.QueuesClient(ctx, *resourceGroup, accountName)
+		queuesClient, err := storageClient.QueuesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Queues Client: %s", err)
 		}
 
-		metaData, err := queueClient.GetMetaData(ctx, accountName, name)
+		metaData, err := queuesClient.GetMetaData(ctx, accountName, name)
 		if err != nil {
 			if utils.ResponseWasNotFound(metaData.Response) {
 				return fmt.Errorf("Bad: Storage Queue %q (storage account: %q) does not exist", name, accountName)
@@ -197,22 +197,21 @@ func testCheckAzureRMStorageQueueDestroy(s *terraform.State) error {
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Queue %q (Account %s): %s", name, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Queue %q: %s", accountName, name, err)
 		}
-
 		// expected if this has been deleted
-		if resourceGroup == nil {
+		if account == nil {
 			return nil
 		}
 
-		queueClient, err := storageClient.QueuesClient(ctx, *resourceGroup, accountName)
+		queuesClient, err := storageClient.QueuesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Queues Client: %s", err)
 		}
 
-		props, err := queueClient.GetMetaData(ctx, accountName, name)
+		props, err := queuesClient.GetMetaData(ctx, accountName, name)
 		if err != nil {
 			return nil
 		}

--- a/azurerm/resource_arm_storage_share_directory_test.go
+++ b/azurerm/resource_arm_storage_share_directory_test.go
@@ -193,15 +193,15 @@ func testCheckAzureRMStorageShareDirectoryExists(resourceName string) resource.T
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Share Directory %q (Share %s, Account %s): %s", name, shareName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Directory %q (Share %q): %s", accountName, name, shareName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Share Directory %q (Share %s, Account %s) ", name, shareName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.FileShareDirectoriesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.FileShareDirectoriesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}
@@ -212,7 +212,7 @@ func testCheckAzureRMStorageShareDirectoryExists(resourceName string) resource.T
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Directory %q (File Share %q / Account %q / Resource Group %q) does not exist", name, shareName, accountName, *resourceGroup)
+			return fmt.Errorf("Bad: Directory %q (File Share %q / Account %q / Resource Group %q) does not exist", name, shareName, accountName, account.ResourceGroup)
 		}
 
 		return nil
@@ -232,17 +232,21 @@ func testCheckAzureRMStorageShareDirectoryDestroy(s *terraform.State) error {
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
+		if err != nil {
+			return fmt.Errorf("Error retrieving Account %q for Directory %q (Share %q): %s", accountName, name, shareName, err)
+		}
+
+		// not found, the account's gone
+		if account == nil {
+			return nil
+		}
+
 		if err != nil {
 			return fmt.Errorf("Error locating Resource Group for Storage Share Directory %q (Share %s, Account %s): %s", name, shareName, accountName, err)
 		}
 
-		// not found, the account's gone
-		if resourceGroup == nil {
-			return nil
-		}
-
-		client, err := storageClient.FileShareDirectoriesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.FileShareDirectoriesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}

--- a/azurerm/resource_arm_storage_share_test.go
+++ b/azurerm/resource_arm_storage_share_test.go
@@ -206,15 +206,15 @@ func testCheckAzureRMStorageShareExists(resourceName string) resource.TestCheckF
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Share %q (Account %s): %s", shareName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Share %q: %s", accountName, shareName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Share %q (Account %s) - assuming removed & removing from state", shareName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.FileSharesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.FileSharesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}
@@ -240,15 +240,15 @@ func testCheckAzureRMStorageShareDisappears(resourceName string) resource.TestCh
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Share %q (Account %s): %s", shareName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Share %q: %s", accountName, shareName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Share %q (Account %s) - assuming removed & removing from state", shareName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.FileSharesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.FileSharesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}
@@ -273,15 +273,17 @@ func testCheckAzureRMStorageShareDestroy(s *terraform.State) error {
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Share %q (Account %s): %s", shareName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Share %q: %s", accountName, shareName, err)
 		}
-		if resourceGroup == nil {
+
+		// expected since it's been deleted
+		if account == nil {
 			return nil
 		}
 
-		client, err := storageClient.FileSharesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.FileSharesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building FileShare Client: %s", err)
 		}

--- a/azurerm/resource_arm_storage_table.go
+++ b/azurerm/resource_arm_storage_table.go
@@ -116,15 +116,15 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 	aclsRaw := d.Get("acl").(*schema.Set).List()
 	acls := expandStorageTableACLs(aclsRaw)
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, accountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", tableName, accountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Table %q: %s", accountName, tableName, err)
 	}
-	if resourceGroup == nil {
-		return fmt.Errorf("Unable to locate Resource Group for Storage Share %q (Account %s) - assuming removed & removing from state", tableName, accountName)
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 	}
 
-	client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
+	client, err := storageClient.TablesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Table Client: %s", err)
 	}
@@ -134,7 +134,7 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 		existing, err := client.Exists(ctx, accountName, tableName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing) {
-				return fmt.Errorf("Error checking for existence of existing Storage Table %q (Account %q / Resource Group %q): %+v", tableName, accountName, *resourceGroup, err)
+				return fmt.Errorf("Error checking for existence of existing Storage Table %q (Account %q / Resource Group %q): %+v", tableName, accountName, account.ResourceGroup, err)
 			}
 		}
 
@@ -149,7 +149,7 @@ func resourceArmStorageTableCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if _, err := client.SetACL(ctx, accountName, tableName, acls); err != nil {
-		return fmt.Errorf("Error setting ACL's for Storage Table %q (Account %q / Resource Group %q): %+v", tableName, accountName, *resourceGroup, err)
+		return fmt.Errorf("Error setting ACL's for Storage Table %q (Account %q / Resource Group %q): %+v", tableName, accountName, account.ResourceGroup, err)
 	}
 
 	d.SetId(id)
@@ -166,18 +166,17 @@ func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", id.TableName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Table %q: %s", id.AccountName, id.TableName, err)
 	}
-
-	if resourceGroup == nil {
+	if account == nil {
 		log.Printf("Unable to determine Resource Group for Storage Storage Table %q (Account %s) - assuming removed & removing from state", id.TableName, id.AccountName)
 		d.SetId("")
 		return nil
 	}
 
-	client, err := storageClient.TablesClient(ctx, *resourceGroup, id.AccountName)
+	client, err := storageClient.TablesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Table Client: %s", err)
 	}
@@ -200,7 +199,7 @@ func resourceArmStorageTableRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("name", id.TableName)
 	d.Set("storage_account_name", id.AccountName)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("resource_group_name", account.ResourceGroup)
 
 	if err := d.Set("acl", flattenStorageTableACLs(acls)); err != nil {
 		return fmt.Errorf("Error flattening `acl`: %+v", err)
@@ -219,17 +218,15 @@ func resourceArmStorageTableDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", id.TableName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Table %q: %s", id.AccountName, id.TableName, err)
+	}
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	if resourceGroup == nil {
-		log.Printf("Unable to determine Resource Group for Storage Storage Table %q (Account %s) - assuming removed & removing from state", id.TableName, id.AccountName)
-		return nil
-	}
-
-	client, err := storageClient.TablesClient(ctx, *resourceGroup, id.AccountName)
+	client, err := storageClient.TablesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Table Client: %s", err)
 	}
@@ -252,18 +249,15 @@ func resourceArmStorageTableUpdate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", id.TableName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Table %q: %s", id.AccountName, id.TableName, err)
+	}
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	if resourceGroup == nil {
-		log.Printf("Unable to determine Resource Group for Storage Storage Table %q (Account %s) - assuming removed & removing from state", id.TableName, id.AccountName)
-		d.SetId("")
-		return nil
-	}
-
-	client, err := storageClient.TablesClient(ctx, *resourceGroup, id.AccountName)
+	client, err := storageClient.TablesClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Table Client: %s", err)
 	}

--- a/azurerm/resource_arm_storage_table_entity.go
+++ b/azurerm/resource_arm_storage_table_entity.go
@@ -78,21 +78,21 @@ func resourceArmStorageTableEntityCreateUpdate(d *schema.ResourceData, meta inte
 	rowKey := d.Get("row_key").(string)
 	entity := d.Get("entity").(map[string]interface{})
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+	account, err := storageClient.FindAccount(ctx, accountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Stable %q (Account %s): %s", tableName, accountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Table %q: %s", accountName, tableName, err)
 	}
-	if resourceGroup == nil {
+	if account == nil {
 		if d.IsNewResource() {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Table %q (Account %s)", tableName, accountName)
+			return fmt.Errorf("Unable to locate Account %q for Storage Table %q", accountName, tableName)
 		} else {
-			log.Printf("[DEBUG] Unable to locate Resource Group for Storage Table %q (Account %s) - assuming removed & removing from state", tableName, accountName)
+			log.Printf("[DEBUG] Unable to locate Account %q for Storage Table %q - assuming removed & removing from state", accountName, tableName)
 			d.SetId("")
 			return nil
 		}
 	}
 
-	client, err := storageClient.TableEntityClient(ctx, *resourceGroup, accountName)
+	client, err := storageClient.TableEntityClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Entity Client: %s", err)
 	}
@@ -106,7 +106,7 @@ func resourceArmStorageTableEntityCreateUpdate(d *schema.ResourceData, meta inte
 		existing, err := client.Get(ctx, accountName, tableName, input)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", partitionKey, rowKey, tableName, accountName, *resourceGroup, err)
+				return fmt.Errorf("Error checking for presence of existing Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", partitionKey, rowKey, tableName, accountName, account.ResourceGroup, err)
 			}
 		}
 
@@ -123,7 +123,7 @@ func resourceArmStorageTableEntityCreateUpdate(d *schema.ResourceData, meta inte
 	}
 
 	if _, err := client.InsertOrMerge(ctx, accountName, tableName, input); err != nil {
-		return fmt.Errorf("Error creating Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %+v", partitionKey, rowKey, tableName, accountName, *resourceGroup, err)
+		return fmt.Errorf("Error creating Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %+v", partitionKey, rowKey, tableName, accountName, account.ResourceGroup, err)
 	}
 
 	resourceID := client.GetResourceID(accountName, tableName, partitionKey, rowKey)
@@ -142,19 +142,19 @@ func resourceArmStorageTableEntityRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", id.TableName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Table %q: %s", id.AccountName, id.TableName, err)
 	}
-	if resourceGroup == nil {
+	if account == nil {
 		log.Printf("[WARN] Unable to determine Resource Group for Storage Table %q (Account %s) - assuming removed & removing from state", id.TableName, id.AccountName)
 		d.SetId("")
 		return nil
 	}
 
-	client, err := storageClient.TableEntityClient(ctx, *resourceGroup, id.AccountName)
+	client, err := storageClient.TableEntityClient(ctx, *account)
 	if err != nil {
-		return fmt.Errorf("Error building Table Entity Client for Storage Account %q (Resource Group %q): %s", id.AccountName, *resourceGroup, err)
+		return fmt.Errorf("Error building Table Entity Client for Storage Account %q (Resource Group %q): %s", id.AccountName, account.ResourceGroup, err)
 	}
 
 	input := entities.GetEntityInput{
@@ -165,7 +165,7 @@ func resourceArmStorageTableEntityRead(d *schema.ResourceData, meta interface{})
 
 	result, err := client.Get(ctx, id.AccountName, id.TableName, input)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", id.PartitionKey, id.RowKey, id.TableName, id.AccountName, *resourceGroup, err)
+		return fmt.Errorf("Error retrieving Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", id.PartitionKey, id.RowKey, id.TableName, id.AccountName, account.ResourceGroup, err)
 	}
 
 	d.Set("storage_account_name", id.AccountName)
@@ -173,7 +173,7 @@ func resourceArmStorageTableEntityRead(d *schema.ResourceData, meta interface{})
 	d.Set("partition_key", id.PartitionKey)
 	d.Set("row_key", id.RowKey)
 	if err := d.Set("entity", flattenEntity(result.Entity)); err != nil {
-		return fmt.Errorf("Error setting `entity` for Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", id.PartitionKey, id.RowKey, id.TableName, id.AccountName, *resourceGroup, err)
+		return fmt.Errorf("Error setting `entity` for Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", id.PartitionKey, id.RowKey, id.TableName, id.AccountName, account.ResourceGroup, err)
 	}
 
 	return nil
@@ -189,18 +189,17 @@ func resourceArmStorageTableEntityDelete(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", id.TableName, id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Table %q: %s", id.AccountName, id.TableName, err)
 	}
-	if resourceGroup == nil {
-		log.Printf("[WARN] Unable to determine Resource Group for Storage Table %q (Account %s) - assuming removed already", id.TableName, id.AccountName)
-		return nil
+	if account == nil {
+		return fmt.Errorf("Storage Account %q was not found!", id.AccountName)
 	}
 
-	client, err := storageClient.TableEntityClient(ctx, *resourceGroup, id.AccountName)
+	client, err := storageClient.TableEntityClient(ctx, *account)
 	if err != nil {
-		return fmt.Errorf("Error building Entity Client for Storage Account %q (Resource Group %q): %s", id.AccountName, *resourceGroup, err)
+		return fmt.Errorf("Error building Entity Client for Storage Account %q (Resource Group %q): %s", id.AccountName, account.ResourceGroup, err)
 	}
 
 	input := entities.DeleteEntityInput{
@@ -209,7 +208,7 @@ func resourceArmStorageTableEntityDelete(d *schema.ResourceData, meta interface{
 	}
 
 	if _, err := client.Delete(ctx, id.AccountName, id.TableName, input); err != nil {
-		return fmt.Errorf("Error deleting Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", id.PartitionKey, id.RowKey, id.TableName, id.AccountName, *resourceGroup, err)
+		return fmt.Errorf("Error deleting Entity (Partition Key %q / Row Key %q) (Table %q / Storage Account %q / Resource Group %q): %s", id.PartitionKey, id.RowKey, id.TableName, id.AccountName, account.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_storage_table_entity_test.go
+++ b/azurerm/resource_arm_storage_table_entity_test.go
@@ -123,15 +123,15 @@ func testCheckAzureRMTableEntityExists(resourceName string) resource.TestCheckFu
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
 			return fmt.Errorf("Error locating Resource Group for Storage Table Entity (Partition Key %q / Row Key %q) (Table %q / Account %q): %v", partitionKey, rowKey, tableName, accountName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Table Entity (Partition Key %q / Row Key %q) (Table %q / Account %q)", partitionKey, rowKey, tableName, accountName)
+		if account == nil {
+			return fmt.Errorf("Storage Account %q was not found!", accountName)
 		}
 
-		client, err := storageClient.TableEntityClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.TableEntityClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Table Entity Client: %s", err)
 		}
@@ -147,7 +147,7 @@ func testCheckAzureRMTableEntityExists(resourceName string) resource.TestCheckFu
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Entity (Partition Key %q / Row Key %q) (Table %q / Account %q / Resource Group %q) does not exist", partitionKey, rowKey, tableName, accountName, *resourceGroup)
+			return fmt.Errorf("Bad: Entity (Partition Key %q / Row Key %q) (Table %q / Account %q / Resource Group %q) does not exist", partitionKey, rowKey, tableName, accountName, account.ResourceGroup)
 		}
 
 		return nil
@@ -168,17 +168,17 @@ func testCheckAzureRMTableEntityDestroy(s *terraform.State) error {
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Table Entity (Partition Key %q / Row Key %q) (Table %q / Account %q / Resource Group %q): %v", partitionKey, rowKey, tableName, accountName, *resourceGroup, err)
+			return fmt.Errorf("Error locating Resource Group for Storage Table Entity (Partition Key %q / Row Key %q) (Table %q / Account %q): %v", partitionKey, rowKey, tableName, accountName, err)
 		}
 
 		// not found, the account's gone
-		if resourceGroup == nil {
+		if account == nil {
 			return nil
 		}
 
-		client, err := storageClient.TableEntityClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.TableEntityClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building TableEntity Client: %s", err)
 		}

--- a/azurerm/resource_arm_storage_table_test.go
+++ b/azurerm/resource_arm_storage_table_test.go
@@ -143,15 +143,15 @@ func testCheckAzureRMStorageTableExists(resourceName string) resource.TestCheckF
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", tableName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Table %q: %s", accountName, tableName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Table %q (Account %s)", tableName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.TablesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Table Client: %s", err)
 		}
@@ -182,15 +182,15 @@ func testAccARMStorageTableDisappears(resourceName string) resource.TestCheckFun
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", tableName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Table %q: %s", accountName, tableName, err)
 		}
-		if resourceGroup == nil {
-			return fmt.Errorf("Unable to locate Resource Group for Storage Table %q (Account %s)", tableName, accountName)
+		if account == nil {
+			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.TablesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Table Client: %s", err)
 		}
@@ -224,15 +224,15 @@ func testCheckAzureRMStorageTableDestroy(s *terraform.State) error {
 		storageClient := testAccProvider.Meta().(*ArmClient).Storage
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-		resourceGroup, err := storageClient.FindResourceGroup(ctx, accountName)
+		account, err := storageClient.FindAccount(ctx, accountName)
 		if err != nil {
-			return fmt.Errorf("Error locating Resource Group for Storage Table %q (Account %s): %s", tableName, accountName, err)
+			return fmt.Errorf("Error retrieving Account %q for Table %q: %s", accountName, tableName, err)
 		}
-		if resourceGroup == nil {
+		if account == nil {
 			return nil
 		}
 
-		client, err := storageClient.TablesClient(ctx, *resourceGroup, accountName)
+		client, err := storageClient.TablesClient(ctx, *account)
 		if err != nil {
 			return fmt.Errorf("Error building Table Client: %s", err)
 		}

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -1027,15 +1027,15 @@ func resourceArmVirtualMachineDeleteVhd(ctx context.Context, storageClient *intS
 		return fmt.Errorf("Error parsing %q: %s", uri, err)
 	}
 
-	resourceGroup, err := storageClient.FindResourceGroup(ctx, id.AccountName)
+	account, err := storageClient.FindAccount(ctx, id.AccountName)
 	if err != nil {
-		return fmt.Errorf("Error locating Resource Group for Storage Account %q: %s", id.AccountName, err)
+		return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", id.AccountName, id.BlobName, id.ContainerName, err)
 	}
-	if resourceGroup == nil {
-		return fmt.Errorf("Unable to locate Resource Group for Storage Account %q (Disk %q)!", id.AccountName, uri)
+	if account == nil {
+		return fmt.Errorf("Unable to locate Storage Account %q (Disk %q)!", id.AccountName, uri)
 	}
 
-	blobsClient, err := storageClient.BlobsClient(ctx, *resourceGroup, id.AccountName)
+	blobsClient, err := storageClient.BlobsClient(ctx, *account)
 	if err != nil {
 		return fmt.Errorf("Error building Blobs Client: %s", err)
 	}
@@ -1044,7 +1044,7 @@ func resourceArmVirtualMachineDeleteVhd(ctx context.Context, storageClient *intS
 		DeleteSnapshots: false,
 	}
 	if _, err := blobsClient.Delete(ctx, id.AccountName, id.ContainerName, id.BlobName, input); err != nil {
-		return fmt.Errorf("Error deleting Blob %q (Container %q / Account %q / Resource Group %q): %s", id.BlobName, id.ContainerName, id.AccountName, *resourceGroup, err)
+		return fmt.Errorf("Error deleting Blob %q (Container %q / Account %q / Resource Group %q): %s", id.BlobName, id.ContainerName, id.AccountName, account.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
+++ b/azurerm/resource_arm_virtual_machine_unmanaged_disks_test.go
@@ -3019,14 +3019,21 @@ func testCheckAzureRMVirtualMachineVHDExistence(blobName string, shouldExist boo
 				continue
 			}
 
-			resourceGroup := rs.Primary.Attributes["resource_group_name"]
 			accountName := rs.Primary.Attributes["storage_account_name"]
 			containerName := rs.Primary.Attributes["name"]
 
 			storageClient := testAccProvider.Meta().(*ArmClient).Storage
 			ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
-			client, err := storageClient.BlobsClient(ctx, resourceGroup, accountName)
+			account, err := storageClient.FindAccount(ctx, accountName)
+			if err != nil {
+				return fmt.Errorf("Error retrieving Account %q for Blob %q (Container %q): %s", accountName, blobName, containerName, err)
+			}
+			if account == nil {
+				return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
+			}
+
+			client, err := storageClient.BlobsClient(ctx, *account)
 			if err != nil {
 				return fmt.Errorf("Error building Blobs Client: %s", err)
 			}


### PR DESCRIPTION
This PR introduces more extensive caching for Storage Accounts - which allows us to work around a low rate limit due to an unperforment API; which should improve the performance when provisioning large quantities of storage related resources