### PR TITLE
BUG: `azurerm_private_link_endpoint`: fixes subresource name validation

### DIFF
--- a/azurerm/internal/services/network/private_link_endpoint_test.go
+++ b/azurerm/internal/services/network/private_link_endpoint_test.go
@@ -1,0 +1,54 @@
+package network
+
+import (
+	"testing"
+)
+
+func TestValidatePrivateLinkSubResourceName(t *testing.T) {
+	testData := []struct {
+		Name  string
+		Input string
+		Valid bool
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Valid: false,
+		},
+		{
+			Name:  "Sql Server",
+			Input: "sqlServer",
+			Valid: true,
+		},
+		{
+			Name:  "Blob Secondary",
+			Input: "blob_secondary",
+			Valid: true,
+		},
+		{
+			Name:  "Blob Secondary Invalid",
+			Input: "blob-secondary",
+			Valid: false,
+		},
+		{
+			Name:  "Minimum Value Valid",
+			Input: "A",
+			Valid: true,
+		},
+		{
+			Name:  "Minimum Value Invalid",
+			Input: "~",
+			Valid: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		_, errors := ValidatePrivateLinkSubResourceName(v.Input, "private_link_endpoint_subresource")
+		isValid := len(errors) == 0
+		if v.Valid != isValid {
+			t.Fatalf("Expected %t but got %t", v.Valid, isValid)
+		}
+	}
+}

--- a/azurerm/internal/services/network/private_link_endpoint_test.go
+++ b/azurerm/internal/services/network/private_link_endpoint_test.go
@@ -11,13 +11,23 @@ func TestValidatePrivateLinkSubResourceName(t *testing.T) {
 		Valid bool
 	}{
 		{
-			Name:  "Empty",
+			Name:  "Empty Value",
 			Input: "",
+			Valid: false,
+		},
+		{
+			Name:  "Whitespace",
+			Input: " ",
 			Valid: false,
 		},
 		{
 			Name:  "Sql Server",
 			Input: "sqlServer",
+			Valid: true,
+		},
+		{
+			Name:  "Sql Server All Stop",
+			Input: "sql.Server",
 			Valid: true,
 		},
 		{
@@ -28,6 +38,11 @@ func TestValidatePrivateLinkSubResourceName(t *testing.T) {
 		{
 			Name:  "Blob Secondary Invalid",
 			Input: "blob-secondary",
+			Valid: false,
+		},
+		{
+			Name:  "Blob Secondary Space",
+			Input: "blob secondary",
 			Valid: false,
 		},
 		{
@@ -43,7 +58,7 @@ func TestValidatePrivateLinkSubResourceName(t *testing.T) {
 	}
 
 	for _, v := range testData {
-		t.Logf("[DEBUG] Testing %q", v.Input)
+		t.Logf("[DEBUG] Testing %q", v.Name)
 
 		_, errors := ValidatePrivateLinkSubResourceName(v.Input, "private_link_endpoint_subresource")
 		isValid := len(errors) == 0

--- a/azurerm/internal/services/network/validate.go
+++ b/azurerm/internal/services/network/validate.go
@@ -132,7 +132,7 @@ func ValidatePrivateLinkSubResourceName(i interface{}, k string) (_ []string, er
 	}
 
 	if len(strings.TrimSpace(v)) >= 1 {
-		if m, _ := validate.RegExHelper(i, k, `^[\w\.]$`); !m {
+		if m, _ := validate.RegExHelper(i, k, `^[\w\.]*$`); !m {
 			errors = append(errors, fmt.Errorf("%s must only contain upper or lowercase letters, numbers, underscores, and periods", k))
 		}
 	} else {


### PR DESCRIPTION
(fixes #5110 )