### PR TITLE
Add `fqdn` attribute for DNS record resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FEATURES:
 
-* **New Resource:** `azurerm_iothub_fallback_route` (#4965)
+* **New Resource:** `azurerm_iothub_fallback_route` [GH-4965]
 
 ## 1.37.0 (November 26, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.38.0 (Unreleased)
+
+FEATURES:
+
+* **New Resource:** `azurerm_iothub_fallback_route` (#4965)
+
 ## 1.37.0 (November 26, 2019)
 
 NOTES

--- a/azurerm/resource_arm_dns_a_record.go
+++ b/azurerm/resource_arm_dns_a_record.go
@@ -58,6 +58,11 @@ func resourceArmDnsARecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -144,6 +149,7 @@ func resourceArmDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("records", flattenAzureRmDnsARecords(resp.ARecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_a_record_test.go
+++ b/azurerm/resource_arm_dns_a_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsARecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsARecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_aaaa_record.go
+++ b/azurerm/resource_arm_dns_aaaa_record.go
@@ -58,6 +58,11 @@ func resourceArmDnsAAAARecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -144,6 +149,7 @@ func resourceArmDnsAaaaRecordRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("records", flattenAzureRmDnsAaaaRecords(resp.AaaaRecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_aaaa_record_test.go
+++ b/azurerm/resource_arm_dns_aaaa_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsAAAARecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsAaaaRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_caa_record.go
+++ b/azurerm/resource_arm_dns_caa_record.go
@@ -85,6 +85,11 @@ func resourceArmDnsCaaRecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -171,6 +176,7 @@ func resourceArmDnsCaaRecordRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("record", flattenAzureRmDnsCaaRecords(resp.CaaRecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_caa_record_test.go
+++ b/azurerm/resource_arm_dns_caa_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsCaaRecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsCaaRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_cname_record.go
+++ b/azurerm/resource_arm_dns_cname_record.go
@@ -63,6 +63,11 @@ func resourceArmDnsCNameRecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -152,6 +157,7 @@ func resourceArmDnsCNameRecordRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if props := resp.RecordSetProperties; props != nil {
 		if record := props.CnameRecord; record != nil {

--- a/azurerm/resource_arm_dns_cname_record_test.go
+++ b/azurerm/resource_arm_dns_cname_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsCNameRecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsCNameRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_mx_record.go
+++ b/azurerm/resource_arm_dns_mx_record.go
@@ -74,6 +74,11 @@ func resourceArmDnsMxRecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -160,6 +165,7 @@ func resourceArmDnsMxRecordRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("record", flattenAzureRmDnsMxRecords(resp.MxRecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_mx_record_test.go
+++ b/azurerm/resource_arm_dns_mx_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsMxRecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsMxRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_ns_record.go
+++ b/azurerm/resource_arm_dns_ns_record.go
@@ -76,6 +76,11 @@ func resourceArmDnsNsRecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -162,6 +167,7 @@ func resourceArmDnsNsRecordRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("records", flattenAzureRmDnsNsRecords(resp.NsRecords)); err != nil {
 		return fmt.Errorf("Error settings `records`: %+v", err)

--- a/azurerm/resource_arm_dns_ns_record_test.go
+++ b/azurerm/resource_arm_dns_ns_record_test.go
@@ -27,6 +27,7 @@ func TestAccAzureRMDnsNsRecord_deprecatedBasic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsNsRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 		},

--- a/azurerm/resource_arm_dns_ns_record_test.go
+++ b/azurerm/resource_arm_dns_ns_record_test.go
@@ -27,7 +27,6 @@ func TestAccAzureRMDnsNsRecord_deprecatedBasic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsNsRecordExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 		},
@@ -48,6 +47,7 @@ func TestAccAzureRMDnsNsRecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsNsRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_ptr_record.go
+++ b/azurerm/resource_arm_dns_ptr_record.go
@@ -58,6 +58,11 @@ func resourceArmDnsPtrRecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -145,6 +150,7 @@ func resourceArmDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("records", flattenAzureRmDnsPtrRecords(resp.PtrRecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_ptr_record_test.go
+++ b/azurerm/resource_arm_dns_ptr_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsPtrRecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsPtrRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_srv_record.go
+++ b/azurerm/resource_arm_dns_srv_record.go
@@ -82,6 +82,11 @@ func resourceArmDnsSrvRecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -168,6 +173,7 @@ func resourceArmDnsSrvRecordRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("record", flattenAzureRmDnsSrvRecords(resp.SrvRecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_srv_record_test.go
+++ b/azurerm/resource_arm_dns_srv_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsSrvRecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsSrvRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_dns_txt_record.go
+++ b/azurerm/resource_arm_dns_txt_record.go
@@ -64,6 +64,11 @@ func resourceArmDnsTxtRecord() *schema.Resource {
 				Required: true,
 			},
 
+			"fqdn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -150,6 +155,7 @@ func resourceArmDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", resGroup)
 	d.Set("zone_name", zoneName)
 	d.Set("ttl", resp.TTL)
+	d.Set("fqdn", resp.Fqdn)
 
 	if err := d.Set("record", flattenAzureRmDnsTxtRecords(resp.TxtRecords)); err != nil {
 		return err

--- a/azurerm/resource_arm_dns_txt_record_test.go
+++ b/azurerm/resource_arm_dns_txt_record_test.go
@@ -26,6 +26,7 @@ func TestAccAzureRMDnsTxtRecord_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsTxtRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "fqdn"),
 				),
 			},
 			{

--- a/website/docs/r/dns_a_record.html.markdown
+++ b/website/docs/r/dns_a_record.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The DNS A Record ID.
+* `fqdn` - The FQDN of the DNS A Record.
 
 ## Import
 

--- a/website/docs/r/dns_aaaa_record.html.markdown
+++ b/website/docs/r/dns_aaaa_record.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The DNS AAAA Record ID.
+* `fqdn` - The FQDN of the DNS AAAA Record.
 
 ## Import
 

--- a/website/docs/r/dns_caa_record.html.markdown
+++ b/website/docs/r/dns_caa_record.html.markdown
@@ -88,6 +88,7 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS CAA Record ID.
+* `fqdn` - The FQDN of the DNS CAA Record.
 
 ## Import
 

--- a/website/docs/r/dns_cname_record.html.markdown
+++ b/website/docs/r/dns_cname_record.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The DNS CName Record ID.
+* `fqdn` - The FQDN of the DNS CName Record.
 
 ## Import
 

--- a/website/docs/r/dns_mx_record.html.markdown
+++ b/website/docs/r/dns_mx_record.html.markdown
@@ -72,6 +72,7 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS MX Record ID.
+* `fqdn` - The FQDN of the DNS MX Record.
 
 ## Import
 

--- a/website/docs/r/dns_ns_record.html.markdown
+++ b/website/docs/r/dns_ns_record.html.markdown
@@ -64,6 +64,7 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS NS Record ID.
+* `fqdn` - The FQDN of the DNS NS Record.
 
 ## Import
 

--- a/website/docs/r/dns_ptr_record.html.markdown
+++ b/website/docs/r/dns_ptr_record.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The DNS PTR Record ID.
+* `fqdn` - The FQDN of the DNS PTR Record.
 
 ## Import
 

--- a/website/docs/r/dns_srv_record.html.markdown
+++ b/website/docs/r/dns_srv_record.html.markdown
@@ -74,6 +74,7 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS SRV Record ID.
+* `fqdn` - The FQDN of the DNS SRV Record.
 
 ## Import
 

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -68,6 +68,7 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS TXT Record ID.
+* `fqdn` - The FQDN of the DNS TXT Record.
 
 ## Import
 


### PR DESCRIPTION
Fixes: #4391

Adds the `fqdn` attribute for all DNS record resources.