### PR TITLE
Website markdown fixes for duplicate 'the'.

### DIFF
--- a/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
@@ -35,7 +35,7 @@ output "rule_id" {
 
 ## Attributes Reference
 
-* `id` - The id of the the ServiceBus Namespace Authorization Rule.
+* `id` - The id of the ServiceBus Namespace Authorization Rule.
 
 * `primary_connection_string` - The primary connection string for the authorization rule.
     

--- a/website/docs/r/bot_channel_email.markdown
+++ b/website/docs/r/bot_channel_email.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `email_address` - (Required) The email address that the Bot will authenticate with.
 
-* `email_password` - (Required) The email password that the the Bot will authenticate with.
+* `email_password` - (Required) The email password that the Bot will authenticate with.
 
 
 ## Attributes Reference

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required for `Classic` Sku - Forbidden otherwise) The ID of a Storage Account which must be located in the same Azure Region as the Container Registry.
 
-* `sku` - (Optional) The SKU name of the the container registry. Possible values are `Classic` (which was previously `Basic`), `Basic`, `Standard` and `Premium`.
+* `sku` - (Optional) The SKU name of the container registry. Possible values are `Classic` (which was previously `Basic`), `Basic`, `Standard` and `Premium`.
 
 ~> **NOTE:** The `Classic` SKU is Deprecated and will no longer be available for new resources from the end of March 2019.
 

--- a/website/docs/r/data_factory_trigger_schedule.html.markdown
+++ b/website/docs/r/data_factory_trigger_schedule.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `frequency` - (Optional) The trigger freqency. Valid values include `Minute`, `Hour`, `Day`, `Week`, `Month`. Defaults to `Minute`.
 
-* `pipeline_parameters` - (Optional) The pipeline parameters that the the trigger will act upon.
+* `pipeline_parameters` - (Optional) The pipeline parameters that the trigger will act upon.
 
 * `annotations` - (Optional) List of tags that can be used for describing the Data Factory Schedule Trigger.
 

--- a/website/docs/r/front_door_firewall_policy.html.markdown
+++ b/website/docs/r/front_door_firewall_policy.html.markdown
@@ -129,7 +129,7 @@ The `custom_rule` block supports the following:
 
 * `priority` - (Required) The priority of the rule. Rules with a lower value will be evaluated before rules with a higher value. Defaults to `1`.
 
-* `type` - (Required) The the type of rule. Possible values are `MatchRule` or `RateLimitRule`.
+* `type` - (Required) The type of rule. Possible values are `MatchRule` or `RateLimitRule`.
 
 * `match_condition` - (Required) One or more `match_condition` block defined below.
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 `os_disk` supports the following:
 
-* `os_type` - (Required) Specifies the type of operating system contained in the the virtual machine image. Possible values are: Windows or Linux.
+* `os_type` - (Required) Specifies the type of operating system contained in the virtual machine image. Possible values are: Windows or Linux.
 * `os_state` - (Required) Specifies the state of the operating system contained in the blob. Currently, the only value is Generalized.
 * `managed_disk_id` - (Optional) Specifies the ID of the managed disk resource that you want to use to create the image.
 * `blob_uri` - (Optional) Specifies the URI in Azure storage of the blob that you want to use to create the image.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -126,7 +126,7 @@ resource "azurerm_subnet" "virtual" {
 
 -> **NOTE:** If `network_profile` is not defined, `kubenet` profile will be used by default.
 
-* `node_resource_group` - (Optional) The name of the Resource Group where the the Kubernetes Nodes should exist. Changing this forces a new resource to be created.
+* `node_resource_group` - (Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created.
 
 -> **NOTE:** Azure requires that a new, non-existent Resource Group is used, as otherwise the provisioning of the Kubernetes Service will fail.
 

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -76,7 +76,7 @@ The following attributes are exported:
 * `id` - The Public IP ID.
 * `ip_address` - The IP address value that was allocated.
 
-~> **Note** `Dynamic` Public IP Addresses aren't allocated until they're attached to a device (e.g. a Virtual Machine/Load Balancer). Instead you can obtain the IP Address once the the Public IP has been assigned via the [`azurerm_public_ip` Data Source](../d/public_ip.html).
+~> **Note** `Dynamic` Public IP Addresses aren't allocated until they're attached to a device (e.g. a Virtual Machine/Load Balancer). Instead you can obtain the IP Address once the Public IP has been assigned via the [`azurerm_public_ip` Data Source](../d/public_ip.html).
 
 * `fqdn` - Fully qualified domain name of the A DNS record associated with the public IP. `domain_name_label` must be specified to get the `fqdn`. This is the concatenation of the `domain_name_label` and the regionalized DNS zone
 

--- a/website/docs/r/scheduler_job.html.markdown
+++ b/website/docs/r/scheduler_job.html.markdown
@@ -226,8 +226,8 @@ The following arguments are supported:
 
 `action_storage_queue` & `error_action_storage_queue` block supports the following:
 
-* `storage_account_name` - (Required) Specifies the the storage account name.
-* `storage_queue_name` - (Required) Specifies the the storage account queue.
+* `storage_account_name` - (Required) Specifies the storage account name.
+* `storage_queue_name` - (Required) Specifies the storage account queue.
 * `sas_token` - (Required) Specifies a SAS token/key to authenticate with.
 * `message` - (Required) The message to send into the queue.
 


### PR DESCRIPTION
Noticed a duplicate 'the' while reading the docs for a resource and decided to clean them all up.