### PR TITLE
`azurerm_application_gateway` - Fixes crash when using an empty body for probe match

### DIFF
--- a/azurerm/resource_arm_application_gateway.go
+++ b/azurerm/resource_arm_application_gateway.go
@@ -2619,18 +2619,20 @@ func expandApplicationGatewayProbes(d *schema.ResourceData) *[]network.Applicati
 
 		matchConfigs := v["match"].([]interface{})
 		if len(matchConfigs) > 0 {
-			match := matchConfigs[0].(map[string]interface{})
-			matchBody := match["body"].(string)
+			matchBody := ""
+			outputMatch := &network.ApplicationGatewayProbeHealthResponseMatch{}
+			if matchConfigs[0] != nil {
+				match := matchConfigs[0].(map[string]interface{})
+				matchBody = match["body"].(string)
 
-			statusCodes := make([]string, 0)
-			for _, statusCode := range match["status_code"].([]interface{}) {
-				statusCodes = append(statusCodes, statusCode.(string))
+				statusCodes := make([]string, 0)
+				for _, statusCode := range match["status_code"].([]interface{}) {
+					statusCodes = append(statusCodes, statusCode.(string))
+				}
+				outputMatch.StatusCodes = &statusCodes
 			}
-
-			output.ApplicationGatewayProbePropertiesFormat.Match = &network.ApplicationGatewayProbeHealthResponseMatch{
-				Body:        utils.String(matchBody),
-				StatusCodes: &statusCodes,
-			}
+			outputMatch.Body = utils.String(matchBody)
+			output.ApplicationGatewayProbePropertiesFormat.Match = outputMatch
 		}
 
 		results = append(results, output)

--- a/azurerm/resource_arm_application_gateway_test.go
+++ b/azurerm/resource_arm_application_gateway_test.go
@@ -538,6 +538,30 @@ func TestAccAzureRMApplicationGateway_probes(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApplicationGateway_probesEmptyMatch(t *testing.T) {
+	resourceName := "azurerm_application_gateway.test"
+	ri := tf.AccRandTimeInt()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMApplicationGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApplicationGateway_probesEmptyMatch(ri, testLocation()),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationGatewayExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMApplicationGateway_probesPickHostNameFromBackendHTTPSettings(t *testing.T) {
 	resourceName := "azurerm_application_gateway.test"
 	ri := tf.AccRandTimeInt()
@@ -2692,6 +2716,112 @@ resource "azurerm_application_gateway" "test" {
     timeout             = 120
     interval            = 300
     unhealthy_threshold = 8
+  }
+
+  http_listener {
+    name                           = "${local.listener_name}"
+    frontend_ip_configuration_name = "${local.frontend_ip_configuration_name}"
+    frontend_port_name             = "${local.frontend_port_name}"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "${local.request_routing_rule_name}"
+    rule_type                  = "Basic"
+    http_listener_name         = "${local.listener_name}"
+    backend_address_pool_name  = "${local.backend_address_pool_name}"
+    backend_http_settings_name = "${local.http_setting_name}"
+  }
+}
+`, template, rInt)
+}
+
+func testAccAzureRMApplicationGateway_probesEmptyMatch(rInt int, location string) string {
+	template := testAccAzureRMApplicationGateway_template(rInt, location)
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  probe1_name                    = "${azurerm_virtual_network.test.name}-probe1"
+  probe2_name                    = "${azurerm_virtual_network.test.name}-probe2"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+
+  sku {
+    name     = "Standard_Small"
+    tier     = "Standard"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  frontend_port {
+    name = "${local.frontend_port_name}"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "${local.frontend_ip_configuration_name}"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
+
+  backend_address_pool {
+    name = "${local.backend_address_pool_name}"
+  }
+
+  backend_http_settings {
+    name                  = "${local.http_setting_name}"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    probe_name            = "${local.probe1_name}"
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  backend_http_settings {
+    name                  = "${local.http_setting_name}-2"
+    cookie_based_affinity = "Disabled"
+    port                  = 8080
+    probe_name            = "${local.probe2_name}"
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  probe {
+    name                = "${local.probe1_name}"
+    protocol            = "Http"
+    path                = "/test"
+    host                = "azure.com"
+    timeout             = 120
+    interval            = 300
+    unhealthy_threshold = 8
+  }
+
+  probe {
+    name                = "${local.probe2_name}"
+    protocol            = "Http"
+    path                = "/other"
+    host                = "azure.com"
+    timeout             = 120
+    interval            = 300
+    unhealthy_threshold = 8
+    match {
+      body = ""
+    }
   }
 
   http_listener {


### PR DESCRIPTION
Fixes #4772

```
--- PASS: TestAccAzureRMApplicationGateway_probes (1265.09s)
--- PASS: TestAccAzureRMApplicationGateway_probesEmptyMatch (1340.66s)
--- PASS: TestAccAzureRMApplicationGateway_probesPickHostNameFromBackendHTTPSettings (1374.74s)
```