### PR TITLE
Fix product api not reassigned on manual delete

### DIFF
--- a/azurerm/resource_arm_api_management_product_api.go
+++ b/azurerm/resource_arm_api_management_product_api.go
@@ -102,6 +102,14 @@ func resourceArmApiManagementProductApiRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error retrieving API %q / Product %q (API Management Service %q / Resource Group %q): %+v", apiName, productId, serviceName, resourceGroup, err)
 	}
 
+	// This can be removed once updated to apimanagement API to 2019-01-01
+	// https://github.com/Azure/azure-sdk-for-go/blob/master/services/apimanagement/mgmt/2019-01-01/apimanagement/productapi.go#L134
+	if utils.ResponseWasNotFound(resp) {
+		log.Printf("[DEBUG] API %q was not found in Product  %q (API Management Service %q / Resource Group %q) was not found - removing from state!", apiName, productId, serviceName, resourceGroup)
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("api_name", apiName)
 	d.Set("product_id", productId)
 	d.Set("resource_group_name", resourceGroup)


### PR DESCRIPTION
fixes #5002 

Due to behaviour changes in Azure apimanagement API, HTTP 404 response code was not considered an error in version 2018-01-01 and is now considered an error in 2019-01-01. To fix the behavior in the currently used API version, we need to also check for ResponseWasNotFound, when the CheckEntityExists produces no error.
