### PR TITLE
refactor: moving A-C of the Compute clients

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -90,18 +90,6 @@ type ArmClient struct {
 
 	// Services
 	// NOTE: all new services should be Public as they're going to be relocated in the near-future
-	AnalysisServices *analysisservices.Client
-	ApiManagement    *apimanagement.Client
-	AppInsights      *applicationinsights.Client
-	Automation       *automation.Client
-	Authorization    *authorization.Client
-	Batch            *batch.Client
-	Bot              *bot.Client
-	Cdn              *cdn.Client
-	Cognitive        *cognitive.Client
-	Compute          *clients.ComputeClient
-	Containers       *containers.Client
-	Cosmos           *cosmos.Client
 	DataBricks       *databricks.Client
 	DataFactory      *datafactory.Client
 	Datalake         *datalake.Client

--- a/azurerm/internal/clients/client.go
+++ b/azurerm/internal/clients/client.go
@@ -2,11 +2,34 @@ package clients
 
 import (
 	"context"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/analysisservices"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/applicationinsights"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/authorization"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/automation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/batch"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/bot"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cognitive"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos"
 )
 
 type Client struct {
 	// StopContext is used for propagating control from Terraform Core (e.g. Ctrl/Cmd+C)
 	StopContext context.Context
 
-	Compute ComputeClient
+	AnalysisServices *analysisservices.Client
+	ApiManagement    *apimanagement.Client
+	AppInsights      *applicationinsights.Client
+	Automation       *automation.Client
+	Authorization    *authorization.Client
+	Batch            *batch.Client
+	Bot              *bot.Client
+	Cdn              *cdn.Client
+	Cognitive        *cognitive.Client
+	Containers       *containers.Client
+	Cosmos           *cosmos.Client
+	Compute          *ComputeClient
 }


### PR DESCRIPTION
This PR moves Clients A through C into the new package as part of the ongoing work of gradually moving to packages for 2.0