### PR TITLE
azurerm_mysql_server - add support for version 8.0

### DIFF
--- a/azurerm/resource_arm_mysql_server.go
+++ b/azurerm/resource_arm_mysql_server.go
@@ -139,6 +139,7 @@ func resourceArmMySqlServer() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(mysql.FiveFullStopSix),
 					string(mysql.FiveFullStopSeven),
+					"8.0", //TODO: Update to EightFullStopZero ServerVersion constant when available in Azure Go SDK
 				}, true),
 				DiffSuppressFunc: suppress.CaseDifference,
 				ForceNew:         true,

--- a/azurerm/resource_arm_mysql_server.go
+++ b/azurerm/resource_arm_mysql_server.go
@@ -139,7 +139,7 @@ func resourceArmMySqlServer() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(mysql.FiveFullStopSix),
 					string(mysql.FiveFullStopSeven),
-					"8.0", //TODO: Update to EightFullStopZero ServerVersion constant when available in Azure Go SDK
+					"8.0", //TODO: Update to EightFullStopZero ServerVersion constant when available in Azure Go SDK https://github.com/Azure/azure-rest-api-specs/pull/7864
 				}, true),
 				DiffSuppressFunc: suppress.CaseDifference,
 				ForceNew:         true,

--- a/azurerm/resource_arm_mysql_server_test.go
+++ b/azurerm/resource_arm_mysql_server_test.go
@@ -99,6 +99,33 @@ func TestAccAzureRMMySQLServer_basicFiveSeven(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMMySQLServer_basicEightZero(t *testing.T) {
+	resourceName := "azurerm_mysql_server.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMMySQLServerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMySQLServer_basicEightZero(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMySQLServerExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"administrator_login_password", // not returned as sensitive
+				},
+			},
+		},
+	})
+}
+
 func TestAccAzureRMMySqlServer_generalPurpose(t *testing.T) {
 	resourceName := "azurerm_mysql_server.test"
 	ri := tf.AccRandTimeInt()
@@ -386,6 +413,39 @@ resource "azurerm_mysql_server" "test" {
   administrator_login          = "acctestun"
   administrator_login_password = "H@Sh1CoR3!"
   version                      = "5.7"
+  ssl_enforcement              = "Enabled"
+}
+`, rInt, location, rInt)
+}
+
+func testAccAzureRMMySQLServer_basicEightZero(rInt int, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_mysql_server" "test" {
+  name                = "acctestmysqlsvr-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    name     = "GP_Gen5_2"
+    capacity = 2
+    tier     = "GeneralPurpose"
+    family   = "Gen5"
+  }
+
+  storage_profile {
+    storage_mb            = 51200
+    backup_retention_days = 7
+    geo_redundant_backup  = "Disabled"
+  }
+
+  administrator_login          = "acctestun"
+  administrator_login_password = "H@Sh1CoR3!"
+  version                      = "8.0"
   ssl_enforcement              = "Enabled"
 }
 `, rInt, location, rInt)

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Required) The Password associated with the `administrator_login` for the MySQL Server.
 
-* `version` - (Required) Specifies the version of MySQL to use. Valid values are `5.6` and `5.7`. Changing this forces a new resource to be created.
+* `version` - (Required) Specifies the version of MySQL to use. Valid values are `5.6`, `5.7`, and `8.0`. Changing this forces a new resource to be created.
 
 * `ssl_enforcement` - (Required) Specifies if SSL should be enforced on connections. Possible values are `Enabled` and `Disabled`.
 


### PR DESCRIPTION
Fixes: #4380 

Adds `8.0` as a valid value for `azurerm_mysql_server`'s `version` argument to support creating a MySQL server version `8.0`.

```
=== RUN   TestAccAzureRMMySQLServer_basicEightZero
=== PAUSE TestAccAzureRMMySQLServer_basicEightZero
=== CONT  TestAccAzureRMMySQLServer_basicEightZero
--- PASS: TestAccAzureRMMySQLServer_basicEightZero (359.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       359.585s
```