### PR TITLE
`azurerm_postgres_database` allow `-`s in database collation

### DIFF
--- a/azurerm/helpers/validate/database.go
+++ b/azurerm/helpers/validate/database.go
@@ -15,7 +15,7 @@ func DatabaseCollation(i interface{}, k string) (warnings []string, errors []err
 	matched, _ := regexp.MatchString(`^[-A-Za-z0-9_. ]+$`, v)
 
 	if !matched {
-		errors = append(errors, fmt.Errorf("%s contains invalid characters, only underscores are supported, got %s", k, v))
+		errors = append(errors, fmt.Errorf("%s contains invalid characters, only alphanumeric, underscores, spaces or hyphens characters are supported, got %s", k, v))
 		return
 	}
 

--- a/azurerm/helpers/validate/database.go
+++ b/azurerm/helpers/validate/database.go
@@ -15,7 +15,7 @@ func DatabaseCollation(i interface{}, k string) (warnings []string, errors []err
 	matched, _ := regexp.MatchString(`^[-A-Za-z0-9_. ]+$`, v)
 
 	if !matched {
-		errors = append(errors, fmt.Errorf("%s contains invalid characters, only alphanumeric, underscores, spaces or hyphens characters are supported, got %s", k, v))
+		errors = append(errors, fmt.Errorf("%s contains invalid characters, only alphanumeric, underscore, space or hyphen characters are supported, got %s", k, v))
 		return
 	}
 

--- a/azurerm/helpers/validate/database.go
+++ b/azurerm/helpers/validate/database.go
@@ -12,7 +12,7 @@ func DatabaseCollation(i interface{}, k string) (warnings []string, errors []err
 		return
 	}
 
-	matched, _ := regexp.MatchString(`^[A-Za-z0-9_. ]+$`, v)
+	matched, _ := regexp.MatchString(`^[-A-Za-z0-9_. ]+$`, v)
 
 	if !matched {
 		errors = append(errors, fmt.Errorf("%s contains invalid characters, only underscores are supported, got %s", k, v))

--- a/azurerm/helpers/validate/database_test.go
+++ b/azurerm/helpers/validate/database_test.go
@@ -8,6 +8,10 @@ func TestDatabaseCollation(t *testing.T) {
 		Errors int
 	}{
 		{
+			Value:  "en@US",
+			Errors: 1,
+		},
+		{
 			Value:  "en-US",
 			Errors: 0,
 		},

--- a/azurerm/helpers/validate/database_test.go
+++ b/azurerm/helpers/validate/database_test.go
@@ -9,7 +9,7 @@ func TestDatabaseCollation(t *testing.T) {
 	}{
 		{
 			Value:  "en-US",
-			Errors: 1,
+			Errors: 0,
 		},
 		{
 			Value:  "en_US",

--- a/azurerm/resource_arm_postgresql_database.go
+++ b/azurerm/resource_arm_postgresql_database.go
@@ -152,11 +152,7 @@ func resourceArmPostgreSQLDatabaseRead(d *schema.ResourceData, meta interface{})
 
 	if props := resp.DatabaseProperties; props != nil {
 		d.Set("charset", props.Charset)
-
-		if collation := props.Collation; collation != nil {
-			v := strings.Replace(*collation, "-", "_", -1)
-			d.Set("collation", v)
-		}
+		d.Set("collation", props.Collation)
 	}
 
 	return nil

--- a/azurerm/resource_arm_postgresql_database.go
+++ b/azurerm/resource_arm_postgresql_database.go
@@ -3,7 +3,6 @@ package azurerm
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/postgresql/mgmt/2017-12-01/postgresql"


### PR DESCRIPTION
According to feedback from Azure Support we should use hyphens instead of underscore if we create databases in azure postgresql. This PR adress issue #4447  

**Changes:**
- add - to database collation validation
- adjust validation test
- emove hyphen underscore rewrite

Fixes #4447