### PR TITLE
azurerm_automation_credential  -  deprecate `account_name` in favour of `automation_account_name`

### DIFF
--- a/azurerm/automation_variable.go
+++ b/azurerm/automation_variable.go
@@ -67,7 +67,7 @@ func resourceAutomationVariableCommonSchema(attType schema.ValueType, validateFu
 			Type:         schema.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validate.NoEmptyStrings,
+			ValidateFunc: azure.ValidateAutomationRunbookName(),
 		},
 
 		"description": {
@@ -102,7 +102,7 @@ func datasourceAutomationVariableCommonSchema(attType schema.ValueType) map[stri
 		"automation_account_name": {
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validate.NoEmptyStrings,
+			ValidateFunc: azure.ValidateAutomationRunbookName(),
 		},
 
 		"description": {

--- a/azurerm/resource_arm_automation_account.go
+++ b/azurerm/resource_arm_automation_account.go
@@ -36,9 +36,9 @@ func resourceArmAutomationAccount() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 

--- a/azurerm/resource_arm_automation_account.go
+++ b/azurerm/resource_arm_automation_account.go
@@ -3,7 +3,6 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation"
@@ -40,11 +39,7 @@ func resourceArmAutomationAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringMatch(
-					//todo this will not allow single character names, even thou they are valid
-					regexp.MustCompile(`^[0-9a-zA-Z]([-0-9a-zA-Z]{0,48}[0-9a-zA-Z])?$`),
-					`The account name must not be empty, and must not exceed 50 characters in length.  The account name must start with a letter or number.  The account name can contain letters, numbers, and dashes. The final character must be a letter or a number.`,
-				),
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"location": azure.SchemaLocation(),

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -41,10 +41,23 @@ func resourceArmAutomationCredential() *schema.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
 
+			//this is AutomationAccountName in the SDK
 			"account_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Deprecated:    "account_name has been renamed to automation_account_name for clarity and to match the azure API",
+				ConflictsWith: []string{"automation_account_name"},
+				ValidateFunc: azure.ValidateAutomationAccountName(),
+			},
+
+			"automation_account_name": {
 				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Optional: true, //todo change to required once account_name has been removed
+				Computed: true,
+				//ForceNew:      true, //todo this needs to come back once account_name has been removed
+				ConflictsWith: []string{"account_name"},
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"username": {
@@ -75,13 +88,20 @@ func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta in
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
-	accName := d.Get("account_name").(string)
+	//CustomizeDiff should ensure one of these two is set
+	//todo remove this once `account_name` is removed
+	accountName := ""
+	if v, ok := d.GetOk("automation_account_name"); ok {
+		accountName = v.(string)
+	} else if v, ok := d.GetOk("account_name"); ok {
+		accountName = v.(string)
+	}
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, accName, name)
+		existing, err := client.Get(ctx, resGroup, accountName, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Automation Credential %q (Account %q / Resource Group %q): %s", name, accName, resGroup, err)
+				return fmt.Errorf("Error checking for presence of existing Automation Credential %q (Account %q / Resource Group %q): %s", name, accountName, resGroup, err)
 			}
 		}
 
@@ -103,11 +123,11 @@ func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta in
 		Name: &name,
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resGroup, accName, name, parameters); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, resGroup, accountName, name, parameters); err != nil {
 		return err
 	}
 
-	read, err := client.Get(ctx, resGroup, accName, name)
+	read, err := client.Get(ctx, resGroup, accountName, name)
 	if err != nil {
 		return err
 	}
@@ -131,10 +151,10 @@ func resourceArmAutomationCredentialRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 	resGroup := id.ResourceGroup
-	accName := id.Path["automationAccounts"]
+	accountName := id.Path["automationAccounts"]
 	name := id.Path["credentials"]
 
