### PR TITLE
New Resource: `azurerm_api_management_diagnostic `

### DIFF
--- a/azurerm/internal/services/apimanagement/client/client.go
+++ b/azurerm/internal/services/apimanagement/client/client.go
@@ -15,6 +15,7 @@ type Client struct {
 	AuthorizationServersClient *apimanagement.AuthorizationServerClient
 	BackendClient              *apimanagement.BackendClient
 	CertificatesClient         *apimanagement.CertificateClient
+	DiagnosticClient           *apimanagement.DiagnosticClient
 	GroupClient                *apimanagement.GroupClient
 	GroupUsersClient           *apimanagement.GroupUserClient
 	LoggerClient               *apimanagement.LoggerClient
@@ -59,6 +60,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	certificatesClient := apimanagement.NewCertificateClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&certificatesClient.Client, o.ResourceManagerAuthorizer)
+
+	diagnosticClient := apimanagement.NewDiagnosticClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&diagnosticClient.Client, o.ResourceManagerAuthorizer)
 
 	groupClient := apimanagement.NewGroupClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&groupClient.Client, o.ResourceManagerAuthorizer)
@@ -115,6 +119,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		AuthorizationServersClient: &authorizationServersClient,
 		BackendClient:              &backendClient,
 		CertificatesClient:         &certificatesClient,
+		DiagnosticClient:           &diagnosticClient,
 		GroupClient:                &groupClient,
 		GroupUsersClient:           &groupUsersClient,
 		LoggerClient:               &loggerClient,

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_api_management_authorization_server":                   resourceArmApiManagementAuthorizationServer(),
 		"azurerm_api_management_backend":                                resourceArmApiManagementBackend(),
 		"azurerm_api_management_certificate":                            resourceArmApiManagementCertificate(),
+		"azurerm_api_management_diagnostic":                             resourceArmApiManagementDiagnostic(),
 		"azurerm_api_management_group":                                  resourceArmApiManagementGroup(),
 		"azurerm_api_management_group_user":                             resourceArmApiManagementGroupUser(),
 		"azurerm_api_management_logger":                                 resourceArmApiManagementLogger(),

--- a/azurerm/resource_arm_api_management_diagnostic.go
+++ b/azurerm/resource_arm_api_management_diagnostic.go
@@ -127,7 +127,7 @@ func resourceArmApiManagementDiagnosticRead(d *schema.ResourceData, meta interfa
 	d.Set("api_management_name", serviceName)
 
 	if props := resp.DiagnosticContractProperties; props != nil {
-		d.Set("enabled", *props.Enabled)
+		d.Set("enabled", props.Enabled)
 	}
 
 	return nil

--- a/azurerm/resource_arm_api_management_diagnostic.go
+++ b/azurerm/resource_arm_api_management_diagnostic.go
@@ -36,6 +36,7 @@ func resourceArmApiManagementDiagnostic() *schema.Resource {
 			"identifier": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"applicationinsights",
 				}, false),

