### PR TITLE
Fix typo

### DIFF
--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -358,7 +358,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   }
 
   identity {
-    type = "systemAssigned"
+    type = "SystemAssigned"
   }
 
   extension {


### PR DESCRIPTION
This needs to be capitalised otherwise you will get:
Error: expected identity.0.type to be one of [SystemAssigned UserAssigned
SystemAssigned, UserAssigned], got systemAssigned