### PR TITLE
`azurerm_container_group` - Prevent empty string from being passed into `commands`

### DIFF
--- a/azurerm/resource_arm_container_group.go
+++ b/azurerm/resource_arm_container_group.go
@@ -323,7 +323,10 @@ func resourceArmContainerGroup() *schema.Resource {
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validate.NoEmptyStrings,
+							},
 						},
 
 						"volume": {

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -515,31 +515,6 @@ func TestAccAzureRMContainerGroup_windowsComplete(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMContainerGroup_emptyCommand(t *testing.T) {
-	resourceName := "azurerm_container_group.test"
-	ri := tf.AccRandTimeInt()
-	config := testAccAzureRMContainerGroup_emptyCommand(ri, testLocation())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerGroupDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMContainerGroupExists(resourceName),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccAzureRMContainerGroup_SystemAssignedIdentity(ri int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -1232,46 +1207,6 @@ resource "azurerm_container_group" "test" {
   }
 }
 `, ri, location, ri, ri, ri, ri, ri)
-}
-
-func testAccAzureRMContainerGroup_emptyCommand(ri int, location string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_container_group" "test" {
-  name                = "acctestcontainergroup-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  ip_address_type     = "public"
-  os_type             = "windows"
-
-  container {
-    name   = "windowsservercore"
-    image  = "microsoft/iis:windowsservercore"
-    cpu    = "2.0"
-    memory = "3.5"
-
-    ports {
-      port     = 80
-      protocol = "TCP"
-    }
-
-    ports {
-      port     = 443
-      protocol = "TCP"
-    }
-
-    commands = ["", "ls"]
-  }
-
-  tags = {
-    environment = "Testing"
-  }
-}
-`, ri, location, ri)
 }
 
 func testCheckAzureRMContainerGroupExists(resourceName string) resource.TestCheckFunc {

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -281,7 +281,7 @@ func TestAccAzureRMContainerGroup_linuxBasicUpdate(t *testing.T) {
 	ri := tf.AccRandTimeInt()
 
 	config := testAccAzureRMContainerGroup_linuxBasic(ri, testLocation())
-	updatedConfig := testAccAzureRMContainerGroup_linuxBasicUpdated(ri, testLocation())
+	updatedConfig := testaccazurermcontainergroupLinuxbasicupdated(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -510,6 +510,31 @@ func TestAccAzureRMContainerGroup_windowsComplete(t *testing.T) {
 					"container.0.secure_environment_variables.secureFoo1",
 					"diagnostics.0.log_analytics.0.workspace_key",
 				},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMContainerGroup_emptyCommand(t *testing.T) {
+	resourceName := "azurerm_container_group.test"
+	ri := tf.AccRandTimeInt()
+	config := testAccAzureRMContainerGroup_emptyCommand(ri, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMContainerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMContainerGroupExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -823,7 +848,7 @@ resource "azurerm_container_group" "test" {
 `, ri, location, ri, ri)
 }
 
-func testAccAzureRMContainerGroup_linuxBasicUpdated(ri int, location string) string {
+func testaccazurermcontainergroupLinuxbasicupdated(ri int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -1207,6 +1232,46 @@ resource "azurerm_container_group" "test" {
   }
 }
 `, ri, location, ri, ri, ri, ri, ri)
+}
+
+func testAccAzureRMContainerGroup_emptyCommand(ri int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroup-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  ip_address_type     = "public"
+  os_type             = "windows"
+
+  container {
+    name   = "windowsservercore"
+    image  = "microsoft/iis:windowsservercore"
+    cpu    = "2.0"
+    memory = "3.5"
+
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+
+    ports {
+      port     = 443
+      protocol = "TCP"
+    }
+
+    commands = ["", "ls"]
+  }
+
+  tags = {
+    environment = "Testing"
+  }
+}
+`, ri, location, ri)
 }
 
 func testCheckAzureRMContainerGroupExists(resourceName string) resource.TestCheckFunc {

--- a/azurerm/resource_arm_container_group_test.go
+++ b/azurerm/resource_arm_container_group_test.go
@@ -281,7 +281,7 @@ func TestAccAzureRMContainerGroup_linuxBasicUpdate(t *testing.T) {
 	ri := tf.AccRandTimeInt()
 
 	config := testAccAzureRMContainerGroup_linuxBasic(ri, testLocation())
-	updatedConfig := testaccazurermcontainergroupLinuxbasicupdated(ri, testLocation())
+	updatedConfig := testAccAzureRMContainerGroup_linuxBasicUpdated(ri, testLocation())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -823,7 +823,7 @@ resource "azurerm_container_group" "test" {
 `, ri, location, ri, ri)
 }
 
-func testaccazurermcontainergroupLinuxbasicupdated(ri int, location string) string {
+func testAccAzureRMContainerGroup_linuxBasicUpdated(ri int, location string) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"


### PR DESCRIPTION
Fixes crash #4937 by preventing an empty string from being passed into `commands`