### PR TITLE
storage_account: Fix Advanced Threat Protection matching for Azure Germany

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1134,7 +1134,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 	atp, err := advancedThreatProtectionClient.Get(ctx, d.Id())
 	if err != nil {
 		msg := err.Error()
-		if msg != "The resource namespace 'Microsoft.Security' is invalid." {
+		if !strings.Contains(msg, "The resource namespace 'Microsoft.Security' is invalid.") {
 			if !strings.Contains(msg, "No registered resource provider found for location '") {
 				if !strings.Contains(msg, "' and API version '2017-08-01-preview' for type ") {
 					return fmt.Errorf("Error reading the advanced threat protection settings of AzureRM Storage Account %q: %+v", name, err)


### PR DESCRIPTION
Although the error message returned from Azure Germany Cloud is precisely "The resource namespace 'Microsoft.Security' is invalid." the error message we are seeing in `r/storage_account` has other contents added on it, so we cannot do an equals check directly. The ATP fix was being pushed as v1.36.0, but this change provides the actual resolution.

Ref #4563, #4564.