### PR TITLE
r/storage_account: configuring `secure_transfer_required`

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -165,6 +165,7 @@ func resourceArmStorageAccount() *schema.Resource {
 			"enable_https_traffic_only": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 
 			"is_hns_enabled": {


### PR DESCRIPTION
Please refer to issue: https://github.com/terraform-providers/terraform-provider-azurerm/issues/5010
Azure strongly suggest that `enable_https_traffic_only` should be enabled by default from aspect of security reasons

Fixes #5010