### PR TITLE
fix private dns cname record delete

### DIFF
--- a/azurerm/resource_arm_private_dns_cname_record.go
+++ b/azurerm/resource_arm_private_dns_cname_record.go
@@ -176,7 +176,7 @@ func resourceArmPrivateDnsCNameRecordDelete(d *schema.ResourceData, meta interfa
 	name := id.Path["CNAME"]
 	zoneName := id.Path["privateDnsZones"]
 
-	_, err = dnsClient.Get(ctx, resGroup, zoneName, privatedns.CNAME, name)
+	_, err = dnsClient.Delete(ctx, resGroup, zoneName, privatedns.CNAME, name, "")
 	if err != nil {
 		return fmt.Errorf("Error deleting Private DNS CNAME Record %s: %+v", name, err)
 	}

--- a/azurerm/resource_arm_private_dns_cname_record_test.go
+++ b/azurerm/resource_arm_private_dns_cname_record_test.go
@@ -198,7 +198,7 @@ func testCheckAzureRMPrivateDnsCNameRecordDestroy(s *terraform.State) error {
 		zoneName := rs.Primary.Attributes["zone_name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		resp, err := conn.Get(ctx, resourceGroup, zoneName, privatedns.A, aName)
+		resp, err := conn.Get(ctx, resourceGroup, zoneName, privatedns.CNAME, aName)
 
 		if err != nil {
 			if resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Small PR to address #4803. Updates `resourceArmPrivateDnsCNameRecordDelete` to call `dnsClient.Delete` instead of `dnsClient.Get` and fixes the test's record type to properly test that the resource was destroyed.

Fixes #4803