### PR TITLE
`azurerm_netapp_pool`: `size_in_4_tb` -> `size_in_tb`

### DIFF
--- a/azurerm/data_source_netapp_pool.go
+++ b/azurerm/data_source_netapp_pool.go
@@ -35,7 +35,7 @@ func dataSourceArmNetAppPool() *schema.Resource {
 				Computed: true,
 			},
 
-			"size": {
+			"size_in_tb": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
@@ -70,7 +70,7 @@ func dataSourceArmNetAppPoolRead(d *schema.ResourceData, meta interface{}) error
 	if poolProperties := resp.PoolProperties; poolProperties != nil {
 		d.Set("service_level", poolProperties.ServiceLevel)
 		if poolProperties.Size != nil {
-			d.Set("size", *poolProperties.Size/1099511627776)
+			d.Set("size_in_tb", *poolProperties.Size/1099511627776)
 		}
 	}
 

--- a/azurerm/data_source_netapp_pool.go
+++ b/azurerm/data_source_netapp_pool.go
@@ -70,7 +70,7 @@ func dataSourceArmNetAppPoolRead(d *schema.ResourceData, meta interface{}) error
 	if poolProperties := resp.PoolProperties; poolProperties != nil {
 		d.Set("service_level", poolProperties.ServiceLevel)
 		if poolProperties.Size != nil {
-			d.Set("size", *poolProperties.Size/4398046511104)
+			d.Set("size", *poolProperties.Size/1099511627776)
 		}
 	}
 

--- a/azurerm/data_source_netapp_pool.go
+++ b/azurerm/data_source_netapp_pool.go
@@ -35,7 +35,7 @@ func dataSourceArmNetAppPool() *schema.Resource {
 				Computed: true,
 			},
 
-			"size_in_4_tb": {
+			"size": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
@@ -70,7 +70,7 @@ func dataSourceArmNetAppPoolRead(d *schema.ResourceData, meta interface{}) error
 	if poolProperties := resp.PoolProperties; poolProperties != nil {
 		d.Set("service_level", poolProperties.ServiceLevel)
 		if poolProperties.Size != nil {
-			d.Set("size_in_4_tb", *poolProperties.Size/4398046511104)
+			d.Set("size", *poolProperties.Size/4398046511104)
 		}
 	}
 

--- a/azurerm/data_source_netapp_pool_test.go
+++ b/azurerm/data_source_netapp_pool_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceAzureRMNetAppPool_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "name"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "account_name"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "service_level"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "size_in_4_tb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "size"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_netapp_pool.go
+++ b/azurerm/resource_arm_netapp_pool.go
@@ -57,7 +57,7 @@ func resourceArmNetAppPool() *schema.Resource {
 				}, true),
 			},
 
-			"size": {
+			"size_in_tb": {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: validation.IntBetween(4, 500),
@@ -88,7 +88,7 @@ func resourceArmNetAppPoolCreateUpdate(d *schema.ResourceData, meta interface{})
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	serviceLevel := d.Get("service_level").(string)
-	size := int64(d.Get("size").(int) * 1099511627776)
+	size := int64(d.Get("size_in_tb").(int) * 1099511627776)
 
 	capacityPoolParameters := netapp.CapacityPool{
 		Location: utils.String(location),
@@ -149,7 +149,7 @@ func resourceArmNetAppPoolRead(d *schema.ResourceData, meta interface{}) error {
 	if poolProperties := resp.PoolProperties; poolProperties != nil {
 		d.Set("service_level", poolProperties.ServiceLevel)
 		if poolProperties.Size != nil {
-			d.Set("size", *poolProperties.Size/1099511627776)
+			d.Set("size_in_tb", *poolProperties.Size/1099511627776)
 		}
 	}
 

--- a/azurerm/resource_arm_netapp_pool.go
+++ b/azurerm/resource_arm_netapp_pool.go
@@ -57,10 +57,10 @@ func resourceArmNetAppPool() *schema.Resource {
 				}, true),
 			},
 
-			"size_in_4_tb": {
+			"size": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 125),
+				ValidateFunc: validation.IntBetween(4, 500),
 			},
 		},
 	}
