### PR TITLE
refactor: moving off the deprecated fields/functions

### DIFF
--- a/azurerm/data_source_healthcare_service.go
+++ b/azurerm/data_source_healthcare_service.go
@@ -110,7 +110,7 @@ func dataSourceArmHealthcareService() *schema.Resource {
 				},
 			},
 
-			"tags": tagsSchema(),
+			"tags": tags.SchemaDataSource(),
 		},
 	}
 }

--- a/azurerm/data_source_storage_management_policy.go
+++ b/azurerm/data_source_storage_management_policy.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 )
 
@@ -113,7 +114,7 @@ func dataSourceArmStorageManagementPolicyRead(d *schema.ResourceData, meta inter
 
 	storageAccountId := d.Get("storage_account_id").(string)
 
-	rid, err := parseAzureResourceID(storageAccountId)
+	rid, err := azure.ParseAzureResourceID(storageAccountId)
 	if err != nil {
 		return err
 	}

--- a/azurerm/deprecated.go
+++ b/azurerm/deprecated.go
@@ -16,11 +16,6 @@ import (
 var requireResourcesToBeImported = features.ShouldResourcesBeImported()
 
 // nolint: deadcode unused
-func expandTags(tagsMap map[string]interface{}) map[string]*string {
-	return tags.Expand(tagsMap)
-}
-
-// nolint: deadcode unused
 func tagsSchema() *schema.Schema {
 	return tags.Schema()
 }

--- a/azurerm/deprecated.go
+++ b/azurerm/deprecated.go
@@ -16,12 +16,6 @@ import (
 var requireResourcesToBeImported = features.ShouldResourcesBeImported()
 
 // nolint: deadcode unused
-func flattenAndSetTags(d *schema.ResourceData, tagMap map[string]*string) {
-	// we intentionally ignore the error here, since this method doesn't expose it
-	_ = tags.FlattenAndSet(d, tagMap)
-}
-
-// nolint: deadcode unused
 func expandTags(tagsMap map[string]interface{}) map[string]*string {
 	return tags.Expand(tagsMap)
 }

--- a/azurerm/deprecated.go
+++ b/azurerm/deprecated.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
@@ -13,11 +12,6 @@ import (
 
 // nolint: deadcode unused
 var requireResourcesToBeImported = features.ShouldResourcesBeImported()
-
-// nolint: deadcode unused
-func parseAzureResourceID(id string) (*azure.ResourceID, error) {
-	return azure.ParseAzureResourceID(id)
-}
 
 func evaluateSchemaValidateFunc(i interface{}, k string, validateFunc schema.SchemaValidateFunc) (bool, error) { // nolint: unparam
 	_, errors := validateFunc(i, k)

--- a/azurerm/deprecated.go
+++ b/azurerm/deprecated.go
@@ -5,13 +5,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
 // NOTE: these methods are deprecated, but provided to ease compatibility for open PR's
-
-// nolint: deadcode unused
-var requireResourcesToBeImported = features.ShouldResourcesBeImported()
 
 func evaluateSchemaValidateFunc(i interface{}, k string, validateFunc schema.SchemaValidateFunc) (bool, error) { // nolint: unparam
 	_, errors := validateFunc(i, k)

--- a/azurerm/deprecated.go
+++ b/azurerm/deprecated.go
@@ -7,18 +7,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 )
 
 // NOTE: these methods are deprecated, but provided to ease compatibility for open PR's
 
 // nolint: deadcode unused
 var requireResourcesToBeImported = features.ShouldResourcesBeImported()
-
-// nolint: deadcode unused
-func tagsSchema() *schema.Schema {
-	return tags.Schema()
-}
 
 // nolint: deadcode unused
 func parseAzureResourceID(id string) (*azure.ResourceID, error) {

--- a/azurerm/resource_arm_automation_job_schedule.go
+++ b/azurerm/resource_arm_automation_job_schedule.go
@@ -169,7 +169,7 @@ func resourceArmAutomationJobScheduleRead(d *schema.ResourceData, meta interface
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func resourceArmAutomationJobScheduleDelete(d *schema.ResourceData, meta interfa
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_automation_job_schedule.go
+++ b/azurerm/resource_arm_automation_job_schedule.go
@@ -11,6 +11,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -106,7 +107,7 @@ func resourceArmAutomationJobScheduleCreate(d *schema.ResourceData, meta interfa
 	runbookName := d.Get("runbook_name").(string)
 	scheduleName := d.Get("schedule_name").(string)
 
-	if requireResourcesToBeImported && d.IsNewResource() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, accountName, jobScheduleUUID)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_automation_job_schedule_test.go
+++ b/azurerm/resource_arm_automation_job_schedule_test.go
@@ -9,6 +9,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -87,7 +88,7 @@ func TestAccAzureRMAutomationJobSchedule_update(t *testing.T) {
 }
 
 func TestAccAzureRMAutomationJobSchedule_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_automation_job_schedule_test.go
+++ b/azurerm/resource_arm_automation_job_schedule_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	uuid "github.com/satori/go.uuid"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -121,7 +122,7 @@ func testCheckAzureRMAutomationJobScheduleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		id, err := parseAzureResourceID(rs.Primary.Attributes["id"])
+		id, err := azure.ParseAzureResourceID(rs.Primary.Attributes["id"])
 		if err != nil {
 			return err
 		}
@@ -161,7 +162,7 @@ func testCheckAzureRMAutomationJobScheduleExists(resourceName string) resource.T
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		id, err := parseAzureResourceID(rs.Primary.Attributes["id"])
+		id, err := azure.ParseAzureResourceID(rs.Primary.Attributes["id"])
 		if err != nil {
 			return err
 		}

--- a/azurerm/resource_arm_bastion_host.go
+++ b/azurerm/resource_arm_bastion_host.go
@@ -181,7 +181,7 @@ func resourceArmBastionHostDelete(d *schema.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_bastion_host.go
+++ b/azurerm/resource_arm_bastion_host.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -93,7 +94,7 @@ func resourceArmBastionHostCreateUpdate(d *schema.ResourceData, meta interface{}
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
-	if requireResourcesToBeImported && d.IsNewResource() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_bastion_host.go
+++ b/azurerm/resource_arm_bastion_host.go
@@ -91,7 +91,7 @@ func resourceArmBastionHostCreateUpdate(d *schema.ResourceData, meta interface{}
 	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
 	location := azure.NormalizeLocation(d.Get("location").(string))
-	tags := d.Get("tags").(map[string]interface{})
+	t := d.Get("tags").(map[string]interface{})
 
 	if requireResourcesToBeImported && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, name)
@@ -111,7 +111,7 @@ func resourceArmBastionHostCreateUpdate(d *schema.ResourceData, meta interface{}
 		BastionHostPropertiesFormat: &network.BastionHostPropertiesFormat{
 			IPConfigurations: expandArmBastionHostIPConfiguration(d.Get("ip_configuration").([]interface{})),
 		},
-		Tags: expandTags(tags),
+		Tags: tags.Expand(t),
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters)

--- a/azurerm/resource_arm_front_door.go
+++ b/azurerm/resource_arm_front_door.go
@@ -596,7 +596,7 @@ func resourceArmFrontDoorRead(d *schema.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -668,7 +668,7 @@ func resourceArmFrontDoorDelete(d *schema.ResourceData, meta interface{}) error 
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -1409,7 +1409,7 @@ func flattenArmFrontDoorSubResource(input *frontdoor.SubResource, resourceType s
 	name := ""
 
 	if id := input.ID; id != nil {
-		aid, err := parseAzureResourceID(*id)
+		aid, err := azure.ParseAzureResourceID(*id)
 		if err != nil {
 			return ""
 		}

--- a/azurerm/resource_arm_front_door_firewall_policy.go
+++ b/azurerm/resource_arm_front_door_firewall_policy.go
@@ -395,7 +395,7 @@ func resourceArmFrontDoorFirewallPolicyRead(d *schema.ResourceData, meta interfa
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -449,7 +449,7 @@ func resourceArmFrontDoorFirewallPolicyDelete(d *schema.ResourceData, meta inter
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_healthcare_service.go
+++ b/azurerm/resource_arm_healthcare_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -173,7 +174,7 @@ func resourceArmHealthcareServiceCreateUpdate(d *schema.ResourceData, meta inter
 	kind := d.Get("kind").(string)
 	cdba := int32(d.Get("cosmosdb_throughput").(int))
 
-	if requireResourcesToBeImported && d.IsNewResource() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resGroup, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_healthcare_service.go
+++ b/azurerm/resource_arm_healthcare_service.go
@@ -276,8 +276,6 @@ func resourceArmHealthcareServiceRead(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	flattenAndSetTags(d, resp.Tags)
-
 	return tags.FlattenAndSet(d, resp.Tags)
 }
 

--- a/azurerm/resource_arm_healthcare_service.go
+++ b/azurerm/resource_arm_healthcare_service.go
@@ -168,8 +168,7 @@ func resourceArmHealthcareServiceCreateUpdate(d *schema.ResourceData, meta inter
 	resGroup := d.Get("resource_group_name").(string)
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
-	tags := d.Get("tags").(map[string]interface{})
-	expandedTags := expandTags(tags)
+	t := d.Get("tags").(map[string]interface{})
 
 	kind := d.Get("kind").(string)
 	cdba := int32(d.Get("cosmosdb_throughput").(int))
@@ -189,7 +188,7 @@ func resourceArmHealthcareServiceCreateUpdate(d *schema.ResourceData, meta inter
 
 	healthcareServiceDescription := healthcareapis.ServicesDescription{
 		Location: utils.String(location),
-		Tags:     expandedTags,
+		Tags:     tags.Expand(t),
 		Kind:     healthcareapis.Kind(kind),
 		Properties: &healthcareapis.ServicesProperties{
 			AccessPolicies: expandAzureRMhealthcareapisAccessPolicyEntries(d),

--- a/azurerm/resource_arm_healthcare_service.go
+++ b/azurerm/resource_arm_healthcare_service.go
@@ -227,7 +227,7 @@ func resourceArmHealthcareServiceRead(d *schema.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func resourceArmHealthcareServiceDelete(d *schema.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return fmt.Errorf("Error Parsing Azure Resource ID: %+v", err)
 	}

--- a/azurerm/resource_arm_healthcare_service.go
+++ b/azurerm/resource_arm_healthcare_service.go
@@ -152,7 +152,7 @@ func resourceArmHealthcareService() *schema.Resource {
 				},
 			},
 
-			"tags": tagsSchema(),
+			"tags": tags.Schema(),
 		},
 	}
 }

--- a/azurerm/resource_arm_iothub_endpoint_eventhub.go
+++ b/azurerm/resource_arm_iothub_endpoint_eventhub.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -117,7 +118,7 @@ func resourceArmIotHubEndpointEventHubCreateUpdate(d *schema.ResourceData, meta 
 	for _, existingEndpoint := range *routing.Endpoints.EventHubs {
 		if existingEndpointName := existingEndpoint.Name; existingEndpointName != nil {
 			if strings.EqualFold(*existingEndpointName, endpointName) {
-				if d.IsNewResource() && requireResourcesToBeImported {
+				if d.IsNewResource() && features.ShouldResourcesBeImported() {
 					return tf.ImportAsExistsError("azurerm_iothub_endpoint_eventhub", resourceId)
 				}
 				endpoints = append(endpoints, eventhubEndpoint)

--- a/azurerm/resource_arm_iothub_endpoint_eventhub.go
+++ b/azurerm/resource_arm_iothub_endpoint_eventhub.go
@@ -153,7 +153,7 @@ func resourceArmIotHubEndpointEventHubRead(d *schema.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -193,7 +193,7 @@ func resourceArmIotHubEndpointEventHubDelete(d *schema.ResourceData, meta interf
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_iothub_endpoint_eventhub_test.go
+++ b/azurerm/resource_arm_iothub_endpoint_eventhub_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -37,7 +38,7 @@ func TestAccAzureRMIotHubEndpointEventHub_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubEndpointEventHub_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_queue.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_queue.go
@@ -154,7 +154,7 @@ func resourceArmIotHubEndpointServiceBusQueueRead(d *schema.ResourceData, meta i
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 
 	if err != nil {
 		return err
@@ -195,7 +195,7 @@ func resourceArmIotHubEndpointServiceBusQueueDelete(d *schema.ResourceData, meta
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 
 	if err != nil {
 		return err

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_queue.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -117,7 +118,7 @@ func resourceArmIotHubEndpointServiceBusQueueCreateUpdate(d *schema.ResourceData
 	for _, existingEndpoint := range *routing.Endpoints.ServiceBusQueues {
 		if existingEndpointName := existingEndpoint.Name; existingEndpointName != nil {
 			if strings.EqualFold(*existingEndpointName, endpointName) {
-				if d.IsNewResource() && requireResourcesToBeImported {
+				if d.IsNewResource() && features.ShouldResourcesBeImported() {
 					return tf.ImportAsExistsError("azurerm_iothub_endpoint_servicebus_queue", resourceId)
 				}
 				endpoints = append(endpoints, queueEndpoint)

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_queue_test.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_queue_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -37,7 +38,7 @@ func TestAccAzureRMIotHubEndpointServiceBusQueue_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubEndpointServiceBusQueue_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_topic.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_topic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -117,7 +118,7 @@ func resourceArmIotHubEndpointServiceBusTopicCreateUpdate(d *schema.ResourceData
 	for _, existingEndpoint := range *routing.Endpoints.ServiceBusTopics {
 		if existingEndpointName := existingEndpoint.Name; existingEndpointName != nil {
 			if strings.EqualFold(*existingEndpointName, endpointName) {
-				if d.IsNewResource() && requireResourcesToBeImported {
+				if d.IsNewResource() && features.ShouldResourcesBeImported() {
 					return tf.ImportAsExistsError("azurerm_iothub_endpoint_servicebus_topic", resourceId)
 				}
 				endpoints = append(endpoints, topicEndpoint)

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_topic.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_topic.go
@@ -154,7 +154,7 @@ func resourceArmIotHubEndpointServiceBusTopicRead(d *schema.ResourceData, meta i
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 
 	if err != nil {
 		return err
@@ -195,7 +195,7 @@ func resourceArmIotHubEndpointServiceBusTopicDelete(d *schema.ResourceData, meta
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 
 	if err != nil {
 		return err

--- a/azurerm/resource_arm_iothub_endpoint_servicebus_topic_test.go
+++ b/azurerm/resource_arm_iothub_endpoint_servicebus_topic_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -37,7 +38,7 @@ func TestAccAzureRMIotHubEndpointServiceBusTopic_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubEndpointServiceBusTopic_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_endpoint_storage_container.go
+++ b/azurerm/resource_arm_iothub_endpoint_storage_container.go
@@ -203,7 +203,7 @@ func resourceArmIotHubEndpointStorageContainerRead(d *schema.ResourceData, meta 
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func resourceArmIotHubEndpointStorageContainerDelete(d *schema.ResourceData, met
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubEndpointId, err := parseAzureResourceID(d.Id())
+	parsedIothubEndpointId, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_iothub_endpoint_storage_container.go
+++ b/azurerm/resource_arm_iothub_endpoint_storage_container.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -166,7 +167,7 @@ func resourceArmIotHubEndpointStorageContainerCreateUpdate(d *schema.ResourceDat
 	for _, existingEndpoint := range *routing.Endpoints.StorageContainers {
 		if existingEndpointName := existingEndpoint.Name; existingEndpointName != nil {
 			if strings.EqualFold(*existingEndpointName, endpointName) {
-				if d.IsNewResource() && requireResourcesToBeImported {
+				if d.IsNewResource() && features.ShouldResourcesBeImported() {
 					return tf.ImportAsExistsError("azurerm_iothub_endpoint_storage_container", resourceId)
 				}
 				endpoints = append(endpoints, storageContainerEndpoint)

--- a/azurerm/resource_arm_iothub_endpoint_storage_container_test.go
+++ b/azurerm/resource_arm_iothub_endpoint_storage_container_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -41,7 +42,7 @@ func TestAccAzureRMIotHubEndpointStorageContainer_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubEndpointStorageContainer_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_fallback_route.go
+++ b/azurerm/resource_arm_iothub_fallback_route.go
@@ -8,6 +8,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -87,7 +88,7 @@ func resourceArmIotHubFallbackRouteCreateUpdate(d *schema.ResourceData, meta int
 	}
 
 	resourceId := fmt.Sprintf("%s/FallbackRoute/defined", *iothub.ID)
-	if d.IsNewResource() && routing.FallbackRoute != nil && requireResourcesToBeImported {
+	if d.IsNewResource() && routing.FallbackRoute != nil && features.ShouldResourcesBeImported() {
 		return tf.ImportAsExistsError("azurerm_iothub_fallback_route", resourceId)
 	}
 

--- a/azurerm/resource_arm_iothub_fallback_route.go
+++ b/azurerm/resource_arm_iothub_fallback_route.go
@@ -117,7 +117,7 @@ func resourceArmIotHubFallbackRouteRead(d *schema.ResourceData, meta interface{}
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubRouteId, err := parseAzureResourceID(d.Id())
+	parsedIothubRouteId, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func resourceArmIotHubFallbackRouteDelete(d *schema.ResourceData, meta interface
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubRouteId, err := parseAzureResourceID(d.Id())
+	parsedIothubRouteId, err := azure.ParseAzureResourceID(d.Id())
 
 	if err != nil {
 		return err

--- a/azurerm/resource_arm_iothub_fallback_route_test.go
+++ b/azurerm/resource_arm_iothub_fallback_route_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -38,7 +39,7 @@ func TestAccAzureRMIotHubFallbackRoute_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubFallbackRoute_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_iothub_route.go
+++ b/azurerm/resource_arm_iothub_route.go
@@ -173,7 +173,7 @@ func resourceArmIotHubRouteRead(d *schema.ResourceData, meta interface{}) error 
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubRouteId, err := parseAzureResourceID(d.Id())
+	parsedIothubRouteId, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func resourceArmIotHubRouteDelete(d *schema.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	parsedIothubRouteId, err := parseAzureResourceID(d.Id())
+	parsedIothubRouteId, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_iothub_route.go
+++ b/azurerm/resource_arm_iothub_route.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -135,7 +136,7 @@ func resourceArmIotHubRouteCreateUpdate(d *schema.ResourceData, meta interface{}
 	for _, existingRoute := range *routing.Routes {
 		if existingRoute.Name != nil {
 			if strings.EqualFold(*existingRoute.Name, routeName) {
-				if d.IsNewResource() && requireResourcesToBeImported {
+				if d.IsNewResource() && features.ShouldResourcesBeImported() {
 					return tf.ImportAsExistsError("azurerm_iothub_route", resourceId)
 				}
 				routes = append(routes, route)

--- a/azurerm/resource_arm_iothub_route_test.go
+++ b/azurerm/resource_arm_iothub_route_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -39,7 +40,7 @@ func TestAccAzureRMIotHubRoute_basic(t *testing.T) {
 }
 
 func TestAccAzureRMIotHubRoute_requiresImport(t *testing.T) {
-	if !requireResourcesToBeImported {
+	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return
 	}

--- a/azurerm/resource_arm_kubernetes_cluster_node_pool.go
+++ b/azurerm/resource_arm_kubernetes_cluster_node_pool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -171,7 +172,7 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 		return fmt.Errorf("The Default Node Pool for Kubernetes Cluster %q (Resource Group %q) must be a VirtualMachineScaleSet to attach multiple node pools!", clusterName, resourceGroup)
 	}
 
-	if requireResourcesToBeImported && d.IsNewResource() {
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := poolsClient.Get(ctx, resourceGroup, clusterName, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/azurerm/resource_arm_private_dns_zone_virtual_network_link.go
+++ b/azurerm/resource_arm_private_dns_zone_virtual_network_link.go
@@ -139,7 +139,7 @@ func resourceArmPrivateDnsZoneVirtualNetworkLinkRead(d *schema.ResourceData, met
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,7 @@ func resourceArmPrivateDnsZoneVirtualNetworkLinkDelete(d *schema.ResourceData, m
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := parseAzureResourceID(d.Id())
+	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_storage_management_policy.go
+++ b/azurerm/resource_arm_storage_management_policy.go
@@ -139,7 +139,7 @@ func resourceArmStorageManagementPolicyCreateOrUpdate(d *schema.ResourceData, me
 
 	storageAccountId := d.Get("storage_account_id").(string)
 
-	rid, err := parseAzureResourceID(storageAccountId)
+	rid, err := azure.ParseAzureResourceID(storageAccountId)
 	if err != nil {
 		return err
 	}
@@ -186,7 +186,7 @@ func resourceArmStorageManagementPolicyRead(d *schema.ResourceData, meta interfa
 
 	id := d.Id()
 
-	rid, err := parseAzureResourceID(id)
+	rid, err := azure.ParseAzureResourceID(id)
 	if err != nil {
 		return err
 	}
@@ -198,6 +198,7 @@ func resourceArmStorageManagementPolicyRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
+	// TODO: switch this to look up the account and use that, rather than building this up
 	storageAccountID := "/subscriptions/" + rid.SubscriptionID + "/resourceGroups/" + rid.ResourceGroup + "/providers/" + rid.Provider + "/storageAccounts/" + storageAccountName
 	d.Set("storage_account_id", storageAccountID)
 
@@ -220,7 +221,7 @@ func resourceArmStorageManagementPolicyDelete(d *schema.ResourceData, meta inter
 
 	id := d.Id()
 
-	rid, err := parseAzureResourceID(id)
+	rid, err := azure.ParseAzureResourceID(id)
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_storage_management_policy_test.go
+++ b/azurerm/resource_arm_storage_management_policy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 )
@@ -263,7 +264,7 @@ func testCheckAzureRMStorageAccountManagementPolicyExists(resourceName string) r
 }
 
 func testCheckAzureRMStorageAccountManagementPolicyExistsInternal(storageAccountID string) (bool, error) {
-	rid, err := parseAzureResourceID(storageAccountID)
+	rid, err := azure.ParseAzureResourceID(storageAccountID)
 	if err != nil {
 		return false, fmt.Errorf("Bad: Failed to parse ID (id: %s): %+v", storageAccountID, err)
 	}


### PR DESCRIPTION
This PR removes usages of the top-level deprecated fields/functions:

* `flattenAndSetTags`
* `expandTags`
* `parseAzureResourceID`
* `tagsSchema`

It also removes these functions - since there's been sufficient time that the majority of open PR's have moved off of them, and unfortunately keeping them around much longer prevents some of the upcoming refactoring.