### PR TITLE
refactor: moving Account Information into it's own struct

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -77,7 +77,6 @@ type ArmClient struct {
 	// inherit the fields from the parent, so that we should be able to set/access these at either level
 	clients.Client
 
-	tenantId       string
 	subscriptionId string
 	partnerId      string
 	environment    azure.Environment
@@ -142,7 +141,6 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 			Account: account,
 		},
 
-		tenantId:              authConfig.TenantID,
 		subscriptionId:        authConfig.SubscriptionID,
 		usingServicePrincipal: authConfig.AuthenticatedAsAServicePrincipal,
 		environment:           *env,

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -76,10 +76,6 @@ type ArmClient struct {
 	// inherit the fields from the parent, so that we should be able to set/access these at either level
 	clients.Client
 
-	subscriptionId string
-
-	skipProviderRegistration bool
-
 	// Services
 	// NOTE: all new services should be Public as they're going to be relocated in the near-future
 	ManagementGroups *managementgroup.Client
@@ -134,9 +130,6 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		Client: clients.Client{
 			Account: account,
 		},
-
-		subscriptionId:           authConfig.SubscriptionID,
-		skipProviderRegistration: skipProviderRegistration,
 	}
 
 	oauthConfig, err := authConfig.BuildOAuthConfig(env.ActiveDirectoryEndpoint)

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -78,11 +78,7 @@ type ArmClient struct {
 	clients.Client
 
 	subscriptionId string
-	partnerId      string
 	environment    azure.Environment
-
-	getAuthenticatedObjectID func(context.Context) (string, error)
-	usingServicePrincipal    bool
 
 	skipProviderRegistration bool
 
@@ -141,12 +137,8 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 			Account: account,
 		},
 
-		subscriptionId:        authConfig.SubscriptionID,
-		usingServicePrincipal: authConfig.AuthenticatedAsAServicePrincipal,
-		environment:           *env,
-
-		partnerId:                partnerId,
-		getAuthenticatedObjectID: authConfig.GetAuthenticatedObjectID,
+		subscriptionId:           authConfig.SubscriptionID,
+		environment:              *env,
 		skipProviderRegistration: skipProviderRegistration,
 	}
 

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/go-azure-helpers/sender"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -78,7 +77,6 @@ type ArmClient struct {
 	clients.Client
 
 	subscriptionId string
-	environment    azure.Environment
 
 	skipProviderRegistration bool
 
@@ -138,7 +136,6 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		},
 
 		subscriptionId:           authConfig.SubscriptionID,
-		environment:              *env,
 		skipProviderRegistration: skipProviderRegistration,
 	}
 

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -111,17 +111,25 @@ type ArmClient struct {
 	Web              *web.Client
 }
 
+type armClientBuilder struct {
+	authConfig                  *authentication.Config
+	skipProviderRegistration    bool
+	tfVersion                   string
+	partnerId                   string
+	disableCorrelationRequestID bool
+	disableTerraformPartnerID   bool
+}
+
 // getArmClient is a helper method which returns a fully instantiated
 // *ArmClient based on the Config's current settings.
-func getArmClient(authConfig *authentication.Config, skipProviderRegistration bool, tfVersion, partnerId string, disableCorrelationRequestID, disableTerraformPartnerID bool) (*ArmClient, error) {
-	env, err := authentication.DetermineEnvironment(authConfig.Environment)
+func getArmClient(ctx context.Context, builder armClientBuilder) (*ArmClient, error) {
+	env, err := authentication.DetermineEnvironment(builder.authConfig.Environment)
 	if err != nil {
 		return nil, err
 	}
 
 	// client declarations:
-	ctx := context.TODO() // TODO: thread me through
-	account, err := clients.NewResourceManagerAccount(ctx, *authConfig, *env)
+	account, err := clients.NewResourceManagerAccount(ctx, *builder.authConfig, *env)
 	if err != nil {
 		return nil, fmt.Errorf("Error building account: %+v", err)
 	}
@@ -132,46 +140,46 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		},
 	}
 
-	oauthConfig, err := authConfig.BuildOAuthConfig(env.ActiveDirectoryEndpoint)
+	oauthConfig, err := builder.authConfig.BuildOAuthConfig(env.ActiveDirectoryEndpoint)
 	if err != nil {
 		return nil, err
 	}
 
 	// OAuthConfigForTenant returns a pointer, which can be nil.
 	if oauthConfig == nil {
-		return nil, fmt.Errorf("Unable to configure OAuthConfig for tenant %s", authConfig.TenantID)
+		return nil, fmt.Errorf("Unable to configure OAuthConfig for tenant %s", builder.authConfig.TenantID)
 	}
 
 	sender := sender.BuildSender("AzureRM")
 
 	// Resource Manager endpoints
 	endpoint := env.ResourceManagerEndpoint
-	auth, err := authConfig.GetAuthorizationToken(sender, oauthConfig, env.TokenAudience)
+	auth, err := builder.authConfig.GetAuthorizationToken(sender, oauthConfig, env.TokenAudience)
 	if err != nil {
 		return nil, err
 	}
 
 	// Graph Endpoints
 	graphEndpoint := env.GraphEndpoint
