### PR TITLE
dependencies: updating github.com/Azure/azure-sdk-for-go to v36.2.0

### DIFF
--- a/azurerm/resource_arm_signalr_service.go
+++ b/azurerm/resource_arm_signalr_service.go
@@ -81,6 +81,10 @@ func resourceArmSignalRService() *schema.Resource {
 						"flag": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(signalr.EnableConnectivityLogs),
+								string(signalr.ServiceMode),
+							}, false),
 						},
 
 						"value": {
@@ -310,7 +314,7 @@ func expandSignalRFeatures(input []interface{}) *[]signalr.Feature {
 		value := featureValue.(map[string]interface{})
 
 		feature := signalr.Feature{
-			Flag:  utils.String(value["flag"].(string)),
+			Flag:  signalr.FeatureFlags(value["flag"].(string)),
 			Value: utils.String(value["value"].(string)),
 		}
 
@@ -324,18 +328,13 @@ func flattenSignalRFeatures(features *[]signalr.Feature) []interface{} {
 	result := make([]interface{}, 0)
 	if features != nil {
 		for _, feature := range *features {
-			flag := ""
-			if feature.Flag != nil {
-				flag = *feature.Flag
-			}
-
 			value := ""
 			if feature.Value != nil {
 				value = *feature.Value
 			}
 
 			result = append(result, map[string]interface{}{
-				"flag":  flag,
+				"flag":  string(feature.Flag),
 				"value": value,
 			})
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-azurerm
 
 require (
-	github.com/Azure/azure-sdk-for-go v35.0.0+incompatible
+	github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.9.2
 	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/btubbs/datetime v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/Azure/azure-sdk-for-go v34.1.0+incompatible h1:uW/dgSzmRQEPXwaRUN8WzB
 github.com/Azure/azure-sdk-for-go v34.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v35.0.0+incompatible h1:PkmdmQUmeSdQQ5258f4SyCf2Zcz0w67qztEg37cOR7U=
 github.com/Azure/azure-sdk-for-go v35.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v36.2.0+incompatible h1:09cv2WoH0g6jl6m2iT+R9qcIPZKhXEL0sbmLhxP895s=
+github.com/Azure/azure-sdk-for-go v36.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.15.4+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v13.0.0+incompatible h1:56c11ykhsFSPNNQuS73Ri8h/ezqVhr2h6t9LJIEKVO0=
 github.com/Azure/go-autorest v13.0.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-06-01/containerservice/agentpools.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-06-01/containerservice/agentpools.go
@@ -64,14 +64,7 @@ func (client AgentPoolsClient) CreateOrUpdate(ctx context.Context, resourceGroup
 		{TargetValue: resourceName,
 			Constraints: []validation.Constraint{{Target: "resourceName", Name: validation.MaxLength, Rule: 63, Chain: nil},
 				{Target: "resourceName", Name: validation.MinLength, Rule: 1, Chain: nil},
-				{Target: "resourceName", Name: validation.Pattern, Rule: `^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$`, Chain: nil}}},
-		{TargetValue: parameters,
-			Constraints: []validation.Constraint{{Target: "parameters.ManagedClusterAgentPoolProfileProperties", Name: validation.Null, Rule: false,
-				Chain: []validation.Constraint{{Target: "parameters.ManagedClusterAgentPoolProfileProperties.Count", Name: validation.Null, Rule: true,
-					Chain: []validation.Constraint{{Target: "parameters.ManagedClusterAgentPoolProfileProperties.Count", Name: validation.InclusiveMaximum, Rule: int64(100), Chain: nil},
-						{Target: "parameters.ManagedClusterAgentPoolProfileProperties.Count", Name: validation.InclusiveMinimum, Rule: 1, Chain: nil},
-					}},
-				}}}}}); err != nil {
+				{Target: "resourceName", Name: validation.Pattern, Rule: `^[a-zA-Z0-9]$|^[a-zA-Z0-9][-_a-zA-Z0-9]{0,61}[a-zA-Z0-9]$`, Chain: nil}}}}); err != nil {
 		return result, validation.NewError("containerservice.AgentPoolsClient", "CreateOrUpdate", err.Error())
 	}
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/netapp/mgmt/2019-06-01/netapp/models.go
@@ -596,7 +596,7 @@ type ExportPolicyRule struct {
 	Cifs *bool `json:"cifs,omitempty"`
 	// Nfsv3 - Allows NFSv3 protocol
 	Nfsv3 *bool `json:"nfsv3,omitempty"`
-	// Nfsv4 - Allows NFSv4 protocol
+	// Nfsv4 - Deprecated: Will use the NFSv4.1 protocol, please use swagger version 2019-07-01 or later
 	Nfsv4 *bool `json:"nfsv4,omitempty"`
 	// AllowedClients - Client ingress specification as comma separated string with IPv4 CIDRs, IPv4 host addresses and host names
 	AllowedClients *string `json:"allowedClients,omitempty"`

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-07-01/network/models.go
@@ -23185,8 +23185,8 @@ type PrivateLinkServiceConnectionState struct {
 	Status *string `json:"status,omitempty"`
 	// Description - The reason for approval/rejection of the connection.
 	Description *string `json:"description,omitempty"`
-	// ActionRequired - A message indicating if changes on the service provider require any updates on the consumer.
-	ActionRequired *string `json:"actionRequired,omitempty"`
+	// ActionsRequired - A message indicating if changes on the service provider require any updates on the consumer.
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
 }
 
 // PrivateLinkServiceIPConfiguration the private link service ip configuration.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr/models.go
@@ -30,6 +30,21 @@ import (
 // The package's fully qualified name.
 const fqdn = "github.com/Azure/azure-sdk-for-go/services/signalr/mgmt/2018-10-01/signalr"
 
+// FeatureFlags enumerates the values for feature flags.
+type FeatureFlags string
+
+const (
+	// EnableConnectivityLogs ...
+	EnableConnectivityLogs FeatureFlags = "EnableConnectivityLogs"
+	// ServiceMode ...
+	ServiceMode FeatureFlags = "ServiceMode"
+)
+
+// PossibleFeatureFlagsValues returns an array of possible values for the FeatureFlags const type.
+func PossibleFeatureFlagsValues() []FeatureFlags {
+	return []FeatureFlags{EnableConnectivityLogs, ServiceMode}
+}
+
 // KeyType enumerates the values for key type.
 type KeyType string
 
@@ -211,10 +226,31 @@ type Dimension struct {
 	ToBeExportedForShoebox *bool `json:"toBeExportedForShoebox,omitempty"`
 }
 
+// ErrorResponse contains information about an API error.
+type ErrorResponse struct {
+	// Error - Describes a particular API error with an error code and a message.
+	Error *ErrorResponseBody `json:"error,omitempty"`
+}
+
+// ErrorResponseBody describes a particular API error with an error code and a message.
+type ErrorResponseBody struct {
+	// Code - An error code that describes the error condition more precisely than an HTTP status code.
+	// Can be used to programmatically handle specific error cases.
+	Code *string `json:"code,omitempty"`
+	// Message - A message that describes the error in detail and provides debugging information.
+	Message *string `json:"message,omitempty"`
+	// Target - The target of the particular error (for example, the name of the property in error).
+	Target *string `json:"target,omitempty"`
+	// Details - Contains nested errors that are related to this error.
+	Details *[]ErrorResponseBody `json:"details,omitempty"`
+}
+
 // Feature feature of a SignalR resource, which controls the SignalR runtime behavior.
 type Feature struct {
-	// Flag - Kind of feature. Required.
-	Flag *string `json:"flag,omitempty"`
+	// Flag - FeatureFlags is the supported features of Azure SignalR service.
+	// - ServiceMode: Flag for backend server for SignalR service. Values allowed: "Default": have your own backend server; "Serverless": your application doesn't have a backend server; "Classic": for backward compatibility. Support both Default and Serverless mode but not recommended; "PredefinedOnly": for future use.
+	// - EnableConnectivityLogs: "true"/"false", to enable/disable the connectivity log category respectively. Possible values include: 'ServiceMode', 'EnableConnectivityLogs'
+	Flag FeatureFlags `json:"flag,omitempty"`
 	// Value - Value of the feature flag. See Azure SignalR service document https://docs.microsoft.com/en-us/azure/azure-signalr/ for allowed values.
 	Value *string `json:"value,omitempty"`
 	// Properties - Optional properties related to this feature.
@@ -224,7 +260,7 @@ type Feature struct {
 // MarshalJSON is the custom marshaler for Feature.
 func (f Feature) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	if f.Flag != nil {
+	if f.Flag != "" {
 		objectMap["flag"] = f.Flag
 	}
 	if f.Value != nil {
@@ -247,6 +283,14 @@ type Keys struct {
 	PrimaryConnectionString *string `json:"primaryConnectionString,omitempty"`
 	// SecondaryConnectionString - SignalR connection string constructed via the secondaryKey
 	SecondaryConnectionString *string `json:"secondaryConnectionString,omitempty"`
+}
+
+// LogSpecification specifications of the Logs for Azure Monitoring.
+type LogSpecification struct {
+	// Name - Name of the log.
+	Name *string `json:"name,omitempty"`
+	// DisplayName - Localized friendly display name of the log.
+	DisplayName *string `json:"displayName,omitempty"`
 }
 
 // MetricSpecification specifications of the Metrics for Azure Monitoring.
@@ -852,6 +896,8 @@ func (future *RestartFuture) Result(client Client) (ar autorest.Response, err er
 type ServiceSpecification struct {
 	// MetricSpecifications - Specifications of the Metrics for Azure Monitoring.
 	MetricSpecifications *[]MetricSpecification `json:"metricSpecifications,omitempty"`
+	// LogSpecifications - Specifications of the Logs for Azure Monitoring.
+	LogSpecifications *[]LogSpecification `json:"logSpecifications,omitempty"`
 }
 
 // TrackedResource the resource model definition for a ARM tracked top level resource.

--- a/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
@@ -18,4 +18,4 @@ package version
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 // Number contains the semantic version of this SDK.
-const Number = "v35.0.0"
+const Number = "v36.2.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/Azure/azure-sdk-for-go v35.0.0+incompatible
+# github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
 github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources
 github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2017-08-01/analysisservices
 github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimanagement

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -68,7 +68,7 @@ A `cors` block supports the following:
 
 A `features` block supports the following:
 
-* `flag` - (Required) A kind of feature. At this time the only supported value is `ServiceMode`.
+* `flag` - (Required) The kind of Feature. Possible values are `EnableConnectivityLogs` and `ServiceMode`.
 
 * `value` - (Required) A value of a feature flag. Possible values are `Classic`, `Default` and `Serverless`.
 


### PR DESCRIPTION
This PR updates github.com/Azure/azure-sdk-for-go to v36.2.0 which unblocks #4898 