### PR TITLE
Custom Timeouts: adding compile-time checks

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,6 +31,7 @@ fmt:
 # Currently required by tf-deploy compile, duplicated by linters
 fmtcheck:
 	@sh "$(CURDIR)/scripts/gofmtcheck.sh"
+	@sh "$(CURDIR)/scripts/timeouts.sh"
 
 goimports:
 	@echo "==> Fixing imports code with goimports..."

--- a/azurerm/data_source_nat_gateway.go
+++ b/azurerm/data_source_nat_gateway.go
@@ -2,17 +2,22 @@ package azurerm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmNatGateway() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceArmNatGatewayRead,
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -73,7 +78,8 @@ func dataSourceArmNatGateway() *schema.Resource {
 
 func dataSourceArmNatGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.NatGatewayClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_private_link_endpoint_connection.go
+++ b/azurerm/data_source_private_link_endpoint_connection.go
@@ -2,17 +2,22 @@ package azurerm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	aznet "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmPrivateLinkEndpointConnection() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceArmPrivateLinkEndpointConnectionRead,
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -56,7 +61,8 @@ func dataSourceArmPrivateLinkEndpointConnection() *schema.Resource {
 
 func dataSourceArmPrivateLinkEndpointConnectionRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.PrivateEndpointClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)

--- a/azurerm/data_source_private_link_service_endpoint_connections.go
+++ b/azurerm/data_source_private_link_service_endpoint_connections.go
@@ -2,16 +2,21 @@ package azurerm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func dataSourceArmPrivateLinkServiceEndpointConnections() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceArmPrivateLinkServiceEndpointConnectionsRead,
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"service_id": {
@@ -71,7 +76,8 @@ func dataSourceArmPrivateLinkServiceEndpointConnections() *schema.Resource {
 
 func dataSourceArmPrivateLinkServiceEndpointConnectionsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.PrivateLinkServiceClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	serviceId := d.Get("service_id").(string)
 

--- a/azurerm/data_source_resources.go
+++ b/azurerm/data_source_resources.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -15,6 +16,10 @@ import (
 func dataSourceArmResources() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceArmResourcesRead,
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -535,21 +534,7 @@ func Provider() terraform.ResourceProvider {
 	}
 
 	// TODO: remove all of this in 2.0 once Custom Timeouts are supported
-	if features.SupportsCustomTimeouts() {
-		// default everything to 3 hours for now
-		for _, v := range resources {
-			if v.Timeouts == nil {
-				v.Timeouts = &schema.ResourceTimeout{
-					Create: schema.DefaultTimeout(3 * time.Hour),
-					Update: schema.DefaultTimeout(3 * time.Hour),
-					Delete: schema.DefaultTimeout(3 * time.Hour),
-
-					// Read is the only exception, since if it's taken more than 5 minutes something's seriously wrong
-					Read: schema.DefaultTimeout(5 * time.Minute),
-				}
-			}
-		}
-	} else {
+	if !features.SupportsCustomTimeouts() {
 		// ensure any timeouts configured on the resources are removed until 2.0
 		for _, v := range resources {
 			v.Timeouts = nil

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -540,10 +540,9 @@ func Provider() terraform.ResourceProvider {
 		for _, v := range resources {
 			if v.Timeouts == nil {
 				v.Timeouts = &schema.ResourceTimeout{
-					Create:  schema.DefaultTimeout(3 * time.Hour),
-					Update:  schema.DefaultTimeout(3 * time.Hour),
-					Delete:  schema.DefaultTimeout(3 * time.Hour),
-					Default: schema.DefaultTimeout(3 * time.Hour),
+					Create: schema.DefaultTimeout(3 * time.Hour),
+					Update: schema.DefaultTimeout(3 * time.Hour),
+					Delete: schema.DefaultTimeout(3 * time.Hour),
 
 					// Read is the only exception, since if it's taken more than 5 minutes something's seriously wrong
 					Read: schema.DefaultTimeout(5 * time.Minute),

--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -1,6 +1,8 @@
 package azurerm
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -32,6 +34,82 @@ func init() {
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestDataSourcesSupportCustomTimeouts(t *testing.T) {
+	// this is required until 2.0
+	os.Setenv("ARM_PROVIDER_CUSTOM_TIMEOUTS", "true")
+
+	provider := Provider().(*schema.Provider)
+	for dataSourceName, dataSource := range provider.DataSourcesMap {
+		t.Run(fmt.Sprintf("DataSource/%s", dataSourceName), func(t *testing.T) {
+			t.Logf("[DEBUG] Testing Data Source %q..", dataSourceName)
+
+			if dataSource.Timeouts == nil {
+				t.Fatalf("Data Source %q has no timeouts block defined!", dataSourceName)
+			}
+
+			// Azure's bespoke enough we want to be explicit about the timeouts for each value
+			if dataSource.Timeouts.Default != nil {
+				t.Fatalf("Data Source %q defines a Default timeout when it shouldn't!", dataSourceName)
+			}
+
+			// Data Sources must have a Read
+			if dataSource.Timeouts.Read == nil {
+				t.Fatalf("Data Source %q doesn't define a Read timeout", dataSourceName)
+			}
+
+			// but shouldn't have anything else
+			if dataSource.Timeouts.Create != nil {
+				t.Fatalf("Data Source %q defines a Create timeout when it shouldn't!", dataSourceName)
+			}
+
+			if dataSource.Timeouts.Update != nil {
+				t.Fatalf("Data Source %q defines a Update timeout when it shouldn't!", dataSourceName)
+			}
+
+			if dataSource.Timeouts.Delete != nil {
+				t.Fatalf("Data Source %q defines a Delete timeout when it shouldn't!", dataSourceName)
+			}
+		})
+	}
+}
+
+func TestResourcesSupportCustomTimeouts(t *testing.T) {
+	// this is required until 2.0
+	os.Setenv("ARM_PROVIDER_CUSTOM_TIMEOUTS", "true")
+
+	provider := Provider().(*schema.Provider)
+	for resourceName, resource := range provider.ResourcesMap {
+		t.Run(fmt.Sprintf("DataSource/%s", resourceName), func(t *testing.T) {
+			t.Logf("[DEBUG] Testing Resource %q..", resourceName)
+
+			if resource.Timeouts == nil {
+				t.Fatalf("Resource %q has no timeouts block defined!", resourceName)
+			}
+
+			// Azure's bespoke enough we want to be explicit about the timeouts for each value
+			if resource.Timeouts.Default != nil {
+				t.Fatalf("Resource %q defines a Default timeout when it shouldn't!", resourceName)
+			}
+
+			// every Resource has to have a Create, Read & Destroy timeout
+			if resource.Timeouts.Create == nil && resource.Create != nil {
+				t.Fatalf("Resource %q defines a Create method but no Create Timeout", resourceName)
+			}
+			if resource.Timeouts.Delete == nil && resource.Delete != nil {
+				t.Fatalf("Resource %q defines a Delete method but no Delete Timeout", resourceName)
+			}
+			if resource.Timeouts.Read == nil {
+				t.Fatalf("Resource %q doesn't define a Read timeout", resourceName)
+			}
+
+			// Optional
+			if resource.Timeouts.Update == nil && resource.Update != nil {
+				t.Fatalf("Resource %q defines a Update method but no Update Timeout", resourceName)
+			}
+		})
 	}
 }
 

--- a/azurerm/resource_arm_container_registry_migrate.go
+++ b/azurerm/resource_arm_container_registry_migrate.go
@@ -1,9 +1,11 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -91,7 +93,9 @@ func updateV1ToV2StorageAccountName(is *terraform.InstanceState, meta interface{
 }
 
 func findAzureStorageAccountIdFromName(name string, meta interface{}) (string, error) {
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := context.WithTimeout(meta.(*ArmClient).StopContext, time.Minute*5)
+	defer cancel()
+
 	client := meta.(*ArmClient).Storage.AccountsClient
 	accounts, err := client.List(ctx)
 	if err != nil {

--- a/azurerm/resource_arm_data_factory_integration_runtime_managed.go
+++ b/azurerm/resource_arm_data_factory_integration_runtime_managed.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -11,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -20,9 +22,15 @@ func resourceArmDataFactoryIntegrationRuntimeManaged() *schema.Resource {
 		Read:   resourceArmDataFactoryIntegrationRuntimeManagedRead,
 		Update: resourceArmDataFactoryIntegrationRuntimeManagedCreateUpdate,
 		Delete: resourceArmDataFactoryIntegrationRuntimeManagedDelete,
-
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -194,7 +202,8 @@ func resourceArmDataFactoryIntegrationRuntimeManaged() *schema.Resource {
 
 func resourceArmDataFactoryIntegrationRuntimeManagedCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).DataFactory.IntegrationRuntimesClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	name := d.Get("name").(string)
 	factoryName := d.Get("data_factory_name").(string)
@@ -250,7 +259,8 @@ func resourceArmDataFactoryIntegrationRuntimeManagedCreateUpdate(d *schema.Resou
 
 func resourceArmDataFactoryIntegrationRuntimeManagedRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).DataFactory.IntegrationRuntimesClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -323,7 +333,8 @@ func resourceArmDataFactoryIntegrationRuntimeManagedRead(d *schema.ResourceData,
 
 func resourceArmDataFactoryIntegrationRuntimeManagedDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).DataFactory.IntegrationRuntimesClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_iothub_fallback_route.go
+++ b/azurerm/resource_arm_iothub_fallback_route.go
@@ -2,6 +2,7 @@ package azurerm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/iothub/mgmt/2018-12-01-preview/devices"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -22,6 +23,13 @@ func resourceArmIotHubFallbackRoute() *schema.Resource {
 		Delete: resourceArmIotHubFallbackRouteDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/azurerm/resource_arm_iothub_route.go
+++ b/azurerm/resource_arm_iothub_route.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/iothub/mgmt/2018-12-01-preview/devices"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -25,6 +26,13 @@ func resourceArmIotHubRoute() *schema.Resource {
 		Delete: resourceArmIotHubRouteDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/azurerm/resource_arm_metric_alertrule.go
+++ b/azurerm/resource_arm_metric_alertrule.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -28,6 +29,13 @@ func resourceArmMetricAlertRule() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		DeprecationMessage: `The 'azurerm_metric_alertrule' resource is deprecated in favour of the renamed version 'azurerm_monitor_metric_alertrule'.
 
 Information on migrating to the renamed resource can be found here: https://terraform.io/docs/providers/azurerm/guides/migrating-between-renamed-resources.html

--- a/azurerm/resource_arm_nat_gateway.go
+++ b/azurerm/resource_arm_nat_gateway.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/hashicorp/go-azure-helpers/response"
@@ -13,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	aznet "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -24,6 +26,13 @@ func resourceArmNatGateway() *schema.Resource {
 		Read:   resourceArmNatGatewayRead,
 		Update: resourceArmNatGatewayCreateUpdate,
 		Delete: resourceArmNatGatewayDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -89,7 +98,8 @@ func resourceArmNatGateway() *schema.Resource {
 
 func resourceArmNatGatewayCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.NatGatewayClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	name := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
@@ -150,7 +160,8 @@ func resourceArmNatGatewayCreateUpdate(d *schema.ResourceData, meta interface{})
 
 func resourceArmNatGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.NatGatewayClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
@@ -198,7 +209,8 @@ func resourceArmNatGatewayRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceArmNatGatewayDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.NatGatewayClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {

--- a/azurerm/resource_arm_storage_data_lake_gen2_filesystem.go
+++ b/azurerm/resource_arm_storage_data_lake_gen2_filesystem.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -25,7 +26,8 @@ func resourceArmStorageDataLakeGen2FileSystem() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				storageClients := meta.(*ArmClient).Storage
-				ctx := meta.(*ArmClient).StopContext
+				ctx, cancel := context.WithTimeout(meta.(*ArmClient).StopContext, 5*time.Minute)
+				defer cancel()
 
 				id, err := filesystems.ParseResourceID(d.Id())
 				if err != nil {

--- a/azurerm/resource_arm_subnet_nat_gateway_association.go
+++ b/azurerm/resource_arm_subnet_nat_gateway_association.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -10,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -20,6 +22,12 @@ func resourceArmSubnetNatGatewayAssociation() *schema.Resource {
 		Delete: resourceArmSubnetNatGatewayAssociationDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -42,7 +50,8 @@ func resourceArmSubnetNatGatewayAssociation() *schema.Resource {
 
 func resourceArmSubnetNatGatewayAssociationCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.SubnetsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for Subnet <-> NAT Gateway Association creation.")
 	subnetId := d.Get("subnet_id").(string)
@@ -112,7 +121,9 @@ func resourceArmSubnetNatGatewayAssociationCreate(d *schema.ResourceData, meta i
 
 func resourceArmSubnetNatGatewayAssociationRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.SubnetsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err
@@ -151,7 +162,9 @@ func resourceArmSubnetNatGatewayAssociationRead(d *schema.ResourceData, meta int
 
 func resourceArmSubnetNatGatewayAssociationDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Network.SubnetsClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
+	defer cancel()
+
 	id, err := azure.ParseAzureResourceID(d.Id())
 	if err != nil {
 		return err

--- a/azurerm/resource_arm_virtual_machine_scale_set_migration.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_migration.go
@@ -1,8 +1,10 @@
 package azurerm
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -26,7 +28,8 @@ func resourceVirtualMachineScaleSetStateV0toV1(is *terraform.InstanceState, meta
 	log.Printf("[DEBUG] ARM Virtual Machine Scale Set Attributes before Migration: %#v", is.Attributes)
 
 	client := meta.(*ArmClient).Compute.VMScaleSetClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := context.WithTimeout(meta.(*ArmClient).StopContext, 5*time.Minute)
+	defer cancel()
 
 	resGroup := is.Attributes["resource_group_name"]
 	name := is.Attributes["name"]

--- a/azurerm/resource_arm_windows_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_windows_virtual_machine_scale_set.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -15,6 +16,7 @@ import (
 	computeSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/base64"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -26,6 +28,13 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 		Delete: resourceArmWindowsVirtualMachineScaleSetDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
 		// TODO: exposing requireGuestProvisionSignal once it's available
@@ -336,7 +345,8 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 
 func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Compute.VMScaleSetClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
@@ -580,7 +590,8 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 
 func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Compute.VMScaleSetClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForUpdate(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
 	if err != nil {
@@ -864,7 +875,8 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 
 func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Compute.VMScaleSetClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
 	if err != nil {
@@ -1040,7 +1052,8 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 
 func resourceArmWindowsVirtualMachineScaleSetDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient).Compute.VMScaleSetClient
-	ctx := meta.(*ArmClient).StopContext
+	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
+	defer cancel()
 
 	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
 	if err != nil {

--- a/scripts/timeouts.sh
+++ b/scripts/timeouts.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+files=$(ls ./azurerm/*.go)
+error=false
+
+echo "==> Checking that Custom Timeouts are used..."
+
+for f in $files; do
+  if grep "ctx := meta." "$f" > /dev/null; then
+    echo $f
+    error=true
+  fi
+done
+
+if $error; then
+  echo ""
+  echo "------------------------------------------------"
+  echo ""
+  echo "The files listed above must use a Wrapped StopContext to enable Custom Timeouts."
+  echo "You can do this by changing:"
+  echo ""
+  echo "> ctx := meta.(*ArmClient).StopContext"
+  echo ""
+  echo "to"
+  echo ""
+  echo "> ctx, cancel := timeouts.ForCreate(meta.(*ArmClient).StopContext, d)"
+  echo "> defer cancel()"
+  echo ""
+  echo "where 'ForCreate', 'ForCreateUpdate', 'ForDelete', 'ForRead' and 'ForUpdate' are available"
+  echo ""
+  echo "and then configuring Timeouts on the resource:"
+  echo ""
+  echo "> return &schema.Resource{"
+  echo ">   ..."
+  echo ">   Timeouts: &schema.ResourceTimeout{"
+  echo ">     Create: schema.DefaultTimeout(30 * time.Minute),"
+  echo ">     Read:   schema.DefaultTimeout(5 * time.Minute),"
+  echo ">     Update: schema.DefaultTimeout(30 * time.Minute),"
+  echo ">     Delete: schema.DefaultTimeout(30 * time.Minute),"
+  echo ">   },"
+  echo ">   ..."
+  echo "> }"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This PR adds compile-time checks to ensure that all Data Sources & Resources have Timeouts defined and subsequently ensures that contexts which are used have timeouts configured

This also removes the default timeout since all resources now have one defined - and new ones will be caught via compile-time checks. This probably could be moved into the Linter - but it's fine here for now.