### PR TITLE
Bug: `azurerm_private_endpoint` fix regex length constraint

### DIFF
--- a/azurerm/internal/services/network/private_link_endpoint_test.go
+++ b/azurerm/internal/services/network/private_link_endpoint_test.go
@@ -52,7 +52,7 @@ func TestValidatePrivateLinkSubResourceName(t *testing.T) {
 		},
 		{
 			Name:  "Minimum Value Valid",
-			Input: "Sql",
+			Input: "dfs",
 			Valid: true,
 		},
 		{
@@ -87,7 +87,7 @@ func TestValidatePrivateLinkSubResourceName(t *testing.T) {
 		},
 		{
 			Name:  "Too Long",
-			Input: "the-name-of-this-subresource-is-way-way-too-long-for-this-resource",
+			Input: "the-name-of-this-subresource-is-way-too-looong-for-this-resource",
 			Valid: false,
 		},
 		{

--- a/azurerm/internal/services/network/validate.go
+++ b/azurerm/internal/services/network/validate.go
@@ -132,7 +132,7 @@ func ValidatePrivateLinkSubResourceName(i interface{}, k string) (_ []string, er
 	}
 
 	if len(strings.TrimSpace(v)) >= 3 {
-		if m, _ := validate.RegExHelper(i, k, `^([a-zA-Z0-9])([\w\.-]{1,62})([a-zA-Z0-9])$`); !m {
+		if m, _ := validate.RegExHelper(i, k, `^([a-zA-Z0-9])([\w\.-]{1,61})([a-zA-Z0-9])$`); !m {
 			errors = append(errors, fmt.Errorf("%s must begin and end with a alphanumeric character, be between 3 and 63 characters in length, only contain letters, numbers, underscores, periods, and dashes", k))
 		}
 	} else {


### PR DESCRIPTION
The regEx expression was allowing 64 characters instead of 63.