### PR TITLE
Support for Custom Timeouts in Custom Refresh Func's

### DIFF
--- a/azurerm/resource_arm_automation_module.go
+++ b/azurerm/resource_arm_automation_module.go
@@ -142,7 +142,6 @@ func resourceArmAutomationModuleCreateUpdate(d *schema.ResourceData, meta interf
 		Target: []string{
 			string(automation.ModuleProvisioningStateSucceeded),
 		},
-		Timeout:    30 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err2 := client.Get(ctx, resGroup, accName, name)
@@ -156,6 +155,15 @@ func resourceArmAutomationModuleCreateUpdate(d *schema.ResourceData, meta interf
 
 			return resp, "Unknown", nil
 		},
+	}
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 30 * time.Minute
 	}
 
 	_, err := stateConf.WaitForState()

--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -658,10 +658,16 @@ func resourceArmContainerGroupDelete(d *schema.ResourceData, meta interface{}) e
 			Pending:                   []string{"Attached"},
 			Target:                    []string{"Detached"},
 			Refresh:                   containerGroupEnsureDetachedFromNetworkProfileRefreshFunc(ctx, networkProfileClient, networkProfileResourceGroup, networkProfileName, resourceGroup, name),
-			Timeout:                   10 * time.Minute,
 			MinTimeout:                15 * time.Second,
 			ContinuousTargetOccurence: 5,
 		}
+
+		if features.SupportsCustomTimeouts() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+		} else {
+			stateConf.Timeout = 10 * time.Minute
+		}
+
 		if _, err := stateConf.WaitForState(); err != nil {
 			return fmt.Errorf("Error waiting for Container Group %q (Resource Group %q) to finish deleting: %s", name, resourceGroup, err)
 		}

--- a/azurerm/resource_arm_cosmosdb_account.go
+++ b/azurerm/resource_arm_cosmosdb_account.go
@@ -391,7 +391,7 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	resp, err := resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account)
+	resp, err := resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account, d)
 	if err != nil {
 		return fmt.Errorf("Error creating CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
@@ -496,7 +496,7 @@ func resourceArmCosmosDbAccountUpdate(d *schema.ResourceData, meta interface{}) 
 		Tags: tags.Expand(t),
 	}
 
-	if _, err = resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account); err != nil {
+	if _, err = resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account, d); err != nil {
 		return fmt.Errorf("Error updating CosmosDB Account %q properties (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
@@ -532,14 +532,14 @@ func resourceArmCosmosDbAccountUpdate(d *schema.ResourceData, meta interface{}) 
 		}
 
 		account.DatabaseAccountCreateUpdateProperties.Locations = &locationsUnchanged
-		if _, err = resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account); err != nil {
+		if _, err = resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account, d); err != nil {
 			return fmt.Errorf("Error removing CosmosDB Account %q renamed locations (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
 
 	//add any new/renamed locations
 	account.DatabaseAccountCreateUpdateProperties.Locations = &newLocations
-	upsertResponse, err := resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account)
+	upsertResponse, err := resourceArmCosmosDbAccountApiUpsert(client, ctx, resourceGroup, name, account, d)
 	if err != nil {
 		return fmt.Errorf("Error updating CosmosDB Account %q locations (Resource Group %q): %+v", name, resourceGroup, err)
 	}
@@ -741,7 +741,6 @@ func resourceArmCosmosDbAccountDelete(d *schema.ResourceData, meta interface{}) 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"Deleting"},
 		Target:     []string{"NotFound"},
-		Timeout:    180 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err2 := client.Get(ctx, resourceGroup, name)
@@ -755,6 +754,12 @@ func resourceArmCosmosDbAccountDelete(d *schema.ResourceData, meta interface{}) 
 			return resp, "Deleting", nil
 		},
 	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		stateConf.Timeout = 180 * time.Minute
+	}
 	if _, err = stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Waiting forCosmosDB Account %q to delete (Resource Group %q): %+v", name, resourceGroup, err)
 	}
