### PR TITLE
api_management_subscription: Change possible state values to lowercase

### DIFF
--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 ---
 
-* `state` - (Optional) The state of this Subscription. Possible values are `Active`, `Cancelled`, `Expired`, `Rejected`, `Submitted` and `Suspended`. Defaults to `Submitted`.
+* `state` - (Optional) The state of this Subscription. Possible values are `active`, `cancelled`, `expired`, `rejected`, `submitted` and `suspended`. Defaults to `submitted`.
 
 * `subscription_id` - (Optional) An Identifier which should used as the ID of this Subscription. If not specified a new Subscription ID will be generated. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This PR fixes #4551 to avoid confusion for possible state values. The API is case sensitive and expects lowercase values.

