### PR TITLE
Feature: data source for PostgreSQL

### DIFF
--- a/azurerm/data_source_postgresql_server.go
+++ b/azurerm/data_source_postgresql_server.go
@@ -69,12 +69,10 @@ func dataSourceArmPostgreSqlServerRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error retrieving PostgreSql Server %q (Resource Group %q): %s", name, resourceGroup, err)
 	}
 
-	if id := resp.ID; id != nil {
-		d.SetId(*resp.ID)
 	if resp.ID == nil {
 		return fmt.Errorf("Error retrieving PostgreSql Server %q (Resource Group %q): `id` was nil", name, resourceGroup)
 	}
-	
+
 	d.SetId(*resp.ID)
 
 	if location := resp.Location; location != nil {

--- a/azurerm/data_source_postgresql_server.go
+++ b/azurerm/data_source_postgresql_server.go
@@ -1,0 +1,87 @@
+package azurerm
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourcePostgreSqlServer() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmPostgreSqlServerRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"administrator_login": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceArmPostgreSqlServerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).Postgres.ServersClient
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("PostgreSql Server %q was not found in Resource Group %q", name, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving PostgreSql Server %q (Resource Group %q): %s", name, resourceGroup, err)
+	}
+
+	if id := resp.ID; id != nil {
+		d.SetId(*resp.ID)
+	}
+
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+
+	if props := resp.ServerProperties; props != nil {
+		d.Set("fqdn", props.FullyQualifiedDomainName)
+		d.Set("version", props.Version)
+		d.Set("administrator_login", props.AdministratorLogin)
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}

--- a/azurerm/data_source_postgresql_server.go
+++ b/azurerm/data_source_postgresql_server.go
@@ -71,7 +71,11 @@ func dataSourceArmPostgreSqlServerRead(d *schema.ResourceData, meta interface{})
 
 	if id := resp.ID; id != nil {
 		d.SetId(*resp.ID)
+	if resp.ID == nil {
+		return fmt.Errorf("Error retrieving PostgreSql Server %q (Resource Group %q): `id` was nil", name, resourceGroup)
 	}
+	
+	d.SetId(*resp.ID)
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))

--- a/azurerm/data_source_postgresql_server_test.go
+++ b/azurerm/data_source_postgresql_server_test.go
@@ -1,0 +1,47 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+)
+
+func TestAccDataSourceAzureRMPPostgreSqlServer_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_postgresql_server.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	version := "9.5"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMPostgreSQLServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMPostgreSqlServer_basic(ri, location, version),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPostgreSQLServerExists(dataSourceName),
+					resource.TestCheckResourceAttrSet(dataSourceName, "location"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fqdn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "administrator_login"),
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMPostgreSqlServer_basic(rInt int, location string, version string) string {
+	template := testAccAzureRMPostgreSQLServer_basic(rInt, location, version)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_postgresql_server" "test" {
+  name                = "${azurerm_postgresql_server.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, template)
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -112,6 +112,7 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_notification_hub":                        dataSourceNotificationHub(),
 		"azurerm_platform_image":                          dataSourceArmPlatformImage(),
 		"azurerm_policy_definition":                       dataSourceArmPolicyDefinition(),
+		"azurerm_postgresql_server":                       dataSourcePostgreSqlServer(),
 		"azurerm_proximity_placement_group":               dataSourceArmProximityPlacementGroup(),
 		"azurerm_public_ip":                               dataSourceArmPublicIP(),
 		"azurerm_public_ips":                              dataSourceArmPublicIPs(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -283,6 +283,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/d/postgresql_server.html.markdown">azurerm_postgresql_server</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/public_ip_prefix.html">azurerm_public_ip_prefix</a>
                 </li>
 

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -283,7 +283,7 @@
                 </li>
 
                 <li>
-                    <a href="/docs/d/postgresql_server.html.markdown">azurerm_postgresql_server</a>
+                    <a href="/docs/d/postgresql_server.html">azurerm_postgresql_server</a>
                 </li>
 
                 <li>

--- a/website/docs/d/postgresql_server.html.markdown
+++ b/website/docs/d/postgresql_server.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_postgresql_server"
+sidebar_current: "docs-azurerm-datasource-postgresql-server"
+description: |-
+  Gets information about an existing PostgreSQL Azure Database Server.
+---
+
+# Data Source: azurerm_postgresql_server
+
+Use this data source to access information about an existing PostgreSQL Azure Database Server.
+
+## Example Usage
+
+```hcl
+data "azurerm_postgresql_server" "test" {
+  name                = "postgresql-server-1"
+  resource_group_name = "api-rg-pro"
+}
+
+output "postgresql_server_id" {
+  value = "${data.azurerm_postgresql_server.test.id}"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the PostgreSQL Server.
+
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the PostgreSQL Server exists.
+
+## Attributes Reference
+
+* `location` - The location of the Resource Group in which the PostgreSQL Server exists.
+
+* `fqdn` - The fully qualified domain name of the PostgreSQL Server.
+
+* `version` - The version of the PostgreSQL Server.
+
+* `administrator_login` - The administrator username of the PostgreSQL Server.
+
+* `tags` - A mapping of tags assigned to the resource.


### PR DESCRIPTION
Status: I've got to finish the documentation.

Questions for reviewers:
- In my`TestAccDataSourceAzureRMPPostgreSqlServer_basic` test, I've hard coded to use version `9.5`, would you prefer I create basic tests for all versions supported?
- Do I need to commit my `go.sum`?

Closes #4662 