@@ -762,7 +767,7 @@ func resourceArmCosmosDbAccountDelete(d *schema.ResourceData, meta interface{}) 
 	return nil
 }
 
-func resourceArmCosmosDbAccountApiUpsert(client *documentdb.DatabaseAccountsClient, ctx context.Context, resourceGroup string, name string, account documentdb.DatabaseAccountCreateUpdateParameters) (*documentdb.DatabaseAccount, error) {
+func resourceArmCosmosDbAccountApiUpsert(client *documentdb.DatabaseAccountsClient, ctx context.Context, resourceGroup string, name string, account documentdb.DatabaseAccountCreateUpdateParameters, d *schema.ResourceData) (*documentdb.DatabaseAccount, error) {
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, account)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating/updating CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
@@ -776,7 +781,6 @@ func resourceArmCosmosDbAccountApiUpsert(client *documentdb.DatabaseAccountsClie
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"Creating", "Updating", "Deleting"},
 		Target:     []string{"Succeeded"},
-		Timeout:    180 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Delay:      30 * time.Second, // required because it takes some time before the 'creating' location shows up
 		Refresh: func() (interface{}, string, error) {
@@ -794,6 +798,16 @@ func resourceArmCosmosDbAccountApiUpsert(client *documentdb.DatabaseAccountsClie
 
 			return resp, status, nil
 		},
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 180 * time.Minute
 	}
 
 	resp, err := stateConf.WaitForState()

--- a/azurerm/resource_arm_eventhub_namespace.go
+++ b/azurerm/resource_arm_eventhub_namespace.go
@@ -360,18 +360,24 @@ func resourceArmEventHubNamespaceDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error issuing delete request of EventHub Namespace %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
-	return waitForEventHubNamespaceToBeDeleted(ctx, client, resGroup, name)
+	return waitForEventHubNamespaceToBeDeleted(ctx, client, resGroup, name, d)
 }
 
-func waitForEventHubNamespaceToBeDeleted(ctx context.Context, client *eventhub.NamespacesClient, resourceGroup, name string) error {
+func waitForEventHubNamespaceToBeDeleted(ctx context.Context, client *eventhub.NamespacesClient, resourceGroup, name string, d *schema.ResourceData) error {
 	// we can't use the Waiter here since the API returns a 200 once it's deleted which is considered a polling status code..
 	log.Printf("[DEBUG] Waiting for EventHub Namespace (%q in Resource Group %q) to be deleted", name, resourceGroup)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"200"},
 		Target:  []string{"404"},
 		Refresh: eventHubNamespaceStateStatusCodeRefreshFunc(ctx, client, resourceGroup, name),
-		Timeout: 40 * time.Minute,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		stateConf.Timeout = 40 * time.Minute
+	}
+
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for EventHub NameSpace (%q in Resource Group %q) to be deleted: %+v", name, resourceGroup, err)
 	}

