### PR TITLE
`azurerm_key_vault_secret` - support for `not_before_date` and `expiration_date` 

### DIFF
--- a/azurerm/resource_arm_key_vault_secret.go
+++ b/azurerm/resource_arm_key_vault_secret.go
@@ -334,12 +334,14 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("version", respID.Version)
 	d.Set("content_type", resp.ContentType)
 
-	if v := resp.Attributes.NotBefore; v != nil {
-		d.Set("not_before_date", time.Time(*v).Format(time.RFC3339))
-	}
+	if attributes := resp.Attributes; attributes != nil {
+		if v := attributes.NotBefore; v != nil {
+			d.Set("not_before_date", time.Time(*v).Format(time.RFC3339))
+		}
 
-	if v := resp.Attributes.Expires; v != nil {
-		d.Set("expiration_date", time.Time(*v).Format(time.RFC3339))
+		if v := attributes.Expires; v != nil {
+			d.Set("expiration_date", time.Time(*v).Format(time.RFC3339))
+		}
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/resource_arm_key_vault_secret.go
+++ b/azurerm/resource_arm_key_vault_secret.go
@@ -151,19 +151,13 @@ func resourceArmKeyVaultSecretCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if v, ok := d.GetOk("not_before_date"); ok {
-		notBeforeDate, err := time.Parse(time.RFC3339, v.(string))
-		if err != nil {
-			return fmt.Errorf("error parsing `not_before_date` time: %s", err)
-		}
+		notBeforeDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
 		notBeforeUnixTime := date.UnixTime(notBeforeDate)
 		parameters.SecretAttributes.NotBefore = &notBeforeUnixTime
 	}
 
 	if v, ok := d.GetOk("expiration_date"); ok {
-		expirationDate, err := time.Parse(time.RFC3339, v.(string))
-		if err != nil {
-			return fmt.Errorf("error parsing `expiration_date` time: %s", err)
-		}
+		expirationDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
 		expirationUnixTime := date.UnixTime(expirationDate)
 		parameters.SecretAttributes.Expires = &expirationUnixTime
 	}
@@ -223,19 +217,13 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 	secretAttributes := &keyvault.SecretAttributes{}
 
 	if v, ok := d.GetOk("not_before_date"); ok {
-		notBeforeDate, err := time.Parse(time.RFC3339, v.(string))
-		if err != nil {
-			return fmt.Errorf("error parsing `not_before_date` time: %s", err)
-		}
+		notBeforeDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
 		notBeforeUnixTime := date.UnixTime(notBeforeDate)
 		secretAttributes.NotBefore = &notBeforeUnixTime
 	}
 
 	if v, ok := d.GetOk("expiration_date"); ok {
-		expirationDate, err := time.Parse(time.RFC3339, v.(string))
-		if err != nil {
-			return fmt.Errorf("error parsing `expiration_date` time: %s", err)
-		}
+		expirationDate, _ := time.Parse(time.RFC3339, v.(string)) //validated by schema
 		expirationUnixTime := date.UnixTime(expirationDate)
 		secretAttributes.Expires = &expirationUnixTime
 	}

--- a/azurerm/resource_arm_key_vault_secret_test.go
+++ b/azurerm/resource_arm_key_vault_secret_test.go
@@ -153,6 +153,9 @@ func TestAccAzureRMKeyVaultSecret_complete(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKeyVaultSecretExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "not_before_date", "2019-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(resourceName, "expiration_date", "2020-01-01T01:02:03Z"),
+					resource.TestCheckResourceAttr(resourceName, "tags.hello", "world"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.hello", "world"),
 				),
@@ -445,10 +448,12 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_secret" "test" {
-  name         = "secret-%s"
-  value        = "<rick><morty /></rick>"
-  key_vault_id = "${azurerm_key_vault.test.id}"
-  content_type = "application/xml"
+  name            = "secret-%s"
+  value           = "<rick><morty /></rick>"
+  key_vault_id    = "${azurerm_key_vault.test.id}"
+  content_type    = "application/xml"
+  not_before_date = "2019-01-01T01:02:03Z"
+  expiration_date = "2020-01-01T01:02:03Z"
 
   tags = {
     "hello" = "world"

--- a/azurerm/resource_arm_key_vault_secret_test.go
+++ b/azurerm/resource_arm_key_vault_secret_test.go
@@ -155,7 +155,6 @@ func TestAccAzureRMKeyVaultSecret_complete(t *testing.T) {
 					testCheckAzureRMKeyVaultSecretExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "not_before_date", "2019-01-01T01:02:03Z"),
 					resource.TestCheckResourceAttr(resourceName, "expiration_date", "2020-01-01T01:02:03Z"),
-					resource.TestCheckResourceAttr(resourceName, "tags.hello", "world"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.hello", "world"),
 				),

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -81,13 +81,17 @@ The following arguments are supported:
 
 * `value` - (Required) Specifies the value of the Key Vault Secret.
 
-~> **Note:** Key Vault strips newlines. To preserve newlines in multi-line secrets try replacing them with `\n` or by base 64 encoding them with `replace(file("my_secret_file"), "/\n/", "\n")` or `base64encode(file("my_secret_file"))`, respectively. 
+~> **Note:** Key Vault strips newlines. To preserve newlines in multi-line secrets try replacing them with `\n` or by base 64 encoding them with `replace(file("my_secret_file"), "/\n/", "\n")` or `base64encode(file("my_secret_file"))`, respectively.
 
 * `key_vault_id` - (Required) The ID of the Key Vault where the Secret should be created.
 
 * `content_type` - (Optional) Specifies the content type for the Key Vault Secret.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+* `not_before_date` - (Optional) Key not usable before the provided UTC datetime (Y-m-d'T'H:M:S'Z').
+
+* `expiration_date` - (Optional) Expiration UTC datetime (Y-m-d'T'H:M:S'Z').
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes #4858 

Adds the `not_before_date` and `expiration_date` options to the `azurerm_key_vault_secret` resource.

```
--- PASS: TestAccAzureRMKeyVaultSecret_complete (219.48s)
--- PASS: TestAccAzureRMKeyVaultSecret_disappearsWhenParentKeyVaultDeleted (224.89s)
--- PASS: TestAccAzureRMKeyVaultSecret_basic (235.53s)
--- PASS: TestAccAzureRMKeyVaultSecret_update (238.80s)
--- PASS: TestAccAzureRMKeyVaultSecret_disappears (244.47s)
--- PASS: TestAccAzureRMKeyVaultSecret_basicClassic (247.29s)
```