### PR TITLE
Add signalr args: 'service_mode' and 'allowed_origins'

### DIFF
--- a/azurerm/internal/services/signalr/client.go
+++ b/azurerm/internal/services/signalr/client.go
@@ -1,7 +1,7 @@
 package signalr
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/preview/signalr/mgmt/2018-03-01-preview/signalr"
+	"github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 )
 

--- a/azurerm/resource_arm_signalr_service.go
+++ b/azurerm/resource_arm_signalr_service.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/preview/signalr/mgmt/2018-03-01-preview/signalr"
+	"github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -72,6 +72,48 @@ func resourceArmSignalRService() *schema.Resource {
 				},
 			},
 
+			"features": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"flag": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"ServiceMode",
+							}, false),
+						},
+
+						"value": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Default",
+								"Serverless",
+								"Classic",
+							}, false),
+						},
+					},
+				},
+			},
+
+			"cors": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allowed_origins": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+
 			"hostname": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -132,6 +174,8 @@ func resourceArmSignalRServiceCreateUpdate(d *schema.ResourceData, meta interfac
 
 	sku := d.Get("sku").([]interface{})
 	t := d.Get("tags").(map[string]interface{})
+	featureFlags := d.Get("features").([]interface{})
+	cors := d.Get("cors").([]interface{})
 	expandedTags := tags.Expand(t)
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
@@ -147,10 +191,16 @@ func resourceArmSignalRServiceCreateUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
+	properties := &signalr.CreateOrUpdateProperties{
+		Cors:     expandSignalRCors(cors),
+		Features: expandSignalRFeatures(featureFlags),
+	}
+
 	parameters := &signalr.CreateParameters{
-		Location: utils.String(location),
-		Sku:      expandSignalRServiceSku(sku),
-		Tags:     expandedTags,
+		Location:   utils.String(location),
+		Sku:        expandSignalRServiceSku(sku),
+		Tags:       expandedTags,
+		Properties: properties,
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters)
@@ -215,6 +265,8 @@ func resourceArmSignalRServiceRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("ip_address", properties.ExternalIP)
 		d.Set("public_port", properties.PublicPort)
 		d.Set("server_port", properties.ServerPort)
+		d.Set("features", flattenSignalRFeatures(properties.Features))
+		d.Set("cors", flattenSignalRCors(properties.Cors))
 	}
 
 	d.Set("primary_access_key", keys.PrimaryKey)
@@ -251,6 +303,80 @@ func resourceArmSignalRServiceDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	return nil
+}
+
+func expandSignalRFeatures(input []interface{}) *[]signalr.Feature {
+	features := make([]signalr.Feature, 0)
+	for _, featureValue := range input {
+		value := featureValue.(map[string]interface{})
+
+		feature := signalr.Feature{
+			Flag:  utils.String(value["flag"].(string)),
+			Value: utils.String(value["value"].(string)),
+		}
+
+		features = append(features, feature)
+	}
+
+	return &features
+}
+
+func flattenSignalRFeatures(features *[]signalr.Feature) []interface{} {
+	result := make([]interface{}, 0)
+	if features != nil {
+		for _, feature := range *features {
+			value := make(map[string]interface{})
+
+			if feature.Flag != nil {
+				value["flag"] = *feature.Flag
+			}
+			if feature.Value != nil {
+				value["value"] = *feature.Value
+			}
+
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func expandSignalRCors(input []interface{}) *signalr.CorsSettings {
+	corsSettings := signalr.CorsSettings{}
+
+	if len(input) == 0 {
+		return &corsSettings
+	}
+
+	setting := input[0].(map[string]interface{})
+	origins := setting["allowed_origins"].(*schema.Set).List()
+
+	allowedOrigins := make([]string, 0)
+	for _, param := range origins {
+		allowedOrigins = append(allowedOrigins, param.(string))
+	}
+
+	corsSettings.AllowedOrigins = &allowedOrigins
+
+	return &corsSettings
+}
+
+func flattenSignalRCors(input *signalr.CorsSettings) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	result := make(map[string]interface{})
+
+	allowedOrigins := make([]interface{}, 0)
+	if s := input.AllowedOrigins; s != nil {
+		for _, v := range *s {
+			allowedOrigins = append(allowedOrigins, v)
+		}
+	}
+	result["allowed_origins"] = schema.NewSet(schema.HashString, allowedOrigins)
+
+	return append(results, result)
 }
 
 func expandSignalRServiceSku(input []interface{}) *signalr.ResourceSku {

--- a/azurerm/resource_arm_signalr_service.go
+++ b/azurerm/resource_arm_signalr_service.go
@@ -76,25 +76,16 @@ func resourceArmSignalRService() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"flag": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"ServiceMode",
-							}, false),
 						},
 
 						"value": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"Default",
