### PR TITLE
azurerm_subnet - make `network_security_group_id` as computed

### DIFF
--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -60,6 +60,7 @@ func resourceArmSubnet() *schema.Resource {
 			"network_security_group_id": {
 				Type:       schema.TypeString,
 				Optional:   true,
+				Computed:   true,
 				Deprecated: "Use the `azurerm_subnet_network_security_group_association` resource instead.",
 			},
 

--- a/azurerm/resource_arm_subnet_network_security_group_association_test.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association_test.go
@@ -236,7 +236,6 @@ resource "azurerm_subnet" "test" {
   resource_group_name       = "${azurerm_resource_group.test.name}"
   virtual_network_name      = "${azurerm_virtual_network.test.name}"
   address_prefix            = "10.0.2.0/24"
-  network_security_group_id = "${azurerm_network_security_group.test.id}"
 }
 
 resource "azurerm_network_security_group" "test" {


### PR DESCRIPTION
when use `azurerm_subnet_network_security_group_association` without `network_security_group_id` in subnet, 
first terraform apply, everything is OK
but terraform plan will show `network_security_group_id` state is not consistent, and the second time terraform apply, the terraform will set subnet network security group null

Though `network_security_group_id` is a deprecated field and will be removed soon, but currently I think it's better for fix the bug

(fixes #4983)