### PR TITLE
Add APIVersion and APIVersionSetID to import

### DIFF
--- a/azurerm/resource_arm_api_management_api.go
+++ b/azurerm/resource_arm_api_management_api.go
@@ -204,7 +204,7 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 	apiId := fmt.Sprintf("%s;rev=%s", name, revision)
 	version := d.Get("version").(string)
 	versionSetId := d.Get("version_set_id").(string)
-	
+
 	if version != "" && versionSetId == "" {
 		return fmt.Errorf("Error setting `version` without the required `version_set_id`")
 	}
@@ -263,7 +263,6 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	serviceUrl := d.Get("service_url").(string)
-
 
 	protocolsRaw := d.Get("protocols").(*schema.Set).List()
 	protocols := expandApiManagementApiProtocols(protocolsRaw)

--- a/azurerm/resource_arm_api_management_api.go
+++ b/azurerm/resource_arm_api_management_api.go
@@ -202,6 +202,8 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 	revision := d.Get("revision").(string)
 	path := d.Get("path").(string)
 	apiId := fmt.Sprintf("%s;rev=%s", name, revision)
+	version := d.Get("version").(string)
+	versionSetId := d.Get("version_set_id").(string)
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, serviceName, apiId)
@@ -230,6 +232,7 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 				ContentFormat: apimanagement.ContentFormat(contentFormat),
 				ContentValue:  utils.String(contentValue),
 				Path:          utils.String(path),
+				APIVersion:    utils.String(version),
 			},
 		}
 		wsdlSelectorVs := importV["wsdl_selector"].([]interface{})
@@ -244,6 +247,10 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 			}
 		}
 
+		if versionSetId != "" {
+			apiParams.APICreateOrUpdateProperties.APIVersionSetID = utils.String(versionSetId)
+		}
+
 		if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, apiId, apiParams, ""); err != nil {
 			return fmt.Errorf("Error creating/updating API Management API %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
@@ -252,9 +259,6 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 	description := d.Get("description").(string)
 	displayName := d.Get("display_name").(string)
 	serviceUrl := d.Get("service_url").(string)
-
-	version := d.Get("version").(string)
-	versionSetId := d.Get("version_set_id").(string)
 
 	if version != "" && versionSetId == "" {
 		return fmt.Errorf("Error setting `version` without the required `version_set_id`")

--- a/azurerm/resource_arm_api_management_api.go
+++ b/azurerm/resource_arm_api_management_api.go
@@ -204,6 +204,10 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 	apiId := fmt.Sprintf("%s;rev=%s", name, revision)
 	version := d.Get("version").(string)
 	versionSetId := d.Get("version_set_id").(string)
+	
+	if version != "" && versionSetId == "" {
+		return fmt.Errorf("Error setting `version` without the required `version_set_id`")
+	}
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, serviceName, apiId)
@@ -260,9 +264,6 @@ func resourceArmApiManagementApiCreateUpdate(d *schema.ResourceData, meta interf
 	displayName := d.Get("display_name").(string)
 	serviceUrl := d.Get("service_url").(string)
 
-	if version != "" && versionSetId == "" {
-		return fmt.Errorf("Error setting `version` without the required `version_set_id`")
-	}
 
 	protocolsRaw := d.Get("protocols").(*schema.Set).List()
 	protocols := expandApiManagementApiProtocols(protocolsRaw)


### PR DESCRIPTION
Adds the APIVersion and APIVersionSetID to the REST call for creating an API using an import from a file (swagger, WSDL etc.). This fixes the bug in https://github.com/terraform-providers/terraform-provider-azurerm/issues/4985 that would result in creation failing if attempting to create more than 1 version of a single API with the same path.

Fixes #4985