### PR TITLE
Healthcare resource. CORS block is fixed to avoid unnecessary diffs

### DIFF
--- a/azurerm/resource_arm_healthcare_service.go
+++ b/azurerm/resource_arm_healthcare_service.go
@@ -90,12 +90,13 @@ func resourceArmHealthcareService() *schema.Resource {
 			"cors_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allowed_origins": {
 							Type:     schema.TypeSet,
-							Required: true,
+							Optional: true,
 							MaxItems: 64,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
@@ -104,7 +105,7 @@ func resourceArmHealthcareService() *schema.Resource {
 						},
 						"allowed_headers": {
 							Type:     schema.TypeSet,
-							Required: true,
+							Optional: true,
 							MaxItems: 64,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
@@ -113,7 +114,7 @@ func resourceArmHealthcareService() *schema.Resource {
 						},
 						"allowed_methods": {
 							Type:     schema.TypeList,
-							Required: true,
+							Optional: true,
 							MaxItems: 64,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
@@ -132,8 +133,8 @@ func resourceArmHealthcareService() *schema.Resource {
 						},
 						"max_age_in_seconds": {
 							Type:         schema.TypeInt,
-							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 2000000000),
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 2000000000),
 						},
 						"allow_credentials": {
 							Type:     schema.TypeBool,
@@ -264,8 +265,6 @@ func resourceArmHealthcareServiceRead(d *schema.ResourceData, meta interface{}) 
 			}
 		}
 	}
-
-	flattenAndSetTags(d, resp.Tags)
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }


### PR DESCRIPTION
The issue is that default CORS values are create in Azure, even if none are specified in the TF script. If none are specified in the TF script then any TF plan or apply will see that there is a CORS Configuration and want to delete it accordingly, since it's not in the script.