### PR TITLE
Storage network rules are now stored in state, regardless of the valu…

### DIFF
--- a/azurerm/resource_arm_cognitive_account.go
+++ b/azurerm/resource_arm_cognitive_account.go
@@ -94,7 +94,7 @@ func resourceArmCognitiveAccount() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								"F0", "F1", "S0", "S1", "S2", "S3", "S4", "S5", "S6", "P0", "P1", "P2",
+								"F0", "F1", "S", "S0", "S1", "S2", "S3", "S4", "S5", "S6", "P0", "P1", "P2",
 							}, false),
 						},
 

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1406,7 +1406,6 @@ func expandQueuePropertiesCors(input []interface{}) *queues.Cors {
 }
 
 func flattenStorageAccountNetworkRules(input *storage.NetworkRuleSet) []interface{} {
-
 	networkRules := make(map[string]interface{})
 
 	if len(*input.IPRules) > 0 {

--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1406,13 +1406,15 @@ func expandQueuePropertiesCors(input []interface{}) *queues.Cors {
 }
 
 func flattenStorageAccountNetworkRules(input *storage.NetworkRuleSet) []interface{} {
-	if len(*input.IPRules) == 0 && len(*input.VirtualNetworkRules) == 0 {
-		return []interface{}{}
-	}
+
 	networkRules := make(map[string]interface{})
 
-	networkRules["ip_rules"] = schema.NewSet(schema.HashString, flattenStorageAccountIPRules(input.IPRules))
-	networkRules["virtual_network_subnet_ids"] = schema.NewSet(schema.HashString, flattenStorageAccountVirtualNetworks(input.VirtualNetworkRules))
+	if len(*input.IPRules) > 0 {
+		networkRules["ip_rules"] = schema.NewSet(schema.HashString, flattenStorageAccountIPRules(input.IPRules))
+	}
+	if len(*input.VirtualNetworkRules) > 0 {
+		networkRules["virtual_network_subnet_ids"] = schema.NewSet(schema.HashString, flattenStorageAccountVirtualNetworks(input.VirtualNetworkRules))
+	}
 	networkRules["bypass"] = schema.NewSet(schema.HashString, flattenStorageAccountBypass(input.Bypass))
 	networkRules["default_action"] = string(input.DefaultAction)
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 A `sku` block supports the following:
 
-* `name` - (Required) Specifies the Name of the Sku. Possible values are `F0`, `F1`, `S0`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1` and `P2`.
+* `name` - (Required) Specifies the Name of the Sku. Possible values are `F0`, `F1`, `S`, `S0`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1` and `P2`.
 
 * `tier` - (Required) Specifies the Tier of the Sku. Possible values include `Free`, `Standard` and `Premium`.
 


### PR DESCRIPTION
…es of IPRules and VNetRules, which are optional.  Plan now detects changes properly.

Moved check.  

Network rules now stored in statefile

"network_rules": [
  {
    "bypass": [
      "AzureServices",
      "Logging",
      "Metrics"
    ],
    "default_action": "Deny",
    "ip_rules": [],
    "virtual_network_subnet_ids": []
  }
],

and Plan now diffs this section properly.

      ~ network_rules {
          ~ bypass                     = [
                "AzureServices",
                "Logging",
              - "Metrics",
            ]
            default_action             = "Deny"
            ip_rules                   = []
            virtual_network_subnet_ids = []
        }

Validated configuration in Azure portal as valid.
<img width="905" alt="Screen Shot 2019-11-23 at 4 40 23 PM" src="https://user-images.githubusercontent.com/877051/69485703-16ebb380-0e11-11ea-8b1f-025db6812f2a.png">