-								"Serverless",
-								"Classic",
-							}, false),
 						},
 					},
 				},
@@ -104,7 +95,6 @@ func resourceArmSignalRService() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_origins": {

--- a/azurerm/resource_arm_signalr_service.go
+++ b/azurerm/resource_arm_signalr_service.go
@@ -75,6 +75,7 @@ func resourceArmSignalRService() *schema.Resource {
 			"features": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -102,6 +103,7 @@ func resourceArmSignalRService() *schema.Resource {
 			"cors": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -480,12 +480,18 @@ resource "azurerm_signalr_service" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
+  sku {
+    name     = "Free_F1"
+    capacity = 1
+  }
+
   cors {
 	allowed_origins = [
 	  "http://www.contoso.com",
 	  "www.contoso.com",
 	  "contoso.com",
 	]
+  }
 }
 `, rInt, location, rInt)
 }
@@ -501,6 +507,11 @@ resource "azurerm_signalr_service" "test" {
   name                = "acctestSignalR-%d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    name     = "Free_F1"
+    capacity = 1
+  }
 
   features {
     flag  = "ServiceMode"

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -390,8 +390,8 @@ func TestAccAzureRMSignalRService_cors(t *testing.T) {
 				Config: testAccAzureRMSignalRService_withCors(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSignalRServiceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.cors.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.cors.0.allowed_origins.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors.0.allowed_origins.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_port"),
@@ -487,8 +487,8 @@ resource "azurerm_signalr_service" "test" {
 
   cors {
 	allowed_origins = [
-	  "www.contoso.com",
-	  "contoso.com",
+	  "https://example.com",
+	  "https://contoso.com",
 	]
   }
 }

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -391,7 +391,7 @@ func TestAccAzureRMSignalRService_cors(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSignalRServiceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "site_config.0.cors.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "site_config.0.cors.0.allowed_origins.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.cors.0.allowed_origins.#", "2"),
 					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
 					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_port"),
@@ -487,7 +487,6 @@ resource "azurerm_signalr_service" "test" {
 
   cors {
 	allowed_origins = [
-	  "http://www.contoso.com",
 	  "www.contoso.com",
 	  "contoso.com",
 	]

--- a/azurerm/resource_arm_signalr_service_test.go
+++ b/azurerm/resource_arm_signalr_service_test.go
@@ -44,6 +44,7 @@ func TestAccAzureRMSignalRService_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccAzureRMSignalRService_requiresImport(t *testing.T) {
 	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -341,6 +342,75 @@ func TestAccAzureRMSignalRService_skuAndCapacityUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSignalRService_serviceMode(t *testing.T) {
+	resourceName := "azurerm_signalr_service.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSignalRServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSignalRService_withServiceMode(ri, testLocation(), "Serverless"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSignalRServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "features.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "features.0.flag", "ServiceMode"),
+					resource.TestCheckResourceAttr(resourceName, "features.0.value", "Serverless"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_port"),
+					resource.TestCheckResourceAttrSet(resourceName, "server_port"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_access_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_access_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_connection_string"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMSignalRService_cors(t *testing.T) {
+	resourceName := "azurerm_signalr_service.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSignalRServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSignalRService_withCors(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSignalRServiceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.cors.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.cors.0.allowed_origins.#", "3"),
+					resource.TestCheckResourceAttrSet(resourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_port"),
+					resource.TestCheckResourceAttrSet(resourceName, "server_port"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_access_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_access_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "secondary_connection_string"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccAzureRMSignalRService_basic(rInt int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -396,6 +466,48 @@ resource "azurerm_signalr_service" "test" {
   }
 }
 `, rInt, location, rInt, capacity)
