### PR TITLE
Add test for changing loadbalancer health probe on VMSS

### DIFF
--- a/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -6188,7 +6188,7 @@ resource "azurerm_lb" "test" {
   name                = "acctestlb-%[1]d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
-	sku                 = "Standard"
+  sku                 = "Standard"
 
   frontend_ip_configuration {
     name                 = "PublicIPAddress"


### PR DESCRIPTION
This adds a test for updating the VMSS loadbalancer when the VMSS has the `health_probe_id` property assigned to an `azurerm_lb_probe` resource.

For more info: #4769 