### PR TITLE
r/front_door: Fix typos in doc

### DIFF
--- a/website/docs/r/front_door.html.markdown
+++ b/website/docs/r/front_door.html.markdown
@@ -193,7 +193,7 @@ The `forwarding_configuration` block supports the following:
 
 * `custom_forwarding_path` - (Optional) Path to use when constructing the request to forward to the backend. This functions as a URL Rewrite. Default behavior preserves the URL path.
 
-* `forwarding_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HTTPOnly`, `HTTPSOnly`, or `MatchRequest`. Defaults to `MatchRequest`.
+* `forwarding_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HttpOnly`, `HttpsOnly`, or `MatchRequest`. Defaults to `MatchRequest`.
 
 ---
 
@@ -201,7 +201,7 @@ The `redirect_configuration` block supports the following:
 
 * `custom_host` - (Optional)  Set this to change the URL for the redirection. 
 
-* `redirect_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HTTPOnly`, `HTTPSOnly`, `MatchRequest`. Defaults to `MatchRequest`
+* `redirect_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HttpOnly`, `HttpsOnly`, `MatchRequest`. Defaults to `MatchRequest`
 
 * `redirect_type` - (Optional) Status code for the redirect. Valida options are `Moved`, `Found`, `TemporaryRedirect`, `PermanentRedirect`. Defaults to `Found`
 


### PR DESCRIPTION
HTTPOnly -> HttpOnly
HTTPSOnly -> HttpsOnly

They're `HTTPOnly`, `HTTPSOnly` and `MatchRequest` as go consts, but `HttpOnly`, `HttpsOnly` and `MatchRequest` as string literals.

Ref:
* https://github.com/terraform-providers/terraform-provider-azurerm/blob/v1.37.0/vendor/github.com/Azure/azure-sdk-for-go/services/frontdoor/mgmt/2019-04-01/frontdoor/models.go#L226-L233
* https://github.com/terraform-providers/terraform-provider-azurerm/blob/v1.37.0/vendor/github.com/Azure/azure-sdk-for-go/services/frontdoor/mgmt/2019-04-01/frontdoor/models.go#L439-L446
* https://github.com/terraform-providers/terraform-provider-azurerm/blob/v1.37.0/azurerm/resource_arm_front_door.go#L142-L150
* https://github.com/terraform-providers/terraform-provider-azurerm/blob/v1.37.0/azurerm/resource_arm_front_door.go#L193-L202