+}
+
+func testAccAzureRMSignalRService_withCors(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_signalr_service" "test" {
+  name                = "acctestSignalR-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  cors {
+	allowed_origins = [
+	  "http://www.contoso.com",
+	  "www.contoso.com",
+	  "contoso.com",
+	]
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMSignalRService_withServiceMode(rInt int, location string, serviceMode string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_signalr_service" "test" {
+  name                = "acctestSignalR-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  features {
+    flag  = "ServiceMode"
+    value = "%s"
+  }
+}
+`, rInt, location, rInt, serviceMode)
 }
 
 func testCheckAzureRMSignalRServiceDestroy(s *terraform.State) error {

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/client.go
@@ -1,4 +1,4 @@
-// Package signalr implements the Azure ARM Signalr service API version 2018-03-01-preview.
+// Package signalr implements the Azure ARM Signalr service API version 2018-10-01.
 //
 // REST API for Azure SignalR Service
 package signalr

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/models.go
@@ -28,7 +28,7 @@ import (
 )
 
 // The package's fully qualified name.
-const fqdn = "github.com/Azure/azure-sdk-for-go/services/preview/signalr/mgmt/2018-03-01-preview/signalr"
+const fqdn = "github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr"
 
 // KeyType enumerates the values for key type.
 type KeyType string
@@ -93,6 +93,12 @@ func PossibleSkuTierValues() []SkuTier {
 	return []SkuTier{Basic, Free, Premium, Standard}
 }
 
+// CorsSettings cross-Origin Resource Sharing (CORS) settings.
+type CorsSettings struct {
+	// AllowedOrigins - Gets or sets the list of origins that should be allowed to make cross-origin calls (for example: http://example.com:12345). Use "*" to allow all. If omitted, allow all by default.
+	AllowedOrigins *[]string `json:"allowedOrigins,omitempty"`
+}
+
 // CreateOrUpdateFuture an abstraction for monitoring and retrieving the results of a long-running
 // operation.
 type CreateOrUpdateFuture struct {
@@ -127,6 +133,15 @@ type CreateOrUpdateProperties struct {
 	// HostNamePrefix - Prefix for the hostName of the SignalR service. Retained for future use.
 	// The hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net.
 	HostNamePrefix *string `json:"hostNamePrefix,omitempty"`
+	// Features - List of SignalR featureFlags. e.g. ServiceMode.
+	//
+	// FeatureFlags that are not included in the parameters for the update operation will not be modified.
+	// And the response will only include featureFlags that are explicitly set.
+	// When a featureFlag is not explicitly set, SignalR service will use its globally default value.
+	// But keep in mind, the default value doesn't mean "false". It varies in terms of different FeatureFlags.
+	Features *[]Feature `json:"features,omitempty"`
+	// Cors - Cross-Origin Resource Sharing (CORS) settings.
+	Cors *CorsSettings `json:"cors,omitempty"`
 }
 
 // CreateParameters parameters for SignalR service create/update operation.
@@ -194,6 +209,31 @@ type Dimension struct {
 	InternalName *string `json:"internalName,omitempty"`
 	// ToBeExportedForShoebox - A Boolean flag indicating whether this dimension should be included for the shoebox export scenario.
 	ToBeExportedForShoebox *bool `json:"toBeExportedForShoebox,omitempty"`
+}
+
+// Feature feature of a SignalR resource, which controls the SignalR runtime behavior.
+type Feature struct {
+	// Flag - Kind of feature. Required.
+	Flag *string `json:"flag,omitempty"`
+	// Value - Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/en-us/azure/azure-signalr/ for allowed values.
+	Value *string `json:"value,omitempty"`
+	// Properties - Optional properties related to this feature.
+	Properties map[string]*string `json:"properties"`
+}
+
+// MarshalJSON is the custom marshaler for Feature.
+func (f Feature) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if f.Flag != nil {
+		objectMap["flag"] = f.Flag
+	}
+	if f.Value != nil {
+		objectMap["value"] = f.Value
+	}
+	if f.Properties != nil {
+		objectMap["properties"] = f.Properties
+	}
+	return json.Marshal(objectMap)
 }
 
 // Keys a class represents the access keys of SignalR service.
@@ -437,15 +477,24 @@ type Properties struct {
 	ExternalIP *string `json:"externalIP,omitempty"`
 	// HostName - READ-ONLY; FQDN of the SignalR service instance. Format: xxx.service.signalr.net
 	HostName *string `json:"hostName,omitempty"`
-	// PublicPort - READ-ONLY; The publicly accessibly port of the SignalR service which is designed for browser/client side usage.
+	// PublicPort - READ-ONLY; The publicly accessible port of the SignalR service which is designed for browser/client side usage.
 	PublicPort *int32 `json:"publicPort,omitempty"`
-	// ServerPort - READ-ONLY; The publicly accessibly port of the SignalR service which is designed for customer server side usage.
+	// ServerPort - READ-ONLY; The publicly accessible port of the SignalR service which is designed for customer server side usage.
 	ServerPort *int32 `json:"serverPort,omitempty"`
 	// Version - Version of the SignalR resource. Probably you need the same or higher version of client SDKs.
 	Version *string `json:"version,omitempty"`
 	// HostNamePrefix - Prefix for the hostName of the SignalR service. Retained for future use.
 	// The hostname will be of format: &lt;hostNamePrefix&gt;.service.signalr.net.
 	HostNamePrefix *string `json:"hostNamePrefix,omitempty"`
+	// Features - List of SignalR featureFlags. e.g. ServiceMode.
+	//
+	// FeatureFlags that are not included in the parameters for the update operation will not be modified.
+	// And the response will only include featureFlags that are explicitly set.
+	// When a featureFlag is not explicitly set, SignalR service will use its globally default value.
+	// But keep in mind, the default value doesn't mean "false". It varies in terms of different FeatureFlags.
+	Features *[]Feature `json:"features,omitempty"`
+	// Cors - Cross-Origin Resource Sharing (CORS) settings.
+	Cors *CorsSettings `json:"cors,omitempty"`
 }
 
 // RegenerateKeyFuture an abstraction for monitoring and retrieving the results of a long-running
@@ -640,18 +689,25 @@ func NewResourceListPage(getNextPage func(context.Context, ResourceList) (Resour
 	return ResourceListPage{fn: getNextPage}
 }
 
-// ResourceSku the billing information of the resource.(e.g. basic vs. standard)
+// ResourceSku the billing information of the SignalR resource.
 type ResourceSku struct {
-	// Name - The name of the SKU. This is typically a letter + number code, such as A0 or P3.  Required (if sku is specified)
+	// Name - The name of the SKU. Required.
+	//
+	// Allowed values: Standard_S1, Free_F1
 	Name *string `json:"name,omitempty"`
-	// Tier - Optional tier of this particular SKU. `Basic` is deprecated, use `Standard` instead for Basic tier. Possible values include: 'Free', 'Basic', 'Standard', 'Premium'
+	// Tier - Optional tier of this particular SKU. 'Standard' or 'Free'.
+	//
+	// `Basic` is deprecated, use `Standard` instead. Possible values include: 'Free', 'Basic', 'Standard', 'Premium'
 	Tier SkuTier `json:"tier,omitempty"`
-	// Size - Optional, string. When the name field is the combination of tier and some other value, this would be the standalone code.
+	// Size - Optional string. For future use.
 	Size *string `json:"size,omitempty"`
-	// Family - Optional, string. If the service has different generations of hardware, for the same SKU, then that can be captured here.
+	// Family - Optional string. For future use.
 	Family *string `json:"family,omitempty"`
-	// Capacity - Optional, integer. If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not
-	// possible for the resource this may be omitted.
+	// Capacity - Optional, integer. The unit count of SignalR resource. 1 by default.
+	//
+	// If present, following values are allowed:
+	//     Free: 1
+	//     Standard: 1,2,5,10,20,50,100
 	Capacity *int32 `json:"capacity,omitempty"`
 }
 
@@ -768,6 +824,28 @@ func (rt *ResourceType) UnmarshalJSON(body []byte) error {
 	}
 
 	return nil
+}
+
+// RestartFuture an abstraction for monitoring and retrieving the results of a long-running operation.
+type RestartFuture struct {
+	azure.Future
+}
+
+// Result returns the result of the asynchronous operation.
+// If the operation has not completed it will return an error.
+func (future *RestartFuture) Result(client Client) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.DoneWithContext(context.Background(), client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "signalr.RestartFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("signalr.RestartFuture")
+		return
+	}
+	ar.Response = future.Response()
+	return
 }
 
 // ServiceSpecification an object that describes a specification.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/operations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/operations.go
@@ -76,7 +76,7 @@ func (client OperationsClient) List(ctx context.Context) (result OperationListPa
 
 // ListPreparer prepares the List request.
 func (client OperationsClient) ListPreparer(ctx context.Context) (*http.Request, error) {
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/signalr.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/signalr.go
@@ -93,7 +93,7 @@ func (client Client) CheckNameAvailabilityPreparer(ctx context.Context, location
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -178,7 +178,7 @@ func (client Client) CreateOrUpdatePreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -187,7 +187,7 @@ func (client Client) CreateOrUpdatePreparer(ctx context.Context, resourceGroupNa
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPut(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}", pathParameters),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	if parameters != nil {
 		preparer = autorest.DecoratePreparer(preparer,
@@ -261,7 +261,7 @@ func (client Client) DeletePreparer(ctx context.Context, resourceGroupName strin
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -269,7 +269,7 @@ func (client Client) DeletePreparer(ctx context.Context, resourceGroupName strin
 	preparer := autorest.CreatePreparer(
 		autorest.AsDelete(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}", pathParameters),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -344,7 +344,7 @@ func (client Client) GetPreparer(ctx context.Context, resourceGroupName string, 
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -352,7 +352,7 @@ func (client Client) GetPreparer(ctx context.Context, resourceGroupName string, 
 	preparer := autorest.CreatePreparer(
 		autorest.AsGet(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}", pathParameters),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	return preparer.Prepare((&http.Request{}).WithContext(ctx))
 }
@@ -421,7 +421,7 @@ func (client Client) ListByResourceGroupPreparer(ctx context.Context, resourceGr
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -531,7 +531,7 @@ func (client Client) ListBySubscriptionPreparer(ctx context.Context) (*http.Requ
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -646,7 +646,7 @@ func (client Client) ListKeysPreparer(ctx context.Context, resourceGroupName str
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -720,7 +720,7 @@ func (client Client) RegenerateKeyPreparer(ctx context.Context, resourceGroupNam
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -764,6 +764,83 @@ func (client Client) RegenerateKeyResponder(resp *http.Response) (result Keys, e
 	return
 }
 
+// Restart operation to restart a SignalR service.
+// Parameters:
+// resourceGroupName - the name of the resource group that contains the resource. You can obtain this value
+// from the Azure Resource Manager API or the portal.
+// resourceName - the name of the SignalR resource.
+func (client Client) Restart(ctx context.Context, resourceGroupName string, resourceName string) (result RestartFuture, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/Client.Restart")
+		defer func() {
+			sc := -1
+			if result.Response() != nil {
+				sc = result.Response().StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.RestartPreparer(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "signalr.Client", "Restart", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.RestartSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "signalr.Client", "Restart", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// RestartPreparer prepares the Restart request.
+func (client Client) RestartPreparer(ctx context.Context, resourceGroupName string, resourceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"resourceName":      autorest.Encode("path", resourceName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2018-10-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}/restart", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// RestartSender sends the Restart request. The method will close the
+// http.Response Body if it receives an error.
+func (client Client) RestartSender(req *http.Request) (future RestartFuture, err error) {
+	sd := autorest.GetSendDecorators(req.Context(), azure.DoRetryWithRegistration(client.Client))
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req, sd...)
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
+	return
+}
+
+// RestartResponder handles the response to the Restart request. The method always
+// closes the http.Response Body.
+func (client Client) RestartResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
 // Update operation to update an exiting SignalR service.
 // Parameters:
 // resourceGroupName - the name of the resource group that contains the resource. You can obtain this value
@@ -804,7 +881,7 @@ func (client Client) UpdatePreparer(ctx context.Context, resourceGroupName strin
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -813,7 +890,7 @@ func (client Client) UpdatePreparer(ctx context.Context, resourceGroupName strin
 		autorest.AsContentType("application/json; charset=utf-8"),
 		autorest.AsPatch(),
 		autorest.WithBaseURL(client.BaseURI),
-		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/SignalR/{resourceName}", pathParameters),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.SignalRService/signalR/{resourceName}", pathParameters),
 		autorest.WithQueryParameters(queryParameters))
 	if parameters != nil {
 		preparer = autorest.DecoratePreparer(preparer,

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/usages.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/usages.go
@@ -83,7 +83,7 @@ func (client UsagesClient) ListPreparer(ctx context.Context, location string) (*
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-03-01-preview"
+	const APIVersion = "2018-10-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/version.go
@@ -21,7 +21,7 @@ import "github.com/Azure/azure-sdk-for-go/version"
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/" + version.Number + " signalr/2018-03-01-preview"
+	return "Azure-SDK-For-Go/" + version.Number + " signalr/2018-10-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/Azure/azure-sdk-for-go/services/preview/portal/mgmt/2019-01-01-previe
 github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2018-03-01-preview/managementgroups
 github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v1.0/security
 github.com/Azure/azure-sdk-for-go/services/preview/servicebus/mgmt/2018-01-01-preview/servicebus
-github.com/Azure/azure-sdk-for-go/services/preview/signalr/mgmt/2018-03-01-preview/signalr
+github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr
 github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2015-05-01-preview/sql
 github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/2017-10-01-preview/sql
 github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -27,6 +27,15 @@ resource "azurerm_signalr_service" "example" {
     name     = "Free_F1"
     capacity = 1
   }
+
+  features {
+    flag = "ServiceMode"
+    value = "Default"
+  }
+
+  cors {
+    allowed_origins = ["http://www.example.com"]
+  }
 }
 ```
 
