### PR TITLE
Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The AzureRM Provider supports Terraform 0.10.x and later - but Terraform 0.12.x 
 provider "azurerm" {
   # We recommend pinning to the specific version of the Azure Provider you're using
   # since new versions are released frequently
-  version = "=1.36.0"
+  version = "=1.38.0"
 
   # More information on the authentication methods supported by
   # the AzureRM Provider can be found here:

--- a/azurerm/data_source_nat_gateway.go
+++ b/azurerm/data_source_nat_gateway.go
@@ -58,19 +58,6 @@ func dataSourceArmNatGateway() *schema.Resource {
 				Computed: true,
 			},
 
-			"subnet_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-
-			"type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"zones": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -121,10 +108,6 @@ func dataSourceArmNatGatewayRead(d *schema.ResourceData, meta interface{}) error
 
 		if err := d.Set("public_ip_prefix_ids", flattenArmNatGatewaySubResourceID(props.PublicIPPrefixes)); err != nil {
 			return fmt.Errorf("Error setting `public_ip_prefix_ids`: %+v", err)
-		}
-
-		if err := d.Set("subnet_ids", flattenArmNatGatewaySubResourceID(props.Subnets)); err != nil {
-			return fmt.Errorf("Error setting `subnet_ids`: %+v", err)
 		}
 	}
 

--- a/azurerm/data_source_private_link_service.go
+++ b/azurerm/data_source_private_link_service.go
@@ -44,15 +44,6 @@ func dataSourceArmPrivateLinkService() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			// currently not implemented yet, timeline unknown, exact purpose unknown, maybe coming to a future API near you
-			// "fqdns": {
-			// 	Type:     schema.TypeList,
-			// 	Computed: true,
-			// 	Elem: &schema.Schema{
-			// 		Type: schema.TypeString,
-			// 	},
-			// },
-
 			"nat_ip_configuration": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -95,9 +86,10 @@ func dataSourceArmPrivateLinkService() *schema.Resource {
 			},
 
 			"network_interface_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:       schema.TypeList,
+				Computed:   true,
+				Deprecated: "This field has been deprecated and will be removed in version 2.0 of the Azure Provider",
+				Elem:       &schema.Schema{Type: schema.TypeString},
 			},
 
 			"tags": tags.SchemaDataSource(),

--- a/azurerm/data_source_private_link_service_test.go
+++ b/azurerm/data_source_private_link_service_test.go
@@ -30,7 +30,6 @@ func TestAccDataSourceAzureRMPrivateLinkService_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "auto_approval_subscription_ids.0", subscriptionId),
 					resource.TestCheckResourceAttr(dataSourceName, "visibility_subscription_ids.0", subscriptionId),
 					resource.TestCheckResourceAttr(dataSourceName, "load_balancer_frontend_ip_configuration_ids.#", "1"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "network_interface_ids.0"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "load_balancer_frontend_ip_configuration_ids.0"),
 				),
 			},

--- a/azurerm/resource_arm_nat_gateway.go
+++ b/azurerm/resource_arm_nat_gateway.go
@@ -69,22 +69,13 @@ func resourceArmNatGateway() *schema.Resource {
 			"sku_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  string(network.Standard),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(network.Standard),
 				}, false),
-				Default: string(network.Standard),
 			},
 
 			"zones": azure.SchemaZones(),
-
-			"subnet_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: azure.ValidateResourceID,
-				},
-			},
 
 			"resource_guid": {
 				Type:     schema.TypeString,
@@ -195,10 +186,6 @@ func resourceArmNatGatewayRead(d *schema.ResourceData, meta interface{}) error {
 
 		if err := d.Set("public_ip_prefix_ids", flattenArmNatGatewaySubResourceID(props.PublicIPPrefixes)); err != nil {
 			return fmt.Errorf("Error setting `public_ip_prefix_ids`: %+v", err)
-		}
-
-		if err := d.Set("subnet_ids", flattenArmNatGatewaySubResourceID(props.Subnets)); err != nil {
-			return fmt.Errorf("Error setting `subnet_ids`: %+v", err)
 		}
 	}
 

--- a/azurerm/resource_arm_private_link_service.go
+++ b/azurerm/resource_arm_private_link_service.go
@@ -71,16 +71,6 @@ func resourceArmPrivateLinkService() *schema.Resource {
 				Set: schema.HashString,
 			},
 
-			// currently not implemented yet, timeline unknown, exact purpose unknown, maybe coming to a future API near you
-			// "fqdns": {
-			// 	Type:     schema.TypeList,
-			// 	Optional: true,
-			// 	Elem: &schema.Schema{
-			// 		Type:         schema.TypeString,
-			// 		ValidateFunc: validate.NoEmptyStrings,
-			// 	},
-			// },
-
 			// Required by the API you can't create the resource without at least
 			// one ip configuration once primary is set it is set forever unless
 			// you destroy the resource and recreate it.
@@ -125,9 +115,6 @@ func resourceArmPrivateLinkService() *schema.Resource {
 				},
 			},
 
-			// private_endpoint_connections have been removed and placed inside the
-			// azurerm_private_link_service_endpoint_connections datasource.
-
 			// Required by the API you can't create the resource without at least one load balancer id
 			"load_balancer_frontend_ip_configuration_ids": {
 				Type:     schema.TypeSet,
@@ -145,8 +132,9 @@ func resourceArmPrivateLinkService() *schema.Resource {
 			},
 
 			"network_interface_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Computed:   true,
+				Deprecated: "This field is deprecated and be removed in version 2.0 of the Azure Provider",
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: azure.ValidateResourceID,
@@ -188,26 +176,23 @@ func resourceArmPrivateLinkServiceCreateUpdate(d *schema.ResourceData, meta inte
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
-	autoApproval := d.Get("auto_approval_subscription_ids").(*schema.Set)
-	// currently not implemented yet, timeline unknown, exact purpose unknown, maybe coming to a future API near you
-	//fqdns := d.Get("fqdns").([]interface{})
+	autoApproval := d.Get("auto_approval_subscription_ids").(*schema.Set).List()
 	primaryIpConfiguration := d.Get("nat_ip_configuration").([]interface{})
-	loadBalancerFrontendIpConfigurations := d.Get("load_balancer_frontend_ip_configuration_ids").(*schema.Set)
-	visibility := d.Get("visibility_subscription_ids").(*schema.Set)
+	loadBalancerFrontendIpConfigurations := d.Get("load_balancer_frontend_ip_configuration_ids").(*schema.Set).List()
+	visibility := d.Get("visibility_subscription_ids").(*schema.Set).List()
 	t := d.Get("tags").(map[string]interface{})
 
 	parameters := network.PrivateLinkService{
 		Location: utils.String(location),
 		PrivateLinkServiceProperties: &network.PrivateLinkServiceProperties{
 			AutoApproval: &network.PrivateLinkServicePropertiesAutoApproval{
-				Subscriptions: utils.ExpandStringSlice(autoApproval.List()),
+				Subscriptions: utils.ExpandStringSlice(autoApproval),
 			},
 			Visibility: &network.PrivateLinkServicePropertiesVisibility{
-				Subscriptions: utils.ExpandStringSlice(visibility.List()),
+				Subscriptions: utils.ExpandStringSlice(visibility),
 			},
 			IPConfigurations:                     expandArmPrivateLinkServiceIPConfiguration(primaryIpConfiguration),
 			LoadBalancerFrontendIPConfigurations: expandArmPrivateLinkServiceFrontendIPConfiguration(loadBalancerFrontendIpConfigurations),
-			//Fqdns:                                utils.ExpandStringSlice(fqdns),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -235,11 +220,21 @@ func resourceArmPrivateLinkServiceCreateUpdate(d *schema.ResourceData, meta inte
 		Pending:    []string{"Pending", "Updating", "Creating"},
 		Target:     []string{"Succeeded"},
 		Refresh:    privateLinkServiceWaitForReadyRefreshFunc(ctx, client, resourceGroup, name),
-		Timeout:    60 * time.Minute,
 		MinTimeout: 15 * time.Second,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		if d.IsNewResource() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = d.Timeout(schema.TimeoutUpdate)
+		}
+	} else {
+		stateConf.Timeout = 60 * time.Minute
+	}
+
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for Private Link Service %q (Resource Group %q) to complete: %s", name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for Private Link Service %q (Resource Group %q) to become available: %s", name, resourceGroup, err)
 	}
 
 	d.SetId(*resp.ID)
