### PR TITLE
resource_arm_virtual_machine.go: Add read and update support for license_type.

### DIFF
--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -159,13 +159,13 @@ func resourceArmVirtualMachine() *schema.Resource {
 			},
 
 			"license_type": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: suppress.CaseDifference,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "None",
 				ValidateFunc: validation.StringInSlice([]string{
 					"Windows_Client",
 					"Windows_Server",
+					"None",
 				}, true),
 			},
 

--- a/azurerm/resource_arm_virtual_machine.go
+++ b/azurerm/resource_arm_virtual_machine.go
@@ -912,6 +912,10 @@ func resourceArmVirtualMachineRead(d *schema.ResourceData, meta interface{}) err
 				}
 			}
 		}
+
+		if licenseType := props.LicenseType; licenseType != nil {
+			d.Set("license_type", licenseType)
+		}
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -131,7 +131,7 @@ The following arguments are supported:
 
 * `identity` - (Optional) A `identity` block.
 
-* `license_type` - (Optional) Specifies the BYOL Type for this Virtual Machine. This is only applicable to Windows Virtual Machines. Possible values are `Windows_Client` and `Windows_Server`.
+* `license_type` - (Optional) Specifies the BYOL Type for this Virtual Machine. This is only applicable to Windows Virtual Machines. Possible values are `Windows_Client`, `Windows_Server` and `None`. Defaults to `None`.
 
 * `os_profile` - (Optional) An `os_profile` block. Required when `create_option` in the `storage_os_disk` block is set to `FromImage`.
 


### PR DESCRIPTION
At the moment `license_type` was not read and refreshed. This PR adds read support for this attribute.

Furthermore you could only set `license_type` to one of `Windows_Client` or `Windows_Server` but not back to the default. The Azure API uses `None` as default so it should be used in Terraform as well. This allows you to switch back.