### PR TITLE
resource_arm_network_interface.go: Fixes #4721

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -549,7 +549,7 @@ func flattenNetworkInterfaceIPConfigurations(ipConfigs *[]network.InterfaceIPCon
 
 		niIPConfig["private_ip_address_allocation"] = strings.ToLower(string(props.PrivateIPAllocationMethod))
 
-		if props.PrivateIPAllocationMethod == network.Static {
+		if props.PrivateIPAddress != nil {
 			niIPConfig["private_ip_address"] = *props.PrivateIPAddress
 		}
 


### PR DESCRIPTION
This fixes the bug mentioned in #4721.

`private_ip_address` was only filled if allocation method was `Static`. With this pull request it will be filled also if allocation method is set to `Dynamic`. This is corresponding to the behaviour of the Azure API, which always displays the private IP addresses.

Fixes #4721