### PR TITLE
r/eventhub_namespace: deprecating `kafka_enabled` since this is now managed by Azure

### DIFF
--- a/azurerm/data_source_eventhub_namespace_test.go
+++ b/azurerm/data_source_eventhub_namespace_test.go
@@ -42,7 +42,6 @@ func TestAccDataSourceAzureRMEventHubNamespace_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "sku", "Standard"),
 					resource.TestCheckResourceAttr(dataSourceName, "capacity", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "auto_inflate_enabled", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "kafka_enabled", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "maximum_throughput_units", "20"),
 				),
 			},
@@ -85,7 +84,6 @@ resource "azurerm_eventhub_namespace" "test" {
   sku                      = "Standard"
   capacity                 = "2"
   auto_inflate_enabled     = true
-  kafka_enabled            = true
   maximum_throughput_units = 20
 }
 

--- a/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/azurerm/resource_arm_eventhub_namespace_test.go
@@ -66,31 +66,6 @@ func TestAccAzureRMEventHubNamespace_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMEventHubNamespace_KafkaEnabled(t *testing.T) {
-	resourceName := "azurerm_eventhub_namespace.test"
-	ri := tf.AccRandTimeInt()
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMEventHubNamespace_KafkaEnabled(ri, testLocation()),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMEventHubNamespaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "kafka_enabled", "true"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccAzureRMEventHubNamespace_standard(t *testing.T) {
 	resourceName := "azurerm_eventhub_namespace.test"
 	ri := tf.AccRandTimeInt()
@@ -476,23 +451,6 @@ resource "azurerm_eventhub_namespace" "import" {
   sku                 = "${azurerm_eventhub_namespace.test.sku}"
 }
 `, template)
-}
-
-func testAccAzureRMEventHubNamespace_KafkaEnabled(rInt int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_eventhub_namespace" "test" {
-  name                = "acctesteventhubnamespace-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  sku                 = "Standard"
-  kafka_enabled       = true
-}
-`, rInt, location, rInt)
 }
 
 func testAccAzureRMEventHubNamespace_standard(rInt int, location string) string {

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -276,6 +276,8 @@ The deprecated `location` field will be removed, since this is no longer used.
 
 ## Resource: `azurerm_eventhub_namespace`
 
+The deprecated `kafka_enabled` field will be removed, since this is no longer used.
+
 The deprecated `location` field will be removed, since this is no longer used.
 
 ### Resource: `azurerm_firewall`

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -14,12 +14,12 @@ Manages an EventHub Namespace.
 
 ```hcl
 resource "azurerm_resource_group" "test" {
-  name     = "resourceGroup1"
-  location = "West US"
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_eventhub_namespace" "test" {
-  name                = "acceptanceTestEventHubNamespace"
+  name                = "example-namespace"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
@@ -49,7 +49,9 @@ The following arguments are supported:
 
 * `maximum_throughput_units` - (Optional) Specifies the maximum number of throughput units when Auto Inflate is Enabled. Valid values range from `1` - `20`.
 
-* `kafka_enabled` - (Optional) Is Kafka enabled for the EventHub Namespace? Defaults to `false`. Changing this forces a new resource to be created.
+* `kafka_enabled` - (Optional / **Deprecated**) Is Kafka enabled for the EventHub Namespace? Defaults to `false`.
+
+-> **NOTE:** `kafka_enabled` is now configured depending on the `sku` being provisioned, where this is Disabled for a `Basic` sku and Enabled for a Standard sku.  
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
The field `kafka_enabled` is now automatically configured by Azure depending on the
sku being used - where it's Disabled for a `Basic` sku but Enabled for a `Standard`
sku - as such this field is no longer user configurable and will be removed in 2.0

Fixes #4598