### PR TITLE
r/key_vault / r/maps: making the sku case insensitive temporarily

### DIFF
--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -93,7 +93,8 @@ func resourceArmKeyVault() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(keyvault.Standard),
 					string(keyvault.Premium),
-				}, false),
+					// TODO: revert this in 2.0
+				}, true),
 			},
 
 			"vault_uri": {

--- a/azurerm/resource_arm_maps_account.go
+++ b/azurerm/resource_arm_maps_account.go
@@ -51,7 +51,8 @@ func resourceArmMapsAccount() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"s0",
 					"s1",
-				}, false),
+					// TODO: revert this in 2.0
+				}, true),
 			},
 
 			"tags": tags.Schema(),


### PR DESCRIPTION
Breaking Changes in the Azure API mean that the Sku's defined in the Swagger (in lower-case) no longer match the return type. This PR temporarily makes the sku name case-insensitive for the Key Vault and Maps Account resources - to allow users to continue working; in 2.0 we'll replace these lower-cased versions with Title Case versions as is now being returned in the API, and then revert the case insensitivity fix in this PR

Fixes #4707
Fixes #4706