### PR TITLE
In-place update of Cosmos DB geo_location

### DIFF
--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -185,7 +185,12 @@ func resourceArmCosmosDbAccount() *schema.Resource {
 							Computed: true,
 						},
 
-						"location": azure.SchemaLocation(),
+						"location": {
+							Type:             schema.TypeString,
+							Required:         true,
+							StateFunc:        azure.NormalizeLocation,
+							DiffSuppressFunc: azure.SuppressLocationDiff,
+						},
 
 						"failover_priority": {
 							Type:         schema.TypeInt,


### PR DESCRIPTION
Fixes #3532
Removes `ForceNew` from location property of `geo_location`

Rebase of https://github.com/terraform-providers/terraform-provider-azurerm/pull/4315

Removes failing test 