### PR TITLE
`azurerm_application_insights` - support for `sampling_percentage`

### DIFF
--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -63,6 +63,11 @@ func resourceArmApplicationInsights() *schema.Resource {
 				}, true),
 			},
 
+			"sampling_percentage": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+
 			"tags": tags.Schema(),
 
 			"app_id": {
@@ -109,6 +114,10 @@ func resourceArmApplicationInsightsCreateUpdate(d *schema.ResourceData, meta int
 	applicationInsightsComponentProperties := insights.ApplicationInsightsComponentProperties{
 		ApplicationID:   &name,
 		ApplicationType: insights.ApplicationType(applicationType),
+	}
+
+	if v, ok := d.GetOk("sampling_percentage"); ok {
+		applicationInsightsComponentProperties.SamplingPercentage = utils.Float(v.(float64))
 	}
 
 	insightProperties := insights.ApplicationInsightsComponent{
@@ -176,6 +185,10 @@ func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}
 		d.Set("application_type", string(props.ApplicationType))
 		d.Set("app_id", props.AppID)
 		d.Set("instrumentation_key", props.InstrumentationKey)
+
+		if v := props.SamplingPercentage; v != nil {
+			d.Set("sampling_percentage", v)
+		}
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -64,9 +64,10 @@ func resourceArmApplicationInsights() *schema.Resource {
 			},
 
 			"sampling_percentage": {
-				Type:     schema.TypeFloat,
-				Optional: true,
-				Default:  100,
+				Type:         schema.TypeFloat,
+				Optional:     true,
+				Default:      100,
+				ValidateFunc: validation.FloatBetween(0, 100),
 			},
 
 			"tags": tags.Schema(),

--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -184,9 +184,6 @@ func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}
 		d.Set("application_type", string(props.ApplicationType))
 		d.Set("app_id", props.AppID)
 		d.Set("instrumentation_key", props.InstrumentationKey)
-
-		if v := props.SamplingPercentage; v != nil {
-			d.Set("sampling_percentage", v)
 		d.Set("sampling_percentage", props.SamplingPercentage)
 	}
 

--- a/azurerm/resource_arm_application_insights.go
+++ b/azurerm/resource_arm_application_insights.go
@@ -66,6 +66,7 @@ func resourceArmApplicationInsights() *schema.Resource {
 			"sampling_percentage": {
 				Type:     schema.TypeFloat,
 				Optional: true,
+				Default:  100,
 			},
 
 			"tags": tags.Schema(),
@@ -108,16 +109,14 @@ func resourceArmApplicationInsightsCreateUpdate(d *schema.ResourceData, meta int
 	}
 
 	applicationType := d.Get("application_type").(string)
+	samplingPercentage := utils.Float(d.Get("sampling_percentage").(float64))
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
 	applicationInsightsComponentProperties := insights.ApplicationInsightsComponentProperties{
-		ApplicationID:   &name,
-		ApplicationType: insights.ApplicationType(applicationType),
-	}
-
-	if v, ok := d.GetOk("sampling_percentage"); ok {
-		applicationInsightsComponentProperties.SamplingPercentage = utils.Float(v.(float64))
+		ApplicationID:      &name,
+		ApplicationType:    insights.ApplicationType(applicationType),
+		SamplingPercentage: samplingPercentage,
 	}
 
 	insightProperties := insights.ApplicationInsightsComponent{

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 
 * `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `ios` for _iOS_, `java` for _Java web_, `MobileCenter` for _App Center_, `Node.JS` for _Node.js_, `other` for _General_, `phone` for _Windows Phone_, `store` for _Windows Store_ and `web` for _ASP.NET_. Please note these values are case sensitive; unmatched values are treated as _ASP.NET_ by Azure. Changing this forces a new resource to be created.
 
+* `sampling_percentage` - (Optional) Specifies the percentage of the data produced by the application being monitored that is being sampled for Application Insights telemetry.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `ios` for _iOS_, `java` for _Java web_, `MobileCenter` for _App Center_, `Node.JS` for _Node.js_, `other` for _General_, `phone` for _Windows Phone_, `store` for _Windows Store_ and `web` for _ASP.NET_. Please note these values are case sensitive; unmatched values are treated as _ASP.NET_ by Azure. Changing this forces a new resource to be created.
 
-* `sampling_percentage` - (Optional) Specifies the percentage of the data produced by the application being monitored that is being sampled for Application Insights telemetry.
+* `sampling_percentage` - (Optional) Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Fixes #4487 

Adds the `sampling_percentage` argument for the `azurerm_application_insights`  resource.

```
--- PASS: TestAccAzureRMApplicationInsights_complete (92.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       92.504s
```