### PR TITLE
Virtual Wan: refactoring & temporarily removing from the release

### DIFF
--- a/azurerm/data_source_virtual_hub.go
+++ b/azurerm/data_source_virtual_hub.go
@@ -128,33 +128,37 @@ func dataSourceArmVirtualHubRead(d *schema.ResourceData, meta interface{}) error
 	}
 	if props := resp.VirtualHubProperties; props != nil {
 		d.Set("address_prefix", props.AddressPrefix)
-		if props.VirtualWan != nil {
-			if err := d.Set("virtual_wan_id", props.VirtualWan.ID); err != nil {
-				return fmt.Errorf("Error setting `virtual_wan_id`: %+v", err)
-			}
-		}
-		if props.VpnGateway != nil {
-			if err := d.Set("s2s_vpn_gateway_id", props.VpnGateway.ID); err != nil {
-				return fmt.Errorf("Error setting `s2s_vpn_gateway_id`: %+v", err)
-			}
-		}
-		if props.P2SVpnGateway != nil {
-			if err := d.Set("p2s_vpn_gateway_id", props.P2SVpnGateway.ID); err != nil {
-				return fmt.Errorf("Error setting `p2s_vpn_gateway_id`: %+v", err)
-			}
-		}
+
+		var expressRouteGatewayId *string
 		if props.ExpressRouteGateway != nil {
-			if err := d.Set("express_route_gateway_id", props.ExpressRouteGateway.ID); err != nil {
-				return fmt.Errorf("Error setting `express_route_gateway_id`: %+v", err)
-			}
+			expressRouteGatewayId = props.ExpressRouteGateway.ID
 		}
+		d.Set("express_route_gateway_id", expressRouteGatewayId)
+
+		var p2sVpnGatewayId *string
+		if props.P2SVpnGateway != nil {
+			p2sVpnGatewayId = props.P2SVpnGateway.ID
+		}
+		d.Set("p2s_vpn_gateway_id", p2sVpnGatewayId)
+
+		if err := d.Set("route", flattenArmVirtualHubRoute(props.RouteTable)); err != nil {
+			return fmt.Errorf("Error setting `route`: %+v", err)
+		}
+
+		var vpnGatewayId *string
+		if props.VpnGateway != nil {
+			vpnGatewayId = props.VpnGateway.ID
+		}
+		d.Set("s2s_vpn_gateway_id", vpnGatewayId)
+
+		var virtualWanId *string
+		if props.VirtualWan != nil {
+			virtualWanId = props.VirtualWan.ID
+		}
+		d.Set("virtual_wan_id", virtualWanId)
+
 		if err := d.Set("virtual_network_connection", flattenArmVirtualHubVirtualNetworkConnection(props.VirtualNetworkConnections)); err != nil {
 			return fmt.Errorf("Error setting `virtual_network_connection`: %+v", err)
-		}
-		if props.RouteTable != nil {
-			if err := d.Set("route", flattenArmVirtualHubRoute(props.RouteTable.Routes)); err != nil {
-				return fmt.Errorf("Error setting `route`: %+v", err)
-			}
 		}
 	}
 

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -484,7 +484,6 @@ func Provider() terraform.ResourceProvider {
 		"azurerm_virtual_network_peering":                                                resourceArmVirtualNetworkPeering(),
 		"azurerm_virtual_network":                                                        resourceArmVirtualNetwork(),
 		"azurerm_virtual_wan":                                                            resourceArmVirtualWan(),
-		"azurerm_virtual_hub":                                                            resourceArmVirtualHub(),
 		"azurerm_web_application_firewall_policy":                                        resourceArmWebApplicationFirewallPolicy(),
 	}
 
