### PR TITLE
Shared Image Gallery is no longer in preview

### DIFF
--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -11,8 +11,6 @@ description: |-
 
 Manages a Shared Image within a Shared Image Gallery.
 
--> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -11,8 +11,6 @@ description: |-
 
 Manages a Shared Image Gallery.
 
--> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
-
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -11,8 +11,6 @@ description: |-
 
 Manages a Version of a Shared Image within a Shared Image Gallery.
 
--> **NOTE** Shared Image Galleries are currently in Public Preview. You can find more information, including [how to register for the Public Preview here](https://azure.microsoft.com/en-gb/blog/announcing-the-public-preview-of-shared-image-gallery/).
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
See https://azure.microsoft.com/en-us/updates/shared-image-gallery-generally-available/
for the May 2019 GA announcement.