### PR TITLE
Update bastion host ip config name validation to allow for hyphens

### DIFF
--- a/azurerm/resource_arm_bastion_host.go
+++ b/azurerm/resource_arm_bastion_host.go
@@ -210,16 +210,16 @@ func validateAzureRMBastionHostName(v interface{}, k string) (warnings []string,
 
 func validateAzureRMBastionIPConfigName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("lowercase letters, highercase letters numbers only are allowed in %q: %q", k, value))
+	if !regexp.MustCompile(`^[A-Za-z0-9][a-zA-Z0-9_.-]+[a-zA-Z0-9_]$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("The name must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens. %q: %q", k, value))
 	}
 
 	if 1 > len(value) {
 		errors = append(errors, fmt.Errorf("%q cannot be less than 1 characters: %q", k, value))
 	}
 
-	if len(value) > 32 {
-		errors = append(errors, fmt.Errorf("%q cannot be longer than 32 characters: %q %d", k, value, len(value)))
+	if len(value) > 80 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters: %q %d", k, value, len(value)))
 	}
 
 	return warnings, errors

--- a/azurerm/resource_arm_bastion_host_test.go
+++ b/azurerm/resource_arm_bastion_host_test.go
@@ -127,7 +127,7 @@ resource "azurerm_bastion_host" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   ip_configuration {
-    name                 = "configuration"
+    name                 = "ip-configuration"
     subnet_id            = "${azurerm_subnet.test.id}"
     public_ip_address_id = "${azurerm_public_ip.test.id}"
   }
@@ -170,7 +170,7 @@ resource "azurerm_bastion_host" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   ip_configuration {
-    name                 = "configuration"
+    name                 = "ip-configuration"
     subnet_id            = "${azurerm_subnet.test.id}"
     public_ip_address_id = "${azurerm_public_ip.test.id}"
   }
@@ -192,7 +192,7 @@ resource "azurerm_bastion_host" "import" {
   location            = "${azurerm_bastion_host.test.location}"
 
   ip_configuration {
-    name                 = "configuration"
+    name                 = "ip-configuration"
     subnet_id            = "${azurerm_subnet.test.id}"
     public_ip_address_id = "${azurerm_public_ip.test.id}"
   }


### PR DESCRIPTION
Updates the bastion host ip config name validation to match the azure requirements to allow for hyphens in the name. Also updated tests to include hyphen in ip configuration name to cover this issue. 

Fixes: #4807