@@ -42,6 +51,10 @@ The following arguments are supported:
 
 * `sku` - A `sku` block as documented below.
 
+* `features` - (Optional) A `features` block as documented below.
+
+* `cors` - (Optional) A `cors` block as documented below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -51,6 +64,20 @@ A `sku` block supports the following:
 * `name` - (Required) Specifies which tier to use. Valid values are `Free_F1` and `Standard_S1`.
 
 * `capacity` - (Required) Specifies the number of units associated with this SignalR service. Valid values are `1`, `2`, `5`, `10`, `20`, `50` and `100`.
+
+---
+
+A `features` block supports the following:
+
+* `flag` - (Required) A kind of feature. e.g. ServiceMode.
+
+* `value` - (Required) A value of a feature flag. e.g. Default, Serverless, or Classic.
+
+---
+
+A `cors` block supports the following:
+
+* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
 ## Attributes Reference
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -28,13 +28,13 @@ resource "azurerm_signalr_service" "example" {
     capacity = 1
   }
 
+  cors {
+    allowed_origins = ["http://www.example.com"]
+  }
+
   features {
     flag = "ServiceMode"
     value = "Default"
-  }
-
-  cors {
-    allowed_origins = ["http://www.example.com"]
   }
 }
 ```
@@ -51,11 +51,25 @@ The following arguments are supported:
 
 * `sku` - A `sku` block as documented below.
 
-* `features` - (Optional) A `features` block as documented below.
-
 * `cors` - (Optional) A `cors` block as documented below.
 
+* `features` - (Optional) A `features` block as documented below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `cors` block supports the following:
+
+* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+
+---
+
+A `features` block supports the following:
+
+* `flag` - (Required) A kind of feature. At this time the only supported value is `ServiceMode`.
+
+* `value` - (Required) A value of a feature flag. Possible values are `Classic`, `Default` and `Serverless`.
 
 ---
 
@@ -64,20 +78,6 @@ A `sku` block supports the following:
 * `name` - (Required) Specifies which tier to use. Valid values are `Free_F1` and `Standard_S1`.
 
 * `capacity` - (Required) Specifies the number of units associated with this SignalR service. Valid values are `1`, `2`, `5`, `10`, `20`, `50` and `100`.
-
----
-
-A `features` block supports the following:
-
-* `flag` - (Required) A kind of feature. e.g. ServiceMode.
-
-* `value` - (Required) A value of a feature flag. e.g. Default, Serverless, or Classic.
-
----
-
-A `cors` block supports the following:
-
-* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #4422 by adding service_mode and allowed_origins to the azurerm_signalr_service. 

Needed to update the signalr api version as the preview version did not have these fields present. Added acceptance tests verifying as well.
