### PR TITLE
import: adding a validator prior to import

### DIFF
--- a/azurerm/internal/services/resource/group_parser.go
+++ b/azurerm/internal/services/resource/group_parser.go
@@ -1,0 +1,37 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ResourceGroupResourceID struct {
+	Base azure.ResourceID
+
+	Name string
+}
+
+func ParseResourceGroupID(input string) (*ResourceGroupResourceID, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Resource Group ID %q: %+v", input, err)
+	}
+
+	group := ResourceGroupResourceID{
+		Base: *id,
+		Name: id.ResourceGroup,
+	}
+
+	if group.Name == "" {
+		return nil, fmt.Errorf("ID was missing the `resourceGroups` element")
+	}
+
+	pathWithoutSubs := group.Base.Path
+	delete(pathWithoutSubs, "subscriptions")
+	if len(pathWithoutSubs) != 0 {
+		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
+	}
+
+	return &group, nil
+}

--- a/azurerm/internal/services/resource/group_parser_test.go
+++ b/azurerm/internal/services/resource/group_parser_test.go
@@ -1,0 +1,68 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+func TestParseResourceGroup(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *ResourceGroupResourceID
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:  "Completed",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: &ResourceGroupResourceID{
+				Name: "foo",
+				Base: azure.ResourceID{
+					ResourceGroup: "foo",
+				},
+			},
+		},
+		{
+			Name:     "App Service Resource ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/instance1",
+			Expected: nil,
+		},
+		{
+			Name:     "Virtual Machine Resource ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.compute/virtualMachines/machine1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ParseResourceGroupID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/resource/group_validator.go
+++ b/azurerm/internal/services/resource/group_validator.go
@@ -1,0 +1,34 @@
+package resource
+
+import "fmt"
+
+// ValidateResourceGroupID validates that the specified Resource Group ID is Valid
+func ValidateResourceGroupID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := ParseResourceGroupID(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", k, err))
+		return
+	}
+
+	return warnings, errors
+}
+
+// ValidateResourceGroupIDOrEmpty validates that the specified ID is either Empty or a Valid Resource Group ID
+func ValidateResourceGroupIDOrEmpty(i interface{}, k string) (_ []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if v == "" {
+		return
+	}
+
+	return ValidateResourceGroupID(i, k)
+}

--- a/azurerm/internal/services/resource/group_validator_test.go
+++ b/azurerm/internal/services/resource/group_validator_test.go
@@ -1,0 +1,92 @@
+package resource
+
+import "testing"
+
+func TestValidateResourceGroupID(t *testing.T) {
+	cases := []struct {
+		ID     string
+		Errors int
+	}{
+		{
+			ID:     "",
+			Errors: 1,
+		},
+		{
+			ID:     "nonsense",
+			Errors: 1,
+		},
+		{
+			ID:     "/slash",
+			Errors: 1,
+		},
+		{
+			ID:     "/path/to/nothing",
+			Errors: 1,
+		},
+		{
+			ID:     "/subscriptions",
+			Errors: 1,
+		},
+		{
+			ID:     "/providers",
+			Errors: 1,
+		},
+		{
+			ID:     "/subscriptions/not-a-guid",
+			Errors: 0,
+		},
+		{
+			ID:     "/providers/test",
+			Errors: 0,
+		},
+		{
+			ID:     "/subscriptions/00000000-0000-0000-0000-00000000000/",
+			Errors: 0,
+		},
+		{
+			ID:     "/providers/provider.name/",
+			Errors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ID, func(t *testing.T) {
+			_, errors := ValidateResourceGroupID(tc.ID, "test")
+
+			if len(errors) < tc.Errors {
+				t.Fatalf("Expected ValidateResourceGroupID to have %d not %d errors for %q", tc.Errors, len(errors), tc.ID)
+			}
+		})
+	}
+}
+
+func TestValidateResourceGroupIDOrEmpty(t *testing.T) {
+	cases := []struct {
+		ID     string
+		Errors int
+	}{
+		{
+			ID:     "",
+			Errors: 0,
+		},
+		{
+			ID:     "nonsense",
+			Errors: 1,
+		},
+		//as this function just calls TestAzureResourceGroupId lets not be as comprehensive
+		{
+			ID:     "/providers/provider.name/",
+			Errors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ID, func(t *testing.T) {
+			_, errors := ValidateResourceGroupIDOrEmpty(tc.ID, "test")
+
+			if len(errors) < tc.Errors {
+				t.Fatalf("Expected TestAzureResourceGroupIdOrEmpty to have %d not %d errors for %q", tc.Errors, len(errors), tc.ID)
+			}
+		})
+	}
+}