@@ -281,18 +276,15 @@ func resourceArmPrivateLinkServiceRead(d *schema.ResourceData, meta interface{})
 		if err := d.Set("visibility_subscription_ids", utils.FlattenStringSlice(props.Visibility.Subscriptions)); err != nil {
 			return fmt.Errorf("Error setting `visibility_subscription_ids`: %+v", err)
 		}
-		// currently not implemented yet, timeline unknown, exact purpose unknown, maybe coming to a future API near you
-		// if props.Fqdns != nil {
-		// 	if err := d.Set("fqdns", utils.FlattenStringSlice(props.Fqdns)); err != nil {
-		// 		return fmt.Errorf("Error setting `fqdns`: %+v", err)
-		// 	}
-		// }
 		if err := d.Set("nat_ip_configuration", flattenArmPrivateLinkServiceIPConfiguration(props.IPConfigurations)); err != nil {
 			return fmt.Errorf("Error setting `nat_ip_configuration`: %+v", err)
 		}
+
 		if err := d.Set("load_balancer_frontend_ip_configuration_ids", flattenArmPrivateLinkServiceFrontendIPConfiguration(props.LoadBalancerFrontendIPConfigurations)); err != nil {
 			return fmt.Errorf("Error setting `load_balancer_frontend_ip_configuration_ids`: %+v", err)
 		}
+
+		// TODO: remove in 2.0
 		if err := d.Set("network_interface_ids", flattenArmPrivateLinkServiceInterface(props.NetworkInterfaces)); err != nil {
 			return fmt.Errorf("Error setting `network_interface_ids`: %+v", err)
 		}
