### PR TITLE
Use the current way to access object_id

### DIFF
--- a/website/docs/r/sql_active_directory_administrator.markdown
+++ b/website/docs/r/sql_active_directory_administrator.markdown
@@ -34,7 +34,7 @@ resource "azurerm_sql_active_directory_administrator" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   login               = "sqladmin"
   tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
-  object_id           = "${data.azurerm_client_config.current.service_principal_object_id}"
+  object_id           = "${data.azurerm_client_config.current.object_id}"
 }
 ```
 


### PR DESCRIPTION
The field is not populated if you are running terraform using a CLI authentication method. Changing the value allows the example to work in the majority of use cases