### PR TITLE
Only lock each virtual network once

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1213,6 +1213,11 @@ func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) e
 					}
 
 					networkName := id.Path["virtualNetworks"]
+					for _, virtualNetworkName := range virtualNetworkNames {
+						if networkName == virtualNetworkName {
+							continue
+						}
+					}
 					virtualNetworkNames = append(virtualNetworkNames, networkName)
 				}
 			}


### PR DESCRIPTION
If multiple subnets belonging to the same virtual networks are
listed in the network rules, then the deletion attempts to lock
the same virtual network twice, which can't happen because it
already owns the lock, thereby deadlocking itself.

fixes #3156