@@ -88,7 +88,7 @@ func resourceArmNetAppPoolCreateUpdate(d *schema.ResourceData, meta interface{})
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	serviceLevel := d.Get("service_level").(string)
-	size := int64(d.Get("size_in_4_tb").(int) * 4398046511104)
+	size := int64(d.Get("size").(int) * 1099511627776)
 
 	capacityPoolParameters := netapp.CapacityPool{
 		Location: utils.String(location),
@@ -149,7 +149,7 @@ func resourceArmNetAppPoolRead(d *schema.ResourceData, meta interface{}) error {
 	if poolProperties := resp.PoolProperties; poolProperties != nil {
 		d.Set("service_level", poolProperties.ServiceLevel)
 		if poolProperties.Size != nil {
-			d.Set("size_in_4_tb", *poolProperties.Size/4398046511104)
+			d.Set("size", *poolProperties.Size/1099511627776)
 		}
 	}
 

--- a/azurerm/resource_arm_netapp_pool_test.go
+++ b/azurerm/resource_arm_netapp_pool_test.go
@@ -79,7 +79,7 @@ func TestAccAzureRMNetAppPool_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Standard"),
-					resource.TestCheckResourceAttr(resourceName, "size_in_tb", "8"),
+					resource.TestCheckResourceAttr(resourceName, "size_in_tb", "15"),
 				),
 			},
 			{
@@ -119,7 +119,7 @@ func TestAccAzureRMNetAppPool_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Standard"),
-					resource.TestCheckResourceAttr(resourceName, "size_in_tb", "8"),
+					resource.TestCheckResourceAttr(resourceName, "size_in_tb", "15"),
 				),
 			},
 			{
@@ -236,7 +236,7 @@ resource "azurerm_netapp_pool" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   service_level       = "Standard"
-  size_in_tb          = "8"
+  size_in_tb          = "15"
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_netapp_pool_test.go
+++ b/azurerm/resource_arm_netapp_pool_test.go
@@ -79,7 +79,7 @@ func TestAccAzureRMNetAppPool_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Standard"),
-					resource.TestCheckResourceAttr(resourceName, "size_in_4_tb", "2"),
+					resource.TestCheckResourceAttr(resourceName, "size", "8"),
 				),
 			},
 			{
@@ -106,7 +106,7 @@ func TestAccAzureRMNetAppPool_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Premium"),
-					resource.TestCheckResourceAttr(resourceName, "size_in_4_tb", "1"),
+					resource.TestCheckResourceAttr(resourceName, "size", "4"),
 				),
 			},
 			{
@@ -119,7 +119,7 @@ func TestAccAzureRMNetAppPool_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Standard"),
-					resource.TestCheckResourceAttr(resourceName, "size_in_4_tb", "2"),
+					resource.TestCheckResourceAttr(resourceName, "size", "8"),
 				),
 			},
 			{
@@ -200,7 +200,7 @@ resource "azurerm_netapp_pool" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   service_level       = "Premium"
-  size_in_4_tb        = "1"
+  size                = "4"
 }
 `, rInt, location, rInt, rInt)
 }
@@ -236,7 +236,7 @@ resource "azurerm_netapp_pool" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   service_level       = "Standard"
-  size_in_4_tb        = "2"
+  size                = "8"
 }
 `, rInt, location, rInt, rInt)
 }

--- a/azurerm/resource_arm_netapp_pool_test.go
+++ b/azurerm/resource_arm_netapp_pool_test.go
@@ -79,7 +79,7 @@ func TestAccAzureRMNetAppPool_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Standard"),
-					resource.TestCheckResourceAttr(resourceName, "size", "8"),
+					resource.TestCheckResourceAttr(resourceName, "size_in_tb", "8"),
 				),
 			},
 			{
@@ -106,7 +106,7 @@ func TestAccAzureRMNetAppPool_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Premium"),
-					resource.TestCheckResourceAttr(resourceName, "size", "4"),
+					resource.TestCheckResourceAttr(resourceName, "size_in_tb", "4"),
 				),
 			},
 			{
@@ -119,7 +119,7 @@ func TestAccAzureRMNetAppPool_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMNetAppPoolExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "service_level", "Standard"),
-					resource.TestCheckResourceAttr(resourceName, "size", "8"),
+					resource.TestCheckResourceAttr(resourceName, "size_in_tb", "8"),
 				),
 			},
 			{
@@ -200,7 +200,7 @@ resource "azurerm_netapp_pool" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   service_level       = "Premium"
-  size                = "4"
+  size_in_tb          = "4"
 }
 `, rInt, location, rInt, rInt)
 }
@@ -236,7 +236,7 @@ resource "azurerm_netapp_pool" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   service_level       = "Standard"
-  size                = "8"
+  size_in_tb          = "8"
 }
 `, rInt, location, rInt, rInt)
 }

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -46,6 +46,6 @@ The following attributes are exported:
 
 * `service_level` - The service level of the file system.
 
-* `size_in_4_tb` - Provisioned size of the pool (in bytes). Values are in 4TiB chunks.
+* `size` - Provisioned size of the pool (in TB).
 
 ---

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -46,6 +46,6 @@ The following attributes are exported:
 
 * `service_level` - The service level of the file system.
 
-* `size` - Provisioned size of the pool (in TB).
+* `size_in_tb` - Provisioned size of the pool in TB.
 
 ---

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_netapp_pool" "example" {
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
   service_level       = "Premium"
-  size                = "4"
+  size_in_tb          = "4"
 }
 ```
 
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `service_level` - (Required) The service level of the file system. Valid values include `Premium`, `Standard`, or `Ultra`.
 
-* `size` - (Required) Provisioned size of the pool (in TB). Value must be between `4` and `500`.
+* `size_in_tb` - (Required) Provisioned size of the pool in TB. Value must be between `4` and `500`.
 
 ---
 

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_netapp_pool" "example" {
   location            = "${azurerm_resource_group.example.location}"
   resource_group_name = "${azurerm_resource_group.example.name}"
   service_level       = "Premium"
-  size_in_4_tb        = "1"
+  size                = "4"
 }
 ```
 
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `service_level` - (Required) The service level of the file system. Valid values include `Premium`, `Standard`, or `Ultra`.
 
-* `size_in_4_tb` - (Required) Provisioned size of the pool (in bytes). Values are in 4TiB chunks.
+* `size` - (Required) Provisioned size of the pool (in TB). Value must be between `4` and `500`.
 
 ---
 


### PR DESCRIPTION
This PR moves `size_in_4_tb` to just `size_in_tb`. It also validates that size can be passed in as any number between `4` and `500` and not just multiples of `4`