### PR TITLE
Bastion Host: Alter Hostname Validation Function to correct Azure Bastion Naming Requirements

### DIFF
--- a/azurerm/resource_arm_bastion_host.go
+++ b/azurerm/resource_arm_bastion_host.go
@@ -193,16 +193,16 @@ func resourceArmBastionHostDelete(d *schema.ResourceData, meta interface{}) erro
 
 func validateAzureRMBastionHostName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("lowercase letters, highercase letters numbers only are allowed in %q: %q", k, value))
+	if !regexp.MustCompile(`^[A-Za-z0-9][a-zA-Z0-9_.-]+[a-zA-Z0-9_]$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("The name must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens. %q: %q", k, value))
 	}
 
 	if 1 > len(value) {
 		errors = append(errors, fmt.Errorf("%q cannot be less than 1 characters: %q", k, value))
 	}
 
-	if len(value) > 64 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 64 characters: %q %d", k, value, len(value)))
+	if len(value) > 80 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters: %q %d", k, value, len(value)))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
Fixes #4759

Includes: 
* Better regex for allowing Bastion Host names with underscores, periods, and hyphens. 
* Testing the correct limit to the Bastion Host names with 80 char limit. 