### PR TITLE
Partner ID: allowing users to opt-out of the default Terraform Partner ID

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -152,7 +152,7 @@ type ArmClient struct {
 
 // getArmClient is a helper method which returns a fully instantiated
 // *ArmClient based on the Config's current settings.
-func getArmClient(authConfig *authentication.Config, skipProviderRegistration bool, tfVersion, partnerId string, disableCorrelationRequestID bool) (*ArmClient, error) {
+func getArmClient(authConfig *authentication.Config, skipProviderRegistration bool, tfVersion, partnerId string, disableCorrelationRequestID, disableTerraformPartnerID bool) (*ArmClient, error) {
 	env, err := authentication.DetermineEnvironment(authConfig.Environment)
 	if err != nil {
 		return nil, err
@@ -221,6 +221,7 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		PollingDuration:             180 * time.Minute,
 		SkipProviderReg:             skipProviderRegistration,
 		DisableCorrelationRequestID: disableCorrelationRequestID,
+		DisableTerraformPartnerID:   disableTerraformPartnerID,
 		Environment:                 *env,
 	}
 

--- a/azurerm/internal/common/client_options.go
+++ b/azurerm/internal/common/client_options.go
@@ -30,6 +30,7 @@ type ClientOptions struct {
 
 	SkipProviderReg             bool
 	DisableCorrelationRequestID bool
+	DisableTerraformPartnerID   bool
 	Environment                 azure.Environment
 
 	// TODO: remove me in 2.0
@@ -37,7 +38,7 @@ type ClientOptions struct {
 }
 
 func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.Authorizer) {
-	setUserAgent(c, o.TerraformVersion, o.PartnerId)
+	setUserAgent(c, o.TerraformVersion, o.PartnerId, o.DisableTerraformPartnerID)
 
 	c.Authorizer = authorizer
 	c.Sender = sender.BuildSender("AzureRM")
@@ -52,7 +53,7 @@ func (o ClientOptions) ConfigureClient(c *autorest.Client, authorizer autorest.A
 	}
 }
 
-func setUserAgent(client *autorest.Client, tfVersion, partnerID string) {
+func setUserAgent(client *autorest.Client, tfVersion, partnerID string, disableTerraformPartnerID bool) {
 	tfUserAgent := httpclient.TerraformUserAgent(tfVersion)
 
 	providerUserAgent := fmt.Sprintf("%s terraform-provider-azurerm/%s", tfUserAgent, version.ProviderVersion)
@@ -64,12 +65,16 @@ func setUserAgent(client *autorest.Client, tfVersion, partnerID string) {
 	}
 
 	// only one pid can be interpreted currently
-	// hence, send partner ID if present, otherrwise send Terraform GUID
-	if partnerID == "" {
+	// hence, send partner ID if present, otherwise send Terraform GUID
+	// unless users have opted out
+	if partnerID == "" && !disableTerraformPartnerID {
 		// Microsoft’s Terraform Partner ID is this specific GUID
 		partnerID = "222c6c49-1b0a-5959-a213-6608f9eb8820"
 	}
-	client.UserAgent = fmt.Sprintf("%s pid-%s", client.UserAgent, partnerID)
+
+	if partnerID != "" {
+		client.UserAgent = fmt.Sprintf("%s pid-%s", client.UserAgent, partnerID)
+	}
 
 	log.Printf("[DEBUG] AzureRM Client User Agent: %s\n", client.UserAgent)
 }

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -608,10 +608,18 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"disable_correlation_request_id": {
-				Type:        schema.TypeBool,
-				Optional:    true,
+				Type:     schema.TypeBool,
+				Optional: true,
+				// TODO: add an ARM_ prefix in 2.0w
 				DefaultFunc: schema.EnvDefaultFunc("DISABLE_CORRELATION_REQUEST_ID", false),
 				Description: "This will disable the x-ms-correlation-request-id header.",
+			},
+
+			"disable_terraform_partner_id": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_DISABLE_TERRAFORM_PARTNER_ID", false),
+				Description: "This will disable the Terraform Partner ID which is used if a custom `partner_id` isn't specified.",
 			},
 
 			// Advanced feature flags
@@ -651,7 +659,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		}
 
 		if len(auxTenants) > 3 {
-			return nil, fmt.Errorf("The provider onlt supports 3 auxiliary tenant IDs")
+			return nil, fmt.Errorf("The provider only supports 3 auxiliary tenant IDs")
 		}
 
 		builder := &authentication.Builder{
@@ -684,6 +692,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		partnerId := d.Get("partner_id").(string)
 		skipProviderRegistration := d.Get("skip_provider_registration").(bool)
 		disableCorrelationRequestID := d.Get("disable_correlation_request_id").(bool)
+		disableTerraformPartnerID := d.Get("disable_terraform_partner_id").(bool)
 
 		terraformVersion := p.TerraformVersion
 		if terraformVersion == "" {
@@ -692,7 +701,8 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			terraformVersion = "0.11+compatible"
 		}
 
-		client, err := getArmClient(config, skipProviderRegistration, terraformVersion, partnerId, disableCorrelationRequestID)
+		// TODO: we should pass in an Object here
+		client, err := getArmClient(config, skipProviderRegistration, terraformVersion, partnerId, disableCorrelationRequestID, disableTerraformPartnerID)
 		if err != nil {
 			return nil, err
 		}

--- a/azurerm/required_resource_providers_test.go
+++ b/azurerm/required_resource_providers_test.go
@@ -14,7 +14,7 @@ func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 	}
 
 	// this test intentionally checks all the RP's are registered - so this is intentional
-	armClient, err := getArmClient(config, true, "0.0.0", "", true)
+	armClient, err := getArmClient(config, true, "0.0.0", "", true, false)
 	if err != nil {
 		t.Fatalf("Error building ARM Client: %+v", err)
 	}

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -21,7 +21,7 @@ func TestAccAzureRMContainerRegistryMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true, false)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_data_lake_store_file_migration_test.go
+++ b/azurerm/resource_arm_data_lake_store_file_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMDataLakeStoreFileMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true, false)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true, false)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true, false)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_queue_migration_test.go
+++ b/azurerm/resource_arm_storage_queue_migration_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMStorageQueueMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true)
+	client, err := getArmClient(config, false, "0.0.0", "", true, false)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -126,6 +126,8 @@ More information on [how to configure a Service Principal using Managed Service 
 
 For some advanced scenarios, such as where more granular permissions are necessary - the following properties can be set:
 
+* `disable_terraform_partner_id` - (Optional) Disable sending the Terraform Partner ID if a custom `partner_id` isn't specified, which allows Microsoft to better understand the usage of Terraform. The Partner ID does not give HashiCorp any direct access to usage information. This can also be sourced from the `ARM_DISABLE_TERRAFORM_PARTNER_ID` environment variable. Defaults to `false`.
+
 * `partner_id` - (Optional) A GUID/UUID that is [registered](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution#register-guids-and-offers) with Microsoft to facilitate partner resource usage attribution. This can also be sourced from the `ARM_PARTNER_ID` Environment Variable.
 
 * `skip_credentials_validation` - (Optional) Should the AzureRM Provider skip verifying the credentials being used are valid? This can also be sourced from the `ARM_SKIP_CREDENTIALS_VALIDATION` Environment Variable. Defaults to `false`.


### PR DESCRIPTION
This PR introduces an opt-out for the Default "Terraform Partner ID" introduced in #4663

Whilst the `partner_id` field can be used for various purposes - this Default Terraform Partner ID is only used by Microsoft to better understand Terraform's usage (and is only sent when a custom Partner ID isn't specified) - [more information can be found in this comment](https://github.com/terraform-providers/terraform-provider-azurerm/issues/4747#issuecomment-547545575).

This PR allows users to opt out of this Default Partner ID either through the Provider Block, like so:

```hcl
provider "azurerm" {
  version = "=1.36.1"
  disable_terraform_partner_id = true
}
```

or by setting the Environment Variable `ARM_DISABLE_TERRAFORM_PARTNER_ID` to `true`.

Fixes #4747