### PR TITLE
azurerm_sql_server: Enable SystemAssigned identity

### DIFF
--- a/azurerm/data_source_sql_server.go
+++ b/azurerm/data_source_sql_server.go
@@ -47,6 +47,27 @@ func dataSourceSqlServer() *schema.Resource {
 				Computed: true,
 			},
 
+			"identity": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"principal_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -81,6 +102,10 @@ func dataSourceArmSqlServerRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("fqdn", props.FullyQualifiedDomainName)
 		d.Set("version", props.Version)
 		d.Set("administrator_login", props.AdministratorLogin)
+	}
+
+	if err := d.Set("identity", flattenAzureRmSqlServerIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("Error setting `identity`: %+v", err)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/website/docs/d/sql_server.html.markdown
+++ b/website/docs/d/sql_server.html.markdown
@@ -39,4 +39,16 @@ output "sql_server_id" {
 
 * `administrator_login` - The administrator username of the SQL Server.
 
+* `identity` - An `identity` block as defined below.
+
 * `tags` - A mapping of tags assigned to the resource.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The ID of the Principal (Client) in Azure Active Directory.
+
+* `tenant_id` - The ID of the Azure Active Directory Tenant.
+
+* `type` - The identity type of the SQL Server.

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -51,7 +51,17 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Required) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx)
 
+* `identity` - (Optional) An `identity` block as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the identity type of the SQL Server. At this time the only allowed value is `SystemAssigned`.
+
+~> **NOTE:** The assigned `principal_id` and `tenant_id` can be retrieved after the identity `type` has been set to `SystemAssigned` and the SQL Server has been created. More details are available below.
 
 ## Attributes Reference
 
@@ -59,6 +69,16 @@ The following attributes are exported:
 
 * `id` - The SQL Server ID.
 * `fully_qualified_domain_name` - The fully qualified domain name of the Azure SQL Server (e.g. myServerName.database.windows.net)
+
+---
+
+`identity` exports the following:
+
+* `principal_id` - The Principal ID for the Service Principal associated with the Identity of this SQL Server.
+
+* `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this SQL Server.
+
+-> You can access the Principal ID via `${azurerm_sql_server.test.identity.0.principal_id}` and the Tenant ID via `${azurerm_sql_server.test.identity.0.tenant_id}`
 
 ## Import
 


### PR DESCRIPTION
This provides the capability to enable "SystemAssigned" identity on SQL Server resources, as in the following:

```terraform
resource "azurerm_sql_server" "test" {
  name                         = "mysqlserver"
  resource_group_name          = azurerm_resource_group.test.name
  location                     = "azurerm_resource_group.test.location"
  version                      = "12.0"
  administrator_login          = "mradministrator"
  administrator_login_password = "thisIsDog11"

  identity {
    type = "SystemAssigned"
  }

  tags = {
    environment = "production"
  }
}
```

This is a prerequisite to enabling SQL TDE with BYOK using Azure Key Vault (requested in #87)