### PR TITLE
`azurerm_function_app` - support for `ftps_state`

### DIFF
--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -235,6 +235,16 @@ func resourceArmFunctionApp() *schema.Resource {
 								string(web.OneFullStopTwo),
 							}, false),
 						},
+						"ftps_state": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.AllAllowed),
+								string(web.Disabled),
+								string(web.FtpsOnly),
+							}, false),
+						},
 						"cors": azure.SchemaWebCorsSettings(),
 					},
 				},
@@ -740,6 +750,10 @@ func expandFunctionAppSiteConfig(d *schema.ResourceData) web.SiteConfig {
 		siteConfig.MinTLSVersion = web.SupportedTLSVersions(v.(string))
 	}
 
+	if v, ok := config["ftps_state"]; ok {
+		siteConfig.FtpsState = web.FtpsState(v.(string))
+	}
+
 	return siteConfig
 }
 
@@ -777,6 +791,7 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 	}
 
 	result["min_tls_version"] = string(input.MinTLSVersion)
+	result["ftps_state"] = string(input.FtpsState)
 
 	result["cors"] = azure.FlattenWebCorsSettings(input.Cors)
 

--- a/azurerm/resource_arm_function_app_test.go
+++ b/azurerm/resource_arm_function_app_test.go
@@ -748,6 +748,33 @@ func TestAccAzureRMFunctionApp_minTlsVersion(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFunctionApp_ftpsState(t *testing.T) {
+	resourceName := "azurerm_function_app.test"
+	ri := tf.AccRandTimeInt()
+	rs := strings.ToLower(acctest.RandString(11))
+	config := testAccAzureRMFunctionApp_ftpsState(ri, rs, testLocation())
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMFunctionAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFunctionAppExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "site_config.0.ftps_state", "AllAllowed"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMFunctionAppDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*ArmClient).Web.AppServicesClient
 
@@ -1804,6 +1831,46 @@ resource "azurerm_function_app" "test" {
 
   site_config {
     min_tls_version = "1.2"
+  }
+}
+`, rInt, location, rString, rInt, rInt)
+}
+
+func testAccAzureRMFunctionApp_ftpsState(rInt int, rString string, location string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "${azurerm_resource_group.test.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_function_app" "test" {
+  name                      = "acctest-%d-func"
+  location                  = "${azurerm_resource_group.test.location}"
+  resource_group_name       = "${azurerm_resource_group.test.name}"
+  app_service_plan_id       = "${azurerm_app_service_plan.test.id}"
+  storage_connection_string = "${azurerm_storage_account.test.primary_connection_string}"
+
+  site_config {
+    ftps_state = "AllAllowed"
   }
 }
 `, rInt, location, rString, rInt, rInt)

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -151,6 +151,8 @@ The following arguments are supported:
 
 * `min_tls_version` - (Optional) The minimum supported TLS version for the function app. Possible values are `1.0`, `1.1`, and `1.2`. Defaults to `1.2` for new function apps.
 
+* `ftps_state` - (Optional) State of FTP / FTPS service for this function app. Possible values include: `AllAllowed`, `FtpsOnly` and `Disabled`.
+
 * `cors` - (Optional) A `cors` block as defined below.
 
 ---


### PR DESCRIPTION
Fixes: #2651

Adds the `ftps_state` option to the `azurerm_function_app` resource.

```
=== RUN   TestAccAzureRMFunctionApp_ftpsState
=== PAUSE TestAccAzureRMFunctionApp_ftpsState
=== CONT  TestAccAzureRMFunctionApp_ftpsState
--- PASS: TestAccAzureRMFunctionApp_ftpsState (161.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm       161.328s
```