-	graphAuth, err := authConfig.GetAuthorizationToken(sender, oauthConfig, graphEndpoint)
+	graphAuth, err := builder.authConfig.GetAuthorizationToken(sender, oauthConfig, graphEndpoint)
 	if err != nil {
 		return nil, err
 	}
 
 	// Storage Endpoints
-	storageAuth, err := authConfig.GetAuthorizationToken(sender, oauthConfig, env.ResourceIdentifiers.Storage)
+	storageAuth, err := builder.authConfig.GetAuthorizationToken(sender, oauthConfig, env.ResourceIdentifiers.Storage)
 	if err != nil {
 		return nil, err
 	}
 
 	// Key Vault Endpoints
-	keyVaultAuth := authConfig.BearerAuthorizerCallback(sender, oauthConfig)
+	keyVaultAuth := builder.authConfig.BearerAuthorizerCallback(sender, oauthConfig)
 
 	o := &common.ClientOptions{
-		SubscriptionId:              authConfig.SubscriptionID,
-		TenantID:                    authConfig.TenantID,
-		PartnerId:                   partnerId,
-		TerraformVersion:            tfVersion,
+		SubscriptionId:              builder.authConfig.SubscriptionID,
+		TenantID:                    builder.authConfig.TenantID,
+		PartnerId:                   builder.partnerId,
+		TerraformVersion:            builder.tfVersion,
 		GraphAuthorizer:             graphAuth,
 		GraphEndpoint:               graphEndpoint,
 		KeyVaultAuthorizer:          keyVaultAuth,
@@ -179,9 +187,9 @@ func getArmClient(authConfig *authentication.Config, skipProviderRegistration bo
 		ResourceManagerEndpoint:     endpoint,
 		StorageAuthorizer:           storageAuth,
 		PollingDuration:             180 * time.Minute,
-		SkipProviderReg:             skipProviderRegistration,
-		DisableCorrelationRequestID: disableCorrelationRequestID,
-		DisableTerraformPartnerID:   disableTerraformPartnerID,
+		SkipProviderReg:             builder.skipProviderRegistration,
+		DisableCorrelationRequestID: builder.disableCorrelationRequestID,
+		DisableTerraformPartnerID:   builder.disableTerraformPartnerID,
 		Environment:                 *env,
 	}
 

--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -114,7 +114,7 @@ type ArmClient struct {
 type armClientBuilder struct {
 	authConfig                  *authentication.Config
 	skipProviderRegistration    bool
-	tfVersion                   string
+	terraformVersion            string
 	partnerId                   string
 	disableCorrelationRequestID bool
 	disableTerraformPartnerID   bool
@@ -179,7 +179,7 @@ func getArmClient(ctx context.Context, builder armClientBuilder) (*ArmClient, er
 		SubscriptionId:              builder.authConfig.SubscriptionID,
 		TenantID:                    builder.authConfig.TenantID,
 		PartnerId:                   builder.partnerId,
-		TerraformVersion:            builder.tfVersion,
+		TerraformVersion:            builder.terraformVersion,
 		GraphAuthorizer:             graphAuth,
 		GraphEndpoint:               graphEndpoint,
 		KeyVaultAuthorizer:          keyVaultAuth,

--- a/azurerm/data_source_client_config.go
+++ b/azurerm/data_source_client_config.go
@@ -58,11 +58,11 @@ func dataSourceArmClientConfigRead(d *schema.ResourceData, meta interface{}) err
 	defer cancel()
 
 	var servicePrincipal *graphrbac.ServicePrincipal
-	if client.usingServicePrincipal {
+	if client.Account.AuthenticatedAsAServicePrincipal {
 		spClient := client.Graph.ServicePrincipalsClient
 		// Application & Service Principal is 1:1 per tenant. Since we know the appId (client_id)
 		// here, we can query for the Service Principal whose appId matches.
-		filter := fmt.Sprintf("appId eq '%s'", client.clientId)
+		filter := fmt.Sprintf("appId eq '%s'", client.Account.ClientId)
 		listResult, listErr := spClient.List(ctx, filter)
 
 		if listErr != nil {
@@ -77,30 +77,18 @@ func dataSourceArmClientConfigRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	d.SetId(time.Now().UTC().String())
-	d.Set("client_id", client.clientId)
-	d.Set("tenant_id", client.tenantId)
-	d.Set("subscription_id", client.subscriptionId)
+	d.Set("client_id", client.Account.ClientId)
+	d.Set("object_id", client.Account.ObjectId)
+	d.Set("subscription_id", client.Account.SubscriptionId)
+	d.Set("tenant_id", client.Account.TenantId)
 
 	if principal := servicePrincipal; principal != nil {
-		d.Set("service_principal_application_id", client.clientId)
+		d.Set("service_principal_application_id", client.Account.ClientId)
 		d.Set("service_principal_object_id", principal.ObjectID)
 	} else {
 		d.Set("service_principal_application_id", "")
 		d.Set("service_principal_object_id", "")
 	}
-
-	d.Set("object_id", "")
-
-	// TODO remove this when we confirm that MSI no longer returns nil with getAuthenticatedObjectID
-	objectId := ""
-	if client.getAuthenticatedObjectID != nil {
-		v, err := client.getAuthenticatedObjectID(ctx)
-		if err != nil {
-			return fmt.Errorf("Error getting authenticated object ID: %v", err)
-		}
-		objectId = v
-	}
-	d.Set("object_id", objectId)
 
 	return nil
 }

--- a/azurerm/data_source_storage_account.go
+++ b/azurerm/data_source_storage_account.go
@@ -265,7 +265,7 @@ func dataSourceArmStorageAccount() *schema.Resource {
 
 func dataSourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Storage.AccountsClient
-	endpointSuffix := meta.(*ArmClient).environment.StorageEndpointSuffix
+	endpointSuffix := meta.(*ArmClient).Account.Environment.StorageEndpointSuffix
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 

--- a/azurerm/data_source_subscription.go
+++ b/azurerm/data_source_subscription.go
@@ -28,7 +28,7 @@ func dataSourceArmSubscriptionRead(d *schema.ResourceData, meta interface{}) err
 
 	subscriptionId := d.Get("subscription_id").(string)
 	if subscriptionId == "" {
-		subscriptionId = client.subscriptionId
+		subscriptionId = client.Account.SubscriptionId
 	}
 
 	resp, err := groupClient.Get(ctx, subscriptionId)

--- a/azurerm/data_source_subscription_test.go
+++ b/azurerm/data_source_subscription_test.go
@@ -64,8 +64,8 @@ func testCheckAzureRMSubscriptionId(resourceName string) resource.TestCheckFunc 
 		attributeName := "subscription_id"
 		subscriptionId := rs.Primary.Attributes[attributeName]
 		client := testAccProvider.Meta().(*ArmClient)
-		if subscriptionId != client.subscriptionId {
-			return fmt.Errorf("%s: Attribute '%s' expected \"%s\", got \"%s\"", resourceName, attributeName, client.subscriptionId, subscriptionId)
+		if subscriptionId != client.Account.SubscriptionId {
+			return fmt.Errorf("%s: Attribute '%s' expected \"%s\", got \"%s\"", resourceName, attributeName, client.Account.SubscriptionId, subscriptionId)
 		}
 
 		return nil

--- a/azurerm/data_source_subscriptions.go
+++ b/azurerm/data_source_subscriptions.go
@@ -104,7 +104,7 @@ func dataSourceArmSubscriptionsRead(d *schema.ResourceData, meta interface{}) er
 		subscriptions = append(subscriptions, s)
 	}
 
-	d.SetId("subscriptions-" + armClient.tenantId)
+	d.SetId("subscriptions-" + armClient.Account.TenantId)
 	if err = d.Set("subscriptions", subscriptions); err != nil {
 		return fmt.Errorf("Error setting `subscriptions`: %+v", err)
 	}

--- a/azurerm/internal/clients/auth.go
+++ b/azurerm/internal/clients/auth.go
@@ -1,0 +1,41 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+)
+
+type ResourceManagerAccount struct {
+	AuthenticatedAsAServicePrincipal bool
+	ClientId                         string
+	Environment                      azure.Environment
+	ObjectId                         string
+	SubscriptionId                   string
+	TenantId                         string
+}
+
+func NewResourceManagerAccount(ctx context.Context, config authentication.Config, env azure.Environment) (*ResourceManagerAccount, error) {
+	objectId := ""
+
+	// TODO remove this when we confirm that MSI no longer returns nil with getAuthenticatedObjectID
+	if getAuthenticatedObjectID := config.GetAuthenticatedObjectID; getAuthenticatedObjectID != nil {
+		v, err := getAuthenticatedObjectID(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("Error getting authenticated object ID: %v", err)
+		}
+		objectId = v
+	}
+
+	account := ResourceManagerAccount{
+		AuthenticatedAsAServicePrincipal: config.AuthenticatedAsAServicePrincipal,
+		ClientId:                         config.ClientID,
+		Environment:                      env,
+		ObjectId:                         objectId,
+		TenantId:                         config.TenantID,
+		SubscriptionId:                   config.SubscriptionID,
+	}
+	return &account, nil
+}

--- a/azurerm/internal/clients/client.go
+++ b/azurerm/internal/clients/client.go
@@ -37,6 +37,8 @@ type Client struct {
 	// StopContext is used for propagating control from Terraform Core (e.g. Ctrl/Cmd+C)
 	StopContext context.Context
 
+	Account *ResourceManagerAccount
+
 	AnalysisServices *analysisservices.Client
 	ApiManagement    *apimanagement.Client
 	AppInsights      *applicationinsights.Client

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -705,11 +705,6 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			return nil, fmt.Errorf("Error building AzureRM Client: %s", err)
 		}
 
-		partnerId := d.Get("partner_id").(string)
-		skipProviderRegistration := d.Get("skip_provider_registration").(bool)
-		disableCorrelationRequestID := d.Get("disable_correlation_request_id").(bool)
-		disableTerraformPartnerID := d.Get("disable_terraform_partner_id").(bool)
-
 		terraformVersion := p.TerraformVersion
 		if terraformVersion == "" {
 			// Terraform 0.12 introduced this field to the protocol
@@ -717,8 +712,16 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			terraformVersion = "0.11+compatible"
 		}
 
-		// TODO: we should pass in an Object here
-		client, err := getArmClient(config, skipProviderRegistration, terraformVersion, partnerId, disableCorrelationRequestID, disableTerraformPartnerID)
+		skipProviderRegistration := d.Get("skip_provider_registration").(bool)
+		clientBuilder := armClientBuilder{
+			authConfig:                  config,
+			skipProviderRegistration:    skipProviderRegistration,
+			tfVersion:                   terraformVersion,
+			partnerId:                   d.Get("partner_id").(string),
+			disableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
+			disableTerraformPartnerID:   d.Get("disable_terraform_partner_id").(bool),
+		}
+		client, err := getArmClient(p.StopContext(), clientBuilder)
 		if err != nil {
 			return nil, err
 		}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -716,7 +716,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		clientBuilder := armClientBuilder{
 			authConfig:                  config,
 			skipProviderRegistration:    skipProviderRegistration,
-			tfVersion:                   terraformVersion,
+			terraformVersion:            terraformVersion,
 			partnerId:                   d.Get("partner_id").(string),
 			disableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
 			disableTerraformPartnerID:   d.Get("disable_terraform_partner_id").(bool),

--- a/azurerm/required_resource_providers_test.go
+++ b/azurerm/required_resource_providers_test.go
@@ -16,7 +16,7 @@ func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 
 	builder := armClientBuilder{
 		authConfig:                  config,
-		tfVersion:                   "0.0.0",
+		terraformVersion:            "0.0.0",
 		partnerId:                   "",
 		disableCorrelationRequestID: true,
 		disableTerraformPartnerID:   false,

--- a/azurerm/required_resource_providers_test.go
+++ b/azurerm/required_resource_providers_test.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"context"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -13,8 +14,16 @@ func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 		return
 	}
 
-	// this test intentionally checks all the RP's are registered - so this is intentional
-	armClient, err := getArmClient(config, true, "0.0.0", "", true, false)
+	builder := armClientBuilder{
+		authConfig:                  config,
+		tfVersion:                   "0.0.0",
+		partnerId:                   "",
+		disableCorrelationRequestID: true,
+		disableTerraformPartnerID:   false,
+		// this test intentionally checks all the RP's are registered - so this is intentional
+		skipProviderRegistration: true,
+	}
+	armClient, err := getArmClient(context.Background(), builder)
 	if err != nil {
 		t.Fatalf("Error building ARM Client: %+v", err)
 	}

--- a/azurerm/resource_arm_api_management_group_user.go
+++ b/azurerm/resource_arm_api_management_group_user.go
@@ -60,7 +60,7 @@ func resourceArmApiManagementGroupUserCreate(d *schema.ResourceData, meta interf
 		}
 
 		if !utils.ResponseWasNotFound(resp) {
-			subscriptionId := meta.(*ArmClient).subscriptionId
+			subscriptionId := meta.(*ArmClient).Account.SubscriptionId
 			resourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s/groups/%s/users/%s", subscriptionId, resourceGroup, serviceName, groupName, userId)
 			return tf.ImportAsExistsError("azurerm_api_management_group_user", resourceId)
 		}

--- a/azurerm/resource_arm_api_management_product_api.go
+++ b/azurerm/resource_arm_api_management_product_api.go
@@ -60,7 +60,7 @@ func resourceArmApiManagementProductApiCreate(d *schema.ResourceData, meta inter
 		}
 
 		if !utils.ResponseWasNotFound(resp) {
-			subscriptionId := meta.(*ArmClient).subscriptionId
+			subscriptionId := meta.(*ArmClient).Account.SubscriptionId
 			resourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s/products/%s/apis/%s", subscriptionId, resourceGroup, serviceName, productId, apiName)
 			return tf.ImportAsExistsError("azurerm_api_management_product_api", resourceId)
 		}

--- a/azurerm/resource_arm_api_management_product_group.go
+++ b/azurerm/resource_arm_api_management_product_group.go
@@ -60,7 +60,7 @@ func resourceArmApiManagementProductGroupCreate(d *schema.ResourceData, meta int
 		}
 
 		if !utils.ResponseWasNotFound(resp) {
-			subscriptionId := meta.(*ArmClient).subscriptionId
+			subscriptionId := meta.(*ArmClient).Account.SubscriptionId
 			resourceId := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s/products/%s/groups/%s", subscriptionId, resourceGroup, serviceName, groupName, productId)
 			return tf.ImportAsExistsError("azurerm_api_management_product_group", resourceId)
 		}

--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -1377,7 +1377,7 @@ func resourceArmApplicationGatewayCreateUpdate(d *schema.ResourceData, meta inte
 
 	// Gateway ID is needed to link sub-resources together in expand functions
 	gatewayIDFmt := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/applicationGateways/%s"
-	gatewayID := fmt.Sprintf(gatewayIDFmt, armClient.subscriptionId, resGroup, name)
+	gatewayID := fmt.Sprintf(gatewayIDFmt, armClient.Account.SubscriptionId, resGroup, name)
 
 	trustedRootCertificates, err := expandApplicationGatewayTrustedRootCertificates(d.Get("trusted_root_certificate").([]interface{}))
 	if err != nil {

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -21,7 +21,15 @@ func TestAccAzureRMContainerRegistryMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true, false)
+	builder := armClientBuilder{
+		authConfig:                  config,
+		tfVersion:                   "0.0.0",
+		partnerId:                   "",
+		disableCorrelationRequestID: true,
+		disableTerraformPartnerID:   false,
+		skipProviderRegistration:    false,
+	}
+	client, err := getArmClient(context.Background(), builder)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -23,7 +23,7 @@ func TestAccAzureRMContainerRegistryMigrateState(t *testing.T) {
 
 	builder := armClientBuilder{
 		authConfig:                  config,
-		tfVersion:                   "0.0.0",
+		terraformVersion:            "0.0.0",
 		partnerId:                   "",
 		disableCorrelationRequestID: true,
 		disableTerraformPartnerID:   false,

--- a/azurerm/resource_arm_data_lake_store_file_migration_test.go
+++ b/azurerm/resource_arm_data_lake_store_file_migration_test.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +17,15 @@ func TestAccAzureRMDataLakeStoreFileMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true, false)
+	builder := armClientBuilder{
+		authConfig:                  config,
+		tfVersion:                   "0.0.0",
+		partnerId:                   "",
+		disableCorrelationRequestID: true,
+		disableTerraformPartnerID:   false,
+		skipProviderRegistration:    false,
+	}
+	client, err := getArmClient(context.Background(), builder)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_data_lake_store_file_migration_test.go
+++ b/azurerm/resource_arm_data_lake_store_file_migration_test.go
@@ -19,7 +19,7 @@ func TestAccAzureRMDataLakeStoreFileMigrateState(t *testing.T) {
 
 	builder := armClientBuilder{
 		authConfig:                  config,
-		tfVersion:                   "0.0.0",
+		terraformVersion:            "0.0.0",
 		partnerId:                   "",
 		disableCorrelationRequestID: true,
 		disableTerraformPartnerID:   false,

--- a/azurerm/resource_arm_databricks_workspace.go
+++ b/azurerm/resource_arm_databricks_workspace.go
@@ -80,7 +80,7 @@ func resourceArmDatabricksWorkspaceCreateUpdate(d *schema.ResourceData, meta int
 	client := meta.(*ArmClient).DataBricks.WorkspacesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	subscriptionID := meta.(*ArmClient).subscriptionId
+	subscriptionID := meta.(*ArmClient).Account.SubscriptionId
 
 	log.Printf("[INFO] preparing arguments for Azure ARM Databricks Workspace creation.")
 

--- a/azurerm/resource_arm_dev_test_virtual_network.go
+++ b/azurerm/resource_arm_dev_test_virtual_network.go
@@ -126,7 +126,7 @@ func resourceArmDevTestVirtualNetworkCreate(d *schema.ResourceData, meta interfa
 	description := d.Get("description").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	subscriptionId := meta.(*ArmClient).subscriptionId
+	subscriptionId := meta.(*ArmClient).Account.SubscriptionId
 	subnetsRaw := d.Get("subnet").([]interface{})
 	subnets := expandDevTestVirtualNetworkSubnets(subnetsRaw, subscriptionId, resourceGroup, name)
 
@@ -218,7 +218,7 @@ func resourceArmDevTestVirtualNetworkUpdate(d *schema.ResourceData, meta interfa
 	description := d.Get("description").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	subscriptionId := meta.(*ArmClient).subscriptionId
+	subscriptionId := meta.(*ArmClient).Account.SubscriptionId
 	subnetsRaw := d.Get("subnet").([]interface{})
 	subnets := expandDevTestVirtualNetworkSubnets(subnetsRaw, subscriptionId, resourceGroup, name)
 

--- a/azurerm/resource_arm_front_door.go
+++ b/azurerm/resource_arm_front_door.go
@@ -451,7 +451,7 @@ func resourceArmFrontDoorCreateUpdate(d *schema.ResourceData, meta interface{}) 
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
-	subscriptionId := meta.(*ArmClient).subscriptionId
+	subscriptionId := meta.(*ArmClient).Account.SubscriptionId
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		resp, err := client.Get(ctx, resourceGroup, name)

--- a/azurerm/resource_arm_image_test.go
+++ b/azurerm/resource_arm_image_test.go
@@ -250,7 +250,7 @@ func testGeneralizeVMImage(resourceGroup string, vmName string, userName string,
 		ctx := armClient.StopContext
 
 		normalizedLocation := azure.NormalizeLocation(location)
-		suffix := armClient.environment.ResourceManagerVMDNSSuffix
+		suffix := armClient.Account.Environment.ResourceManagerVMDNSSuffix
 		dnsName := fmt.Sprintf("%s.%s.%s", hostName, normalizedLocation, suffix)
 
 		if err := deprovisionVM(userName, password, dnsName, port); err != nil {

--- a/azurerm/resource_arm_iothub.go
+++ b/azurerm/resource_arm_iothub.go
@@ -431,7 +431,7 @@ func resourceArmIotHubCreateUpdate(d *schema.ResourceData, meta interface{}) err
 	client := meta.(*ArmClient).IoTHub.ResourceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	subscriptionID := meta.(*ArmClient).subscriptionId
+	subscriptionID := meta.(*ArmClient).Account.SubscriptionId
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/resource_arm_iothub_endpoint_eventhub.go
+++ b/azurerm/resource_arm_iothub_endpoint_eventhub.go
@@ -93,7 +93,7 @@ func resourceArmIotHubEndpointEventHubCreateUpdate(d *schema.ResourceData, meta 
 	eventhubEndpoint := devices.RoutingEventHubProperties{
 		ConnectionString: utils.String(d.Get("connection_string").(string)),
 		Name:             utils.String(endpointName),
-		SubscriptionID:   utils.String(meta.(*ArmClient).subscriptionId),
+		SubscriptionID:   utils.String(meta.(*ArmClient).Account.SubscriptionId),
 		ResourceGroup:    utils.String(resourceGroup),
 	}
 

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_queue.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_queue.go
@@ -71,7 +71,7 @@ func resourceArmIotHubEndpointServiceBusQueueCreateUpdate(d *schema.ResourceData
 	client := meta.(*ArmClient).IoTHub.ResourceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	subscriptionID := meta.(*ArmClient).subscriptionId
+	subscriptionID := meta.(*ArmClient).Account.SubscriptionId
 
 	iothubName := d.Get("iothub_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_topic.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_topic.go
@@ -71,7 +71,7 @@ func resourceArmIotHubEndpointServiceBusTopicCreateUpdate(d *schema.ResourceData
 	client := meta.(*ArmClient).IoTHub.ResourceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	subscriptionID := meta.(*ArmClient).subscriptionId
+	subscriptionID := meta.(*ArmClient).Account.SubscriptionId
 
 	iothubName := d.Get("iothub_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/resource_arm_iothub_endpoint_storage_container.go
+++ b/azurerm/resource_arm_iothub_endpoint_storage_container.go
@@ -106,7 +106,7 @@ func resourceArmIotHubEndpointStorageContainerCreateUpdate(d *schema.ResourceDat
 	client := meta.(*ArmClient).IoTHub.ResourceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	subscriptionID := meta.(*ArmClient).subscriptionId
+	subscriptionID := meta.(*ArmClient).Account.SubscriptionId
 
 	iothubName := d.Get("iothub_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -568,7 +568,7 @@ func resourceArmKubernetesClusterCreate(d *schema.ResourceData, meta interface{}
 	client := meta.(*ArmClient).Containers.KubernetesClustersClient
 	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	tenantId := meta.(*ArmClient).tenantId
+	tenantId := meta.(*ArmClient).Account.TenantId
 
 	log.Printf("[INFO] preparing arguments for Managed Kubernetes Cluster create.")
 
@@ -689,7 +689,7 @@ func resourceArmKubernetesClusterUpdate(d *schema.ResourceData, meta interface{}
 	clusterClient := meta.(*ArmClient).Containers.KubernetesClustersClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	tenantId := meta.(*ArmClient).tenantId
+	tenantId := meta.(*ArmClient).Account.TenantId
 
 	log.Printf("[INFO] preparing arguments for Managed Kubernetes Cluster update.")
 

--- a/azurerm/resource_arm_management_group.go
+++ b/azurerm/resource_arm_management_group.go
@@ -70,7 +70,7 @@ func resourceArmManagementGroupCreateUpdate(d *schema.ResourceData, meta interfa
 	subscriptionsClient := meta.(*ArmClient).ManagementGroups.SubscriptionClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
-	armTenantID := meta.(*ArmClient).tenantId
+	armTenantID := meta.(*ArmClient).Account.TenantId
 
 	groupId := d.Get("group_id").(string)
 	if groupId == "" {

--- a/azurerm/resource_arm_scheduler_job.go
+++ b/azurerm/resource_arm_scheduler_job.go
@@ -742,7 +742,7 @@ func expandAzureArmSchedulerJobActionRequest(b interface{}, meta interface{}) (*
 		if v, ok := b["audience"].(string); ok {
 			oauth.Audience = utils.String(v)
 		} else {
-			oauth.Audience = utils.String(meta.(*ArmClient).environment.ServiceManagementEndpoint)
+			oauth.Audience = utils.String(meta.(*ArmClient).Account.Environment.ServiceManagementEndpoint)
 		}
 
 		request.Authentication = oauth

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -988,7 +988,7 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Storage.AccountsClient
 	advancedThreatProtectionClient := meta.(*ArmClient).SecurityCenter.AdvancedThreatProtectionClient
-	endpointSuffix := meta.(*ArmClient).environment.StorageEndpointSuffix
+	endpointSuffix := meta.(*ArmClient).Account.Environment.StorageEndpointSuffix
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 

--- a/azurerm/resource_arm_storage_blob_migration.go
+++ b/azurerm/resource_arm_storage_blob_migration.go
@@ -25,7 +25,7 @@ func migrateStorageBlobStateV0toV1(is *terraform.InstanceState, meta interface{}
 
 	log.Printf("[DEBUG] ARM Storage Blob Attributes before Migration: %#v", is.Attributes)
 
-	environment := meta.(*ArmClient).environment
+	environment := meta.(*ArmClient).Account.Environment
 
 	blobName := is.Attributes["name"]
 	containerName := is.Attributes["storage_container_name"]

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +17,15 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true, false)
+	builder := armClientBuilder{
+		authConfig:                  config,
+		tfVersion:                   "0.0.0",
+		partnerId:                   "",
+		disableCorrelationRequestID: true,
+		disableTerraformPartnerID:   false,
+		skipProviderRegistration:    false,
+	}
+	client, err := getArmClient(context.Background(), builder)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -24,7 +24,7 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 
 	client.StopContext = testAccProvider.StopContext()
 
-	suffix := client.environment.StorageEndpointSuffix
+	suffix := client.Account.Environment.StorageEndpointSuffix
 
 	cases := map[string]struct {
 		StateVersion       int

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -19,7 +19,7 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 
 	builder := armClientBuilder{
 		authConfig:                  config,
-		tfVersion:                   "0.0.0",
+		terraformVersion:            "0.0.0",
 		partnerId:                   "",
 		disableCorrelationRequestID: true,
 		disableTerraformPartnerID:   false,

--- a/azurerm/resource_arm_storage_container_migration.go
+++ b/azurerm/resource_arm_storage_container_migration.go
@@ -25,7 +25,7 @@ func migrateStorageContainerStateV0toV1(is *terraform.InstanceState, meta interf
 
 	log.Printf("[DEBUG] ARM Storage Container Attributes before Migration: %#v", is.Attributes)
 
-	environment := meta.(*ArmClient).environment
+	environment := meta.(*ArmClient).Account.Environment
 
 	containerName := is.Attributes["name"]
 	storageAccountName := is.Attributes["storage_account_name"]

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +17,15 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true, false)
+	builder := armClientBuilder{
+		authConfig:                  config,
+		tfVersion:                   "0.0.0",
+		partnerId:                   "",
+		disableCorrelationRequestID: true,
+		disableTerraformPartnerID:   false,
+		skipProviderRegistration:    false,
+	}
+	client, err := getArmClient(context.Background(), builder)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -24,7 +24,7 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 
 	client.StopContext = testAccProvider.StopContext()
 
-	suffix := client.environment.StorageEndpointSuffix
+	suffix := client.Account.Environment.StorageEndpointSuffix
 
 	cases := map[string]struct {
 		StateVersion       int

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -19,7 +19,7 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 
 	builder := armClientBuilder{
 		authConfig:                  config,
-		tfVersion:                   "0.0.0",
+		terraformVersion:            "0.0.0",
 		partnerId:                   "",
 		disableCorrelationRequestID: true,
 		disableTerraformPartnerID:   false,

--- a/azurerm/resource_arm_storage_queue_migration.go
+++ b/azurerm/resource_arm_storage_queue_migration.go
@@ -26,7 +26,7 @@ func migrateStorageQueueStateV0toV1(is *terraform.InstanceState, meta interface{
 
 	log.Printf("[DEBUG] ARM Storage Queue Attributes before Migration: %#v", is.Attributes)
 
-	environment := meta.(*ArmClient).environment
+	environment := meta.(*ArmClient).Account.Environment
 
 	queueName := is.Attributes["name"]
 	storageAccountName := is.Attributes["storage_account_name"]

--- a/azurerm/resource_arm_storage_queue_migration_test.go
+++ b/azurerm/resource_arm_storage_queue_migration_test.go
@@ -19,7 +19,7 @@ func TestAccAzureRMStorageQueueMigrateState(t *testing.T) {
 
 	builder := armClientBuilder{
 		authConfig:                  config,
-		tfVersion:                   "0.0.0",
+		terraformVersion:            "0.0.0",
 		partnerId:                   "",
 		disableCorrelationRequestID: true,
 		disableTerraformPartnerID:   false,

--- a/azurerm/resource_arm_storage_queue_migration_test.go
+++ b/azurerm/resource_arm_storage_queue_migration_test.go
@@ -24,7 +24,7 @@ func TestAccAzureRMStorageQueueMigrateState(t *testing.T) {
 
 	client.StopContext = testAccProvider.StopContext()
 
-	suffix := client.environment.StorageEndpointSuffix
+	suffix := client.Account.Environment.StorageEndpointSuffix
 
 	cases := map[string]struct {
 		StateVersion       int

--- a/azurerm/resource_arm_storage_queue_migration_test.go
+++ b/azurerm/resource_arm_storage_queue_migration_test.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -16,7 +17,15 @@ func TestAccAzureRMStorageQueueMigrateState(t *testing.T) {
 		return
 	}
 
-	client, err := getArmClient(config, false, "0.0.0", "", true, false)
+	builder := armClientBuilder{
+		authConfig:                  config,
+		tfVersion:                   "0.0.0",
+		partnerId:                   "",
+		disableCorrelationRequestID: true,
+		disableTerraformPartnerID:   false,
+		skipProviderRegistration:    false,
+	}
+	client, err := getArmClient(context.Background(), builder)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Error building ARM Client: %+v", err))
 		return

--- a/azurerm/resource_arm_storage_share_migration.go
+++ b/azurerm/resource_arm_storage_share_migration.go
@@ -66,7 +66,7 @@ func resourceStorageShareStateUpgradeV1ToV2(rawState map[string]interface{}, met
 	shareName := parsedId[0]
 	accountName := parsedId[2]
 
-	environment := meta.(*ArmClient).environment
+	environment := meta.(*ArmClient).Account.Environment
 	client := shares.NewWithEnvironment(environment)
 
 	newResourceId := client.GetResourceID(accountName, shareName)

--- a/azurerm/resource_arm_storage_share_migration_test.go
+++ b/azurerm/resource_arm_storage_share_migration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAzureRMStorageShareMigrateStateV0ToV1(t *testing.T) {
@@ -27,7 +28,11 @@ func TestAzureRMStorageShareMigrateStateV0ToV1(t *testing.T) {
 			"quota":                5120,
 		}
 		meta := &ArmClient{
-			environment: cloud,
+			Client: clients.Client{
+				Account: &clients.ResourceManagerAccount{
+					Environment: cloud,
+				},
+			},
 		}
 		expected := map[string]interface{}{
 			"id":                   "share1/group1/account1",
@@ -69,7 +74,11 @@ func TestAzureRMStorageShareMigrateStateV1ToV2(t *testing.T) {
 			"quota":                5120,
 		}
 		meta := &ArmClient{
-			environment: cloud,
+			Client: clients.Client{
+				Account: &clients.ResourceManagerAccount{
+					Environment: cloud,
+				},
+			},
 		}
 		expected := map[string]interface{}{
 			"id":                   fmt.Sprintf("https://account1.file.%s/share1", cloud.StorageEndpointSuffix),

--- a/azurerm/resource_arm_storage_table_migration.go
+++ b/azurerm/resource_arm_storage_table_migration.go
@@ -70,7 +70,7 @@ func resourceStorageTableStateResourceV0V1() *schema.Resource {
 func resourceStorageTableStateUpgradeV0ToV1(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	tableName := rawState["name"].(string)
 	accountName := rawState["storage_account_name"].(string)
-	environment := meta.(*ArmClient).environment
+	environment := meta.(*ArmClient).Account.Environment
 
 	id := rawState["id"].(string)
 	newResourceID := fmt.Sprintf("https://%s.table.%s/%s", accountName, environment.StorageEndpointSuffix, tableName)
@@ -83,7 +83,7 @@ func resourceStorageTableStateUpgradeV0ToV1(rawState map[string]interface{}, met
 func resourceStorageTableStateUpgradeV1ToV2(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	tableName := rawState["name"].(string)
 	accountName := rawState["storage_account_name"].(string)
-	environment := meta.(*ArmClient).environment
+	environment := meta.(*ArmClient).Account.Environment
 
 	id := rawState["id"].(string)
 	newResourceID := fmt.Sprintf("https://%s.table.%s/Tables('%s')", accountName, environment.StorageEndpointSuffix, tableName)

--- a/azurerm/resource_arm_storage_table_migration_test.go
+++ b/azurerm/resource_arm_storage_table_migration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAzureRMStorageTableMigrateStateV0ToV1(t *testing.T) {
@@ -25,9 +26,13 @@ func TestAzureRMStorageTableMigrateStateV0ToV1(t *testing.T) {
 			"storage_account_name": "account1",
 		}
 		meta := &ArmClient{
-			environment: cloud,
+			Client: clients.Client{
+				Account: &clients.ResourceManagerAccount{
+					Environment: cloud,
+				},
+			},
 		}
-		suffix := meta.environment.StorageEndpointSuffix
+		suffix := meta.Account.Environment.StorageEndpointSuffix
 
 		expected := map[string]interface{}{
 			"id":                   fmt.Sprintf("https://account1.table.%s/table1", suffix),
@@ -60,9 +65,13 @@ func TestAzureRMStorageTableMigrateStateV1ToV2(t *testing.T) {
 		t.Logf("[DEBUG] Testing with Cloud %q", cloud.Name)
 
 		meta := &ArmClient{
-			environment: cloud,
+			Client: clients.Client{
+				Account: &clients.ResourceManagerAccount{
+					Environment: cloud,
+				},
+			},
 		}
-		suffix := meta.environment.StorageEndpointSuffix
+		suffix := meta.Account.Environment.StorageEndpointSuffix
 
 		input := map[string]interface{}{
 			"id":                   fmt.Sprintf("https://account1.table.%s/table1", suffix),


### PR DESCRIPTION
Since we need to move this up into the packaged Client anyway - it made sense to group this information into a struct. In addition this PR switches to always retrieving the Object ID, since it seems preferable to cache this information in the same object