--- a/azurerm/resource_arm_eventhub_namespace_disaster_recovery_config.go
+++ b/azurerm/resource_arm_eventhub_namespace_disaster_recovery_config.go
@@ -106,7 +106,7 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigCreate(d *schema.Resource
 		return fmt.Errorf("Error creating/updating EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 	}
 
-	if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name); err != nil {
+	if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("Error waiting for replication to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 	}
 
@@ -145,7 +145,7 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigUpdate(d *schema.Resource
 			return fmt.Errorf("Error issuing break pairing request for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 		}
 
-		if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name); err != nil {
+		if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("Error waiting for break pairing request to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 		}
 	}
@@ -164,7 +164,7 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigUpdate(d *schema.Resource
 		return fmt.Errorf("Error creating/updating EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 	}
 
-	if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name); err != nil {
+	if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return fmt.Errorf("Error waiting for replication to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 	}
 
@@ -228,7 +228,7 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.Resource
 		return fmt.Errorf("Error breaking pairing for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 	}
 
-	if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name); err != nil {
+	if err := resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx, client, resourceGroup, namespaceName, name, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("Error waiting for break pairing request to complete for EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): %s", name, namespaceName, resourceGroup, err)
 	}
 
@@ -240,7 +240,6 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.Resource
 	deleteWait := &resource.StateChangeConf{
 		Pending:    []string{"200"},
 		Target:     []string{"404"},
-		Timeout:    30 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := client.Get(ctx, resourceGroup, namespaceName, name)
@@ -255,6 +254,13 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.Resource
 			return resp, strconv.Itoa(resp.StatusCode), nil
 		},
 	}
+
+	if features.SupportsCustomTimeouts() {
+		deleteWait.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		deleteWait.Timeout = 30 * time.Minute
+	}
+
 	if _, err := deleteWait.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting the deletion of EventHub Namespace Disaster Recovery Configs %q deletion (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
 	}
@@ -264,7 +270,6 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.Resource
 	nameFreeWait := &resource.StateChangeConf{
 		Pending:    []string{"NameInUse"},
 		Target:     []string{"None"},
-		Timeout:    30 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := client.CheckNameAvailability(ctx, resourceGroup, namespaceName, eventhub.CheckNameAvailabilityParameter{Name: utils.String(name)})
@@ -275,6 +280,13 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.Resource
 			return resp, string(resp.Reason), nil
 		},
 	}
+
+	if features.SupportsCustomTimeouts() {
+		nameFreeWait.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		nameFreeWait.Timeout = 30 * time.Minute
+	}
+
 	if _, err := nameFreeWait.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting the the EventHub Namespace Disaster Recovery Configs %q name to be available (Namespace %q / Resource Group %q): %v", name, namespaceName, resourceGroup, err)
 	}
@@ -282,12 +294,10 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigDelete(d *schema.Resource
 	return nil
 }
 
-func resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx context.Context, client *eventhub.DisasterRecoveryConfigsClient, resourceGroup, namespaceName, name string) error {
+func resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx context.Context, client *eventhub.DisasterRecoveryConfigsClient, resourceGroup, namespaceName, name string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
-		Pending: []string{string(eventhub.Accepted)},
-		Target:  []string{string(eventhub.Succeeded)},
-		// Delay:      15 * time.Second,
-		Timeout:    30 * time.Minute,
+		Pending:    []string{string(eventhub.Accepted)},
+		Target:     []string{string(eventhub.Succeeded)},
 		MinTimeout: 30 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			read, err := client.Get(ctx, resourceGroup, namespaceName, name)
@@ -304,6 +314,12 @@ func resourceArmEventHubNamespaceDisasterRecoveryConfigWaitForState(ctx context.
 
 			return read, "nil", fmt.Errorf("Waiting for replication error EventHub Namespace Disaster Recovery Configs %q (Namespace %q / Resource Group %q): provisioning state is nil", name, namespaceName, resourceGroup)
 		},
+	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = timeout
+	} else {
+		stateConf.Timeout = 30 * time.Minute
 	}
 
 	_, err := stateConf.WaitForState()

--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -317,10 +317,15 @@ func resourceArmKeyVaultCreateUpdate(d *schema.ResourceData, meta interface{}) e
 					Pending:                   []string{"pending"},
 					Target:                    []string{"available"},
 					Refresh:                   keyVaultRefreshFunc(*vault),
-					Timeout:                   30 * time.Minute,
 					Delay:                     30 * time.Second,
 					PollInterval:              10 * time.Second,
 					ContinuousTargetOccurence: 10,
+				}
+
+				if features.SupportsCustomTimeouts() {
+					stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+				} else {
+					stateConf.Timeout = 30 * time.Minute
 				}
 
 				if _, err := stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_mariadb_virtual_network_rule.go
+++ b/azurerm/resource_arm_mariadb_virtual_network_rule.go
@@ -141,10 +141,19 @@ func resourceArmMariaDbVirtualNetworkRuleCreateUpdate(d *schema.ResourceData, me
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{"Initializing", "InProgress", "Unknown", "ResponseNotFound"},
 		Target:                    []string{"Ready"},
-		Refresh:                   MariaDbVirtualNetworkStateStatusCodeRefreshFunc(ctx, client, resourceGroup, serverName, name),
-		Timeout:                   30 * time.Minute,
+		Refresh:                   mariaDbVirtualNetworkStateStatusCodeRefreshFunc(ctx, client, resourceGroup, serverName, name),
 		MinTimeout:                1 * time.Minute,
 		ContinuousTargetOccurence: 5,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 30 * time.Minute
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {
@@ -229,7 +238,7 @@ func resourceArmMariaDbVirtualNetworkRuleDelete(d *schema.ResourceData, meta int
 	return nil
 }
 
-func MariaDbVirtualNetworkStateStatusCodeRefreshFunc(ctx context.Context, client *mariadb.VirtualNetworkRulesClient, resourceGroup string, serverName string, name string) resource.StateRefreshFunc {
+func mariaDbVirtualNetworkStateStatusCodeRefreshFunc(ctx context.Context, client *mariadb.VirtualNetworkRulesClient, resourceGroup string, serverName string, name string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := client.Get(ctx, resourceGroup, serverName, name)
 

--- a/azurerm/resource_arm_monitor_diagnostic_setting.go
+++ b/azurerm/resource_arm_monitor_diagnostic_setting.go
@@ -34,7 +34,7 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 			Create: schema.DefaultTimeout(30 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -350,10 +350,16 @@ func resourceArmMonitorDiagnosticSettingDelete(d *schema.ResourceData, meta inte
 		Pending:                   []string{"Exists"},
 		Target:                    []string{"NotFound"},
 		Refresh:                   monitorDiagnosticSettingDeletedRefreshFunc(ctx, client, targetResourceId, id.name),
-		Timeout:                   60 * time.Minute,
 		MinTimeout:                15 * time.Second,
 		ContinuousTargetOccurence: 5,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		stateConf.Timeout = 60 * time.Minute
+	}
+
 	if _, err = stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Monitor Diagnostic Setting %q for Resource %q to become available: %s", id.name, id.resourceID, err)
 	}

--- a/azurerm/resource_arm_mysql_virtual_network_rule.go
+++ b/azurerm/resource_arm_mysql_virtual_network_rule.go
@@ -142,9 +142,18 @@ func resourceArmMySqlVirtualNetworkRuleCreateUpdate(d *schema.ResourceData, meta
 		Pending:                   []string{"Initializing", "InProgress", "Unknown", "ResponseNotFound"},
 		Target:                    []string{"Ready"},
 		Refresh:                   mySQLVirtualNetworkStateStatusCodeRefreshFunc(ctx, client, resourceGroup, serverName, name),
-		Timeout:                   30 * time.Minute,
 		MinTimeout:                1 * time.Minute,
 		ContinuousTargetOccurence: 5,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 30 * time.Minute
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_notification_hub.go
+++ b/azurerm/resource_arm_notification_hub.go
@@ -194,10 +194,20 @@ func resourceArmNotificationHubCreateUpdate(d *schema.ResourceData, meta interfa
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
 		Refresh:                   notificationHubStateRefreshFunc(ctx, client, resourceGroup, namespaceName, name),
-		Timeout:                   10 * time.Minute,
 		MinTimeout:                15 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 10 * time.Minute
+	}
+
 	if _, err2 := stateConf.WaitForState(); err2 != nil {
 		return fmt.Errorf("Error waiting for Notification Hub %q to become available: %s", name, err2)
 	}

--- a/azurerm/resource_arm_notification_hub_namespace.go
+++ b/azurerm/resource_arm_notification_hub_namespace.go
@@ -178,10 +178,20 @@ func resourceArmNotificationHubNamespaceCreateUpdate(d *schema.ResourceData, met
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
 		Refresh:                   notificationHubNamespaceStateRefreshFunc(ctx, client, resourceGroup, name),
-		Timeout:                   10 * time.Minute,
 		MinTimeout:                15 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 10 * time.Minute
+	}
+
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Notification Hub %q (Resource Group %q) to finish replicating: %s", name, resourceGroup, err)
 	}
@@ -276,7 +286,11 @@ func resourceArmNotificationHubNamespaceDelete(d *schema.ResourceData, meta inte
 		Pending: []string{"200", "202"},
 		Target:  []string{"404"},
 		Refresh: notificationHubNamespaceDeleteStateRefreshFunc(ctx, client, resourceGroup, name),
-		Timeout: 10 * time.Minute,
+	}
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		stateConf.Timeout = 10 * time.Minute
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Notification Hub %q (Resource Group %q) to be deleted: %s", name, resourceGroup, err)

--- a/azurerm/resource_arm_policy_assignment.go
+++ b/azurerm/resource_arm_policy_assignment.go
@@ -181,9 +181,18 @@ func resourceArmPolicyAssignmentCreateUpdate(d *schema.ResourceData, meta interf
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
 		Refresh:                   policyAssignmentRefreshFunc(ctx, client, scope, name),
-		Timeout:                   5 * time.Minute,
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 10,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 5 * time.Minute
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_policy_definition.go
+++ b/azurerm/resource_arm_policy_definition.go
@@ -186,10 +186,20 @@ func resourceArmPolicyDefinitionCreateUpdate(d *schema.ResourceData, meta interf
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
 		Refresh:                   policyDefinitionRefreshFunc(ctx, client, name, managementGroupID),
-		Timeout:                   5 * time.Minute,
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 5 * time.Minute
+	}
+
 	if _, err = stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Policy Definition %q to become available: %s", name, err)
 	}

--- a/azurerm/resource_arm_policy_set_definition.go
+++ b/azurerm/resource_arm_policy_set_definition.go
@@ -193,9 +193,18 @@ func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta int
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
 		Refresh:                   policySetDefinitionRefreshFunc(ctx, client, name, managementGroupID),
-		Timeout:                   5 * time.Minute,
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 10,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 5 * time.Minute
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_postgresql_virtual_network_rule.go
+++ b/azurerm/resource_arm_postgresql_virtual_network_rule.go
@@ -112,9 +112,18 @@ func resourceArmPostgreSQLVirtualNetworkRuleCreateUpdate(d *schema.ResourceData,
 		Pending:                   []string{"Initializing", "InProgress", "Unknown", "ResponseNotFound"},
 		Target:                    []string{"Ready"},
 		Refresh:                   postgreSQLVirtualNetworkStateStatusCodeRefreshFunc(ctx, client, resourceGroup, serverName, name),
-		Timeout:                   10 * time.Minute,
 		MinTimeout:                1 * time.Minute,
 		ContinuousTargetOccurence: 5,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 10 * time.Minute
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_private_dns_zone_virtual_network_link.go
+++ b/azurerm/resource_arm_private_dns_zone_virtual_network_link.go
@@ -215,10 +215,15 @@ func resourceArmPrivateDnsZoneVirtualNetworkLinkDelete(d *schema.ResourceData, m
 			log.Printf("[DEBUG] Virtual Network Link %q (Private DNS Zone %q / Resource Group %q) still exists", name, dnsZoneName, resGroup)
 			return "Available", "Available", nil
 		},
-		Timeout:                   30 * time.Minute,
 		Delay:                     30 * time.Second,
 		PollInterval:              10 * time.Second,
 		ContinuousTargetOccurence: 10,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		stateConf.Timeout = 30 * time.Minute
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_redis_cache.go
+++ b/azurerm/resource_arm_redis_cache.go
@@ -368,9 +368,15 @@ func resourceArmRedisCacheCreate(d *schema.ResourceData, meta interface{}) error
 		Pending:    []string{"Scaling", "Updating", "Creating"},
 		Target:     []string{"Succeeded"},
 		Refresh:    redisStateRefreshFunc(ctx, client, resGroup, name),
-		Timeout:    60 * time.Minute,
 		MinTimeout: 15 * time.Second,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+	} else {
+		stateConf.Timeout = 60 * time.Minute
+	}
+
 	if _, err = stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Redis Cache (%s) to become available: %s", d.Get("name"), err)
 	}
@@ -451,9 +457,15 @@ func resourceArmRedisCacheUpdate(d *schema.ResourceData, meta interface{}) error
 		Pending:    []string{"Scaling", "Updating", "Creating"},
 		Target:     []string{"Succeeded"},
 		Refresh:    redisStateRefreshFunc(ctx, client, resGroup, name),
-		Timeout:    60 * time.Minute,
 		MinTimeout: 15 * time.Second,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+	} else {
+		stateConf.Timeout = 60 * time.Minute
+	}
+
 	if _, err = stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Redis Instance (%s) to become available: %s", d.Get("name"), err)
 	}

--- a/azurerm/resource_arm_relay_hybrid_connection.go
+++ b/azurerm/resource_arm_relay_hybrid_connection.go
@@ -105,7 +105,7 @@ func resourceArmHybridConnectionCreateUpdate(d *schema.ResourceData, meta interf
 
 func resourceArmHybridConnectionRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Relay.HybridConnectionsClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -140,7 +140,7 @@ func resourceArmHybridConnectionRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmHybridConnectionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Relay.HybridConnectionsClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
@@ -166,7 +166,7 @@ func resourceArmHybridConnectionDelete(d *schema.ResourceData, meta interface{})
 		Pending:    []string{"Pending"},
 		Target:     []string{"Deleted"},
 		Refresh:    hybridConnectionDeleteRefreshFunc(ctx, client, resourceGroup, relayNamespace, name),
-		Timeout:    30 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 15 * time.Second,
 	}
 

--- a/azurerm/resource_arm_security_center_workspace.go
+++ b/azurerm/resource_arm_security_center_workspace.go
@@ -110,7 +110,6 @@ func resourceArmSecurityCenterWorkspaceCreateUpdate(d *schema.ResourceData, meta
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"Waiting"},
 		Target:     []string{"Populated"},
-		Timeout:    30 * time.Minute,
 		MinTimeout: 30 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			resp, err2 := client.Get(ctx, name)
@@ -126,6 +125,16 @@ func resourceArmSecurityCenterWorkspaceCreateUpdate(d *schema.ResourceData, meta
 
 			return resp, "Waiting", nil
 		},
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 30 * time.Minute
 	}
 
 	resp, err := stateConf.WaitForState()

--- a/azurerm/resource_arm_sql_virtual_network_rule.go
+++ b/azurerm/resource_arm_sql_virtual_network_rule.go
@@ -108,9 +108,18 @@ func resourceArmSqlVirtualNetworkRuleCreateUpdate(d *schema.ResourceData, meta i
 		Pending:                   []string{"Initializing", "InProgress", "Unknown", "ResponseNotFound"},
 		Target:                    []string{"Ready"},
 		Refresh:                   sqlVirtualNetworkStateStatusCodeRefreshFunc(ctx, client, resourceGroup, serverName, name),
-		Timeout:                   10 * time.Minute,
 		MinTimeout:                1 * time.Minute,
 		ContinuousTargetOccurence: 5,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 10 * time.Minute
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {

--- a/azurerm/resource_arm_storage_share_directory.go
+++ b/azurerm/resource_arm_storage_share_directory.go
@@ -109,9 +109,14 @@ func resourceArmStorageShareDirectoryCreate(d *schema.ResourceData, meta interfa
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
 		Refresh:                   storageShareDirectoryRefreshFunc(ctx, client, accountName, shareName, directoryName),
-		Timeout:                   5 * time.Minute,
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 5,
+	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+	} else {
+		stateConf.Timeout = 5 * time.Minute
 	}
 
 	if _, err := stateConf.WaitForState(); err != nil {


### PR DESCRIPTION
Whilst passing through I noticed that the Custom Refresh Func's weren't reusing the custom timeouts present on the resource; as such this should allow users to fully configure custom timeouts for resources, which enables #22 - when that functionality is feature toggled on

I've split a couple of the refresh funcs out to make this logic simpler too