### PR TITLE
r/network_interface: making the `private_ip_address` computed

### DIFF
--- a/azurerm/resource_arm_network_interface.go
+++ b/azurerm/resource_arm_network_interface.go
@@ -93,6 +93,7 @@ func resourceArmNetworkInterface() *schema.Resource {
 						"private_ip_address": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 
 						"private_ip_address_version": {

--- a/azurerm/resource_arm_network_interface_test.go
+++ b/azurerm/resource_arm_network_interface_test.go
@@ -322,7 +322,7 @@ func TestAccAzureRMNetworkInterface_IPAddressesBug1286(t *testing.T) {
 				Config: testAccAzureRMNetworkInterface_withIPAddressesUpdate(rInt, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetworkInterfaceExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "ip_configuration.0.private_ip_address", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_configuration.0.private_ip_address"),
 					resource.TestCheckResourceAttr(resourceName, "ip_configuration.0.public_ip_address_id", ""),
 				),
 			},


### PR DESCRIPTION
Fixes a bug where Dynamic Network Interfaces would show a diff during a plan