### PR TITLE
r/maps: updating the sku tests to use `S0` rather than `s0`

### DIFF
--- a/azurerm/data_source_maps_account_test.go
+++ b/azurerm/data_source_maps_account_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceAzureRMMapsAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "resource_group_name"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(dataSourceName, "tags.environment", "testing"),
-					resource.TestCheckResourceAttr(dataSourceName, "sku_name", "s0"),
+					resource.TestCheckResourceAttr(dataSourceName, "sku_name", "S0"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "x_ms_client_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "primary_access_key"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "secondary_access_key"),

--- a/azurerm/resource_arm_maps_account_test.go
+++ b/azurerm/resource_arm_maps_account_test.go
@@ -27,7 +27,7 @@ func TestAccAzureRMMapsAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "x_ms_client_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "primary_access_key"),
 					resource.TestCheckResourceAttrSet(resourceName, "secondary_access_key"),
-					resource.TestCheckResourceAttr(resourceName, "sku_name", "s0"),
+					resource.TestCheckResourceAttr(resourceName, "sku_name", "S0"),
 				),
 			},
 			{
@@ -55,7 +55,7 @@ func TestAccAzureRMMapsAccount_sku(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "x_ms_client_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "primary_access_key"),
 					resource.TestCheckResourceAttrSet(resourceName, "secondary_access_key"),
-					resource.TestCheckResourceAttr(resourceName, "sku_name", "s1"),
+					resource.TestCheckResourceAttr(resourceName, "sku_name", "S1"),
 				),
 			},
 			{
@@ -168,7 +168,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_maps_account" "test" {
   name                = "accMapsAccount-%d"
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "s0"
+  sku_name            = "S0"
 }
 `, rInt, location, rInt)
 }
@@ -183,7 +183,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_maps_account" "test" {
   name                = "accMapsAccount-%d"
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "s1"
+  sku_name            = "S1"
 }
 `, rInt, location, rInt)
 }
@@ -198,7 +198,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_maps_account" "test" {
   name                = "accMapsAccount-%d"
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "s0"
+  sku_name            = "S0"
 
   tags = {
     environment = "testing"


### PR DESCRIPTION
```
$ acctests azurerm TestAccAzureRMMapsAccount_
=== RUN   TestAccAzureRMMapsAccount_basic
=== PAUSE TestAccAzureRMMapsAccount_basic
=== RUN   TestAccAzureRMMapsAccount_sku
=== PAUSE TestAccAzureRMMapsAccount_sku
=== RUN   TestAccAzureRMMapsAccount_tags
=== PAUSE TestAccAzureRMMapsAccount_tags
=== CONT  TestAccAzureRMMapsAccount_basic
--- PASS: TestAccAzureRMMapsAccount_basic (96.70s)
=== CONT  TestAccAzureRMMapsAccount_tags
--- PASS: TestAccAzureRMMapsAccount_tags (115.07s)
=== CONT  TestAccAzureRMMapsAccount_sku
--- PASS: TestAccAzureRMMapsAccount_sku (132.91s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	344.735s
```