### PR TITLE
note KV secret value doesnt preserve newlines

### DIFF
--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -80,6 +80,8 @@ The following arguments are supported:
 
 * `value` - (Required) Specifies the value of the Key Vault Secret.
 
+~> **Note:** Key Vault strips newlines. To preserve newlines in multi-line secrets try replacing them with `\n` or by base 64 encoding them with `replace(file("my_secret_file"), "/\n/", "\n")` or `base64encode(file("my_secret_file"))`, respectively. 
+
 * `key_vault_id` - (Required) The ID of the Key Vault where the Secret should be created.
 
 * `content_type` - (Optional) Specifies the content type for the Key Vault Secret.


### PR DESCRIPTION
This has frustrated me in the past. I thought that perhaps this not would help future developers. I'm not sure if this is something that you want to be handled in the resource because that's another option. 