@@ -323,7 +315,7 @@ func resourceArmPrivateLinkServiceDelete(d *schema.ResourceData, meta interface{
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("Error waiting for deleting Private Link Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error waiting for deletion of Private Link Service %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
 
@@ -358,9 +350,9 @@ func expandArmPrivateLinkServiceIPConfiguration(input []interface{}) *[]network.
 		}
 
 		if privateIpAddress != "" {
-			result.PrivateLinkServiceIPConfigurationProperties.PrivateIPAllocationMethod = network.IPAllocationMethod("Static")
+			result.PrivateLinkServiceIPConfigurationProperties.PrivateIPAllocationMethod = network.Static
 		} else {
-			result.PrivateLinkServiceIPConfigurationProperties.PrivateIPAllocationMethod = network.IPAllocationMethod("Dynamic")
+			result.PrivateLinkServiceIPConfigurationProperties.PrivateIPAllocationMethod = network.Dynamic
 		}
 
 		results = append(results, result)
@@ -369,15 +361,14 @@ func expandArmPrivateLinkServiceIPConfiguration(input []interface{}) *[]network.
 	return &results
 }
 
-func expandArmPrivateLinkServiceFrontendIPConfiguration(input *schema.Set) *[]network.FrontendIPConfiguration {
-	ids := input.List()
-	if len(ids) == 0 {
+func expandArmPrivateLinkServiceFrontendIPConfiguration(input []interface{}) *[]network.FrontendIPConfiguration {
+	if len(input) == 0 {
 		return nil
 	}
 
 	results := make([]network.FrontendIPConfiguration, 0)
 
-	for _, item := range ids {
+	for _, item := range input {
 		result := network.FrontendIPConfiguration{
 			ID: utils.String(item.(string)),
 		}
@@ -395,27 +386,39 @@ func flattenArmPrivateLinkServiceIPConfiguration(input *[]network.PrivateLinkSer
 	}
 
 	for _, item := range *input {
-		c := make(map[string]interface{})
-
-		if name := item.Name; name != nil {
-			c["name"] = *name
+		name := ""
+		if item.Name != nil {
+			name = *item.Name
 		}
+
+		privateIpAddress := ""
+		privateIpVersion := ""
+		subnetId := ""
+		primary := false
+
 		if props := item.PrivateLinkServiceIPConfigurationProperties; props != nil {
-			if v := props.PrivateIPAddress; v != nil {
-				c["private_ip_address"] = *v
+			if props.PrivateIPAddress != nil {
+				privateIpAddress = *props.PrivateIPAddress
 			}
-			c["private_ip_address_version"] = string(props.PrivateIPAddressVersion)
-			if v := props.Subnet; v != nil {
-				if i := v.ID; i != nil {
-					c["subnet_id"] = *i
-				}
+
+			privateIpVersion = string(props.PrivateIPAddressVersion)
+
+			if props.Subnet != nil && props.Subnet.ID != nil {
+				subnetId = *props.Subnet.ID
 			}
-			if v := props.Primary; v != nil {
-				c["primary"] = *v
+
+			if props.Primary != nil {
+				primary = *props.Primary
 			}
 		}
 
-		results = append(results, c)
+		results = append(results, map[string]interface{}{
+			"name":                       name,
+			"primary":                    primary,
+			"private_ip_address":         privateIpAddress,
+			"private_ip_address_version": privateIpVersion,
+			"subnet_id":                  subnetId,
+		})
 	}
 
 	return results

--- a/website/docs/d/api_management.html.markdown
+++ b/website/docs/d/api_management.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management"
 sidebar_current: "docs-azurerm-datasource-api-management-x"

--- a/website/docs/d/api_management_api.html.markdown
+++ b/website/docs/d/api_management_api.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api"
 sidebar_current: "docs-azurerm-datasource-azurerm-api-management-api-x"

--- a/website/docs/d/api_management_group.html.markdown
+++ b/website/docs/d/api_management_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_group"
 sidebar_current: "docs-azurerm-datasource-api-management-group"

--- a/website/docs/d/api_management_product.html.markdown
+++ b/website/docs/d/api_management_product.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_product"
 sidebar_current: "docs-azurerm-datasource-api-management-product"

--- a/website/docs/d/api_management_user.html.markdown
+++ b/website/docs/d/api_management_user.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_user"
 sidebar_current: "docs-azurerm-datasource-api-management-user"

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service"
 sidebar_current: "docs-azurerm-datasource-app-service-x"

--- a/website/docs/d/app_service_certificate.html.markdown
+++ b/website/docs/d/app_service_certificate.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_certificate"
 sidebar_current: "docs-azurerm-datasource-app-service-certificate"

--- a/website/docs/d/app_service_certificate_order.html.markdown
+++ b/website/docs/d/app_service_certificate_order.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_certificate_order"
 sidebar_current: "docs-azurerm-datasource-app-service-x"

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_plan"
 sidebar_current: "docs-azurerm-datasource-app-service-plan"

--- a/website/docs/d/application_insights.html.markdown
+++ b/website/docs/d/application_insights.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Application Insights"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_insights"
 sidebar_current: "docs-azurerm-datasource-application-insights"

--- a/website/docs/d/application_security_group.html.markdown
+++ b/website/docs/d/application_security_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_security_group"
 sidebar_current: "docs-azurerm-datasource-network-application-security-group"

--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_registration_info"
 sidebar_current: "docs-azurerm-datasource-automation-registration-info"

--- a/website/docs/d/automation_variable_bool.html.markdown
+++ b/website/docs/d/automation_variable_bool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_bool"
 sidebar_current: "docs-azurerm-datasource-automation-variable-bool"

--- a/website/docs/d/automation_variable_datetime.html.markdown
+++ b/website/docs/d/automation_variable_datetime.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_datetime"
 sidebar_current: "docs-azurerm-datasource-automation-variable-datetime"

--- a/website/docs/d/automation_variable_int.html.markdown
+++ b/website/docs/d/automation_variable_int.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_int"
 sidebar_current: "docs-azurerm-datasource-automation-variable-int"

--- a/website/docs/d/automation_variable_string.html.markdown
+++ b/website/docs/d/automation_variable_string.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_string"
 sidebar_current: "docs-azurerm-datasource-automation-variable-string"

--- a/website/docs/d/availability_set.html.markdown
+++ b/website/docs/d/availability_set.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_availability_set"
 sidebar_current: "docs-azurerm-datasource-availability-set"

--- a/website/docs/d/azuread_application.html.markdown
+++ b/website/docs/d/azuread_application.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Azure Active Directory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_application"
 sidebar_current: "docs-azurerm-datasource-azuread-application"

--- a/website/docs/d/azuread_service_principal.html.markdown
+++ b/website/docs/d/azuread_service_principal.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Azure Active Directory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_service_principal"
 sidebar_current: "docs-azurerm-datasource-azuread-service-principal"

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_account"
 sidebar_current: "docs-azurerm-datasource-batch-account"

--- a/website/docs/d/batch_certificate.html.markdown
+++ b/website/docs/d/batch_certificate.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_certificate"
 sidebar_current: "docs-azurerm-datasource-batch-certificate"

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_pool"
 sidebar_current: "docs-azurerm-datasource-batch-pool"

--- a/website/docs/d/builtin_role_definition.markdown
+++ b/website/docs/d/builtin_role_definition.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_builtin_role_definition"
 sidebar_current: "docs-azurerm-datasource-builtin-role-definition"

--- a/website/docs/d/cdn_profile.html.markdown
+++ b/website/docs/d/cdn_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_profile"
 sidebar_current: "docs-azurerm-datasource-cdn-profile"

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_client_config"
 sidebar_current: "docs-azurerm-datasource-client-config"

--- a/website/docs/d/container_registry.markdown
+++ b/website/docs/d/container_registry.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_container_registry"
 sidebar_current: "docs-azurerm-datasource-container-registry"

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_account"
 sidebar_current: "docs-azurerm-datasource-cosmosdb-account"

--- a/website/docs/d/data_factory.html.markdown
+++ b/website/docs/d/data_factory.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory"
 sidebar_current: "docs-azurerm-datasource-data-factory-x"

--- a/website/docs/d/data_lake_store.html.markdown
+++ b/website/docs/d/data_lake_store.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Data Lake"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_lake_store"
 sidebar_current: "docs-azurerm-datasource-data-lake-store"

--- a/website/docs/d/dev_test_lab.html.markdown
+++ b/website/docs/d/dev_test_lab.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_lab"
 sidebar_current: "docs-azurerm-datasource-dev-test-lab"

--- a/website/docs/d/dev_test_virtual_network.html.markdown
+++ b/website/docs/d/dev_test_virtual_network.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_virtual_network"
 sidebar_current: "docs-azurerm-datasource-dev-test-virtual-network"

--- a/website/docs/d/dns_zone.html.markdown
+++ b/website/docs/d/dns_zone.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_zone"
 sidebar_current: "docs-azurerm-datasource-dns-zone"

--- a/website/docs/d/eventhub_namespace.html.markdown
+++ b/website/docs/d/eventhub_namespace.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub_namespace"
 sidebar_current: "docs-azurerm-datasource-eventhub-namespace"

--- a/website/docs/d/express_route_circuit.html.markdown
+++ b/website/docs/d/express_route_circuit.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_express_route_circuit"
 sidebar_current: "docs-azurerm-datasource-express-route-circuit"

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_firewall"
 sidebar_current: "docs-azurerm-datasource-firewall"

--- a/website/docs/d/hdinsight_cluster.html.markdown
+++ b/website/docs/d/hdinsight_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_cluster"
 sidebar_current: "docs-azurerm-datasource-hdinsight-cluster"

--- a/website/docs/d/healthcare_service.html.markdown
+++ b/website/docs/d/healthcare_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Healthcare"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_healthcare_service"
 sidebar_current: "docs-azurerm-datasource-healthcare-service-x"
@@ -21,17 +21,7 @@ data "azurerm_healthcare_service" "example" {
 }
 
 output "healthcare_service_id" {
-  name                = "uniquefhirname"
-  resource_group_name = "sample-resource-group"
-  kind                = "fhir-R4"
-  cosmosdb_throughput = "2000"
-
-  access_policy_object_ids = ["xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"]
-
-  tags = {
-    "environment" = "testenv"
-    "purpose"     = "AcceptanceTests"
-  }
+  value = data.azurerm_healthcare_service.example.id
 }
 ```
 

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_image"
 sidebar_current: "docs-azurerm-datasource-image"

--- a/website/docs/d/key_vault.html.markdown
+++ b/website/docs/d/key_vault.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault"
 sidebar_current: "docs-azurerm-datasource-key-vault-x"

--- a/website/docs/d/key_vault_access_policy.html.markdown
+++ b/website/docs/d/key_vault_access_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_access_policy"
 sidebar_current: "docs-azurerm-datasource-key-vault-access-policy"

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_key"
 sidebar_current: "docs-azurerm-datasource-key-vault-key"

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_secret"
 sidebar_current: "docs-azurerm-datasource-key-vault-secret"

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_cluster"
 sidebar_current: "docs-azurerm-data-source-kubernetes-cluster"

--- a/website/docs/d/kubernetes_service_versions.html.markdown
+++ b/website/docs/d/kubernetes_service_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_service_versions"
 sidebar_current: "docs-azurerm-datasource-kubernetes-service-versions"

--- a/website/docs/d/loadbalancer.html.markdown
+++ b/website/docs/d/loadbalancer.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb"
 sidebar_current: "docs-azurerm-datasource-load-balancer-x"

--- a/website/docs/d/loadbalancer_backend_address_pool.html.markdown
+++ b/website/docs/d/loadbalancer_backend_address_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_backend_address_pool"
 sidebar_current: "docs-azurerm-datasource-load-balancer-backend-address-pool"

--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Log Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_log_analytics_workspace"
 sidebar_current: "docs-azurerm-datasource-oms-log-analytics-workspace"

--- a/website/docs/d/logic_app_workflow.html.markdown
+++ b/website/docs/d/logic_app_workflow.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_workflow"
 sidebar_current: "docs-azurerm-data-source-logic-app-workflow"

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_managed_disk"
 sidebar_current: "docs-azurerm-datasource-managed-disk"

--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_management_group"
 sidebar_current: "docs-azurerm-datasource-management-group"

--- a/website/docs/d/maps_account.html.markdown
+++ b/website/docs/d/maps_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Maps"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_maps_account"
 sidebar_current: "docs-azurerm-datasource-maps-account"

--- a/website/docs/d/monitor_action_group.html.markdown
+++ b/website/docs/d/monitor_action_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_action_group"
 sidebar_current: "docs-azurerm-datasource-monitor-action-group"

--- a/website/docs/d/monitor_diagnostic_categories.html.markdown
+++ b/website/docs/d/monitor_diagnostic_categories.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_diagnostic_categories"
 sidebar_current: "docs-azurerm-datasource-monitor-diagnostic-categories"

--- a/website/docs/d/monitor_log_profile.html.markdown
+++ b/website/docs/d/monitor_log_profile.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_log_profile"
 sidebar_current: "docs-azurerm-datasource-monitor-log-profile"

--- a/website/docs/d/mssql_elasticpool.html.markdown
+++ b/website/docs/d/mssql_elasticpool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mssql_elasticpool"
 sidebar_current: "docs-azurerm-datasource-mssql-elasticpool"

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Use this data source to access information about an existing NAT Gateway.
 
+-> **NOTE:** The Azure NAT Gateway service is currently in private preview. Your subscription must be on the NAT Gateway private preview whitelist for this resource to be provisioned correctly. If you attempt to provision this resource and receive an `InvalidResourceType` error may mean that your subscription is not part of the NAT Gateway private preview or you are using a region which does not yet support the NAT Gateway private preview service. The NAT Gateway private preview service is currently available in a limited set of regions. Private preview resources may have multiple breaking changes over their lifecycle until they GA. You can opt into the Private Preview by contacting your Microsoft Representative.
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nat_gateway"
 sidebar_current: "docs-azurerm-datasource-nat-gateway"

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -4,20 +4,20 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nat_gateway"
 sidebar_current: "docs-azurerm-datasource-nat-gateway"
 description: |-
-  Gets information about an existing Nat Gateway
+  Gets information about an existing NAT Gateway
 ---
 
 # Data Source: azurerm_nat_gateway
 
-Use this data source to access information about an existing Nat Gateway.
+Use this data source to access information about an existing NAT Gateway.
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The Name of the Resource Group where the Nat Gateway exists.
+* `name` - (Required) The Name of the Resource Group where the NAT Gateway exists.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Nat Gateway exists.
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the NAT Gateway exists.
 
 ## Attributes Reference
 
@@ -25,18 +25,16 @@ The following attributes are exported:
 
 * `location` - The location where the NAT Gateway exists.
 
-* `idle_timeout_in_minutes` - The idle timeout of the Nat Gateway.
+* `idle_timeout_in_minutes` - The idle timeout in minutes which is used for the NAT Gateway.
 
 * `public_ip_address_ids` - A list of existing Public IP Address resource IDs which the NAT Gateway is using.
 
 * `public_ip_prefix_ids` - A list of existing Public IP Prefix resource IDs which the NAT Gateway is using.
 
-* `resource_guid` - The resource GUID property of the Nat Gateway.
+* `resource_guid` - The Resource GUID of the NAT Gateway.
 
 * `sku_name` - The SKU used by the NAT Gateway.
 
-* `subnet_ids` - A list of existing Subnet resource IDs which the NAT Gateway is using.
-
-* `zones` - A list of Availability Zones which the NAT Gateway gets created in.
-
 * `tags` - A mapping of tags assigned to the resource.
+
+* `zones` - A list of Availability Zones which the NAT Gateway exists in.

--- a/website/docs/d/network_ddos_protection_plan.html.markdown
+++ b/website/docs/d/network_ddos_protection_plan.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_ddos_protection_plan"
 sidebar_current: "docs-azurerm-datasource-network-ddos-protection-plan-x"

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_interface"
 sidebar_current: "docs-azurerm-datasource-network-interface"

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_security_group"
 sidebar_current: "docs-azurerm-datasource-network-security-group"

--- a/website/docs/d/network_watcher.html.markdown
+++ b/website/docs/d/network_watcher.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_watcher"
 sidebar_current: "docs-azurerm-datasource-network-watcher"

--- a/website/docs/d/notification_hub.html.markdown
+++ b/website/docs/d/notification_hub.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_notification_hub"
 sidebar_current: "docs-azurerm-datasource-notification-hub-x"

--- a/website/docs/d/notification_hub_namespace.html.markdown
+++ b/website/docs/d/notification_hub_namespace.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_notification_hub_namespace"
 sidebar_current: "docs-azurerm-datasource-notification-hub-namespace"

--- a/website/docs/d/platform_image.html.markdown
+++ b/website/docs/d/platform_image.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_platform_image"
 sidebar_current: "docs-azurerm-datasource-platform-image"

--- a/website/docs/d/policy_definition.markdown
+++ b/website/docs/d/policy_definition.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Policy"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_definition"
 sidebar_current: "docs-azurerm-datasource-policy-definition"

--- a/website/docs/d/postgresql_server.html.markdown
+++ b/website/docs/d/postgresql_server.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_postgresql_server"
 sidebar_current: "docs-azurerm-datasource-postgresql-server"

--- a/website/docs/d/private_link_endpoint_connection.html.markdown
+++ b/website/docs/d/private_link_endpoint_connection.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Use this data source to access the connection status information about an existing Private Link Endpoint.
 
+-> **NOTE** Private Link is currently in Public Preview.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/d/private_link_endpoint_connection.html.markdown
+++ b/website/docs/d/private_link_endpoint_connection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_endpoint_connection"
 sidebar_current: "docs-azurerm-datasource-private-endpoint-connection"

--- a/website/docs/d/private_link_service.html.markdown
+++ b/website/docs/d/private_link_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_service"
 sidebar_current: "docs-azurerm-datasource-private-link-service"

--- a/website/docs/d/private_link_service.html.markdown
+++ b/website/docs/d/private_link_service.html.markdown
@@ -11,8 +11,9 @@ description: |-
 
 Use this data source to access information about an existing Private Link Service.
 
+-> **NOTE** Private Link is currently in Public Preview.
 
-## Private Link Service Usage
+## Example Usage
 
 ```hcl
 data "azurerm_private_link_service" "example" {
@@ -25,7 +26,6 @@ output "private_link_service_id" {
 }
 ```
 
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -34,29 +34,25 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the private link service resides.
 
-
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The Azure resource ID of the Prviate Link Service.
-
-* `location` - The supported Azure location where the resource exists.
+* `id` - The Azure resource ID of the Private Link Service.
 
 * `alias` - The alias is a globally unique name for your private link service which Azure generates for you. Your can use this alias to request a connection to your private link service.
 
 * `auto_approval_subscription_ids` - The list of subscription(s) globally unique identifiers that will be auto approved to use the private link service.
 
-* `visibility_subscription_ids` - The list of subscription(s) globally unique identifiers(GUID) that will be able to see the private link service.
+* `load_balancer_frontend_ip_configuration_ids` - The list of Standard Load Balancer(SLB) resource IDs. The Private Link service is tied to the frontend IP address of a SLB. All traffic destined for the private link service will reach the frontend of the SLB. You can configure SLB rules to direct this traffic to appropriate backend pools where your applications are running.
+
+* `location` - The supported Azure location where the resource exists.
 
 * `nat_ip_configuration` - The `nat_ip_configuration` block as defined below.
 
-* `load_balancer_frontend_ip_configuration_ids` - The list of Standard Load Balancer(SLB) resource IDs. The Private Link service is tied to the frontend IP address of a SLB. All traffic destined for the private link service will reach the frontend of the SLB. You can configure SLB rules to direct this traffic to appropriate backend pools where your applications are running.
-
-* `network_interfaces` - The list of network interface resource ids that are being used by the service.
-
 * `tags` - A mapping of tags to assign to the resource.
 
+* `visibility_subscription_ids` - The list of subscription(s) globally unique identifiers(GUID) that will be able to see the private link service.
 
 ---
 
@@ -66,9 +62,9 @@ The `nat_ip_configuration` block exports the following:
 
 * `private_ip_address` - The private IP address of the NAT IP configuration.
 
-* `private_ip_address_version` - The ip address version of the `ip_configuration`.
+* `private_ip_address_version` - The version of the IP Protocol.
 
-* `subnet_id` - The resource ID of the subnet to be used by the service.
+* `subnet_id` - The ID of the subnet to be used by the service.
 
 * `primary` - Value that indicates if the IP configuration is the primary configuration or not.
 

--- a/website/docs/d/private_link_service_endpoint_connections.html.markdown
+++ b/website/docs/d/private_link_service_endpoint_connections.html.markdown
@@ -11,8 +11,9 @@ description: |-
 
 Use this data source to access endpoint connection information about an existing Private Link Service.
 
+-> **NOTE** Private Link is currently in Public Preview.
 
-## Private Link Service Endpoint Connections Usage
+## Example Usage
 
 ```hcl
 data "azurerm_private_link_service_endpoint_connections" "example" {

--- a/website/docs/d/private_link_service_endpoint_connections.html.markdown
+++ b/website/docs/d/private_link_service_endpoint_connections.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_service_endpoint_connections"
 sidebar_current: "docs-azurerm-datasource-private-link-service-endpoint-connections"

--- a/website/docs/d/proximity_placement_group.html.markdown
+++ b/website/docs/d/proximity_placement_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_proximity_placement_group"
 sidebar_current: "docs-azurerm-datasource-proximity-placement-group"

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ip"
 sidebar_current: "docs-azurerm-datasource-public-ip-x"

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ip_prefix"
 sidebar_current: "docs-azurerm-datasource-public-ip-prefix-x"

--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ips"
 sidebar_current: "docs-azurerm-datasource-public-ips"

--- a/website/docs/d/recovery_services_protection_policy_vm.markdown
+++ b/website/docs/d/recovery_services_protection_policy_vm.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_protection_policy_vm"
 sidebar_current: "docs-azurerm-datasource-recovery-services-protection-policy-vm"

--- a/website/docs/d/recovery_services_vault.markdown
+++ b/website/docs/d/recovery_services_vault.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_vault"
 sidebar_current: "docs-azurerm-datasource-recovery-services-vault"

--- a/website/docs/d/redis_cache.html.markdown
+++ b/website/docs/d/redis_cache.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Redis"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_redis_cache"
 sidebar_current: "docs-azurerm-datasource-redis-cache"

--- a/website/docs/d/resource_group.html.markdown
+++ b/website/docs/d/resource_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_resource_group"
 sidebar_current: "docs-azurerm-datasource-resource-group"

--- a/website/docs/d/resources.html.markdown
+++ b/website/docs/d/resources.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_resources"
 sidebar_current: "docs-azurerm-datasource-resources"

--- a/website/docs/d/role_definition.markdown
+++ b/website/docs/d/role_definition.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_role_definition"
 sidebar_current: "docs-azurerm-datasource-role-definition"

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_route_table"
 sidebar_current: "docs-azurerm-data-source-route-table"

--- a/website/docs/d/scheduler_job_collection.html.markdown
+++ b/website/docs/d/scheduler_job_collection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Scheduler"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_scheduler_job_collection"
 sidebar_current: "docs-azurerm-datasource-scheduler-job-collection"

--- a/website/docs/d/servicebus_namespace.html.markdown
+++ b/website/docs/d/servicebus_namespace.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace"
 sidebar_current: "docs-azurerm-datasource-servicebus-namespace"

--- a/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace_authorization_rule"
 sidebar_current: "docs-azurerm-datasource-servicebus-namespace-authorization-rule"

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image"
 sidebar_current: "docs-azurerm-datasource-shared-image-x"

--- a/website/docs/d/shared_image_gallery.html.markdown
+++ b/website/docs/d/shared_image_gallery.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image_gallery"
 sidebar_current: "docs-azurerm-datasource-shared-image-gallery"

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image_version"
 sidebar_current: "docs-azurerm-datasource-shared-image-version"

--- a/website/docs/d/snapshot.html.markdown
+++ b/website/docs/d/snapshot.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_snapshot"
 sidebar_current: "docs-azurerm-datasource-snapshot"

--- a/website/docs/d/sql_database.html.markdown
+++ b/website/docs/d/sql_database.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_database"
 sidebar_current: "docs-azurerm-datasource-sql-database"

--- a/website/docs/d/sql_server.html.markdown
+++ b/website/docs/d/sql_server.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_server"
 sidebar_current: "docs-azurerm-datasource-sql-server"

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account"
 sidebar_current: "docs-azurerm-datasource-storage-account-x"

--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account_blob_container_sas"
 sidebar_current: "docs-azurerm-datasource-storage-account-blob-container-sas"

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account_sas"
 sidebar_current: "docs-azurerm-datasource-storage-account-sas"

--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_management_policy"
 sidebar_current: "docs-azurerm-datasource-storage-management-policy"

--- a/website/docs/d/stream_analytics_job.html.markdown
+++ b/website/docs/d/stream_analytics_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_job"
 sidebar_current: "docs-azurerm-datasource-stream-analytics-job"

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subnet"
 sidebar_current: "docs-azurerm-datasource-subnet"

--- a/website/docs/d/subscription.html.markdown
+++ b/website/docs/d/subscription.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subscription"
 sidebar_current: "docs-azurerm-datasource-subscription-x"

--- a/website/docs/d/subscriptions.html.markdown
+++ b/website/docs/d/subscriptions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subscriptions"
 sidebar_current: "docs-azurerm-datasource-subscriptions"

--- a/website/docs/d/traffic_manager_geographical_location.html.markdown
+++ b/website/docs/d/traffic_manager_geographical_location.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_traffic_manager_geographical_location"
 sidebar_current: "docs-azurerm-datasource-traffic-manager-geographical-location"

--- a/website/docs/d/user_assigned_identity.html.markdown
+++ b/website/docs/d/user_assigned_identity.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azure_user_assigned_identity"
 sidebar_current: "docs-azurerm-datasource-user-assigned-identity"

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_machine"
 sidebar_current: "docs-azurerm-datasource-virtual-machine"

--- a/website/docs/d/virtual_network.html.markdown
+++ b/website/docs/d/virtual_network.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network"
 sidebar_current: "docs-azurerm-datasource-virtual-network-x"

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network_gateway"
 sidebar_current: "docs-azurerm-datasource-virtual-network-gateway"

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network_gateway_connection"
 sidebar_current: "docs-azurerm-datasource-virtual-network-gateway-connection"

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -354,6 +354,10 @@ The `load_balancer_inbound_nat_rules_ids` field in the `ip_configuration` block 
 
 The `azurerm_packet_capture` resource will be deprecated in favour of a new resources `azurerm_network_packet_capture`.
 
+### Resource: `azurerm_private_link_service`
+
+The deprecated `network_interface_ids` field will be removed.
+
 ### Resource: `azurerm_public_ip`
 
 The deprecated `public_ip_address_allocation` field will be removed. This field has been replaced by `allocation_method`.

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -164,6 +164,10 @@ The deprecated block `agent_pool_profile` will be removed. This has been replace
 
 The deprecated field `internal_fqdn` will be removed.
 
+### Data Source: `azurerm_private_link_service`
+
+The deprecated field `network_interface_ids` will be removed.
+
 ### Data Source: `azurerm_scheduler_job_collection`
 
 Azure Scheduler is being retired in favour of Logic Apps ([more information can be found here](https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps)) - as such this Data Source will be removed.

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -23,7 +23,7 @@ We recommend pinning the version of each Provider you use in Terraform - you can
 
 ```hcl
 provider "azurerm" {
-  version = "=1.36.0"
+  version = "=1.38.0"
 }
 ```
 

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -86,7 +86,7 @@ To configure Terraform to use the Default Subscription defined in the Azure CLI 
 ```hcl
 provider "azurerm" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.36.0"
+  version = "=1.38.0"
 }
 ```
 
@@ -101,7 +101,7 @@ It's also possible to configure Terraform to use a specific Subscription - for e
 ```hcl
 provider "azurerm" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.36.0"
+  version = "=1.38.0"
 
   subscription_id = "00000000-0000-0000-0000-000000000000"
 }
@@ -118,7 +118,7 @@ If you're looking to use Terraform across Tenants - it's possible to do this by 
 ```hcl
 provider "azurerm" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.36.0"
+  version = "=1.38.0"
 
   subscription_id = "00000000-0000-0000-0000-000000000000"
   tenant_id       = "11111111-1111-1111-1111-111111111111"

--- a/website/docs/guides/migrating-to-azuread.html.markdown
+++ b/website/docs/guides/migrating-to-azuread.html.markdown
@@ -25,7 +25,7 @@ As the AzureAD and AzureRM Provider support the same authentication methods - it
 
 ```hcl
 provider "azurerm" {
-  version = "=1.36.0"
+  version = "=1.38.0"
 }
 ```
 

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -105,7 +105,7 @@ The following Provider block can be specified - where `1.21.0` is the version of
 ```hcl
 provider "azurerm" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.36.0"
+  version = "=1.38.0"
 }
 ```
 
@@ -125,7 +125,7 @@ variable "client_certificate_password" {}
 
 provider "azurerm" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.36.0"
+  version = "=1.38.0"
 
   subscription_id             = "00000000-0000-0000-0000-000000000000"
   client_id                   = "00000000-0000-0000-0000-000000000000"

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -181,7 +181,7 @@ The following Provider block can be specified - where `1.34.0` is the version of
 ```hcl
 provider "azurerm" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.36.0"
+  version = "=1.38.0"
 }
 ```
 
@@ -200,7 +200,7 @@ variable "client_secret" {}
 
 provider "azurerm" {
   # Whilst version is optional, we /strongly recommend/ using it to pin the version of the Provider being used
-  version = "=1.36.0"
+  version = "=1.38.0"
 
   subscription_id = "00000000-0000-0000-0000-000000000000"
   client_id       = "00000000-0000-0000-0000-000000000000"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -32,7 +32,7 @@ We recommend using either a Service Principal or Managed Service Identity when r
 # Configure the Azure Provider
 provider "azurerm" {
   # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
-  version = "=1.36.0"
+  version = "=1.38.0"
 }
 
 # Create a resource group

--- a/website/docs/r/healthcare_service.html.markdown
+++ b/website/docs/r/healthcare_service.html.markdown
@@ -1,15 +1,15 @@
 ---
-subcategory: "Healthcare API"
+subcategory: "Healthcare"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_healthcare_service"
 sidebar_current: "docs-azurerm-resource-healthcare-service-x"
 description: |-
-  Manages a Healthcare Service Resource.
+  Manages a Healthcare Service.
 ---
 
 # azurerm_healthcare_service
 
-Manages a Healthcare Service Resource.
+Manages a Healthcare Service.
 
 ## Example Usage
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -53,36 +53,34 @@ resource "azurerm_nat_gateway" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Nat Gateway. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the NAT Gateway. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the NAT Gateway exists.
+* `resource_group_name` - (Required) Specifies the name of the Resource Group in which the NAT Gateway should exist. Changing this forces a new resource to be created.
 
-* `location` - (Optional) Specifies the supported Azure location where the resource should exist. Changing this forces a new resource to be created.
+* `location` - (Optional) Specifies the supported Azure location where the NAT Gateway should exist. Changing this forces a new resource to be created.
 
-* `idle_timeout_in_minutes` - (Optional) The idle timeout of the Nat Gateway. Defaults to `4`.
+* `idle_timeout_in_minutes` - (Optional) The idle timeout which should be used in minutes. Defaults to `4`.
 
-* `public_ip_address_ids` - (Optional) An array of the IDs of Public IP Addresses associated with the NAT Gateway resource.
+* `public_ip_address_ids` - (Optional) A list of Public IP Address ID's which should be associated with the NAT Gateway resource.
 
-* `public_ip_prefix_ids` - (Optional) An array of the IDs of Public IP Prefixes associated with the NAT Gateway resource.
+* `public_ip_prefix_ids` - (Optional) A list of Public IP Prefix ID's which should be associated with the NAT Gateway resource.
 
-* `sku_name` - (Optional) The nat gateway SKU, supported value, `Standard`. Defaults to `Standard`.
-
-* `zones` - (Optional) A list of availability zones where the Nat Gateway should be provisioned. Supported values are `1`, `2`, and `3`. For more information on `zones` please refer to the [product documentation](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview). Changing this forces a new resource to be created.
+* `sku_name` - (Optional) The SKU which should be used. At this time the only supported value is `Standard`. Defaults to `Standard`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+
+* `zones` - (Optional) A list of availability zones where the NAT Gateway should be provisioned. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `resource_guid` - The resource GUID property of the Nat Gateway.
-
-* `subnet_ids` - A list subnet IDs that are using this NAT Gateway resource.
+* `resource_guid` - The resource GUID property of the NAT Gateway.
 
 ## Import
 
 NAT Gateway can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_nat_gateway.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/natGateways/ng1
+terraform import azurerm_nat_gateway.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/natGateways/gateway1
 ```

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nat_gateway"
 sidebar_current: "docs-azurerm-resource-nat-gateway"

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -4,11 +4,11 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nat_gateway"
 sidebar_current: "docs-azurerm-resource-nat-gateway"
 description: |-
-  Manages an Azure NAT Gateway instance.
+  Manages a Azure NAT Gateway.
 ---
 # azurerm_nat_gateway
 
-Manages an Azure NAT Gateway instance.
+Manages a Azure NAT Gateway.
 
 -> **NOTE:** The Azure NAT Gateway service is currently in private preview. Your subscription must be on the NAT Gateway private preview whitelist for this resource to be provisioned correctly. If you attempt to provision this resource and receive an `InvalidResourceType` error may mean that your subscription is not part of the NAT Gateway private preview or you are using a region which does not yet support the NAT Gateway private preview service. The NAT Gateway private preview service is currently available in a limited set of regions. Private preview resources may have multiple breaking changes over their lifecycle until they GA. You can opt into the Private Preview by contacting your Microsoft Representative.
 
@@ -74,6 +74,8 @@ The following arguments are supported:
 ## Attributes Reference
 
 The following attributes are exported:
+
+* `id` - The ID of the NAT Gateway.
 
 * `resource_guid` - The resource GUID property of the NAT Gateway.
 

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -4,13 +4,12 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_pool"
 sidebar_current: "docs-azurerm-resource-netapp-pool"
 description: |-
-  Manages a NetApp Pool.
+  Manages a Pool within a NetApp Account.
 ---
 
 # azurerm_netapp_pool
 
-Manages a NetApp Pool.
-
+Manages a Pool within a NetApp Account.
 
 ## NetApp Pool Usage
 
@@ -22,15 +21,15 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_netapp_account" "example" {
   name                = "example-netappaccount"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_netapp_pool" "example" {
   name                = "example-netapppool"
-  account_name        = "${azurerm_netapp_account.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  account_name        = azurerm_netapp_account.example.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   service_level       = "Premium"
   size_in_tb          = "4"
 }

--- a/website/docs/r/private_link_endpoint.html.markdown
+++ b/website/docs/r/private_link_endpoint.html.markdown
@@ -1,15 +1,17 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_endpoint"
 sidebar_current: "docs-azurerm-resource-private-endpoint"
 description: |-
-  Manages a Azure Private Link Endpoint instance.
+  Manages an Endpoint within a Private Link Service.
 ---
 
 # azurerm_private_link_endpoint
 
-Manages a Azure Private Link Endpoint instance.
+Manages an Endpoint within a Private Link Service.
+
+-> **NOTE** Private Link is currently in Public Preview.
 
 Azure Private Link Endpoint is a network interface that connects you privately and securely to a service powered by Azure Private Link. Private Link Endpoint uses a private IP address from your VNet, effectively bringing the service into your VNet. The service could be an Azure service such as Azure Storage, SQL, etc. or your own Private Link Service.
 
@@ -17,19 +19,19 @@ Azure Private Link Endpoint is a network interface that connects you privately a
 
 ```hcl
 resource "azurerm_resource_group" "example" {
-  name     = "exampleRG"
-  location = "East US"
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_virtual_network" "example" {
-  name                = "examplevnet"
+  name                = "example-network"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "service" {
-  name                 = "exampleSubnet"
+  name                 = "service"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefix       = "10.0.1.0/24"
@@ -38,7 +40,7 @@ resource "azurerm_subnet" "service" {
 }
 
 resource "azurerm_subnet" "endpoint" {
-  name                 = "exampleSubnet"
+  name                 = "endpoint"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefix       = "10.0.2.0/24"
@@ -47,7 +49,7 @@ resource "azurerm_subnet" "endpoint" {
 }
 
 resource "azurerm_public_ip" "example" {
-  name                = "examplePip"
+  name                = "example-pip"
   sku                 = "Standard"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -55,7 +57,7 @@ resource "azurerm_public_ip" "example" {
 }
 
 resource "azurerm_lb" "example" {
-  name                = "exampleLb"
+  name                = "example-lb"
   sku                 = "Standard"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
@@ -67,7 +69,7 @@ resource "azurerm_lb" "example" {
 }
 
 resource "azurerm_private_link_service" "example" {
-  name                = "examplepls"
+  name                = "example-privatelink"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
@@ -77,16 +79,17 @@ resource "azurerm_private_link_service" "example" {
     subnet_id = azurerm_subnet.service.id
   }
 
-  load_balancer_frontend_ip_configuration_ids = [azurerm_lb.test.frontend_ip_configuration.0.id]
+  load_balancer_frontend_ip_configuration_ids = [
+    azurerm_lb.example.frontend_ip_configuration.0.id,
+  ]
 }
 
 resource "azurerm_private_link_endpoint" "example" {
-  name                = "examplepe"
+  name                = "example-endpoint"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   subnet_id           = azurerm_subnet.endpoint.id
 }
-
 ```
 
 ## Argument Reference
@@ -95,54 +98,54 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the Name of the Private Link Endpoint. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the Private Link Endpoint exists. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the Private Link Endpoint should exist. Changing this forces a new resource to be created.
 
 * `location` - (Required) The supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `subnet_id` - (Required) Specifies the resource ID of the subnet from which the private IP addresses will be allocated for the private link endpoint. Changing this forces a new resource to be created.
+* `subnet_id` - (Required) The ID of the Subnet from which Private IP Addresses will be allocated for this Private Link Endpoint. Changing this forces a new resource to be created.
 
-* `private_service_connection` - (Required) A `private_service_connection` block as defined below. Once defined it becomes a required argument.
+* `private_service_connection` - (Required) A `private_service_connection` block as defined below.
 
 ---
 
-A `private_service_connection` contains:
+A `private_service_connection` supports the following:
 
 * `name` - (Required) Specifies the Name of the Private Service Connection. Changing this forces a new resource to be created.
 
-* `is_manual_connection` - (Required) Specifies if the private link endpoint requires manaul approval via the remote resource owner or not. If you are trying to connect the private link endpoint to a remote resource without having the correct RBAC permissions on the remote resource set this value to `true`. Changing this forces a new resource to be created.
+* `is_manual_connection` - (Required) Does the Private Link Endpoint require Manual Approval from the remote resource owner? Changing this forces a new resource to be created.
 
-* `private_connection_resource_id` - (Required) The Azure resource ID of the private link enabled remote resource to connect the private link endpoint to. Changing this forces a new resource to be created.
+-> **NOTE:** If you are trying to connect the Private Link Endpoint to a remote resource without having the correct RBAC permissions on the remote resource set this value to `true`.
 
-* `subresource_names` - (Optional) The subresource name(s) that the Private Link Endpoint is allowed to connect to, see `Subresource Names` below. Changing this forces a new resource to be created.
+* `private_connection_resource_id` - (Required) The ID of the Private Link Enabled Remote Resource which this Private Link Endpoint should be connected to. Changing this forces a new resource to be created.
 
-* `request_message` - (Optional) A message passed to the owner of the remote resource when the private link endpoint attempts to establish the connection to the remote resource. The request message can be a maximum of `140` characters in length. Only valid if `is_manual_connection` is set to `true`.
+* `subresource_names` - (Optional) A list of subresource names which the Private Link Endpoint is able to connect to. Changing this forces a new resource to be created.
 
-## Subresource Names
+-> Several possible values for this field are shown below, however this is not extensive:
 
-Resource type | Subresource name | Subresource secondary name
--- | -- | --
-Sql DB/DW | sqlServer | 
-Storage Account  | blob | blob_secondary
-Storage Account  | table | table_secondary
-Storage Account  | queue | queue_secondary
-Storage Account  | file | file_secondary
-Storage Account  | web | web_secondary
-Data Lake File System Gen2 | dfs | dfs_secondary
+| Resource Type                 | SubResource Name | Secondary SubResource Name |
+| ----------------------------- | ---------------- | -------------------------- |
+| Data Lake File System Gen2    | dfs              | dfs_secondary              |
+| Sql Database / Data Warehouse | sqlServer        |                            |
+| Storage Account               | blob             | blob_secondary             |
+| Storage Account               | file             | file_secondary             |
+| Storage Account               | queue            | queue_secondary            |
+| Storage Account               | table            | table_secondary            |
+| Storage Account               | web              | web_secondary              |
 
 See the product [documentation](https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-overview#dns-configuration) for more information.
+
+* `request_message` - (Optional) A message passed to the owner of the remote resource when the private link endpoint attempts to establish the connection to the remote resource. The request message can be a maximum of `140` characters in length. Only valid if `is_manual_connection` is set to `true`.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The Azure resource ID of the Prviate Link Endpoint.
-
-* `network_interface_ids` - Displays an list of network interface resource IDs that have been created for this Private Link Endpoint.
+* `id` - The ID of the Private Link Endpoint.
 
 ## Import
 
-The `Private Link Endpoint` can be imported using the `resource id`, e.g.
+Private Link Endpoints can be imported using the `resource id`, e.g.
 
 ```shell
-$ terraform import azurerm_private_link_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Network/privateEndpoints/example-private-link-endpoint
+$ terraform import azurerm_private_link_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/privateEndpoints/endpoint1
 ```

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -1,34 +1,35 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_service"
 sidebar_current: "docs-azurerm-resource-private-link-service"
 description: |-
-  Manages an Azure Private Link Service.
+  Manages a Private Link Service.
 ---
 
 # azurerm_private_link_service
 
-Manages an Azure Private Link Service.
+Manages a Private Link Service.
 
+-> **NOTE** Private Link is currently in Public Preview.
 
-## Private Link Service Usage
+## Example Usage
 
 ```hcl
 resource "azurerm_resource_group" "example" {
-  name     = "exampleRG"
-  location = "Eastus2"
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 resource "azurerm_virtual_network" "example" {
-  name                = "example-avn"
+  name                = "example-network"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   address_space       = ["10.5.0.0/16"]
 }
 
 resource "azurerm_subnet" "example" {
-  name                                          = "example-snet"
+  name                                          = "example-subnet"
   resource_group_name                           = azurerm_resource_group.example.name
   virtual_network_name                          = azurerm_virtual_network.example.name
   address_prefix                                = "10.5.1.0/24"
@@ -56,7 +57,7 @@ resource "azurerm_lb" "example" {
 }
 
 resource "azurerm_private_link_service" "example" {
-  name                = "myPrivateLinkService"
+  name                = "example-privatelink"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
 
@@ -65,7 +66,7 @@ resource "azurerm_private_link_service" "example" {
   load_balancer_frontend_ip_configuration_ids = [azurerm_lb.example.frontend_ip_configuration.0.id]
 
   nat_ip_configuration {
-    name                       = "primaryIpConfiguration"
+    name                       = "primary"
     private_ip_address         = "10.5.1.17"
     private_ip_address_version = "IPv4"
     subnet_id                  = azurerm_subnet.example.id
@@ -73,7 +74,7 @@ resource "azurerm_private_link_service" "example" {
   }
 
   nat_ip_configuration {
-    name                       = "secondaryIpConfiguration"
+    name                       = "secondary"
     private_ip_address         = "10.5.1.18"
     private_ip_address_version = "IPv4"
     subnet_id                  = azurerm_subnet.example.id
@@ -86,53 +87,54 @@ resource "azurerm_private_link_service" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the private link service. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of this Private Link Service. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which the private link service resides. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the Private Link Service should exist. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `auto_approval_subscription_ids` - (Optional) A list of subscription globally unique identifiers(GUID) that will be automatically be able to use this service.
+* `nat_ip_configuration` - (Required) One or more (up to 8) `nat_ip_configuration` block as defined below.
 
-* `visibility_subscription_ids` - (Optional) A list of subscription globally unique identifiers(GUID) that will be able to see this service. If left undefined all Azure subscriptions will be able to see this service.
+* `load_balancer_frontend_ip_configuration_ids` - (Required) A list of Frontend IP Configuration ID's from a Standard Load Balancer, where traffic from the Private Link Service should be routed. You can use Load Balancer Rules to direct this traffic to appropriate backend pools where your applications are running. 
 
-* `nat_ip_configuration` - (Required) A `nat_ip_configuration` block as defined below. There maybe upto 8 nat_ip_configuration blocks per private link service.
+---
 
-* `load_balancer_frontend_ip_configuration_ids` - (Required) A list of Standard Load Balancer(SLB) resource IDs. The Private Link service is tied to the frontend IP address of a SLB. All traffic destined for the private link service will reach the frontend of the SLB. You can configure SLB rules to direct this traffic to appropriate backend pools where your applications are running.
+* `auto_approval_subscription_ids` - (Optional) A list of Subscription UUID/GUID's that will be automatically be able to use this Private Link Service.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+
+* `visibility_subscription_ids` - (Optional) A list of Subscription UUID/GUID's that will be able to see this Private Link Service.
+
+-> **NOTE:** If no Subscription ID's are specified then Azure allows every Subscription to see this Private Link Service.
 
 ---
 
 The `nat_ip_configuration` block supports the following:
 
-* `name` - (Required) The name of primary private link service NAT IP configuration. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name which should be used for the NAT IP Configuration. Changing this forces a new resource to be created.
 
-* `private_ip_address` - (Optional) The private IP address of the NAT IP configuration.
+* `subnet_id` - (Required) Specifies the ID of the Subnet which should be used for the Private Link Service.
 
-* `private_ip_address_version` - (Optional) The ip address version of the `ip_configuration`, the supported value is `IPv4`. Defaults to `IPv4`.
+-> **NOTE:** Verify that the Subnet's `enforce_private_link_service_network_policies` attribute is set to `true`.
 
--> **NOTE:** Private Link Service Supports `IPv4` traffic only.
+* `primary` - (Required) Is this is the Primary IP Configuration? Changing this forces a new resource to be created.
 
-* `subnet_id` - (Required) The resource ID of the subnet to be used by the service.
+* `private_ip_address` - (Optional) Specifies a Private Static IP Address for this IP Configuration.
 
--> **NOTE:** Verify that the subnets `enforce_private_link_service_network_policies` attribute is set to `true`.
-
-* `primary` - (Required) Specifies if the `nat_ip_configuration` block is the primary ip configuration for the service or not. Valid values are `true` or `false`. Changing this forces a new resource to be created.
+* `private_ip_address_version` - (Optional) The version of the IP Protocol which should be used. At this time the only supported value is `IPv4`. Defaults to `IPv4`.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `alias` - The alias is a globally unique name for your private link service which Azure generates for you. Your can use this alias to request a connection to your private link service.
+* `alias` - A globally unique DNS Name for your Private Link Service. You can use this alias to request a connection to your Private Link Service.
 
 * `network_interfaces` - A list of network interface resource ids that are being used by the service.
 
-
 ## Import
 
-Private Link Service can be imported using the `resource id`, e.g.
+Private Link Services can be imported using the `resource id`, e.g.
 
 ```shell
-$ terraform import azurerm_private_link_service.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG/providers/Microsoft.Network/privateLinkServices/privatelinkservicename
+$ terraform import azurerm_private_link_service.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/privateLinkServices/service1
 ```

--- a/website/docs/r/subnet_nat_gateway_association.html.markdown
+++ b/website/docs/r/subnet_nat_gateway_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: ""
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subnet_nat_gateway_association"
 sidebar_current: "docs-azurerm-resource-network-subnet-nat-gateway-association"


### PR DESCRIPTION
This PR bundles together a few things:

* Updating the tags for the registry docs so that every resource is now included
* Updating the version used in the documentation to 1.38
* Data Source: `azurerm_nat_gateway`-  removing the `subnet_ids` field
* Data Source: `azurerm_private_link_service` - deprecating the `network_interface_ids` field
* Resource: `azurerm_nat_gateway`-  removing the `subnet_ids` field
* Resource: `azurerm_private_link_endpoint` - removing the `subnet_ids` field
* Resource: `azurerm_private_link_service` - deprecating the `network_interface_ids` field