### PR TITLE
provider docs: change hdinsights kafka cluster example to working version combination

### DIFF
--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -38,11 +38,11 @@ resource "azurerm_hdinsight_kafka_cluster" "example" {
   name                = "example-hdicluster"
   resource_group_name = "${azurerm_resource_group.example.name}"
   location            = "${azurerm_resource_group.example.location}"
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "2.3"
+    kafka = "2.1"
   }
 
   gateway {


### PR DESCRIPTION
azures latest supported version is kafka 2.1 for the HDinsights cluster 4.0