--- a/azurerm/resource_arm_api_management_diagnostic.go
+++ b/azurerm/resource_arm_api_management_diagnostic.go
@@ -1,0 +1,156 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementDiagnostic() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementDiagnosticCreateUpdate,
+		Read:   resourceArmApiManagementDiagnosticRead,
+		Update: resourceArmApiManagementDiagnosticCreateUpdate,
+		Delete: resourceArmApiManagementDiagnosticDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"applicationinsights",
+				}, false),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementDiagnosticCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).ApiManagement.DiagnosticClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	diagnosticId := d.Get("identifier").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	enabled := d.Get("enabled").(bool)
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, serviceName, diagnosticId)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Diagnostic %q (API Management Service %q / Resource Group %q): %s", diagnosticId, serviceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management_diagnostic", *existing.ID)
+		}
+	}
+
+	parameters := apimanagement.DiagnosticContract{
+		DiagnosticContractProperties: &apimanagement.DiagnosticContractProperties{
+			Enabled: utils.Bool(enabled),
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, diagnosticId, parameters, ""); err != nil {
+		return fmt.Errorf("Error creating or updating Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, diagnosticId)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read ID for Diagnostic %q (Resource Group %q / API Management Service %q)", diagnosticId, resourceGroup, serviceName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmApiManagementDiagnosticRead(d, meta)
+}
+
+func resourceArmApiManagementDiagnosticRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).ApiManagement.DiagnosticClient
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	diagnosticId := id.Path["diagnostics"]
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, diagnosticId)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Diagnostic %q (Resource Group %q / API Management Service %q) was not found - removing from state!", diagnosticId, resourceGroup, serviceName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making Read request for Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+	}
+
+	d.Set("identifier", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("api_management_name", serviceName)
+
+	if props := resp.DiagnosticContractProperties; props != nil {
+		d.Set("enabled", *props.Enabled)
+	}
+
+	return nil
+}
+
+func resourceArmApiManagementDiagnosticDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).ApiManagement.DiagnosticClient
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	diagnosticId := id.Path["diagnostics"]
+
+	if resp, err := client.Delete(ctx, resourceGroup, serviceName, diagnosticId, ""); err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error deleting Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/resource_arm_api_management_diagnostic_test.go
+++ b/azurerm/resource_arm_api_management_diagnostic_test.go
@@ -1,0 +1,155 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMApiManagementDiagnostic_basic(t *testing.T) {
+	resourceName := "azurerm_api_management_diagnostic.test"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMApiManagementDiagnostic_basic(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementDiagnosticDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementDiagnosticExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementDiagnostic_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	resourceName := "azurerm_api_management_diagnostic.test"
+	ri := tf.AccRandTimeInt()
+	location := testLocation()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApiManagementDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementDiagnostic_basic(ri, location),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementDiagnosticExists(resourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMApiManagementDiagnostic_requiresImport(ri, location),
+				ExpectError: testRequiresImportError("azurerm_api_management_diagnostic"),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementDiagnosticDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ArmClient).ApiManagement.DiagnosticClient
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_diagnostic" {
+			continue
+		}
+
+		identifier := rs.Primary.Attributes["identifier"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, resourceGroup, serviceName, identifier)
+
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+	return nil
+}
+
+func testCheckAzureRMApiManagementDiagnosticExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		identifier := rs.Primary.Attributes["identifier"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		client := testAccProvider.Meta().(*ArmClient).ApiManagement.DiagnosticClient
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+		resp, err := client.Get(ctx, resourceGroup, serviceName, identifier)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: API Management Diagnostic %q (Resource Group %q / API Management Service %q) does not exist", identifier, resourceGroup, serviceName)
+			}
+			return fmt.Errorf("Bad: Get on apiManagementDiagnosticClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApiManagementDiagnostic_basic(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name = "Developer_1"
+}
+
+resource "azurerm_api_management_diagnostic" "test" {
+  identifier          = "applicationinsights"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  enabled             = true
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMApiManagementDiagnostic_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMApiManagementDiagnostic_basic(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_diagnostic" "import" {
+  identifier          = "${azurerm_api_management_diagnostic.test.identifier}"
+  resource_group_name = "${azurerm_api_management_diagnostic.test.resource_group_name}"
+  api_management_name = "${azurerm_api_management_diagnostic.test.api_management_name}"
+  enabled             = "${azurerm_api_management_diagnostic.test.enabled}"
+}
+`, template)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -546,6 +546,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/api_management_diagnostic.html">azurerm_api_management_diagnostic</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_group.html">azurerm_api_management_group</a>
                 </li>
 

--- a/website/docs/r/api_management_diagnostic.html.markdown
+++ b/website/docs/r/api_management_diagnostic.html.markdown
@@ -1,0 +1,64 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_diagnostic"
+sidebar_current: "docs-azurerm-resource-api-management-diagnostic"
+description: |-
+  Manages an API Management Service Diagnostic.
+---
+
+# azurerm_api_management_diagnostic
+
+Manages an API Management Service Diagnostic.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "example-apim"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_diagnostic" "test" {
+  identifier          = "applicationinsights"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  enabled             = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `identifier` - (Required) The diagnostic identifier for the API Management Service. Allowed values are `applicationinsights`.
+
+* `api_management_name` - (Required) The Name of the API Management Service where this Diagnostic should be created. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+
+* `enabled` - (Required) Indicates whether a Diagnostic should receive data or not.
+
+---
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the API Management Diagnostic.
+
+## Import
+
+API Management Diagnostics can be imported using their `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_diagnostic.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/diagnostics/applicationinsights
+```

--- a/website/docs/r/api_management_diagnostic.html.markdown
+++ b/website/docs/r/api_management_diagnostic.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_diagnostic"
 sidebar_current: "docs-azurerm-resource-api-management-diagnostic"

--- a/website/docs/r/api_management_diagnostic.html.markdown
+++ b/website/docs/r/api_management_diagnostic.html.markdown
@@ -40,7 +40,7 @@ resource "azurerm_api_management_diagnostic" "test" {
 
 The following arguments are supported:
 
-* `identifier` - (Required) The diagnostic identifier for the API Management Service. Allowed values are `applicationinsights`.
+* `identifier` - (Required) The diagnostic identifier for the API Management Service. At this time the only supported value is `applicationinsights`. Changing this forces a new resource to be created.
 
 * `api_management_name` - (Required) The Name of the API Management Service where this Diagnostic should be created. Changing this forces a new resource to be created.
 
@@ -58,7 +58,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-API Management Diagnostics can be imported using their `resource id`, e.g.
+API Management Diagnostics can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_api_management_diagnostic.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/diagnostics/applicationinsights


### PR DESCRIPTION
Partially addresses: #4760

Adds the `azurerm_api_management_diagnostic` resource to the extent that the `2018-01-01` version of the `apimanagement` service allows. As noted in my comment on the feature request, I realize this doesn't have near the amount of options as the `2019-01-01` version would, but perhaps it can provide incremental value/serve as a step to addressing the issue. That being said, this is my first attempt at contributing a new resource to the provider so please let me know if you have any feedback! :)

```
--- PASS: TestAccAzureRMApiManagementDiagnostic_basic (2122.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       2122.193s
```

```
--- PASS: TestAccAzureRMApiManagementDiagnostic_requiresImport (2911.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       2911.465s
```