### PR TITLE
Update min_capacity and max_capacity of application gateway

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -633,12 +633,12 @@ func resourceArmApplicationGateway() *schema.Resource {
 						"min_capacity": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntBetween(2, 10),
+							ValidateFunc: validation.IntBetween(0, 100),
 						},
 						"max_capacity": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(2, 100),
+							ValidateFunc: validation.IntBetween(2, 125),
 						},
 					},
 				},

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -51,12 +51,12 @@ func TestAccAzureRMApplicationGateway_autoscaleConfiguration(t *testing.T) {
 		CheckDestroy: testCheckAzureRMApplicationGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMApplicationGateway_autoscaleConfiguration(ri, testLocation(), 2, 10),
+				Config: testAccAzureRMApplicationGateway_autoscaleConfiguration(ri, testLocation(), 0, 10),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApplicationGatewayExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "sku.0.name", "Standard_v2"),
 					resource.TestCheckResourceAttr(resourceName, "sku.0.tier", "Standard_v2"),
-					resource.TestCheckResourceAttr(resourceName, "autoscale_configuration.0.min_capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, "autoscale_configuration.0.min_capacity", "0"),
 					resource.TestCheckResourceAttr(resourceName, "autoscale_configuration.0.max_capacity", "10"),
 					resource.TestCheckResourceAttr(resourceName, "waf_configuration.#", "0"),
 				),

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -507,9 +507,9 @@ A `redirect_configuration` block supports the following:
 
 A `autoscale_configuration` block supports the following:
 
-* `min_capacity` - (Required) Minimum capacity for autoscaling.
+* `min_capacity` - (Required) Minimum capacity for autoscaling. Accepted values are in the range `0` to `100`.
 
-* `max_capacity` - (Optional) Maximum capacity for autoscaling.
+* `max_capacity` - (Optional) Maximum capacity for autoscaling. Accepted values are in the range `2` to `125`.
 
 ---
 


### PR DESCRIPTION
I've tested the numbers with Azure Portal *Create an Application Gateway*, Azure Portal *Application Gateway Edit Configuration*, and referenced the docs and errors given back while fiddling.

The actual allowed min_capacity is 0-100, inclusive;
The actual allowed max_capacity is 2-125, inclusive, plus the requirement that max_capacity > min_capacity.

Reference doc:
https://docs.microsoft.com/en-US/azure/application-gateway/application-gateway-autoscaling-zone-redundant#scaling-application-gateway-and-waf-v2

Fix #4722.