### PR TITLE
Activity log alert - Add ResourceHealth category

### DIFF
--- a/azurerm/resource_arm_monitor_activity_log_alert.go
+++ b/azurerm/resource_arm_monitor_activity_log_alert.go
@@ -74,6 +74,7 @@ func resourceArmMonitorActivityLogAlert() *schema.Resource {
 								"Autoscale",
 								"Policy",
 								"Recommendation",
+								"ResourceHealth",
 								"Security",
 								"ServiceHealth",
 							}, false),

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -84,7 +84,7 @@ An `action` block supports the following:
 
 A `criteria` block supports the following:
 
-* `category` - (Required) The category of the operation. Possible values are `Administrative`, `Autoscale`, `Policy`, `Recommendation`, `Security` and `ServiceHealth`.
+* `category` - (Required) The category of the operation. Possible values are `Administrative`, `Autoscale`, `Policy`, `Recommendation`, `ResourceHealth`, `Security` and `ServiceHealth`.
 * `operation_name` - (Optional) The Resource Manager Role-Based Access Control operation name. Supported operation should be of the form: `<resourceProvider>/<resourceType>/<operation>`.
 * `resource_provider` - (Optional) The name of the resource provider monitored by the activity log alert.
 * `resource_type` - (Optional) The resource type monitored by the activity log alert.


### PR DESCRIPTION
Add the `ResourceHealth` category as seen [here](https://docs.microsoft.com/en-us/azure/service-health/resource-health-alert-arm-template-guide#resource-manager-template-options-for-resource-health-alerts)