### PR TITLE
azurerm_servicebus_subscription  - support for the `forward_dead_lettered_messages_to` property

### DIFF
--- a/azurerm/resource_arm_servicebus_subscription.go
+++ b/azurerm/resource_arm_servicebus_subscription.go
@@ -102,6 +102,11 @@ func resourceArmServiceBusSubscription() *schema.Resource {
 				Optional: true,
 			},
 
+			"forward_dead_lettered_messages_to": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			// TODO: remove in the next major version
 			"dead_lettering_on_filter_evaluation_exceptions": {
 				Type:       schema.TypeBool,
@@ -162,6 +167,10 @@ func resourceArmServiceBusSubscriptionCreateUpdate(d *schema.ResourceData, meta 
 		parameters.SBSubscriptionProperties.ForwardTo = &forwardTo
 	}
 
+	if forwardDeadLetteredMessagesTo := d.Get("forward_dead_lettered_messages_to").(string); forwardDeadLetteredMessagesTo != "" {
+		parameters.SBSubscriptionProperties.ForwardDeadLetteredMessagesTo = &forwardDeadLetteredMessagesTo
+	}
+
 	if defaultMessageTtl := d.Get("default_message_ttl").(string); defaultMessageTtl != "" {
 		parameters.DefaultMessageTimeToLive = &defaultMessageTtl
 	}
@@ -219,6 +228,7 @@ func resourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interfac
 		d.Set("enable_batched_operations", props.EnableBatchedOperations)
 		d.Set("requires_session", props.RequiresSession)
 		d.Set("forward_to", props.ForwardTo)
+		d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
 
 		if count := props.MaxDeliveryCount; count != nil {
 			d.Set("max_delivery_count", int(*count))

--- a/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/azurerm/resource_arm_servicebus_subscription_test.go
@@ -190,6 +190,41 @@ func TestAccAzureRMServiceBusSubscription_updateForwardTo(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMServiceBusSubscription_updateForwardDeadLetteredMessagesTo(t *testing.T) {
+	resourceName := "azurerm_servicebus_subscription.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+	preConfig := testAccAzureRMServiceBusSubscription_basic(ri, location)
+	postConfig := testAccAzureRMServiceBusSubscription_updateForwardDeadLetteredMessagesTo(ri, location)
+
+	expectedValue := fmt.Sprintf("acctestservicebustopic-forward_dl_messages_to-%d", ri)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusSubscriptionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusSubscriptionExists(resourceName),
+				),
+			},
+			{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "forward_dead_lettered_messages_to", expectedValue),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMServiceBusSubscriptionDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).ServiceBus.SubscriptionsClient
 	ctx := testAccProvider.Meta().(*ArmClient).StopContext
@@ -288,7 +323,7 @@ func testAccAzureRMServiceBusSubscription_basic(rInt int, location string) strin
 func testAccAzureRMServiceBusSubscription_requiresImport(rInt int, location string) string {
 	return fmt.Sprintf(`
 
-%s 
+%s
 
 resource "azurerm_servicebus_subscription" "import" {
     name                = "${azurerm_servicebus_subscription.test.name}"
@@ -327,4 +362,18 @@ resource "azurerm_servicebus_topic" "forward_to" {
 `
 	return fmt.Sprintf(forwardToTf, rInt, location, rInt, rInt, rInt,
 		"forward_to = \"${azurerm_servicebus_topic.forward_to.name}\"\n", rInt)
+}
+
+func testAccAzureRMServiceBusSubscription_updateForwardDeadLetteredMessagesTo(rInt int, location string) string {
+	forwardToTf := testAccAzureRMServiceBusSubscription_tfTemplate + `
+
+resource "azurerm_servicebus_topic" "forward_dl_messages_to" {
+    name = "acctestservicebustopic-forward_dl_messages_to-%d"
+    namespace_name = "${azurerm_servicebus_namespace.test.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+`
+	return fmt.Sprintf(forwardToTf, rInt, location, rInt, rInt, rInt,
+		"forward_dead_lettered_messages_to = \"${azurerm_servicebus_topic.forward_dl_messages_to.name}\"\n", rInt)
 }

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -89,9 +89,12 @@ The following arguments are supported:
     supports the concept of a session. Defaults to false. Changing this forces a
     new resource to be created.
 
-* `forward_to` - (Optional) The name of a Queue or Topic to automatically forward 
+* `forward_to` - (Optional) The name of a Queue or Topic to automatically forward
     messages to.
-    
+
+* `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to
+    automatically forward Dead Letter messages to.
+
 ### TimeSpan Format
 
 Some arguments for this resource are required in the TimeSpan format which is

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -89,16 +89,13 @@ The following arguments are supported:
     supports the concept of a session. Defaults to false. Changing this forces a
     new resource to be created.
 
-* `forward_to` - (Optional) The name of a Queue or Topic to automatically forward
-    messages to.
+* `forward_to` - (Optional) The name of a Queue or Topic to automatically forward messages to.
 
-* `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to
-    automatically forward Dead Letter messages to.
+* `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward Dead Letter messages to.
 
 ### TimeSpan Format
 
-Some arguments for this resource are required in the TimeSpan format which is
-used to represent a length of time. The supported format is documented [here](https://msdn.microsoft.com/en-us/library/se73z7b9(v=vs.110).aspx#Anchor_2)
+Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. The supported format is documented [here](https://msdn.microsoft.com/en-us/library/se73z7b9(v=vs.110).aspx#Anchor_2)
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds the `forward_dead_lettered_messages_to` argument to `azurerm_servicebus_subscription` to address #4542 