### PR TITLE
azurerm_api_management_api - support for `subscription_required`

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_api_data_source.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_data_source.go
@@ -99,6 +99,11 @@ func dataSourceApiManagementApi() *schema.Resource {
 				},
 			},
 
+			"subscription_required": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"version": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -147,6 +152,7 @@ func dataSourceApiManagementApiRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("revision", props.APIRevision)
 		d.Set("service_url", props.ServiceURL)
 		d.Set("soap_pass_through", string(props.APIType) == string(apimanagement.SoapPassThrough))
+		d.Set("subscription_required", props.SubscriptionRequired)
 		d.Set("version", props.APIVersion)
 		d.Set("version_set_id", props.APIVersionSetID)
 

--- a/azurerm/internal/services/apimanagement/api_management_api_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_resource.go
@@ -163,6 +163,12 @@ func resourceArmApiManagementApi() *schema.Resource {
 				},
 			},
 
+			"subscription_required": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
 			"soap_pass_through": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -292,6 +298,7 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	serviceUrl := d.Get("service_url").(string)
+	subscriptionRequired := d.Get("subscription_required").(bool)
 
 	protocolsRaw := d.Get("protocols").(*schema.Set).List()
 	protocols := expandApiManagementApiProtocols(protocolsRaw)
@@ -310,6 +317,7 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 			ServiceURL:                    utils.String(serviceUrl),
 			SubscriptionKeyParameterNames: subscriptionKeyParameterNames,
 			APIVersion:                    utils.String(version),
+			SubscriptionRequired:          &subscriptionRequired,
 		},
 	}
 
@@ -384,6 +392,7 @@ func resourceArmApiManagementApiRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("service_url", props.ServiceURL)
 		d.Set("revision", props.APIRevision)
 		d.Set("soap_pass_through", string(props.APIType) == string(apimanagement.SoapPassThrough))
+		d.Set("subscription_required", props.SubscriptionRequired)
 		d.Set("version", props.APIVersion)
 		d.Set("version_set_id", props.APIVersionSetID)
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_data_source_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceAzureRMApiManagementApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "protocols.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "protocols.0", "https"),
 					resource.TestCheckResourceAttr(data.ResourceName, "soap_pass_through", "false"),
-					resource.TestCheckResourceAttr(data.ResourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "subscription_required", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_current", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_online", "false"),
 				),

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_data_source_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccDataSourceAzureRMApiManagementApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "protocols.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "protocols.0", "https"),
 					resource.TestCheckResourceAttr(data.ResourceName, "soap_pass_through", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "subscription_required", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_current", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_online", "false"),
 				),

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_resource_test.go
@@ -446,13 +446,13 @@ func testAccAzureRMApiManagementApi_subscriptionRequired(data acceptance.TestDat
 %s
 
 resource "azurerm_api_management_api" "test" {
-  name                	= "acctestapi-%d"
-  resource_group_name 	= azurerm_resource_group.test.name
-  api_management_name 	= azurerm_api_management.test.name
-  display_name        	= "api1"
-  path                	= "api1"
-  protocols           	= ["https"]
-  revision            	= "1"
+  name                  = "acctestapi-%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  api_management_name   = azurerm_api_management.test.name
+  display_name          = "api1"
+  path                  = "api1"
+  protocols             = ["https"]
+  revision              = "1"
   subscription_required = false
 }
 `, template, data.RandomInteger)

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_resource_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMApiManagementApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "soap_pass_through", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_current", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_online", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "subscription_required", "true"),
 				),
 			},
 			data.ImportStep(),
@@ -150,6 +151,26 @@ func TestAccAzureRMApiManagementApi_soapPassthrough(t *testing.T) {
 				Config: testAccAzureRMApiManagementApi_soapPassthrough(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementApiExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementApi_subscriptionRequired(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementApi_subscriptionRequired(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementApiExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "subscription_required", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -415,6 +436,24 @@ resource "azurerm_api_management_api" "test" {
   protocols           = ["https"]
   revision            = "1"
   soap_pass_through   = true
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMApiManagementApi_subscriptionRequired(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementApi_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                	= "acctestapi-%d"
+  resource_group_name 	= azurerm_resource_group.test.name
+  api_management_name 	= azurerm_api_management.test.name
+  display_name        	= "api1"
+  path                	= "api1"
+  protocols           	= ["https"]
+  revision            	= "1"
+  subscription_required = false
 }
 `, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_resource_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMApiManagementApi_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "soap_pass_through", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_current", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "is_online", "false"),
-					resource.TestCheckResourceAttr(data.ResourceName, "subscription_required", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "subscription_required", "false"),
 				),
 			},
 			data.ImportStep(),

--- a/website/docs/d/api_management_api.html.markdown
+++ b/website/docs/d/api_management_api.html.markdown
@@ -57,6 +57,8 @@ output "api_management_api_id" {
 
 * `subscription_key_parameter_names` - A `subscription_key_parameter_names` block as documented below.
 
+* `subscription_required` - Should this API require a subscription key?
+
 * `version` - The Version number of this API, if this API is versioned.
 
 * `version_set_id` - The ID of the Version Set which this API is associated with.

--- a/website/docs/d/api_management_api.html.markdown
+++ b/website/docs/d/api_management_api.html.markdown
@@ -65,12 +65,6 @@ output "api_management_api_id" {
 
 ---
 
-An `authentication_settings` block exports the following:
-
-* `subscription_key_required` - Whether the API requires a subscription key or not.
-
----
-
 A `subscription_key_parameter_names` block exports the following:
 
 * `header` - The name of the HTTP Header which should be used for the Subscription Key.

--- a/website/docs/d/api_management_api.html.markdown
+++ b/website/docs/d/api_management_api.html.markdown
@@ -65,6 +65,12 @@ output "api_management_api_id" {
 
 ---
 
+An `authentication_settings` block exports the following:
+
+* `subscription_key_required` - Whether the API requires a subscription key or not.
+
+---
+
 A `subscription_key_parameter_names` block exports the following:
 
 * `header` - The name of the HTTP Header which should be used for the Subscription Key.

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 * `subscription_key_parameter_names` - (Optional) A `subscription_key_parameter_names` block as documented below.
 
+* `subscription_required` - (Optional) Should this API require a subscription key?
+
 * `version` - (Optional) The Version number of this API, if this API is versioned.
 
 * `version_set_id` - (Optional) The ID of the Version Set which this API is associated with.


### PR DESCRIPTION
Add `subscription_required` to data and resource for **azurerm_api_management_api**

(fixes ##3863 )