### PR TITLE
`azurerm_function_app` - support for `min_tls_version`

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -222,6 +222,15 @@ func resourceArmFunctionApp() *schema.Resource {
 							Optional: true,
 							Default:  false,
 						},
+						"min_tls_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.OneFullStopOne),
+								string(web.OneFullStopTwo),
+								string(web.OneFullStopZero),
+							}, true),
+						},
 						"cors": azure.SchemaWebCorsSettings(),
 					},
 				},
@@ -722,6 +731,10 @@ func expandFunctionAppSiteConfig(d *schema.ResourceData) web.SiteConfig {
 		siteConfig.HTTP20Enabled = utils.Bool(v.(bool))
 	}
 
+	if v, ok := config["min_tls_version"]; ok {
+		siteConfig.MinTLSVersion = web.SupportedTLSVersions(v.(string))
+	}
+
 	return siteConfig
 }
 
@@ -757,6 +770,8 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 	if input.HTTP20Enabled != nil {
 		result["http2_enabled"] = *input.HTTP20Enabled
 	}
+
+	result["min_tls_version"] = string(input.MinTLSVersion)
 
 	result["cors"] = azure.FlattenWebCorsSettings(input.Cors)
 

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -225,11 +225,12 @@ func resourceArmFunctionApp() *schema.Resource {
 						"min_tls_version": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ValidateFunc: validation.StringInSlice([]string{
+								string(web.OneFullStopZero),
 								string(web.OneFullStopOne),
 								string(web.OneFullStopTwo),
-								string(web.OneFullStopZero),
-							}, true),
+							}, false),
 						},
 						"cors": azure.SchemaWebCorsSettings(),
 					},

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -721,6 +721,33 @@ func TestAccAzureRMFunctionApp_enableHttp2(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFunctionApp_minTlsVersion(t *testing.T) {
+	resourceName := "azurerm_function_app.test"
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := testAccAzureRMFunctionApp_minTlsVersion(ri, rs, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFunctionAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.min_tls_version", "1.2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMFunctionAppDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).Web.AppServicesClient
 
@@ -1737,6 +1764,46 @@ resource "azurerm_function_app" "test" {
 
   site_config {
     http2_enabled = true
+  }
+}
+`, rInt, location, rString, rInt, rInt)
+}
+
+func testAccAzureRMFunctionApp_minTlsVersion(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                      = "acctest-%d-func"
+  location                  = "${azurerm_resource_group.test.location}"
+  resource_group_name       = "${azurerm_resource_group.test.name}"
+  app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+  storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+
+  site_config {
+    min_tls_version = "1.2"
   }
 }
 `, rInt, location, rString, rInt, rInt)

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -149,7 +149,7 @@ The following arguments are supported:
 
 * `http2_enabled` - (Optional) Specifies whether or not the http2 protocol should be enabled. Defaults to `false`.
 
-* `min_tls_version` - (Optional) The minimum supported TLS version. Possible values are `1.0`, `1.1`, and `1.2`.
+* `min_tls_version` - (Optional) The minimum supported TLS version for the function app. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new function apps.
 
 * `cors` - (Optional) A `cors` block as defined below.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -149,6 +149,8 @@ The following arguments are supported:
 
 * `http2_enabled` - (Optional) Specifies whether or not the http2 protocol should be enabled. Defaults to `false`.
 
+* `min_tls_version` - (Optional) The minimum supported TLS version. Possible values are `1.0`, `1.1`, and `1.2`.
+
 * `cors` - (Optional) A `cors` block as defined below.
 
 ---
@@ -179,7 +181,7 @@ An `auth_settings` block supports the following:
 
 * `default_provider` - (Optional) The default provider to use when multiple providers have been set up. Possible values are `AzureActiveDirectory`, `Facebook`, `Google`, `MicrosoftAccount` and `Twitter`.
 
-~> **NOTE:** When using multiple providers, the default provider must be set for settings like `unauthenticated_client_action` to work. 
+~> **NOTE:** When using multiple providers, the default provider must be set for settings like `unauthenticated_client_action` to work.
 
 * `facebook` - (Optional) A `facebook` block as defined below.
 


### PR DESCRIPTION
Fixes: #3740

Adds the `min_tls_version` option to the `azurerm_function_app` resource.

```
=== RUN   TestAccAzureRMFunctionApp_minTlsVersion
=== PAUSE TestAccAzureRMFunctionApp_minTlsVersion
=== CONT  TestAccAzureRMFunctionApp_minTlsVersion
--- PASS: TestAccAzureRMFunctionApp_minTlsVersion (222.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       222.803s
```