@@ -492,6 +491,11 @@ func Provider() terraform.ResourceProvider {
 	if features.SupportsTwoPointZeroResources() {
 		resources["azurerm_linux_virtual_machine_scale_set"] = resourceArmLinuxVirtualMachineScaleSet()
 		resources["azurerm_windows_virtual_machine_scale_set"] = resourceArmWindowsVirtualMachineScaleSet()
+	}
+
+	// NOTE: these resources have been pulled since they require rework
+	if false {
+		resources["azurerm_virtual_hub"] = resourceArmVirtualHub()
 	}
 
 	// avoids this showing up in test output

--- a/azurerm/resource_arm_virtual_hub_test.go
+++ b/azurerm/resource_arm_virtual_hub_test.go
@@ -11,7 +11,14 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+// The Virtual Hub resource has been merged but isn't available at this time
+var runVirtualHubTests = false
+
 func TestAccAzureRMVirtualHub_basic(t *testing.T) {
+	if !runVirtualHubTests {
+		t.Skip("Virtual Hub isn't available - skipping")
+	}
+
 	resourceName := "azurerm_virtual_hub.test"
 	ri := tf.AccRandTimeInt()
 	location := testLocation()
@@ -37,6 +44,10 @@ func TestAccAzureRMVirtualHub_basic(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualHub_requiresImport(t *testing.T) {
+	if !runVirtualHubTests {
+		t.Skip("Virtual Hub isn't available - skipping")
+	}
+
 	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
@@ -65,6 +76,10 @@ func TestAccAzureRMVirtualHub_requiresImport(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualHub_complete(t *testing.T) {
+	if !runVirtualHubTests {
+		t.Skip("Virtual Hub isn't available - skipping")
+	}
+
 	resourceName := "azurerm_virtual_hub.test"
 	ri := tf.AccRandTimeInt()
 	location := testLocation()
@@ -78,18 +93,6 @@ func TestAccAzureRMVirtualHub_complete(t *testing.T) {
 				Config: testAccAzureRMVirtualHub_complete(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualHubExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "address_prefix", "10.0.2.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "virtual_network_connection.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "virtual_network_connection.0.name", "testConnection"),
-					resource.TestCheckResourceAttr(resourceName, "virtual_network_connection.0.allow_hub_to_remote_vnet_transit", "false"),
-					resource.TestCheckResourceAttr(resourceName, "virtual_network_connection.0.allow_remote_vnet_to_use_hub_vnet_gateways", "false"),
-					resource.TestCheckResourceAttr(resourceName, "virtual_network_connection.0.enable_internet_security", "false"),
-					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "route.0.address_prefixes.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "route.0.address_prefixes.0", "10.0.3.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route.0.next_hop_ip_address", "10.0.5.6"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.ENV", "prod"),
 				),
 			},
 			{
@@ -102,6 +105,10 @@ func TestAccAzureRMVirtualHub_complete(t *testing.T) {
 }
 
 func TestAccAzureRMVirtualHub_update(t *testing.T) {
+	if !runVirtualHubTests {
+		t.Skip("Virtual Hub isn't available - skipping")
+	}
+
 	resourceName := "azurerm_virtual_hub.test"
 	ri := tf.AccRandTimeInt()
 	location := testLocation()
@@ -115,10 +122,6 @@ func TestAccAzureRMVirtualHub_update(t *testing.T) {
 				Config: testAccAzureRMVirtualHub_basic(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualHubExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "address_prefix", "10.0.1.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "virtual_network_connection.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
 			{
@@ -130,13 +133,6 @@ func TestAccAzureRMVirtualHub_update(t *testing.T) {
 				Config: testAccAzureRMVirtualHub_complete(ri, location),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualHubExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "address_prefix", "10.0.2.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "virtual_network_connection.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "route.0.address_prefixes.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "route.0.address_prefixes.0", "10.0.3.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "route.0.next_hop_ip_address", "10.0.5.6"),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 				),
 			},
 			{
@@ -220,6 +216,7 @@ resource "azurerm_virtual_hub" "test" {
 }
 
 func testAccAzureRMVirtualHub_requiresImport(rInt int, location string) string {
+	template := testAccAzureRMVirtualHub_basic(rInt, location)
 	return fmt.Sprintf(`
 %s
 
@@ -228,7 +225,7 @@ resource "azurerm_virtual_hub" "import" {
   location            = "${azurerm_virtual_hub.test.location}"
   resource_group_name = "${azurerm_virtual_hub.test.name}"
 }
-`, testAccAzureRMVirtualHub_basic(rInt, location))
+`, template)
 }
 
 func testAccAzureRMVirtualHub_complete(rInt int, location string) string {
@@ -276,9 +273,9 @@ resource "azurerm_virtual_hub" "test" {
   virtual_network_connection {
     name                                       = "testConnection"
     remote_virtual_network_id                  = "${azurerm_virtual_network.test.id}"
-    allow_hub_to_remote_vnet_transit           = "false"
-    allow_remote_vnet_to_use_hub_vnet_gateways = "false"
-    enable_internet_security                   = "false"
+    allow_hub_to_remote_vnet_transit           = false
+    allow_remote_vnet_to_use_hub_vnet_gateways = false
+    enable_internet_security                   = false
   }
 
   route {

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -457,10 +457,6 @@
                 <li<%= sidebar_current("docs-azurerm-datasource-virtual-network-gateway-connection") %>>
                     <a href="/docs/providers/azurerm/d/virtual_network_gateway_connection.html">azurerm_virtual_network_gateway_connection</a>
                 </li>
-
-                <li<%= sidebar_current("docs-azurerm-datasource-network-virtual-hub") %>>
-                    <a href="/docs/providers/azurerm/d/virtual_hub.html">azurerm_virtual_hub</a>
-                </li>
               </ul>
             </li>
 
@@ -1709,10 +1705,6 @@
 
                 <li<%= sidebar_current("docs-azurerm-resource-network-virtual-wan") %>>
                   <a href="/docs/providers/azurerm/r/virtual_wan.html">azurerm_virtual_wan</a>
-                </li>
-
-                <li<%= sidebar_current("docs-azurerm-resource-network-virtual-hub") %>>
-                  <a href="/docs/providers/azurerm/r/virtual_hub.html">azurerm_virtual_hub</a>
                 </li>
               </ul>
             </li>

--- a/website/docs/r/virtual_hub.html.markdown
+++ b/website/docs/r/virtual_hub.html.markdown
@@ -4,32 +4,33 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_hub"
 sidebar_current: "docs-azurerm-resource-virtual-hub"
 description: |-
-  Manages a Virtual Hub.
+  Manages a Virtual Hub within a Virtual WAN.
 ---
 
 # azurerm_virtual_hub
 
-Manages a Virtual Hub.
+Manages a Virtual Hub within a Virtual WAN.
 
-
-## Virtual Hub Usage
+## Example Usage
 
 ```hcl
 resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
+
 resource "azurerm_virtual_wan" "example" {
   name                = "example-virtualwan"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
+
 resource "azurerm_virtual_hub" "example" {
   name                = "example-virtualhub"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   address_prefix      = "10.0.1.0/24"
-  virtual_wan_id      = "${azurerm_virtual_wan.example.id}"
+  virtual_wan_id      = azurerm_virtual_wan.example.id
 }
 ```
 
@@ -39,33 +40,37 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Virtual Hub. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group where the Virtual Hub should be created. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Virtual Hub should exist. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the Virtual Hub should exist. Changing this forces a new resource to be created.
 
-* `address_prefix` - (Required) Address-prefix for this Virtual Hub.
+* `address_prefix` - (Required) The Address Prefix which should be used for this Virtual Hub.
 
-* `virtual_wan_id` - (Required) The resource id of virtual wan.
+* `virtual_wan_id` - (Required) The ID of a Virtual WAN within which the Virtual Hub should be created.
 
-* `s2s_vpn_gateway_id` - (Optional) The resource id of s2s vpn gateway.
+---
 
-* `p2s_vpn_gateway_id` - (Optional) The resource id of p2s vpn gateway.
+* `express_route_gateway_id` - (Optional) The ID of an Express Route Gateway which should be used for Express Route connections.
 
-* `express_route_gateway_id` - (Optional) The resource id of express route gateway.
+~> **NOTE:** This functionality is in Preview and must be opted into via `az feature register --namespace Microsoft.Network --name AllowCortexExpressRouteGateway` and then `az provider register -n Microsoft.Network`.
 
-* `virtual_network_connection` - (Optional) One or more `virtual_network_connection` block defined below.
+* `p2s_vpn_gateway_id` - (Optional) The ID of a Point-to-Site VPN Gateway which should be used for Point-to-Site connections.
 
-* `route` - (Optional) One `route` block defined below.
+* `route` - (Optional) One or more `route` blocks as defined below.
 
-* `tags` - (Optional) Resource tags. Changing this forces a new resource to be created.
+* `s2s_vpn_gateway_id` - (Optional) The ID of a Site-to-Site VPN Gateway which should be used for Site-to-Site connections.
+
+* `tags` - (Optional) A mapping of tags to assign to the Virtual Hub.
+
+* `virtual_network_connection` - (Optional) One or more `virtual_network_connection` blocks as defined below.
 
 ---
 
 The `route` block supports the following:
 
-* `address_prefixes` - (Required) List of all addressPrefixes.
+* `address_prefixes` - (Required) A list of Address Prefixes.
 
-* `next_hop_ip_address` - (Required) NextHop ip address.
+* `next_hop_ip_address` - (Required) The IP Address that Packets should be forwarded to as the Next Hop.
 
 ---
 
@@ -73,13 +78,13 @@ The `virtual_network_connection` block supports the following:
 
 * `name` - (Required) The name of the resource that is unique within a resource group. This name can be used to access the resource.
 
-* `remote_virtual_network_id` - (Required) The resource id of remote virtual network.
+* `remote_virtual_network_id` - (Required) The ID of a Virtual Network.
 
-* `allow_hub_to_remote_vnet_transit` - (Optional) VirtualHub to RemoteVnet transit to enabled or not.
+* `allow_hub_to_remote_vnet_transit` - (Optional) Should the Virtual Hub be able to transit via Remote Virtual Networks?
 
-* `allow_remote_vnet_to_use_hub_vnet_gateways` - (Optional) Allow RemoteVnet to use Virtual Hub's gateways.
+* `allow_remote_vnet_to_use_hub_vnet_gateways` - (Optional) Should the Remote Virtual Network be able to use the Hub's Virtual Network Gateways?
 
-* `enable_internet_security` - (Optional) Enable internet security.
+* `enable_internet_security` - (Optional) Should internet security be enabled?
 
 ---
 


### PR DESCRIPTION
This PR does several things:

* Removes the `azurerm_virtual_wan` resource from the release, since `virtual_network_connections` need to be managed in a separate resource to allow users to be explicit around ordering 
* Refactors the `azurerm_virtual_wan` Data Source & Resource to ensure that fields are always set, to ensure diff's are always shown
* Updates the documentation to ensure that all fields are descriptive

Whilst it's unfortunate to pull a resource post-merging - prior experience with the Networking API's has shown that Virtual Network Connections need to be managed as independent resources, to allow users to enforce ordering upon deletion to work around issues in the Azure API.

To be able to ship the `azurerm_virtual_wan` resource we'll then split the Virtual Network Connections out to their own resource - at which point we can then ship this resource.