### PR TITLE
remove eventhub's kafka_enabled from all tests

### DIFF
--- a/azurerm/resource_arm_stream_analytics_output_eventhub_test.go
+++ b/azurerm/resource_arm_stream_analytics_output_eventhub_test.go
@@ -353,7 +353,6 @@ resource "azurerm_eventhub_namespace" "updated" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
   capacity            = 1
-  kafka_enabled       = false
 }
 
 resource "azurerm_eventhub" "updated" {
@@ -410,7 +409,6 @@ resource "azurerm_eventhub_namespace" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
   capacity            = 1
-  kafka_enabled       = false
 }
 
 resource "azurerm_eventhub" "test" {

--- a/azurerm/resource_arm_stream_analytics_stream_input_eventhub_test.go
+++ b/azurerm/resource_arm_stream_analytics_stream_input_eventhub_test.go
@@ -294,7 +294,6 @@ resource "azurerm_eventhub_namespace" "updated" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
   capacity            = 1
-  kafka_enabled       = false
 }
 
 resource "azurerm_eventhub" "updated" {
@@ -361,7 +360,6 @@ resource "azurerm_eventhub_namespace" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "Standard"
   capacity            = 1
-  kafka_enabled       = false
 }
 
 resource "azurerm_eventhub" "test" {

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -25,7 +25,6 @@ resource "azurerm_eventhub_namespace" "example" {
   resource_group_name = "${azurerm_resource_group.example.name}"
   sku                 = "Standard"
   capacity            = 1
-  kafka_enabled       = false
 
   tags = {
     environment = "Production"

--- a/website/docs/r/stream_analytics_output_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_output_eventhub.html.markdown
@@ -29,7 +29,6 @@ resource "azurerm_eventhub_namespace" "example" {
   resource_group_name = "${data.azurerm_resource_group.example.name}"
   sku                 = "Standard"
   capacity            = 1
-  kafka_enabled       = false
 }
 
 resource "azurerm_eventhub" "example" {

--- a/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
@@ -29,7 +29,6 @@ resource "azurerm_eventhub_namespace" "example" {
   resource_group_name = "${data.azurerm_resource_group.example.name}"
   sku                 = "Standard"
   capacity            = 1
-  kafka_enabled       = false
 }
 
 resource "azurerm_eventhub" "example" {


### PR DESCRIPTION
this property is no managed by azure so tests were failing with:
```
------- Stdout: -------
=== RUN   TestAccAzureRMStreamAnalyticsStreamInputEventHub_csv
=== PAUSE TestAccAzureRMStreamAnalyticsStreamInputEventHub_csv
=== CONT  TestAccAzureRMStreamAnalyticsStreamInputEventHub_csv
--- FAIL: TestAccAzureRMStreamAnalyticsStreamInputEventHub_csv (188.83s)
    testing.go:569: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: azurerm_eventhub_namespace.test
          auto_inflate_enabled:                      "false" => "false"
          capacity:                                  "1" => "1"
          default_primary_connection_string:         "Endpoint=sb://acctestehn-191125095238726488.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=INM8P5u/S84+AKmWdxdAaPQV3YGxTKCQXjWnCx5mLiE=" => "Endpoint=sb://acctestehn-191125095238726488.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=INM8P5u/S84+AKmWdxdAaPQV3YGxTKCQXjWnCx5mLiE="
          default_primary_key:                       "INM8P5u/S84+AKmWdxdAaPQV3YGxTKCQXjWnCx5mLiE=" => "INM8P5u/S84+AKmWdxdAaPQV3YGxTKCQXjWnCx5mLiE="
          default_secondary_connection_string:       "Endpoint=sb://acctestehn-191125095238726488.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=bXryDYVIDvaiVhULh7w0A9sbUlq1BqkwroEbXhSWCCs=" => "Endpoint=sb://acctestehn-191125095238726488.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=bXryDYVIDvaiVhULh7w0A9sbUlq1BqkwroEbXhSWCCs="
          default_secondary_key:                     "bXryDYVIDvaiVhULh7w0A9sbUlq1BqkwroEbXhSWCCs=" => "bXryDYVIDvaiVhULh7w0A9sbUlq1BqkwroEbXhSWCCs="
          id:                                        "/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/acctestRG-191125095238726488/providers/Microsoft.EventHub/namespaces/acctestehn-191125095238726488" => "/subscriptions/1a6092a6-137e-4025-9a7c-ef77f76f2c02/resourceGroups/acctestRG-191125095238726488/providers/Microsoft.EventHub/namespaces/acctestehn-191125095238726488"
          kafka_enabled:                             "true" => "false"
          location:                                  "westeurope" => "westeurope"
          maximum_throughput_units:                  "0" => "0"
          name:                                      "acctestehn-191125095238726488" => "acctestehn-191125095238726488"
          network_rulesets.#:                        "1" => "1"
          network_rulesets.0.default_action:         "Deny" => "Deny"
          network_rulesets.0.ip_rule.#:              "0" => "0"
          network_rulesets.0.virtual_network_rule.#: "0" => "0"
          resource_group_name:                       "acctestRG-191125095238726488" => "acctestRG-191125095238726488"
          sku:                                       "Standard" => "Standard"
```

this resolves that