--- a/azurerm/internal/tf/schema/import.go
+++ b/azurerm/internal/tf/schema/import.go
@@ -19,7 +19,7 @@ func ValidateResourceIDPriorToImport(idParser ResourceIDValidator) *schema.Resou
 			log.Printf("[DEBUG] Importing Resource - parsing %q", d.Id())
 
 			if err := idParser(d.Id()); err != nil {
-				return []*schema.ResourceData{d}, fmt.Errorf("Error parsing Resource ID: %v", d.Id())
+				return []*schema.ResourceData{d}, fmt.Errorf("Error parsing Resource ID %q: %+v", d.Id(), err)
 			}
 
 			return schema.ImportStatePassthrough(d, meta)

--- a/azurerm/internal/tf/schema/import.go
+++ b/azurerm/internal/tf/schema/import.go
@@ -1,0 +1,28 @@
+package schema
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// ResourceIDValidator takes a Resource ID and confirms that it's Valid
+type ResourceIDValidator func(resourceId string) error
+
+// ValidateResourceIDPriorToImport parses the Resource ID to confirm it's
+// valid for this Resource prior to performing an import - allowing for incorrect
+// Resource ID's to be caught prior to Import and subsequent crashes
+func ValidateResourceIDPriorToImport(idParser ResourceIDValidator) *schema.ResourceImporter {
+	return &schema.ResourceImporter{
+		State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			log.Printf("[DEBUG] Importing Resource - parsing %q", d.Id())
+
+			if err := idParser(d.Id()); err != nil {
+				return []*schema.ResourceData{d}, fmt.Errorf("Error parsing Resource ID: %v", d.Id())
+			}
+
+			return schema.ImportStatePassthrough(d, meta)
+		},
+	}
+}

--- a/azurerm/internal/tf/schema/import_test.go
+++ b/azurerm/internal/tf/schema/import_test.go
@@ -1,0 +1,47 @@
+package schema
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func TestValidateResourceIDPriorToImport(t *testing.T) {
+	testData := []struct {
+		name             string
+		id               string
+		shouldBeImported bool
+		validator        ResourceIDValidator
+	}{
+		{
+			name:             "returns an error",
+			shouldBeImported: false,
+			validator: func(input string) error {
+				return fmt.Errorf("Returns an error")
+			},
+		},
+		{
+			name:             "valid",
+			shouldBeImported: true,
+			validator: func(input string) error {
+				return nil
+			},
+		},
+	}
+
+	for _, v := range testData {
+		log.Printf("[DEBUG] Testing %q", v.name)
+
+		f := ValidateResourceIDPriorToImport(v.validator)
+		resourceData := &schema.ResourceData{}
+		resourceData.SetId("hello")
+		_, err := f.State(resourceData, nil)
+		wasImported := err == nil
+
+		if v.shouldBeImported != wasImported {
+			t.Fatalf("Expected %t but got %t. Errors: %+v", v.shouldBeImported, wasImported, err)
+		}
+	}
+}

--- a/azurerm/resource_arm_resource_group.go
+++ b/azurerm/resource_arm_resource_group.go
@@ -8,7 +8,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/resource"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
@@ -23,9 +25,10 @@ func resourceArmResourceGroup() *schema.Resource {
 		Read:   resourceArmResourceGroupRead,
 		Update: resourceArmResourceGroupCreateUpdate,
 		Delete: resourceArmResourceGroupDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := resource.ParseResourceGroupID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(90 * time.Minute),

--- a/azurerm/resource_arm_route_table.go
+++ b/azurerm/resource_arm_route_table.go
@@ -14,7 +14,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	networkSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -28,9 +30,10 @@ func resourceArmRouteTable() *schema.Resource {
 		Update: resourceArmRouteTableCreateUpdate,
 		Delete: resourceArmRouteTableDelete,
 
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := networkSvc.ParseRouteTableResourceID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),


### PR DESCRIPTION
This allows us to add validation functions which run prior to Import, like so:

```go
Import: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
	_, err := networkSvc.ParseRouteTableResourceID(id)
	return err
}),
```

which can then parse the Resource ID and confirm that all of the required segments
are present so that we can import this successfully