### PR TITLE
subnet: Support address_prefixes for multiple prefixes (ipv6)

### DIFF
--- a/azurerm/internal/services/network/tests/data_source_subnet_test.go
+++ b/azurerm/internal/services/network/tests/data_source_subnet_test.go
@@ -30,6 +30,28 @@ func TestAccDataSourceAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMSubnet_basic_addressPrefixes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_subnet", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMSubnet_basic_addressPrefixes(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(data.ResourceName, "name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "resource_group_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "virtual_network_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "address_prefixes"),
+					resource.TestCheckResourceAttr(data.ResourceName, "network_security_group_id", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "route_table_id", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceAzureRMSubnet_networkSecurityGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_subnet", "test")
 
@@ -118,6 +140,35 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.0.0/24"
+}
+
+data "azurerm_subnet" "test" {
+  name                 = "${azurerm_subnet.test.name}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccDataSourceAzureRMSubnet_basic_addressPrefixes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest%d-rg"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest%d-vn"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctest%d-private"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefixes     = ["10.0.0.0/24", "fd00::/48""]
 }
 
 data "azurerm_subnet" "test" {

--- a/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
@@ -34,6 +34,24 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSubnet_basic_addressPrefixes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSubnet_basic_addressPrefixes(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
 func TestAccAzureRMSubnet_requiresImport(t *testing.T) {
 	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -422,6 +440,29 @@ resource "azurerm_subnet" "test" {
   resource_group_name  = "${azurerm_resource_group.test.name}"
   virtual_network_name = "${azurerm_virtual_network.test.name}"
   address_prefix       = "10.0.2.0/24"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMSubnet_basic_addressPrefixes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefixes     = ["10.0.2.0/24", "fd00::/48"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
The azure subnet resource supports addressPrefix when one prefix is available and addressPrefixes when two or or more are set (for instance, when configuring an ipv4 and ipv6 dual stack configuration for a network). Update `azurerm_subnet` to allow either `address_prefix` or `address_prefixes` as input, where the latter is a list of string. Check that at least one is set, and mark the older address_prefix as deprecated.

The data source for subnet is modified to always return address_prefixes to simplify retrieval (although this could be changed to always return the first address prefix as address_prefix).

Today, if two prefixes are specified via CLI or Azure UI the data source returns no address_prefix and it is not possible to create a new subnet with two prefixes via Terraform.

Fixes #5140