### PR TITLE
Add a note for UltraPerformance express route sku

### DIFF
--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -140,6 +140,9 @@ The following arguments are supported:
     A `PolicyBased` gateway only supports the `Basic` sku. Further, the `UltraPerformance`
     sku is only supported by an `ExpressRoute` gateway.
 
+~> **NOTE:** To build a UltraPerformance ExpressRoute Virtual Network gateway, the associated Public IP needs to be sku "Standard" not "Basic"
+
+
 * `ip_configuration` (Required) One or two `ip_configuration` blocks documented below.
     An active-standby gateway requires exactly one `ip_configuration` block whereas
     an active-active gateway requires exactly two `ip_configuration` blocks.


### PR DESCRIPTION
Adding a note that UltraPerformance SKU requires a "Standard" Public IP sku and not "Basic".