-	resp, err := client.Get(ctx, resGroup, accName, name)
+	resp, err := client.Get(ctx, resGroup, accountName, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
@@ -146,7 +166,8 @@ func resourceArmAutomationCredentialRead(d *schema.ResourceData, meta interface{
 
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", resGroup)
-	d.Set("account_name", accName)
+	d.Set("automation_account_name", accountName)
+	d.Set("account_name", accountName)
 	if props := resp.CredentialProperties; props != nil {
 		d.Set("username", props.UserName)
 	}
@@ -165,10 +186,10 @@ func resourceArmAutomationCredentialDelete(d *schema.ResourceData, meta interfac
 		return err
 	}
 	resGroup := id.ResourceGroup
-	accName := id.Path["automationAccounts"]
+	accountName := id.Path["automationAccounts"]
 	name := id.Path["credentials"]
 
-	resp, err := client.Delete(ctx, resGroup, accName, name)
+	resp, err := client.Delete(ctx, resGroup, accountName, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp) {
 			return nil

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -48,7 +48,7 @@ func resourceArmAutomationCredential() *schema.Resource {
 				Computed:      true,
 				Deprecated:    "account_name has been renamed to automation_account_name for clarity and to match the azure API",
 				ConflictsWith: []string{"automation_account_name"},
-				ValidateFunc: azure.ValidateAutomationAccountName(),
+				ValidateFunc:  azure.ValidateAutomationAccountName(),
 			},
 
 			"automation_account_name": {
@@ -57,7 +57,7 @@ func resourceArmAutomationCredential() *schema.Resource {
 				Computed: true,
 				//ForceNew:      true, //todo this needs to come back once account_name has been removed
 				ConflictsWith: []string{"account_name"},
-				ValidateFunc: azure.ValidateAutomationAccountName(),
+				ValidateFunc:  azure.ValidateAutomationAccountName(),
 			},
 
 			"username": {

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -55,9 +55,9 @@ func resourceArmAutomationCredential() *schema.Resource {
 			"automation_account_name": {
 				Type:          schema.TypeString,
 				Optional:      true, //todo change to required once account_name has been removed
-				Computed:      true,
+				Computed:      true, //todo remove once account_name has been removed
 				ForceNew:      true,
-				ConflictsWith: []string{"account_name"},
+				ConflictsWith: []string{"account_name"}, //todo remove once account_name has been removed
 				ValidateFunc:  azure.ValidateAutomationAccountName(),
 			},
 

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -46,16 +46,17 @@ func resourceArmAutomationCredential() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
+				ForceNew:      true,
 				Deprecated:    "account_name has been renamed to automation_account_name for clarity and to match the azure API",
 				ConflictsWith: []string{"automation_account_name"},
 				ValidateFunc:  azure.ValidateAutomationAccountName(),
 			},
 
 			"automation_account_name": {
-				Type:     schema.TypeString,
-				Optional: true, //todo change to required once account_name has been removed
-				Computed: true,
-				//ForceNew:      true, //todo this needs to come back once account_name has been removed
+				Type:          schema.TypeString,
+				Optional:      true, //todo change to required once account_name has been removed
+				Computed:      true,
+				ForceNew:      true,
 				ConflictsWith: []string{"account_name"},
 				ValidateFunc:  azure.ValidateAutomationAccountName(),
 			},

--- a/azurerm/resource_arm_automation_credential.go
+++ b/azurerm/resource_arm_automation_credential.go
@@ -88,7 +88,6 @@ func resourceArmAutomationCredentialCreateUpdate(d *schema.ResourceData, meta in
 
 	name := d.Get("name").(string)
 	resGroup := d.Get("resource_group_name").(string)
-	//CustomizeDiff should ensure one of these two is set
 	//todo remove this once `account_name` is removed
 	accountName := ""
 	if v, ok := d.GetOk("automation_account_name"); ok {

--- a/azurerm/resource_arm_automation_credential_test.go
+++ b/azurerm/resource_arm_automation_credential_test.go
@@ -103,7 +103,7 @@ func testCheckAzureRMAutomationCredentialDestroy(s *terraform.State) error {
 		}
 
 		name := rs.Primary.Attributes["name"]
-		accName := rs.Primary.Attributes["account_name"]
+		accName := rs.Primary.Attributes["automation_account_name"]
 
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
@@ -135,7 +135,7 @@ func testCheckAzureRMAutomationCredentialExists(resourceName string) resource.Te
 		}
 
 		name := rs.Primary.Attributes["name"]
-		accName := rs.Primary.Attributes["account_name"]
+		accName := rs.Primary.Attributes["automation_account_name"]
 
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
@@ -177,11 +177,11 @@ resource "azurerm_automation_account" "test" {
 }
 
 resource "azurerm_automation_credential" "test" {
-  name                = "acctest-%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  account_name        = "${azurerm_automation_account.test.name}"
-  username            = "test_user"
-  password            = "test_pwd"
+  name                    = "acctest-%d"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  automation_account_name = "${azurerm_automation_account.test.name}"
+  username                = "test_user"
+  password                = "test_pwd"
 }
 `, rInt, location, rInt, rInt)
 }
@@ -192,11 +192,11 @@ func testAccAzureRMAutomationCredential_requiresImport(rInt int, location string
 %s
 
 resource "azurerm_automation_credential" "import" {
-  name                = "${azurerm_automation_credential.test.name}"
-  resource_group_name = "${azurerm_automation_credential.test.resource_group_name}"
-  account_name        = "${azurerm_automation_credential.test.account_name}"
-  username            = "${azurerm_automation_credential.test.username}"
-  password            = "${azurerm_automation_credential.test.password}"
+  name                    = "${azurerm_automation_credential.test.name}"
+  resource_group_name     = "${azurerm_automation_credential.test.resource_group_name}"
+  automation_account_name = "${azurerm_automation_credential.test.automation_account_name}"
+  username                = "${azurerm_automation_credential.test.username}"
+  password                = "${azurerm_automation_credential.test.password}"
 }
 `, template)
 }
@@ -219,12 +219,12 @@ resource "azurerm_automation_account" "test" {
 }
 
 resource "azurerm_automation_credential" "test" {
-  name                = "acctest-%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  account_name        = "${azurerm_automation_account.test.name}"
-  username            = "test_user"
-  password            = "test_pwd"
-  description         = "This is a test credential for terraform acceptance test"
+  name                    = "acctest-%d"
+  resource_group_name     = "${azurerm_resource_group.test.name}"
+  automation_account_name = "${azurerm_automation_account.test.name}"
+  username                = "test_user"
+  password                = "test_pwd"
+  description             = "This is a test credential for terraform acceptance test"
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_automation_dsc_configuration.go
+++ b/azurerm/resource_arm_automation_dsc_configuration.go
@@ -51,7 +51,7 @@ func resourceArmAutomationDscConfiguration() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NoEmptyStrings,
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"content_embedded": {

--- a/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
+++ b/azurerm/resource_arm_automation_dsc_nodeconfiguration.go
@@ -46,7 +46,7 @@ func resourceArmAutomationDscNodeConfiguration() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NoEmptyStrings,
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/azurerm/resource_arm_automation_module.go
+++ b/azurerm/resource_arm_automation_module.go
@@ -46,7 +46,7 @@ func resourceArmAutomationModule() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.NoEmptyStrings,
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -39,16 +39,16 @@ func resourceArmAutomationRunbook() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateAutomationRunbookName(),
 			},
 
 			"account_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 

--- a/azurerm/resource_arm_automation_runbook.go
+++ b/azurerm/resource_arm_automation_runbook.go
@@ -42,12 +42,14 @@ func resourceArmAutomationRunbook() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: azure.ValidateAutomationRunbookName(),
 			},
 
 			"account_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"location": azure.SchemaLocation(),

--- a/azurerm/resource_arm_automation_schedule.go
+++ b/azurerm/resource_arm_automation_schedule.go
@@ -3,7 +3,6 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
@@ -44,10 +43,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile(`^[^<>*%&:\\?.+/]{0,127}[^<>*%&:\\?.+/\s]$`),
-					`The name length must be from 1 to 128 characters. The name cannot contain special characters < > * % & : \ ? . + / and cannot end with a whitespace character.`,
-				),
+				ValidateFunc: azure.ValidateAutomationScheduleName(),
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupName(),
@@ -59,6 +55,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 				Computed:      true,
 				Deprecated:    "account_name has been renamed to automation_account_name for clarity and to match the azure API",
 				ConflictsWith: []string{"automation_account_name"},
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"automation_account_name": {
@@ -67,6 +64,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 				Computed: true,
 				//ForceNew:      true, //todo this needs to come back once account_name has been removed
 				ConflictsWith: []string{"account_name"},
+				ValidateFunc: azure.ValidateAutomationAccountName(),
 			},
 
 			"frequency": {

--- a/azurerm/resource_arm_automation_schedule.go
+++ b/azurerm/resource_arm_automation_schedule.go
@@ -40,9 +40,9 @@ func resourceArmAutomationSchedule() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: azure.ValidateAutomationScheduleName(),
 			},
 
@@ -55,7 +55,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 				Computed:      true,
 				Deprecated:    "account_name has been renamed to automation_account_name for clarity and to match the azure API",
 				ConflictsWith: []string{"automation_account_name"},
-				ValidateFunc: azure.ValidateAutomationAccountName(),
+				ValidateFunc:  azure.ValidateAutomationAccountName(),
 			},
 
 			"automation_account_name": {
@@ -64,7 +64,7 @@ func resourceArmAutomationSchedule() *schema.Resource {
 				Computed: true,
 				//ForceNew:      true, //todo this needs to come back once account_name has been removed
 				ConflictsWith: []string{"account_name"},
-				ValidateFunc: azure.ValidateAutomationAccountName(),
+				ValidateFunc:  azure.ValidateAutomationAccountName(),
 			},
 
 			"frequency": {

--- a/azurerm/resource_arm_automation_schedule_test.go
+++ b/azurerm/resource_arm_automation_schedule_test.go
@@ -278,7 +278,7 @@ func testCheckAzureRMAutomationScheduleDestroy(s *terraform.State) error {
 		}
 
 		name := rs.Primary.Attributes["name"]
-		accName := rs.Primary.Attributes["account_name"]
+		accName := rs.Primary.Attributes["automation_account_name"]
 
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 		if !hasResourceGroup {
@@ -334,7 +334,7 @@ func testCheckAzureRMAutomationScheduleExists(resourceName string) resource.Test
 }
 
 func testAccAzureRMAutomationSchedule_prerequisites(rInt int, location string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -202,6 +202,10 @@ The deprecated `fqdn_list` field in the `backend_address_pool` block will be rem
 
 The deprecated `ip_address_list` field in the `backend_address_pool` block will be removed in favour of the `ip_addresses` field, which is available from v1.22 of the AzureRM Provider.
 
+### Resource: `azurerm_automation_credential`
+
+The deprecated `account_name` field will be removed. This has been deprecated in favour of the `automation_account_name` field.
+
 ### Resource: `azurerm_automation_schedule`
 
 The deprecated `account_name` field will be removed. This has been deprecated in favour of the `automation_account_name` field.

--- a/website/docs/r/automation_credential.html.markdown
+++ b/website/docs/r/automation_credential.html.markdown
@@ -29,12 +29,12 @@ resource "azurerm_automation_account" "example" {
 }
 
 resource "azurerm_automation_credential" "example" {
-  name                = "credential1"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  account_name        = "${azurerm_automation_account.example.name}"
-  username            = "example_user"
-  password            = "example_pwd"
-  description         = "This is an example credential"
+  name                    = "credential1"
+  resource_group_name     = "${azurerm_resource_group.example.name}"
+  automation_account_name = "${azurerm_automation_account.example.name}"
+  username                = "example_user"
+  password                = "example_pwd"
+  description             = "This is an example credential"
 }
 ```
 
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the Credential is created. Changing this forces a new resource to be created.
 
-* `account_name` - (Required) The name of the automation account in which the Credential is created. Changing this forces a new resource to be created.
+* `automation_account_name` - (Required) The name of the automation account in which the Credential is created. Changing this forces a new resource to be created.
 
 * `username` - (Required) The username associated with this Automation Credential.
 


### PR DESCRIPTION
This MR does the following:
- Add validation for automation account names, runbooks and schedules
- Adds the `automation_account_name` parameter to `azurerm_automation_credential`
- Updates test and docs for `azurerm_automation_credential`



Closes #4776