### PR TITLE
Doc changes to certificate import options in KeyVault and preconditions for import to WebApp

### DIFF
--- a/website/docs/r/app_service_certificate.html.markdown
+++ b/website/docs/r/app_service_certificate.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `key_vault_secret_id` - (Optional) The ID of the Key Vault secret. Changing this forces a new resource to be created.
 
--> **NOTE:** If using `key_vault_secret_id`, the magic Resource Principal with id of `abfa0a7c-a6b6-4736-8310-5855508787cd` must have 'Secret -> get' and 'Certificate -> get' permissions on the Key Vault containing the certificate.  (Source: [App Service Blog](https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html))
+-> **NOTE:** If using `key_vault_secret_id`, the WebApp Service Resource Principal ID `abfa0a7c-a6b6-4736-8310-5855508787cd` with object_id `f8daea97-62e7-4026-becf-13c2ea98e8b4` of  must have 'Secret -> get' and 'Certificate -> get' permissions on the Key Vault containing the certificate.  (Source: [App Service Blog](https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html))
 
 ## Attributes Reference
 

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -275,7 +275,7 @@ The following arguments are supported:
 
 `issuer_parameters` supports the following:
 
-* `name` - (Required) The name of the Certificate Issuer. Possible values include `Self` for self-signed certificate, or `Unknown` for a certificate issuing authority like `Let's Encrypt` and Azure direct supported ones. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Certificate Issuer. Possible values include `Self` (for self-signed certificate), or `Unknown` (for a certificate issuing authority like `Let's Encrypt` and Azure direct supported ones). Changing this forces a new resource to be created.
 
 `key_properties` supports the following:
 

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -275,7 +275,7 @@ The following arguments are supported:
 
 `issuer_parameters` supports the following:
 
-* `name` - (Required) The name of the Certificate Issuer. Possible values include `Self`, or the name of a certificate issuing authority supported by Azure. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Certificate Issuer. Possible values include `Self` for self-signed certificate, or `Unknown` for a certificate issuing authority like `Let's Encrypt` and Azure direct supported ones. Changing this forces a new resource to be created.
 
 `key_properties` supports the following:
 


### PR DESCRIPTION
I have the feeling the issuer name parameter only can contain 'Self' or 'Unknown' as value see here: https://docs.microsoft.com/en-us/rest/api/keyvault/importcertificate/importcertificate#issuerparameters

I was confused what to enter there when importing a Let's Encrypt cert but 'Unknown' works just perfect. I do not see a option for Azure supported CAs, I think this is more for creation of new certs?! I didn't ripped that part out, just glued it to the 'Unknown' option.

I will reuse this cert in WebApps and luckily the hint about the WebApps Principal was already there, however in the Terraform access_policy snippet you have to enter the ObjectID, so I looked it up and added it to the documentation. Not sure if it is really a magic one :) The official name in AAD is 'Microsoft Azure WebSites'. And after adding the access policy with ObjectID it worked fine.