### PR TITLE
provider: ensuring the providers slice isn't a nil pointer

### DIFF
--- a/azurerm/provider_test.go
+++ b/azurerm/provider_test.go
@@ -14,16 +14,19 @@ var testAccProvider *schema.Provider
 
 func init() {
 	azureProvider := Provider().(*schema.Provider)
-	supportedProviders := map[string]terraform.ResourceProvider{
+
+	testAccProvider = azureProvider
+	acceptance.AzureProvider = azureProvider
+
+	// NOTE: these /cannot/ be simplified into a single shared variable (tried, it causes a nil-slice)
+	testAccProviders = map[string]terraform.ResourceProvider{
 		"azurerm": testAccProvider,
 		"azuread": azuread.Provider().(*schema.Provider),
 	}
-
-	// TODO: these can be de-duped once this is relocated
-	testAccProvider = azureProvider
-	acceptance.AzureProvider = azureProvider
-	testAccProviders = supportedProviders
-	acceptance.SupportedProviders = supportedProviders
+	acceptance.SupportedProviders = map[string]terraform.ResourceProvider{
+		"azurerm": testAccProvider,
+		"azuread": azuread.Provider().(*schema.Provider),
+	}
 }
 
 func TestProvider(t *testing.T) {


### PR DESCRIPTION
This was a fun one to track down.

Turns out due to the way that parallelization works, `init()` gets called after
the `resource.ParallelTest` has been called - which means that `testAccProviders`
could be an empty slice, which caused an unhelpful crash in the Plugin SDK.

Before this change:

```
2019/12/09 07:55:18 [TRACE] LoadSchemas: retrieving schema for provider type "azurerm"
2019/12/09 07:55:18 [TRACE] GRPCProvider: GetSchema
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2725f14]
goroutine 25 [running]:
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).getProviderSchemaBlock(...)
	/Users/tharvey/code/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.1.1/internal/helper/plugin/grpc_provider.go:76
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).GetSchema(0xc0000b71f8, 0x5aace60, 0xc00094c300, 0xc000548ee0, 0xc0000b71f8, 0xc00094c300, 0xc000074a80)
	/Users/tharvey/code/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.1.1/internal/helper/plugin/grpc_provider.go:55 +0x94
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_GetSchema_Handler(0x4dfec00, 0xc0000b71f8, 0x5aace60, 0xc00094c300, 0xc0009520c0, 0x0, 0x5aace60, 0xc00094c300, 0x0, 0x0)
	/Users/tharvey/code/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.1.1/internal/tfplugin5/tfplugin5.pb.go:3045 +0x217
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000fa2c0, 0x5b073c0, 0xc00088c300, 0xc00097e000, 0xc000727e30, 0x8736660, 0x0, 0x0, 0x0)
	/Users/tharvey/code/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995 +0x460
google.golang.org/grpc.(*Server).handleStream(0xc0000fa2c0, 0x5b073c0, 0xc00088c300, 0xc00097e000, 0x0)
	/Users/tharvey/code/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275 +0xd97
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0004a83e0, 0xc0000fa2c0, 0x5b073c0, 0xc00088c300, 0xc00097e000)
	/Users/tharvey/code/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710 +0xbb
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/tharvey/code/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:708 +0xa1
FAIL	github.com/terraform-providers/terraform-provider-azurerm/azurerm	0.050s
FAIL
```

Tests pass:

```
$ acctests azurerm TestAccAzureRMResourceGroup_basic
=== RUN   TestAccAzureRMResourceGroup_basic
=== PAUSE TestAccAzureRMResourceGroup_basic
=== CONT  TestAccAzureRMResourceGroup_basic
--- PASS: TestAccAzureRMResourceGroup_basic (77.08s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	77.132s
```