### PR TITLE
Update docs for adls gen2

### DIFF
--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) Specifies the ID of the Storage Account in which the Data Lake Gen2 File System should exist. Changing this forces a new resource to be created.
 
+~> **NOTE:** The Storage Account requires an account kind of either `StorageV2` or `BlobStorage` and `is_hns_enabled` has to be set to `true`.
+
 * `properties` - (Optional) A mapping of Key to Base64-Encoded Values which should be assigned to this Data Lake Gen2 File System. 
 
 ## Attributes Reference

--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -26,6 +26,8 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+  is_hns_enabled           = "true"
 }
 
 resource "azurerm_storage_data_lake_gen2_filesystem" "test" {

--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) Specifies the ID of the Storage Account in which the Data Lake Gen2 File System should exist. Changing this forces a new resource to be created.
 
-~> **NOTE:** The Storage Account requires an account kind of either `StorageV2` or `BlobStorage` and `is_hns_enabled` has to be set to `true`.
+~> **NOTE:** The Storage Account requires `account_kind` to be either `StorageV2` or `BlobStorage`. In addition, `is_hns_enabled` has to be set to `true`.
 
 * `properties` - (Optional) A mapping of Key to Base64-Encoded Values which should be assigned to this Data Lake Gen2 File System. 
 


### PR DESCRIPTION
The current ADLS Gen2 example does not work out of the box. 

According to the [official docs](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-account), the account kind has to be `StorageV2`.

In addition, HNS has to be enabled in order to provision an ADLS Gen2 resource. If not, an error message returns, unable to find the resource. 

`Error: Error creating File System "example" in Storage Account "exampladlsstorageact": datalakestore.Client#Create: Failure sending request: StatusCode=0 -- Original Error: Put https://exampladlsstorageact.dfs.core.windows.net/example?resource=filesystem: dial tcp: lookup exampladlsstorageact.dfs.core.windows.net on 10.50.10.50:53: no such host`