### PR TITLE
website/docs/r/kubernetes_cluster: fix kube_dashboard documentation

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -251,8 +251,8 @@ A `oms_agent` block supports the following:
 A `kube_dashboard` block supports the following:
 
 * `enabled` - (Required) Is the Kubernetes Dashboard enabled?
----
 
+---
 
 A `azure_policy` block supports the following:
 


### PR DESCRIPTION
As it is not rendered properly at the moment.

See https://www.terraform.io/docs/providers/azurerm/r/kubernetes_cluster.html#enabled-required-is-the-kubernetes-dashboard-enabled-

![Selection_077](https://user-images.githubusercontent.com/16539896/68395287-b6514b00-016f-11ea-9fb5-9f06e2aec752.png)


Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>