### PR TITLE
comman marshal supports bool/int/float slice

### DIFF
--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -21,3 +21,289 @@ func FlattenStringSlice(input *[]string) []interface{} {
 	}
 	return result
 }
+
+func ExpandBoolSlice(input []interface{}) *[]bool {
+	result := make([]bool, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, item.(bool))
+		} else {
+			result = append(result, false)
+		}
+	}
+	return &result
+}
+
+func FlattenBoolSlice(input *[]bool) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func ExpandUintSlice(input []interface{}) *[]uint {
+	result := make([]uint, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, uint(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenUintSlice(input *[]uint) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandUint8Slice(input []interface{}) *[]uint8 {
+	result := make([]uint8, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, uint8(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenUint8Slice(input *[]uint8) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandUint16Slice(input []interface{}) *[]uint16 {
+	result := make([]uint16, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, uint16(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenUint16Slice(input *[]uint16) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandUint32Slice(input []interface{}) *[]uint32 {
+	result := make([]uint32, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, uint32(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenUint32Slice(input *[]uint32) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandUint64Slice(input []interface{}) *[]uint64 {
+	result := make([]uint64, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, uint64(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenUint64Slice(input *[]uint64) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandIntSlice(input []interface{}) *[]int {
+	result := make([]int, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, item.(int))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenIntSlice(input *[]int) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+func ExpandInt8Slice(input []interface{}) *[]int8 {
+	result := make([]int8, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, int8(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenInt8Slice(input *[]int8) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandInt16Slice(input []interface{}) *[]int16 {
+	result := make([]int16, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, int16(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenInt16Slice(input *[]int16) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandInt32Slice(input []interface{}) *[]int32 {
+	result := make([]int32, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, int32(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenInt32Slice(input *[]int32) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandInt64Slice(input []interface{}) *[]int64 {
+	result := make([]int64, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, int64(item.(int)))
+		} else {
+			result = append(result, 0)
+		}
+	}
+	return &result
+}
+
+func FlattenInt64Slice(input *[]int64) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, int(item))
+		}
+	}
+	return result
+}
+
+func ExpandFloat32Slice(input []interface{}) *[]float32 {
+	result := make([]float32, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, float32(item.(float64)))
+		} else {
+			result = append(result, 0.0)
+		}
+	}
+	return &result
+}
+
+func FlattenFloat32Slice(input *[]float32) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, float64(item))
+		}
+	}
+	return result
+}
+
+func ExpandFloat64Slice(input []interface{}) *[]float64 {
+	result := make([]float64, 0)
+	for _, item := range input {
+		if item != nil {
+			result = append(result, item.(float64))
+		} else {
+			result = append(result, 0.0)
+		}
+	}
+	return &result
+}
+
+func FlattenFloat64Slice(input *[]float64) []interface{} {
+	result := make([]interface{}, 0)
+	if input != nil {
+		for _, item := range *input {
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/azurerm/utils/common_marshal_test.go
+++ b/azurerm/utils/common_marshal_test.go
@@ -1,0 +1,231 @@
+package utils
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func checkTfType(o interface{}, t reflect.Kind) bool {
+	out := o.([]interface{})
+	for _, i := range out {
+		if reflect.ValueOf(i).Kind() != t {
+			return false
+		}
+	}
+	return true
+}
+
+func compareSlices(s1, s2 interface{}) bool {
+	v1 := reflect.ValueOf(s1)
+	v2 := reflect.ValueOf(s2)
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	if v1.Kind() == reflect.Ptr {
+		v1 = v1.Elem()
+	}
+	if v2.Kind() == reflect.Ptr {
+		v2 = v2.Elem()
+	}
+	if v1.Len() != v2.Len() {
+		return false
+	}
+	for i := 0; i < v1.Len(); i++ {
+		if v1.Index(i).Interface() != v2.Index(i).Interface() {
+			return false
+		}
+	}
+	return true
+}
+
+func TestExpandFlattenFunctions(t *testing.T) {
+	cases := []struct {
+		f      interface{}
+		input  interface{}
+		expect interface{}
+		tfType reflect.Kind // for testing flattened to type aligned with terraform schema type
+		// (not used for expand, in which case it equals to reflect.Invalid)
+	}{
+		{
+			f:      ExpandStringSlice,
+			input:  []interface{}{"a", "b"},
+			expect: &[]string{"a", "b"},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenStringSlice,
+			input:  &[]string{"a", "b"},
+			expect: []interface{}{"a", "b"},
+			tfType: reflect.String,
+		},
+		{
+			f:      ExpandBoolSlice,
+			input:  []interface{}{true, false},
+			expect: &[]bool{true, false},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenBoolSlice,
+			input:  &[]bool{true, false},
+			expect: []interface{}{true, false},
+			tfType: reflect.Bool,
+		},
+		{
+			f:      ExpandUintSlice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]uint{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenUintSlice,
+			input:  &[]uint{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandUint8Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]uint8{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenUint8Slice,
+			input:  &[]uint8{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandUint16Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]uint16{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenUint16Slice,
+			input:  &[]uint16{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandUint32Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]uint32{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenUint32Slice,
+			input:  &[]uint32{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandUint64Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]uint64{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenUint64Slice,
+			input:  &[]uint64{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandIntSlice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]int{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenIntSlice,
+			input:  &[]int{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandInt8Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]int8{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenInt8Slice,
+			input:  &[]int8{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandInt16Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]int16{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenInt16Slice,
+			input:  &[]int16{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandInt32Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]int32{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenInt32Slice,
+			input:  &[]int32{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandInt64Slice,
+			input:  []interface{}{1, 2, 3},
+			expect: &[]int64{1, 2, 3},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenInt64Slice,
+			input:  &[]int64{1, 2, 3},
+			expect: []interface{}{1, 2, 3},
+			tfType: reflect.Int,
+		},
+		{
+			f:      ExpandFloat32Slice,
+			input:  []interface{}{1.0, 2.0, 3.0},
+			expect: &[]float32{1.0, 2.0, 3.0},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenFloat32Slice,
+			input:  &[]float32{1.0, 2.0, 3.0},
+			expect: []interface{}{1.0, 2.0, 3.0},
+			tfType: reflect.Float64,
+		},
+		{
+			f:      ExpandFloat64Slice,
+			input:  []interface{}{1.0, 2.0, 3.0},
+			expect: &[]float64{1.0, 2.0, 3.0},
+			tfType: reflect.Invalid,
+		},
+		{
+			f:      FlattenFloat64Slice,
+			input:  &[]float64{1.0, 2.0, 3.0},
+			expect: []interface{}{1.0, 2.0, 3.0},
+			tfType: reflect.Float64,
+		},
+	}
+
+	for _, c := range cases {
+		vf := reflect.ValueOf(c.f)
+		outv := vf.Call([]reflect.Value{reflect.ValueOf(c.input)})
+		out := outv[0].Interface()
+		if !compareSlices(out, c.expect) {
+			t.Fatalf("Function %s failed:\nOutput: %v\n(Expected: %v)\n", runtime.FuncForPC(vf.Pointer()).Name(), out, c.expect)
+		}
+		if c.tfType != reflect.Invalid && !checkTfType(out, c.tfType) {
+			t.Fatalf("Function %s failed:\nElement type in output isn't as expected(%s)\n(output: %v)", runtime.FuncForPC(vf.Pointer()).Name(), c.tfType, out)
+		}
+	}
+}


### PR DESCRIPTION
Currently *common_marshal.go* only supports expand/flatten utilities for
string slice, however, there are 3 more primitive types in terraform:
bool, int, float.

I find it would be helpful if there is direct support in utility so that user could get rid of hassel. For example, in *resource_arm_monitor_autoscale_setting.go*, exists following function:

```go
func expandAzureRmMonitorAutoScaleSettingRecurrence(input []interface{}) *insights.Recurrence {
   if len(input) == 0 {
      return nil
   }

   recurrenceRaw := input[0].(map[string]interface{})

   timeZone := recurrenceRaw["timezone"].(string)
   days := make([]string, 0)
   for _, dayItem := range recurrenceRaw["days"].([]interface{}) {
      days = append(days, dayItem.(string))
   }

   hours := make([]int32, 0)
   for _, hourItem := range recurrenceRaw["hours"].([]interface{}) {
      hours = append(hours, int32(hourItem.(int)))
   }

   minutes := make([]int32, 0)
   for _, minuteItem := range recurrenceRaw["minutes"].([]interface{}) {
      minutes = append(minutes, int32(minuteItem.(int)))
   }

   return &insights.Recurrence{
      // API docs say this has to be `Week`.
      Frequency: insights.RecurrenceFrequencyWeek,
      Schedule: &insights.RecurrentSchedule{
         TimeZone: utils.String(timeZone),
         Days:     &days,
         Hours:    &hours,
         Minutes:  &minutes,
      },
   }
}
```

By leveraging utility functions, it could be simplified as: 

```go
func expandAzureRmMonitorAutoScaleSettingRecurrence(input []interface{}) *insights.Recurrence {
   if len(input) == 0 {
      return nil
   }

   recurrenceRaw := input[0].(map[string]interface{})

   return &insights.Recurrence{
      // API docs say this has to be `Week`.
      Frequency: insights.RecurrenceFrequencyWeek,
      Schedule: &insights.RecurrentSchedule{
         TimeZone: utils.String(recurrenceRaw["timezone"].(string)),
         Days:     utils.ExpandStringSlice(recurrenceRaw["days"].([]interface{})),
         Hours:    utils.ExpandInt32Slice(recurrenceRaw["hours"].([]interface{})),
         Minutes:  utils.ExpandInt32Slice(recurrenceRaw["minutes"].([]interface{})),
      },
   }
}
```

The implementation here follows the shcema type definition as described
in [official page](https://www.terraform.io/docs/extend/schemas/schema-types.html).

The deal here is that:

- for numeric types always expand from or flatten to `int`
- for float types always expand from or flatten to `float64`

Addtionally, add test case for each function in *common_marshal.go*.