### PR TITLE
print storage account name in validation error

### DIFF
--- a/azurerm/resource_arm_storage_account.go
+++ b/azurerm/resource_arm_storage_account.go
@@ -1590,7 +1590,7 @@ func validateArmStorageAccountName(v interface{}, _ string) (warnings []string, 
 	input := v.(string)
 
 	if !regexp.MustCompile(`\A([a-z0-9]{3,24})\z`).MatchString(input) {
-		errors = append(errors, fmt.Errorf("name can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long"))
+		errors = append(errors, fmt.Errorf("name (%q) can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long", input))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
Prints the storage account name in validation error as required in #4932 

Fixes: #4932 