### PR TITLE
refactor: making ID Parsing consistent

### DIFF
--- a/azurerm/helpers/azure/resourceid.go
+++ b/azurerm/helpers/azure/resourceid.go
@@ -17,7 +17,7 @@ type ResourceID struct {
 	Path           map[string]string
 }
 
-// parseAzureResourceID converts a long-form Azure Resource Manager ID
+// ParseAzureResourceID converts a long-form Azure Resource Manager ID
 // into a ResourceID. We make assumptions about the structure of URLs,
 // which is obviously not good, but the best thing available given the
 // SDK.
@@ -91,4 +91,26 @@ func ParseAzureResourceID(id string) (*ResourceID, error) {
 	}
 
 	return idObj, nil
+}
+
+// PopSegment retrieves a segment from the Path and returns it
+// if found it removes it from the Path then return the value
+// if not found, this returns nil
+func (id *ResourceID) PopSegment(name string) (string, error) {
+	val, ok := id.Path[name]
+	if !ok {
+		return "", fmt.Errorf("ID was missing the `%s` element", name)
+	}
+
+	delete(id.Path, name)
+	return val, nil
+}
+
+// ValidateNoEmptySegments validates ...
+func (id *ResourceID) ValidateNoEmptySegments(sourceId string) error {
+	if len(id.Path) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("ID contained more segments than required: %q", sourceId)
 }

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -21,7 +21,7 @@ func ValidateScaleSetResourceID(i interface{}, k string) (s []string, es []error
 		return
 	}
 
-	id, err := ParseVirtualMachineScaleSetResourceID(v)
+	id, err := ParseVirtualMachineScaleSetID(v)
 	if err != nil {
 		es = append(es, fmt.Errorf("Error parsing %q as a VM Scale Set Resource ID: %s", v, err))
 		return

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -12,24 +12,27 @@ import (
 )
 
 type VirtualMachineScaleSetResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
-func ParseVirtualMachineScaleSetResourceID(input string) (*VirtualMachineScaleSetResourceID, error) {
+func ParseVirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetResourceID, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Unable to parse Virtual Machine Scale Set ID %q: %+v", input, err)
 	}
 
 	vmScaleSet := VirtualMachineScaleSetResourceID{
-		Base: *id,
-		Name: id.Path["virtualMachineScaleSets"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if vmScaleSet.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `virtualMachineScaleSets` element")
+	vmScaleSet.Name, err = id.PopSegment("virtualMachineScaleSets")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &vmScaleSet, nil

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -26,8 +26,7 @@ func ParseVirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetResourc
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	vmScaleSet.Name, err = id.PopSegment("virtualMachineScaleSets")
-	if err != nil {
+	if vmScaleSet.Name, err = id.PopSegment("virtualMachineScaleSets"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_extension.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_extension.go
@@ -7,30 +7,33 @@ import (
 )
 
 type VirtualMachineScaleSetExtensionResourceID struct {
-	Base azure.ResourceID
-
+	ResourceGroup      string
 	VirtualMachineName string
 	Name               string
 }
 
-func ParseVirtualMachineScaleSetExtensionResourceID(input string) (*VirtualMachineScaleSetExtensionResourceID, error) {
+func ParseVirtualMachineScaleSetExtensionID(input string) (*VirtualMachineScaleSetExtensionResourceID, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Unable to parse Virtual Machine Scale Set Extension ID %q: %+v", input, err)
 	}
 
 	extension := VirtualMachineScaleSetExtensionResourceID{
-		Base:               *id,
-		VirtualMachineName: id.Path["virtualMachineScaleSets"],
-		Name:               id.Path["extensions"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if extension.VirtualMachineName == "" {
-		return nil, fmt.Errorf("ID was missing the `virtualMachineScaleSets` element")
+	extension.VirtualMachineName, err = id.PopSegment("virtualMachineScaleSets")
+	if err != nil {
+		return nil, err
 	}
 
-	if extension.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `extensions` element")
+	extension.Name, err = id.PopSegment("extensions")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &extension, nil

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_extension.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_extension.go
@@ -22,13 +22,11 @@ func ParseVirtualMachineScaleSetExtensionID(input string) (*VirtualMachineScaleS
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	extension.VirtualMachineName, err = id.PopSegment("virtualMachineScaleSets")
-	if err != nil {
+	if extension.VirtualMachineName, err = id.PopSegment("virtualMachineScaleSets"); err != nil {
 		return nil, err
 	}
 
-	extension.Name, err = id.PopSegment("extensions")
-	if err != nil {
+	if extension.Name, err = id.PopSegment("extensions"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_extension_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_extension_test.go
@@ -1,0 +1,69 @@
+package compute
+
+import (
+	"testing"
+)
+
+func TestParseVirtualMachineScaleSetExtensionID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *VirtualMachineScaleSetExtensionResourceID
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Virtual Machine Scale Set Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo",
+			Expected: nil,
+		},
+		{
+			Name:     "No Virtual Machine Scale Set Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualMachineScaleSets/",
+			Expected: nil,
+		},
+		{
+			Name:     "No Extensions Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualMachineScaleSets/machine1",
+			Expected: nil,
+		},
+		{
+			Name:     "No Extensions Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualMachineScaleSets/machine1/extensions/",
+			Expected: nil,
+		},
+		{
+			Name:  "Completed",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualMachineScaleSets/machine1/extensions/extension1",
+			Expected: &VirtualMachineScaleSetExtensionResourceID{
+				Name:               "extension1",
+				VirtualMachineName: "machine1",
+				ResourceGroup:      "foo",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ParseVirtualMachineScaleSetExtensionID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_test.go
@@ -2,8 +2,6 @@ package compute
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseVirtualMachineScaleSetID(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParseVirtualMachineScaleSetID(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualMachineScaleSets/example",
 			Expected: &VirtualMachineScaleSetResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -42,7 +38,7 @@ func TestParseVirtualMachineScaleSetID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Name)
 
-		actual, err := ParseVirtualMachineScaleSetResourceID(v.Input)
+		actual, err := ParseVirtualMachineScaleSetID(v.Input)
 		if err != nil {
 			if v.Expected == nil {
 				continue
@@ -55,8 +51,8 @@ func TestParseVirtualMachineScaleSetID(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/containers/kubernetes_id.go
+++ b/azurerm/internal/services/containers/kubernetes_id.go
@@ -10,8 +10,6 @@ import (
 type KubernetesClusterID struct {
 	Name          string
 	ResourceGroup string
-
-	ID azure.ResourceID
 }
 
 func KubernetesClusterIDSchema() *schema.Schema {
@@ -23,28 +21,26 @@ func KubernetesClusterIDSchema() *schema.Schema {
 	}
 }
 
-func ParseKubernetesClusterID(id string) (*KubernetesClusterID, error) {
-	clusterId, err := azure.ParseAzureResourceID(id)
+func ParseKubernetesClusterID(input string) (*KubernetesClusterID, error) {
+	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
 
-	resourceGroup := clusterId.ResourceGroup
-	if resourceGroup == "" {
-		return nil, fmt.Errorf("%q is missing a Resource Group", id)
+	cluster := KubernetesClusterID{
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	clusterName := clusterId.Path["managedClusters"]
-	if clusterName == "" {
-		return nil, fmt.Errorf("%q is missing the `managedClusters` segment", id)
+	cluster.Name, err = id.PopSegment("managedClusters")
+	if err != nil {
+		return nil, err
 	}
 
-	output := KubernetesClusterID{
-		Name:          clusterName,
-		ResourceGroup: resourceGroup,
-		ID:            *clusterId,
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
-	return &output, nil
+
+	return &cluster, nil
 }
 
 func ValidateKubernetesClusterID(i interface{}, k string) (warnings []string, errors []error) {
@@ -54,15 +50,8 @@ func ValidateKubernetesClusterID(i interface{}, k string) (warnings []string, er
 		return
 	}
 
-	id, err := azure.ParseAzureResourceID(v)
-	if err != nil {
+	if _, err := ParseKubernetesClusterID(v); err != nil {
 		errors = append(errors, fmt.Errorf("Can not parse %q as a Resource Id: %v", v, err))
-	}
-
-	if id != nil {
-		if id.Path["managedClusters"] == "" {
-			errors = append(errors, fmt.Errorf("The 'managedClusters' segment is missing from Resource ID %q", v))
-		}
 	}
 
 	return warnings, errors

--- a/azurerm/internal/services/containers/kubernetes_id.go
+++ b/azurerm/internal/services/containers/kubernetes_id.go
@@ -31,8 +31,7 @@ func ParseKubernetesClusterID(input string) (*KubernetesClusterID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	cluster.Name, err = id.PopSegment("managedClusters")
-	if err != nil {
+	if cluster.Name, err = id.PopSegment("managedClusters"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/containers/nodepool_id.go
+++ b/azurerm/internal/services/containers/nodepool_id.go
@@ -1,8 +1,6 @@
 package containers
 
 import (
-	"fmt"
-
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
@@ -10,36 +8,31 @@ type KubernetesNodePoolID struct {
 	Name          string
 	ClusterName   string
 	ResourceGroup string
-
-	ID azure.ResourceID
 }
 
-func ParseKubernetesNodePoolID(id string) (*KubernetesNodePoolID, error) {
-	clusterId, err := azure.ParseAzureResourceID(id)
+func ParseKubernetesNodePoolID(input string) (*KubernetesNodePoolID, error) {
+	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
 
-	resourceGroup := clusterId.ResourceGroup
-	if resourceGroup == "" {
-		return nil, fmt.Errorf("%q is missing a Resource Group", id)
+	pool := KubernetesNodePoolID{
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	clusterName := clusterId.Path["managedClusters"]
-	if clusterName == "" {
-		return nil, fmt.Errorf("%q is missing the `managedClusters` segment", id)
+	pool.ClusterName, err = id.PopSegment("managedClusters")
+	if err != nil {
+		return nil, err
 	}
 
-	nodePoolName := clusterId.Path["agentPools"]
-	if nodePoolName == "" {
-		return nil, fmt.Errorf("%q is missing the `agentPools` segment", id)
+	pool.Name, err = id.PopSegment("agentPools")
+	if err != nil {
+		return nil, err
 	}
 
-	output := KubernetesNodePoolID{
-		Name:          nodePoolName,
-		ClusterName:   clusterName,
-		ResourceGroup: resourceGroup,
-		ID:            *clusterId,
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
-	return &output, nil
+
+	return &pool, nil
 }

--- a/azurerm/internal/services/containers/nodepool_id.go
+++ b/azurerm/internal/services/containers/nodepool_id.go
@@ -20,13 +20,11 @@ func ParseKubernetesNodePoolID(input string) (*KubernetesNodePoolID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	pool.ClusterName, err = id.PopSegment("managedClusters")
-	if err != nil {
+	if pool.ClusterName, err = id.PopSegment("managedClusters"); err != nil {
 		return nil, err
 	}
 
-	pool.Name, err = id.PopSegment("agentPools")
-	if err != nil {
+	if pool.Name, err = id.PopSegment("agentPools"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/containers/nodepool_id_test.go
+++ b/azurerm/internal/services/containers/nodepool_id_test.go
@@ -1,0 +1,87 @@
+package containers
+
+import (
+	"testing"
+)
+
+func TestKubernetesNodePoolID(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected *KubernetesNodePoolID
+	}{
+		{
+			input:    "",
+			expected: nil,
+		},
+		{
+			input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			expected: nil,
+		},
+		{
+			input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups",
+			expected: nil,
+		},
+		{
+			input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hello",
+			expected: nil,
+		},
+		{
+			input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hello/managedClusters/",
+			expected: nil,
+		},
+		{
+			input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hello/managedClusters/cluster1",
+			expected: nil,
+		},
+		{
+			input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hello/managedClusters/cluster1/agentPools/",
+			expected: nil,
+		},
+		{
+			input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hello/managedClusters/cluster1/agentPools/pool1",
+			expected: &KubernetesNodePoolID{
+				Name:          "pool1",
+				ClusterName:   "cluster1",
+				ResourceGroup: "hello",
+			},
+		},
+		{
+			// wrong case
+			input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/hello/managedClusters/cluster1/agentpools/pool1",
+			expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.input)
+		actual, err := ParseKubernetesNodePoolID(v.input)
+
+		// if we get something there shouldn't be an error
+		if v.expected != nil && err == nil {
+			continue
+		}
+
+		// if nothing's expected we should get an error
+		if v.expected == nil && err != nil {
+			continue
+		}
+
+		if v.expected == nil && actual == nil {
+			continue
+		}
+
+		if v.expected == nil && actual != nil {
+			t.Fatalf("Expected nothing but got %+v", actual)
+		}
+		if v.expected != nil && actual == nil {
+			t.Fatalf("Expected %+v but got nil", actual)
+		}
+
+		if v.expected.ResourceGroup != actual.ResourceGroup {
+			t.Fatalf("Expected ResourceGroup to be %q but got %q", v.expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if v.expected.Name != actual.Name {
+			t.Fatalf("Expected Name to be %q but got %q", v.expected.Name, actual.Name)
+		}
+	}
+}

--- a/azurerm/internal/services/network/network_security_group.go
+++ b/azurerm/internal/services/network/network_security_group.go
@@ -7,24 +7,27 @@ import (
 )
 
 type NetworkSecurityGroupResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
-func ParseNetworkSecurityGroupResourceID(input string) (*NetworkSecurityGroupResourceID, error) {
+func ParseNetworkSecurityGroupID(input string) (*NetworkSecurityGroupResourceID, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Unable to parse Network Security Group ID %q: %+v", input, err)
 	}
 
 	networkSecurityGroup := NetworkSecurityGroupResourceID{
-		Base: *id,
-		Name: id.Path["networkSecurityGroups"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if networkSecurityGroup.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `networkSecurityGroups` element")
+	networkSecurityGroup.Name, err = id.PopSegment("networkSecurityGroups")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &networkSecurityGroup, nil

--- a/azurerm/internal/services/network/network_security_group.go
+++ b/azurerm/internal/services/network/network_security_group.go
@@ -21,8 +21,7 @@ func ParseNetworkSecurityGroupID(input string) (*NetworkSecurityGroupResourceID,
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	networkSecurityGroup.Name, err = id.PopSegment("networkSecurityGroups")
-	if err != nil {
+	if networkSecurityGroup.Name, err = id.PopSegment("networkSecurityGroups"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/network/network_security_group_test.go
+++ b/azurerm/internal/services/network/network_security_group_test.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseNetworkSecurityGroup(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParseNetworkSecurityGroup(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/networkSecurityGroups/example",
 			Expected: &NetworkSecurityGroupResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -42,7 +38,7 @@ func TestParseNetworkSecurityGroup(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Name)
 
-		actual, err := ParseNetworkSecurityGroupResourceID(v.Input)
+		actual, err := ParseNetworkSecurityGroupID(v.Input)
 		if err != nil {
 			if v.Expected == nil {
 				continue
@@ -55,8 +51,8 @@ func TestParseNetworkSecurityGroup(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/network/point_to_site_vpn_gateway.go
+++ b/azurerm/internal/services/network/point_to_site_vpn_gateway.go
@@ -21,8 +21,7 @@ func ParsePointToSiteVPNGatewayID(input string) (*PointToSiteVPNGatewayResourceI
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	routeTable.Name, err = id.PopSegment("p2sVpnGateways")
-	if err != nil {
+	if routeTable.Name, err = id.PopSegment("p2sVpnGateways"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/network/point_to_site_vpn_gateway.go
+++ b/azurerm/internal/services/network/point_to_site_vpn_gateway.go
@@ -7,9 +7,8 @@ import (
 )
 
 type PointToSiteVPNGatewayResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParsePointToSiteVPNGatewayID(input string) (*PointToSiteVPNGatewayResourceID, error) {
@@ -19,12 +18,16 @@ func ParsePointToSiteVPNGatewayID(input string) (*PointToSiteVPNGatewayResourceI
 	}
 
 	routeTable := PointToSiteVPNGatewayResourceID{
-		Base: *id,
-		Name: id.Path["p2sVpnGateways"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if routeTable.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `p2sVpnGateways` element")
+	routeTable.Name, err = id.PopSegment("p2sVpnGateways")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &routeTable, nil

--- a/azurerm/internal/services/network/point_to_site_vpn_gateway_test.go
+++ b/azurerm/internal/services/network/point_to_site_vpn_gateway_test.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParsePointToSiteVPNGateway(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParsePointToSiteVPNGateway(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/p2sVpnGateways/example",
 			Expected: &PointToSiteVPNGatewayResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -55,8 +51,8 @@ func TestParsePointToSiteVPNGateway(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/network/route_table.go
+++ b/azurerm/internal/services/network/route_table.go
@@ -10,9 +10,8 @@ import (
 // since these top level objects exist
 
 type RouteTableResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseRouteTableResourceID(input string) (*RouteTableResourceID, error) {
@@ -22,12 +21,16 @@ func ParseRouteTableResourceID(input string) (*RouteTableResourceID, error) {
 	}
 
 	routeTable := RouteTableResourceID{
-		Base: *id,
-		Name: id.Path["routeTables"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if routeTable.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `routeTables` element")
+	routeTable.Name, err = id.PopSegment("routeTables")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &routeTable, nil

--- a/azurerm/internal/services/network/route_table.go
+++ b/azurerm/internal/services/network/route_table.go
@@ -14,7 +14,7 @@ type RouteTableResourceID struct {
 	Name          string
 }
 
-func ParseRouteTableResourceID(input string) (*RouteTableResourceID, error) {
+func ParseRouteTableID(input string) (*RouteTableResourceID, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, fmt.Errorf("[ERROR] Unable to parse Route Table ID %q: %+v", input, err)

--- a/azurerm/internal/services/network/route_table.go
+++ b/azurerm/internal/services/network/route_table.go
@@ -24,8 +24,7 @@ func ParseRouteTableID(input string) (*RouteTableResourceID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	routeTable.Name, err = id.PopSegment("routeTables")
-	if err != nil {
+	if routeTable.Name, err = id.PopSegment("routeTables"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/network/route_table_test.go
+++ b/azurerm/internal/services/network/route_table_test.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseRouteTable(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParseRouteTable(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/routeTables/example",
 			Expected: &RouteTableResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -55,8 +51,8 @@ func TestParseRouteTable(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/network/route_table_test.go
+++ b/azurerm/internal/services/network/route_table_test.go
@@ -38,7 +38,7 @@ func TestParseRouteTable(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Name)
 
-		actual, err := ParseRouteTableResourceID(v.Input)
+		actual, err := ParseRouteTableID(v.Input)
 		if err != nil {
 			if v.Expected == nil {
 				continue

--- a/azurerm/internal/services/network/virtual_hub.go
+++ b/azurerm/internal/services/network/virtual_hub.go
@@ -21,8 +21,7 @@ func ParseVirtualHubID(input string) (*VirtualHubResourceID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	virtualHub.Name, err = id.PopSegment("virtualHubs")
-	if err != nil {
+	if virtualHub.Name, err = id.PopSegment("virtualHubs"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/network/virtual_hub.go
+++ b/azurerm/internal/services/network/virtual_hub.go
@@ -7,9 +7,8 @@ import (
 )
 
 type VirtualHubResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseVirtualHubID(input string) (*VirtualHubResourceID, error) {
@@ -19,12 +18,16 @@ func ParseVirtualHubID(input string) (*VirtualHubResourceID, error) {
 	}
 
 	virtualHub := VirtualHubResourceID{
-		Base: *id,
-		Name: id.Path["virtualHubs"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if virtualHub.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `virtualHubs` element")
+	virtualHub.Name, err = id.PopSegment("virtualHubs")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &virtualHub, nil

--- a/azurerm/internal/services/network/virtual_hub_test.go
+++ b/azurerm/internal/services/network/virtual_hub_test.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseVirtualHub(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParseVirtualHub(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualHubs/example",
 			Expected: &VirtualHubResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -55,8 +51,8 @@ func TestParseVirtualHub(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/network/virtual_wan.go
+++ b/azurerm/internal/services/network/virtual_wan.go
@@ -21,8 +21,7 @@ func ParseVirtualWanID(input string) (*VirtualWanResourceID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	virtualWan.Name, err = id.PopSegment("virtualWans")
-	if err != nil {
+	if virtualWan.Name, err = id.PopSegment("virtualWans"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/network/virtual_wan.go
+++ b/azurerm/internal/services/network/virtual_wan.go
@@ -7,9 +7,8 @@ import (
 )
 
 type VirtualWanResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseVirtualWanID(input string) (*VirtualWanResourceID, error) {
@@ -19,12 +18,16 @@ func ParseVirtualWanID(input string) (*VirtualWanResourceID, error) {
 	}
 
 	virtualWan := VirtualWanResourceID{
-		Base: *id,
-		Name: id.Path["virtualWans"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if virtualWan.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `virtualWans` element")
+	virtualWan.Name, err = id.PopSegment("virtualWans")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &virtualWan, nil

--- a/azurerm/internal/services/network/virtual_wan_test.go
+++ b/azurerm/internal/services/network/virtual_wan_test.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseVirtualWan(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParseVirtualWan(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/virtualWans/example",
 			Expected: &VirtualWanResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -55,8 +51,8 @@ func TestParseVirtualWan(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/network/vpn_gateway.go
+++ b/azurerm/internal/services/network/vpn_gateway.go
@@ -7,9 +7,8 @@ import (
 )
 
 type VPNGatewayResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseVPNGatewayID(input string) (*VPNGatewayResourceID, error) {
@@ -19,12 +18,16 @@ func ParseVPNGatewayID(input string) (*VPNGatewayResourceID, error) {
 	}
 
 	gateway := VPNGatewayResourceID{
-		Base: *id,
-		Name: id.Path["vpnGateways"],
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if gateway.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `vpnGateways` element")
+	gateway.Name, err = id.PopSegment("vpnGateways")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &gateway, nil

--- a/azurerm/internal/services/network/vpn_gateway.go
+++ b/azurerm/internal/services/network/vpn_gateway.go
@@ -21,8 +21,7 @@ func ParseVPNGatewayID(input string) (*VPNGatewayResourceID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	gateway.Name, err = id.PopSegment("vpnGateways")
-	if err != nil {
+	if gateway.Name, err = id.PopSegment("vpnGateways"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/network/vpn_gateway_test.go
+++ b/azurerm/internal/services/network/vpn_gateway_test.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseVPNGateway(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParseVPNGateway(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/vpnGateways/example",
 			Expected: &VPNGatewayResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -55,8 +51,8 @@ func TestParseVPNGateway(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/network/vpn_server_configuration.go
+++ b/azurerm/internal/services/network/vpn_server_configuration.go
@@ -7,9 +7,8 @@ import (
 )
 
 type VpnServerConfigurationResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseVpnServerConfigurationID(input string) (*VpnServerConfigurationResourceID, error) {
@@ -18,15 +17,20 @@ func ParseVpnServerConfigurationID(input string) (*VpnServerConfigurationResourc
 		return nil, fmt.Errorf("[ERROR] Unable to parse VPN Server Configuration ID %q: %+v", input, err)
 	}
 
-	vpnServerConfigurationResourceID := VpnServerConfigurationResourceID{
-		Base: *id,
-		Name: id.Path["vpnServerConfigurations"],
-	}
-	if vpnServerConfigurationResourceID.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `vpnServerConfigurations` element")
+	vpnServerConfiguration := VpnServerConfigurationResourceID{
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	return &vpnServerConfigurationResourceID, nil
+	vpnServerConfiguration.Name, err = id.PopSegment("vpnServerConfigurations")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &vpnServerConfiguration, nil
 }
 
 func ValidateVpnServerConfigurationID(i interface{}, k string) (warnings []string, errors []error) {

--- a/azurerm/internal/services/network/vpn_server_configuration.go
+++ b/azurerm/internal/services/network/vpn_server_configuration.go
@@ -21,8 +21,7 @@ func ParseVpnServerConfigurationID(input string) (*VpnServerConfigurationResourc
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	vpnServerConfiguration.Name, err = id.PopSegment("vpnServerConfigurations")
-	if err != nil {
+	if vpnServerConfiguration.Name, err = id.PopSegment("vpnServerConfigurations"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/network/vpn_server_configuration_test.go
+++ b/azurerm/internal/services/network/vpn_server_configuration_test.go
@@ -2,8 +2,6 @@ package network
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseVpnServerConfiguration(t *testing.T) {
@@ -31,10 +29,8 @@ func TestParseVpnServerConfiguration(t *testing.T) {
 			Name:  "Completed",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/vpnServerConfigurations/example",
 			Expected: &VpnServerConfigurationResourceID{
-				Name: "example",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
+				Name:          "example",
+				ResourceGroup: "foo",
 			},
 		},
 	}
@@ -55,8 +51,8 @@ func TestParseVpnServerConfiguration(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/resource/group_parser.go
+++ b/azurerm/internal/services/resource/group_parser.go
@@ -7,8 +7,6 @@ import (
 )
 
 type ResourceGroupResourceID struct {
-	Base azure.ResourceID
-
 	Name string
 }
 
@@ -19,18 +17,15 @@ func ParseResourceGroupID(input string) (*ResourceGroupResourceID, error) {
 	}
 
 	group := ResourceGroupResourceID{
-		Base: *id,
 		Name: id.ResourceGroup,
 	}
 
 	if group.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `resourceGroups` element")
+		return nil, fmt.Errorf("ID contained no `resourceGroups` segment!")
 	}
 
-	pathWithoutSubs := group.Base.Path
-	delete(pathWithoutSubs, "subscriptions")
-	if len(pathWithoutSubs) != 0 {
-		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &group, nil

--- a/azurerm/internal/services/resource/group_parser_test.go
+++ b/azurerm/internal/services/resource/group_parser_test.go
@@ -2,8 +2,6 @@ package resource
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseResourceGroup(t *testing.T) {
@@ -32,9 +30,6 @@ func TestParseResourceGroup(t *testing.T) {
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
 			Expected: &ResourceGroupResourceID{
 				Name: "foo",
-				Base: azure.ResourceID{
-					ResourceGroup: "foo",
-				},
 			},
 		},
 		{

--- a/azurerm/internal/services/storage/id.go
+++ b/azurerm/internal/services/storage/id.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
 )
 
 func AccountIDSchema() *schema.Schema {
@@ -23,15 +23,8 @@ func ValidateAccountID(i interface{}, k string) (warnings []string, errors []err
 		return
 	}
 
-	id, err := azure.ParseAzureResourceID(v)
-	if err != nil {
-		errors = append(errors, fmt.Errorf("Can not parse %q as a Resource Id: %v", v, err))
-	}
-
-	if id != nil {
-		if id.Path["storageAccounts"] == "" {
-			errors = append(errors, fmt.Errorf("The 'storageAccounts' segment is missing from Resource ID %q", v))
-		}
+	if _, err := parsers.ParseAccountID(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a Resource ID: %v", v, err))
 	}
 
 	return warnings, errors

--- a/azurerm/internal/services/storage/parsers/id.go
+++ b/azurerm/internal/services/storage/parsers/id.go
@@ -19,8 +19,7 @@ func ParseAccountID(input string) (*AccountID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	account.Name, err = id.PopSegment("storageAccounts")
-	if err != nil {
+	if account.Name, err = id.PopSegment("storageAccounts"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/storage/parsers/id.go
+++ b/azurerm/internal/services/storage/parsers/id.go
@@ -1,38 +1,32 @@
 package parsers
 
 import (
-	"fmt"
-
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 type AccountID struct {
 	Name          string
 	ResourceGroup string
-
-	ID azure.ResourceID
 }
 
-func ParseAccountID(id string) (*AccountID, error) {
-	storageID, err := azure.ParseAzureResourceID(id)
+func ParseAccountID(input string) (*AccountID, error) {
+	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
 		return nil, err
 	}
 
-	resourceGroup := storageID.ResourceGroup
-	if resourceGroup == "" {
-		return nil, fmt.Errorf("%q is missing a Resource Group", id)
+	account := AccountID{
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	storageAccountName := storageID.Path["storageAccounts"]
-	if storageAccountName == "" {
-		return nil, fmt.Errorf("%q is missing the `storageAccounts` segment", id)
+	account.Name, err = id.PopSegment("storageAccounts")
+	if err != nil {
+		return nil, err
 	}
 
-	accountId := AccountID{
-		Name:          storageAccountName,
-		ResourceGroup: resourceGroup,
-		ID:            *storageID,
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
-	return &accountId, nil
+
+	return &account, nil
 }

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -20,8 +20,8 @@ func ParseAppServiceID(input string) (*AppServiceResourceID, error) {
 	appService := AppServiceResourceID{
 		ResourceGroup: id.ResourceGroup,
 	}
-	appService.Name, err = id.PopSegment("sites")
-	if err != nil {
+
+	if appService.Name, err = id.PopSegment("sites"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/web/app_service.go
+++ b/azurerm/internal/services/web/app_service.go
@@ -7,9 +7,8 @@ import (
 )
 
 type AppServiceResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseAppServiceID(input string) (*AppServiceResourceID, error) {
@@ -18,22 +17,19 @@ func ParseAppServiceID(input string) (*AppServiceResourceID, error) {
 		return nil, fmt.Errorf("[ERROR] Unable to parse App Service ID %q: %+v", input, err)
 	}
 
-	group := AppServiceResourceID{
-		Base: *id,
-		Name: id.Path["sites"],
+	appService := AppServiceResourceID{
+		ResourceGroup: id.ResourceGroup,
+	}
+	appService.Name, err = id.PopSegment("sites")
+	if err != nil {
+		return nil, err
 	}
 
-	if group.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `sites` element")
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
-	pathWithoutElements := group.Base.Path
-	delete(pathWithoutElements, "sites")
-	if len(pathWithoutElements) != 0 {
-		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
-	}
-
-	return &group, nil
+	return &appService, nil
 }
 
 // ValidateAppServiceID validates that the specified ID is a valid App Service ID

--- a/azurerm/internal/services/web/app_service_certificate.go
+++ b/azurerm/internal/services/web/app_service_certificate.go
@@ -20,8 +20,8 @@ func ParseAppServiceCertificateID(input string) (*AppServiceCertificateResourceI
 	certificate := AppServiceCertificateResourceID{
 		ResourceGroup: id.ResourceGroup,
 	}
-	certificate.Name, err = id.PopSegment("certificates")
-	if err != nil {
+
+	if certificate.Name, err = id.PopSegment("certificates"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/web/app_service_certificate.go
+++ b/azurerm/internal/services/web/app_service_certificate.go
@@ -7,9 +7,8 @@ import (
 )
 
 type AppServiceCertificateResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseAppServiceCertificateID(input string) (*AppServiceCertificateResourceID, error) {
@@ -18,22 +17,19 @@ func ParseAppServiceCertificateID(input string) (*AppServiceCertificateResourceI
 		return nil, fmt.Errorf("[ERROR] Unable to parse App Service Certificate ID %q: %+v", input, err)
 	}
 
-	group := AppServiceCertificateResourceID{
-		Base: *id,
-		Name: id.Path["certificates"],
+	certificate := AppServiceCertificateResourceID{
+		ResourceGroup: id.ResourceGroup,
+	}
+	certificate.Name, err = id.PopSegment("certificates")
+	if err != nil {
+		return nil, err
 	}
 
-	if group.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `certificates` element")
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
-	pathWithoutElements := group.Base.Path
-	delete(pathWithoutElements, "certificates")
-	if len(pathWithoutElements) != 0 {
-		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
-	}
-
-	return &group, nil
+	return &certificate, nil
 }
 
 // ValidateAppServiceCertificateID validates that the specified ID is a valid App Service Certificate ID

--- a/azurerm/internal/services/web/app_service_certificate_order.go
+++ b/azurerm/internal/services/web/app_service_certificate_order.go
@@ -19,7 +19,6 @@ func ParseAppServiceCertificateOrderID(input string) (*AppServiceCertificateOrde
 
 	order := AppServiceCertificateOrderResourceID{
 		ResourceGroup: id.ResourceGroup,
-		Name:          id.Path[""],
 	}
 	order.Name, err = id.PopSegment("certificateOrders")
 	if err != nil {

--- a/azurerm/internal/services/web/app_service_certificate_order.go
+++ b/azurerm/internal/services/web/app_service_certificate_order.go
@@ -7,9 +7,8 @@ import (
 )
 
 type AppServiceCertificateOrderResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseAppServiceCertificateOrderID(input string) (*AppServiceCertificateOrderResourceID, error) {
@@ -18,20 +17,18 @@ func ParseAppServiceCertificateOrderID(input string) (*AppServiceCertificateOrde
 		return nil, fmt.Errorf("[ERROR] Unable to parse App Service Certificate Order ID %q: %+v", input, err)
 	}
 
-	group := AppServiceCertificateOrderResourceID{
-		Base: *id,
-		Name: id.Path["certificateOrders"],
+	order := AppServiceCertificateOrderResourceID{
+		ResourceGroup: id.ResourceGroup,
+		Name:          id.Path[""],
+	}
+	order.Name, err = id.PopSegment("certificateOrders")
+	if err != nil {
+		return nil, err
 	}
 
-	if group.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `certificateOrders` element")
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
-	pathWithoutElements := group.Base.Path
-	delete(pathWithoutElements, "certificateOrders")
-	if len(pathWithoutElements) != 0 {
-		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
-	}
-
-	return &group, nil
+	return &order, nil
 }

--- a/azurerm/internal/services/web/app_service_certificate_order.go
+++ b/azurerm/internal/services/web/app_service_certificate_order.go
@@ -20,8 +20,8 @@ func ParseAppServiceCertificateOrderID(input string) (*AppServiceCertificateOrde
 	order := AppServiceCertificateOrderResourceID{
 		ResourceGroup: id.ResourceGroup,
 	}
-	order.Name, err = id.PopSegment("certificateOrders")
-	if err != nil {
+
+	if order.Name, err = id.PopSegment("certificateOrders"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/web/app_service_certificate_order_test.go
+++ b/azurerm/internal/services/web/app_service_certificate_order_test.go
@@ -2,8 +2,6 @@ package web
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseAppServiceCertificateOrder(t *testing.T) {
@@ -46,10 +44,8 @@ func TestParseAppServiceCertificateOrder(t *testing.T) {
 			Name:  "App Service Certificate Order Resource ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/certificateOrders/order1",
 			Expected: &AppServiceCertificateOrderResourceID{
-				Name: "order1",
-				Base: azure.ResourceID{
-					ResourceGroup: "mygroup1",
-				},
+				Name:          "order1",
+				ResourceGroup: "mygroup1",
 			},
 		},
 		{
@@ -75,8 +71,8 @@ func TestParseAppServiceCertificateOrder(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/web/app_service_certificate_test.go
+++ b/azurerm/internal/services/web/app_service_certificate_test.go
@@ -2,8 +2,6 @@ package web
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseAppServiceCertificate(t *testing.T) {
@@ -46,10 +44,8 @@ func TestParseAppServiceCertificate(t *testing.T) {
 			Name:  "App Service Certificate Resource ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/certificates/cert1",
 			Expected: &AppServiceCertificateResourceID{
-				Name: "cert1",
-				Base: azure.ResourceID{
-					ResourceGroup: "mygroup1",
-				},
+				Name:          "cert1",
+				ResourceGroup: "mygroup1",
 			},
 		},
 		{
@@ -75,8 +71,8 @@ func TestParseAppServiceCertificate(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/web/app_service_custom_hostname_binding.go
+++ b/azurerm/internal/services/web/app_service_custom_hostname_binding.go
@@ -18,15 +18,15 @@ func ParseAppServiceCustomHostnameBindingID(input string) (*AppServiceCustomHost
 		return nil, fmt.Errorf("[ERROR] Unable to parse App Service Custom Hostname Binding ID %q: %+v", input, err)
 	}
 
-	group := AppServiceCustomHostnameBindingResourceID{
+	binding := AppServiceCustomHostnameBindingResourceID{
 		ResourceGroup: id.ResourceGroup,
 	}
-	group.AppServiceName, err = id.PopSegment("sites")
+	binding.AppServiceName, err = id.PopSegment("sites")
 	if err != nil {
 		return nil, err
 	}
 
-	group.Name, err = id.PopSegment("hostNameBindings")
+	binding.Name, err = id.PopSegment("hostNameBindings")
 	if err != nil {
 		return nil, err
 	}
@@ -35,5 +35,5 @@ func ParseAppServiceCustomHostnameBindingID(input string) (*AppServiceCustomHost
 		return nil, err
 	}
 
-	return &group, nil
+	return &binding, nil
 }

--- a/azurerm/internal/services/web/app_service_custom_hostname_binding.go
+++ b/azurerm/internal/services/web/app_service_custom_hostname_binding.go
@@ -21,13 +21,12 @@ func ParseAppServiceCustomHostnameBindingID(input string) (*AppServiceCustomHost
 	binding := AppServiceCustomHostnameBindingResourceID{
 		ResourceGroup: id.ResourceGroup,
 	}
-	binding.AppServiceName, err = id.PopSegment("sites")
-	if err != nil {
+
+	if binding.AppServiceName, err = id.PopSegment("sites"); err != nil {
 		return nil, err
 	}
 
-	binding.Name, err = id.PopSegment("hostNameBindings")
-	if err != nil {
+	if binding.Name, err = id.PopSegment("hostNameBindings"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/web/app_service_custom_hostname_binding.go
+++ b/azurerm/internal/services/web/app_service_custom_hostname_binding.go
@@ -7,8 +7,7 @@ import (
 )
 
 type AppServiceCustomHostnameBindingResourceID struct {
-	Base azure.ResourceID
-
+	ResourceGroup  string
 	AppServiceName string
 	Name           string
 }
@@ -20,24 +19,20 @@ func ParseAppServiceCustomHostnameBindingID(input string) (*AppServiceCustomHost
 	}
 
 	group := AppServiceCustomHostnameBindingResourceID{
-		Base:           *id,
-		AppServiceName: id.Path["sites"],
-		Name:           id.Path["hostNameBindings"],
+		ResourceGroup: id.ResourceGroup,
+	}
+	group.AppServiceName, err = id.PopSegment("sites")
+	if err != nil {
+		return nil, err
 	}
 
-	if group.AppServiceName == "" {
-		return nil, fmt.Errorf("ID was missing the `sites` element")
+	group.Name, err = id.PopSegment("hostNameBindings")
+	if err != nil {
+		return nil, err
 	}
 
-	if group.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `hostNameBindings` element")
-	}
-
-	pathWithoutElements := group.Base.Path
-	delete(pathWithoutElements, "sites")
-	delete(pathWithoutElements, "hostNameBindings")
-	if len(pathWithoutElements) != 0 {
-		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
 	return &group, nil

--- a/azurerm/internal/services/web/app_service_custom_hostname_binding_test.go
+++ b/azurerm/internal/services/web/app_service_custom_hostname_binding_test.go
@@ -2,8 +2,6 @@ package web
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseAppServiceCustomHostnameBinding(t *testing.T) {
@@ -53,9 +51,7 @@ func TestParseAppServiceCustomHostnameBinding(t *testing.T) {
 			Expected: &AppServiceCustomHostnameBindingResourceID{
 				Name:           "binding1",
 				AppServiceName: "site1",
-				Base: azure.ResourceID{
-					ResourceGroup: "mygroup1",
-				},
+				ResourceGroup:  "mygroup1",
 			},
 		},
 		{
@@ -85,8 +81,8 @@ func TestParseAppServiceCustomHostnameBinding(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for AppServiceName", v.Expected.AppServiceName, actual.AppServiceName)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/web/app_service_plan.go
+++ b/azurerm/internal/services/web/app_service_plan.go
@@ -21,8 +21,7 @@ func ParseAppServicePlanID(input string) (*AppServicePlanResourceID, error) {
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	appServicePlan.Name, err = id.PopSegment("serverfarms")
-	if err != nil {
+	if appServicePlan.Name, err = id.PopSegment("serverfarms"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/web/app_service_plan.go
+++ b/azurerm/internal/services/web/app_service_plan.go
@@ -7,9 +7,8 @@ import (
 )
 
 type AppServicePlanResourceID struct {
-	Base azure.ResourceID
-
-	Name string
+	ResourceGroup string
+	Name          string
 }
 
 func ParseAppServicePlanID(input string) (*AppServicePlanResourceID, error) {
@@ -18,22 +17,20 @@ func ParseAppServicePlanID(input string) (*AppServicePlanResourceID, error) {
 		return nil, fmt.Errorf("[ERROR] Unable to parse App Service Plan ID %q: %+v", input, err)
 	}
 
-	group := AppServicePlanResourceID{
-		Base: *id,
-		Name: id.Path["serverfarms"],
+	appServicePlan := AppServicePlanResourceID{
+		ResourceGroup: id.ResourceGroup,
 	}
 
-	if group.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `serverfarms` element")
+	appServicePlan.Name, err = id.PopSegment("serverfarms")
+	if err != nil {
+		return nil, err
 	}
 
-	pathWithoutElements := group.Base.Path
-	delete(pathWithoutElements, "serverfarms")
-	if len(pathWithoutElements) != 0 {
-		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
-	return &group, nil
+	return &appServicePlan, nil
 }
 
 // ValidateAppServicePlanID validates that the specified ID is a valid App Service Plan ID

--- a/azurerm/internal/services/web/app_service_plan_test.go
+++ b/azurerm/internal/services/web/app_service_plan_test.go
@@ -2,8 +2,6 @@ package web
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseAppServicePlan(t *testing.T) {
@@ -41,10 +39,8 @@ func TestParseAppServicePlan(t *testing.T) {
 			Name:  "App Service Plan Resource ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/serverfarms/farm1",
 			Expected: &AppServicePlanResourceID{
-				Name: "farm1",
-				Base: azure.ResourceID{
-					ResourceGroup: "mygroup1",
-				},
+				Name:          "farm1",
+				ResourceGroup: "mygroup1",
 			},
 		},
 	}
@@ -65,8 +61,8 @@ func TestParseAppServicePlan(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/web/app_service_slot.go
+++ b/azurerm/internal/services/web/app_service_slot.go
@@ -24,13 +24,11 @@ func ParseAppServiceSlotID(input string) (*AppServiceSlotResourceID, error) {
 		Name:           id.Path["slots"],
 	}
 
-	slot.AppServiceName, err = id.PopSegment("sites")
-	if err != nil {
+	if slot.AppServiceName, err = id.PopSegment("sites"); err != nil {
 		return nil, err
 	}
 
-	slot.Name, err = id.PopSegment("slots")
-	if err != nil {
+	if slot.Name, err = id.PopSegment("slots"); err != nil {
 		return nil, err
 	}
 

--- a/azurerm/internal/services/web/app_service_slot.go
+++ b/azurerm/internal/services/web/app_service_slot.go
@@ -7,8 +7,7 @@ import (
 )
 
 type AppServiceSlotResourceID struct {
-	Base azure.ResourceID
-
+	ResourceGroup  string
 	AppServiceName string
 	Name           string
 }
@@ -19,26 +18,25 @@ func ParseAppServiceSlotID(input string) (*AppServiceSlotResourceID, error) {
 		return nil, fmt.Errorf("[ERROR] Unable to parse App Service Slot ID %q: %+v", input, err)
 	}
 
-	group := AppServiceSlotResourceID{
-		Base:           *id,
+	slot := AppServiceSlotResourceID{
+		ResourceGroup:  id.ResourceGroup,
 		AppServiceName: id.Path["sites"],
 		Name:           id.Path["slots"],
 	}
 
-	if group.AppServiceName == "" {
-		return nil, fmt.Errorf("ID was missing the `sites` element")
+	slot.AppServiceName, err = id.PopSegment("sites")
+	if err != nil {
+		return nil, err
 	}
 
-	if group.Name == "" {
-		return nil, fmt.Errorf("ID was missing the `slots` element")
+	slot.Name, err = id.PopSegment("slots")
+	if err != nil {
+		return nil, err
 	}
 
-	pathWithoutElements := group.Base.Path
-	delete(pathWithoutElements, "sites")
-	delete(pathWithoutElements, "slots")
-	if len(pathWithoutElements) != 0 {
-		return nil, fmt.Errorf("ID contained more segments than a Resource ID requires: %q", input)
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
 	}
 
-	return &group, nil
+	return &slot, nil
 }

--- a/azurerm/internal/services/web/app_service_slot_test.go
+++ b/azurerm/internal/services/web/app_service_slot_test.go
@@ -2,8 +2,6 @@ package web
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseAppServiceSlot(t *testing.T) {
@@ -53,9 +51,7 @@ func TestParseAppServiceSlot(t *testing.T) {
 			Expected: &AppServiceSlotResourceID{
 				Name:           "slot1",
 				AppServiceName: "site1",
-				Base: azure.ResourceID{
-					ResourceGroup: "mygroup1",
-				},
+				ResourceGroup:  "mygroup1",
 			},
 		},
 		{
@@ -85,8 +81,8 @@ func TestParseAppServiceSlot(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for AppServiceName", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/web/app_service_test.go
+++ b/azurerm/internal/services/web/app_service_test.go
@@ -2,8 +2,6 @@ package web
 
 import (
 	"testing"
-
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 func TestParseAppService(t *testing.T) {
@@ -41,10 +39,8 @@ func TestParseAppService(t *testing.T) {
 			Name:  "App Service Resource ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Web/sites/site1",
 			Expected: &AppServiceResourceID{
-				Name: "site1",
-				Base: azure.ResourceID{
-					ResourceGroup: "mygroup1",
-				},
+				Name:          "site1",
+				ResourceGroup: "mygroup1",
 			},
 		},
 		{
@@ -70,8 +66,8 @@ func TestParseAppService(t *testing.T) {
 			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
 		}
 
-		if actual.Base.ResourceGroup != v.Expected.Base.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.Base.ResourceGroup, actual.Base.ResourceGroup)
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/resource_arm_app_service.go
+++ b/azurerm/resource_arm_app_service.go
@@ -327,7 +327,7 @@ func resourceArmAppServiceUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	resGroup := id.Base.ResourceGroup
+	resGroup := id.ResourceGroup
 	name := id.Name
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
@@ -516,7 +516,7 @@ func resourceArmAppServiceRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	resGroup := id.Base.ResourceGroup
+	resGroup := id.ResourceGroup
 	name := id.Name
 
 	resp, err := client.Get(ctx, resGroup, name)
@@ -678,7 +678,7 @@ func resourceArmAppServiceDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	resGroup := id.Base.ResourceGroup
+	resGroup := id.ResourceGroup
 	name := id.Name
 
 	log.Printf("[DEBUG] Deleting App Service %q (resource group %q)", name, resGroup)

--- a/azurerm/resource_arm_app_service_active_slot.go
+++ b/azurerm/resource_arm_app_service_active_slot.go
@@ -102,7 +102,7 @@ func resourceArmAppServiceActiveSlotRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	resGroup := id.Base.ResourceGroup
+	resGroup := id.ResourceGroup
 	name := id.Name
 
 	resp, err := client.Get(ctx, resGroup, name)

--- a/azurerm/resource_arm_app_service_certificate.go
+++ b/azurerm/resource_arm_app_service_certificate.go
@@ -213,7 +213,7 @@ func resourceArmAppServiceCertificateRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Name
 
 	resp, err := client.Get(ctx, resourceGroup, name)
@@ -256,7 +256,7 @@ func resourceArmAppServiceCertificateDelete(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Name
 
 	log.Printf("[DEBUG] Deleting App Service Certificate %q (Resource Group %q)", name, resourceGroup)

--- a/azurerm/resource_arm_app_service_certificate_order.go
+++ b/azurerm/resource_arm_app_service_certificate_order.go
@@ -258,7 +258,7 @@ func resourceArmAppServiceCertificateOrderRead(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Name
 
 	resp, err := client.Get(ctx, resourceGroup, name)
@@ -327,7 +327,7 @@ func resourceArmAppServiceCertificateOrderDelete(d *schema.ResourceData, meta in
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Name
 
 	log.Printf("[DEBUG] Deleting App Service Certificate Order %q (Resource Group %q)", name, resourceGroup)

--- a/azurerm/resource_arm_app_service_custom_hostname_binding.go
+++ b/azurerm/resource_arm_app_service_custom_hostname_binding.go
@@ -156,7 +156,7 @@ func resourceArmAppServiceCustomHostnameBindingRead(d *schema.ResourceData, meta
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	appServiceName := id.AppServiceName
 	hostname := id.Name
 
@@ -193,7 +193,7 @@ func resourceArmAppServiceCustomHostnameBindingDelete(d *schema.ResourceData, me
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	appServiceName := id.AppServiceName
 	hostname := id.Name
 

--- a/azurerm/resource_arm_app_service_plan.go
+++ b/azurerm/resource_arm_app_service_plan.go
@@ -276,7 +276,7 @@ func resourceArmAppServicePlanRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Name
 
 	resp, err := client.Get(ctx, resourceGroup, name)
@@ -343,7 +343,7 @@ func resourceArmAppServicePlanDelete(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	name := id.Name
 
 	log.Printf("[DEBUG] Deleting App Service Plan %q (Resource Group %q)", name, resourceGroup)

--- a/azurerm/resource_arm_app_service_slot.go
+++ b/azurerm/resource_arm_app_service_slot.go
@@ -247,7 +247,7 @@ func resourceArmAppServiceSlotUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	appServiceName := id.AppServiceName
 	slot := id.Name
 
@@ -382,7 +382,7 @@ func resourceArmAppServiceSlotRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	appServiceName := id.AppServiceName
 	slot := id.Name
 
@@ -516,7 +516,7 @@ func resourceArmAppServiceSlotDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
+	resourceGroup := id.ResourceGroup
 	appServiceName := id.AppServiceName
 	slot := id.Name
 

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -669,10 +669,10 @@ func getFunctionAppServiceTier(ctx context.Context, appServicePlanId string, met
 		return "", fmt.Errorf("[ERROR] Unable to parse App Service Plan ID %q: %+v", appServicePlanId, err)
 	}
 
-	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.Name, id.Base.ResourceGroup)
+	log.Printf("[DEBUG] Retrieving App Service Plan %q (Resource Group %q)", id.Name, id.ResourceGroup)
 
 	appServicePlansClient := meta.(*ArmClient).Web.AppServicePlansClient
-	appServicePlan, err := appServicePlansClient.Get(ctx, id.Base.ResourceGroup, id.Name)
+	appServicePlan, err := appServicePlansClient.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		return "", fmt.Errorf("[ERROR] Could not retrieve App Service Plan ID %q: %+v", appServicePlanId, err)
 	}

--- a/azurerm/resource_arm_function_app.go
+++ b/azurerm/resource_arm_function_app.go
@@ -380,7 +380,7 @@ func resourceArmFunctionAppUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	resGroup := id.Base.ResourceGroup
+	resGroup := id.ResourceGroup
 	name := id.Name
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
@@ -488,7 +488,7 @@ func resourceArmFunctionAppRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	resGroup := id.Base.ResourceGroup
+	resGroup := id.ResourceGroup
 	name := id.Name
 
 	resp, err := client.Get(ctx, resGroup, name)
@@ -609,7 +609,7 @@ func resourceArmFunctionAppDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	resGroup := id.Base.ResourceGroup
+	resGroup := id.ResourceGroup
 	name := id.Name
 
 	log.Printf("[DEBUG] Deleting Function App %q (resource group %q)", name, resGroup)

--- a/azurerm/resource_arm_kubernetes_cluster.go
+++ b/azurerm/resource_arm_kubernetes_cluster.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -27,9 +28,11 @@ func resourceArmKubernetesCluster() *schema.Resource {
 		Read:   resourceArmKubernetesClusterRead,
 		Update: resourceArmKubernetesClusterUpdate,
 		Delete: resourceArmKubernetesClusterDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := containers.ParseKubernetesClusterID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(90 * time.Minute),

--- a/azurerm/resource_arm_kubernetes_cluster_node_pool.go
+++ b/azurerm/resource_arm_kubernetes_cluster_node_pool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -23,9 +24,11 @@ func resourceArmKubernetesClusterNodePool() *schema.Resource {
 		Read:   resourceArmKubernetesClusterNodePoolRead,
 		Update: resourceArmKubernetesClusterNodePoolUpdate,
 		Delete: resourceArmKubernetesClusterNodePoolDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := containers.ParseKubernetesNodePoolID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),

--- a/azurerm/resource_arm_linux_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_linux_virtual_machine_scale_set.go
@@ -16,6 +16,7 @@ import (
 	computeSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/base64"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -26,9 +27,13 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 		Read:   resourceArmLinuxVirtualMachineScaleSetRead,
 		Update: resourceArmLinuxVirtualMachineScaleSetUpdate,
 		Delete: resourceArmLinuxVirtualMachineScaleSetDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := computeSvc.ParseVirtualMachineScaleSetID(id)
+			// TODO: (prior to Beta) look up the VM & confirm this is a Linux VMSS
+			return err
+		}),
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(time.Minute * 30),
 			Update: schema.DefaultTimeout(time.Minute * 60),
@@ -506,23 +511,20 @@ func resourceArmLinuxVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta i
 	ctx, cancel := timeouts.ForUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Name
-	resourceGroup := id.Base.ResourceGroup
-
 	updateInstances := false
 
 	// retrieve
-	existing, err := client.Get(ctx, resourceGroup, name)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 	if existing.VirtualMachineScaleSetProperties == nil {
-		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", name, resourceGroup)
+		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
 	}
 
 	updateProps := compute.VirtualMachineScaleSetUpdateProperties{
@@ -699,26 +701,26 @@ func resourceArmLinuxVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta i
 
 	update.VirtualMachineScaleSetUpdateProperties = &updateProps
 
-	log.Printf("[DEBUG] Updating Linux Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
-	future, err := client.Update(ctx, resourceGroup, name, update)
+	log.Printf("[DEBUG] Updating Linux Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
 	if err != nil {
-		return fmt.Errorf("Error updating Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error updating Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	log.Printf("[DEBUG] Waiting for update of Linux Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
+	log.Printf("[DEBUG] Waiting for update of Linux Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for update of Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for update of Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	log.Printf("[DEBUG] Updated Linux Virtual Machine Scale Set %q (Resource Group %q).", name, resourceGroup)
+	log.Printf("[DEBUG] Updated Linux Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
 
 	// if we update the SKU, we also need to subsequently roll the instances using the `UpdateInstances` API
 	if updateInstances {
 		if userWantsToRollInstances := d.Get("terraform_should_roll_instances_when_required").(bool); userWantsToRollInstances {
-			log.Printf("[DEBUG] Rolling the VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
+			log.Printf("[DEBUG] Rolling the VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 			instancesClient := meta.(*ArmClient).Compute.VMScaleSetVMsClient
-			instances, err := instancesClient.ListComplete(ctx, resourceGroup, name, "", "", "")
+			instances, err := instancesClient.ListComplete(ctx, id.ResourceGroup, id.Name, "", "", "")
 			if err != nil {
-				return fmt.Errorf("Error listing VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+				return fmt.Errorf("Error listing VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 			}
 
 			log.Printf("[DEBUG] Determining instances to roll..")
@@ -746,13 +748,13 @@ func resourceArmLinuxVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta i
 				ids := compute.VirtualMachineScaleSetVMInstanceRequiredIDs{
 					InstanceIds: &instanceIds,
 				}
-				future, err := client.UpdateInstances(ctx, resourceGroup, name, ids)
+				future, err := client.UpdateInstances(ctx, id.ResourceGroup, id.Name, ids)
 				if err != nil {
-					return fmt.Errorf("Error updating Instance %q (Linux VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error updating Instance %q (Linux VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 
 				if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("Error waiting for update of Instance %q (Linux VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error waiting for update of Instance %q (Linux VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 				log.Printf("[DEBUG] Updated Instance %q to the Latest Configuration.", instanceId)
 
@@ -761,20 +763,20 @@ func resourceArmLinuxVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta i
 				reimageInput := &compute.VirtualMachineScaleSetReimageParameters{
 					InstanceIds: &instanceIds,
 				}
-				reimageFuture, err := client.Reimage(ctx, resourceGroup, name, reimageInput)
+				reimageFuture, err := client.Reimage(ctx, id.ResourceGroup, id.Name, reimageInput)
 				if err != nil {
-					return fmt.Errorf("Error reimaging Instance %q (Linux VM Scale Set %q / Resource Group %q): %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error reimaging Instance %q (Linux VM Scale Set %q / Resource Group %q): %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 
 				if err = reimageFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("Error waiting for reimage of Instance %q (Linux VM Scale Set %q / Resource Group %q): %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error waiting for reimage of Instance %q (Linux VM Scale Set %q / Resource Group %q): %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 				log.Printf("[DEBUG] Reimaged Instance %q..", instanceId)
 			}
 
-			log.Printf("[DEBUG] Rolled the VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q).", name, resourceGroup)
+			log.Printf("[DEBUG] Rolled the VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
 		} else {
-			log.Printf("[DEBUG] Terraform wants to roll the VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q) - but user has opted out - skipping..", name, resourceGroup)
+			log.Printf("[DEBUG] Terraform wants to roll the VM Instances for Linux Virtual Machine Scale Set %q (Resource Group %q) - but user has opted out - skipping..", id.Name, id.ResourceGroup)
 		}
 	}
 
@@ -786,27 +788,24 @@ func resourceArmLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta int
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Name
-	resourceGroup := id.Base.ResourceGroup
-
-	resp, err := client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Linux Virtual Machine Scale Set %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			log.Printf("[DEBUG] Linux Virtual Machine Scale Set %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -831,7 +830,7 @@ func resourceArmLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta int
 	}
 
 	if resp.VirtualMachineScaleSetProperties == nil {
-		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", name, resourceGroup)
+		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
 	}
 	props := *resp.VirtualMachineScaleSetProperties
 
@@ -948,21 +947,18 @@ func resourceArmLinuxVirtualMachineScaleSetDelete(d *schema.ResourceData, meta i
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Name
-	resourceGroup := id.Base.ResourceGroup
-
-	resp, err := client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	// Sometimes VMSS's aren't fully deleted when the `Delete` call returns - as such we'll try to scale the cluster
@@ -978,32 +974,32 @@ func resourceArmLinuxVirtualMachineScaleSetDelete(d *schema.ResourceData, meta i
 		update := compute.VirtualMachineScaleSetUpdate{
 			Sku: resp.Sku,
 		}
-		future, err := client.Update(ctx, resourceGroup, name, update)
+		future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
 		if err != nil {
-			return fmt.Errorf("Error updating number of instances in Linux Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error updating number of instances in Linux Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
 		}
 
 		log.Printf("[DEBUG] Waiting for scaling of instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 		err = future.WaitForCompletionRef(ctx, client.Client)
 		if err != nil {
-			return fmt.Errorf("Error waiting for number of instances in Linux Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error waiting for number of instances in Linux Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
 		}
 		log.Printf("[DEBUG] Scaled instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 	} else {
 		log.Printf("[DEBUG] Unable to scale instances to `0` since the `sku` block is nil - trying to delete anyway")
 	}
 
-	log.Printf("[DEBUG] Deleting Linux Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
-	future, err := client.Delete(ctx, resourceGroup, name)
+	log.Printf("[DEBUG] Deleting Linux Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error deleting Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	log.Printf("[DEBUG] Waiting for deletion of Linux Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
+	log.Printf("[DEBUG] Waiting for deletion of Linux Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for deletion of Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	log.Printf("[DEBUG] Deleted Linux Virtual Machine Scale Set %q (Resource Group %q).", name, resourceGroup)
+	log.Printf("[DEBUG] Deleted Linux Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
 
 	return nil
 }

--- a/azurerm/resource_arm_point_to_site_vpn_gateway.go
+++ b/azurerm/resource_arm_point_to_site_vpn_gateway.go
@@ -181,21 +181,19 @@ func resourceArmPointToSiteVPNGatewayRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
-
-	resp, err := client.Get(ctx, resourceGroup, id.Name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Point-to-Site VPN Gateway %q was not found in Resource Group %q - removing from state!", id.Name, resourceGroup)
+			log.Printf("[DEBUG] Point-to-Site VPN Gateway %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Point-to-Site VPN Gateway %q (Resource Group %q): %+v", id.Name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Point-to-Site VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	d.Set("name", id.Name)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("resource_group_name", id.ResourceGroup)
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
@@ -238,15 +236,14 @@ func resourceArmPointToSiteVPNGatewayDelete(d *schema.ResourceData, meta interfa
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.Base.ResourceGroup
 
-	future, err := client.Delete(ctx, resourceGroup, id.Name)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Point-to-Site VPN Gateway %q (Resource Group %q): %+v", id.Name, resourceGroup, err)
+		return fmt.Errorf("Error deleting Point-to-Site VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of Point-to-Site VPN Gateway %q (Resource Group %q): %+v", id.Name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for deletion of Point-to-Site VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_resource_group.go
+++ b/azurerm/resource_arm_resource_group.go
@@ -75,12 +75,12 @@ func resourceArmResourceGroupCreateUpdate(d *schema.ResourceData, meta interface
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, name, parameters); err != nil {
-		return fmt.Errorf("Error creating resource group: %+v", err)
+		return fmt.Errorf("Error creating Resource Group %q: %+v", name, err)
 	}
 
 	resp, err := client.Get(ctx, name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving resource group: %+v", err)
+		return fmt.Errorf("Error retrieving Resource Group %q: %+v", name, err)
 	}
 
 	d.SetId(*resp.ID)
@@ -93,12 +93,12 @@ func resourceArmResourceGroupRead(d *schema.ResourceData, meta interface{}) erro
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := resource.ParseResourceGroupID(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error parsing Azure Resource ID %q: %+v", d.Id(), err)
+		return err
 	}
 
-	name := id.ResourceGroup
+	name := id.Name
 
 	resp, err := client.Get(ctx, name)
 	if err != nil {
@@ -123,12 +123,12 @@ func resourceArmResourceGroupDelete(d *schema.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := resource.ParseResourceGroupID(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error parsing Azure Resource ID %q: %+v", d.Id(), err)
+		return err
 	}
 
-	name := id.ResourceGroup
+	name := id.Name
 
 	deleteFuture, err := client.Delete(ctx, name)
 	if err != nil {

--- a/azurerm/resource_arm_route_table.go
+++ b/azurerm/resource_arm_route_table.go
@@ -31,7 +31,7 @@ func resourceArmRouteTable() *schema.Resource {
 		Delete: resourceArmRouteTableDelete,
 
 		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
-			_, err := networkSvc.ParseRouteTableResourceID(id)
+			_, err := networkSvc.ParseRouteTableID(id)
 			return err
 		}),
 
@@ -176,7 +176,7 @@ func resourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := networkSvc.ParseRouteTableResourceID(d.Id())
+	id, err := networkSvc.ParseRouteTableID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func resourceArmRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := networkSvc.ParseRouteTableResourceID(d.Id())
+	id, err := networkSvc.ParseRouteTableID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_route_table.go
+++ b/azurerm/resource_arm_route_table.go
@@ -122,14 +122,14 @@ func resourceArmRouteTableCreateUpdate(d *schema.ResourceData, meta interface{})
 
 	name := d.Get("name").(string)
 	location := azure.NormalizeLocation(d.Get("location").(string))
-	resGroup := d.Get("resource_group_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
 	t := d.Get("tags").(map[string]interface{})
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, name, "")
+		existing, err := client.Get(ctx, resourceGroup, name, "")
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Route Table %q (Resource Group %q): %+v", name, resGroup, err)
+				return fmt.Errorf("Error checking for presence of existing Route Table %q (Resource Group %q): %+v", name, resourceGroup, err)
 			}
 		}
 
@@ -148,21 +148,22 @@ func resourceArmRouteTableCreateUpdate(d *schema.ResourceData, meta interface{})
 		Tags: tags.Expand(t),
 	}
 
-	future, err := client.CreateOrUpdate(ctx, resGroup, name, routeSet)
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, routeSet)
 	if err != nil {
-		return fmt.Errorf("Error Creating/Updating Route Table %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("Error Creating/Updating Route Table %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for completion of Route Table %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("Error waiting for completion of Route Table %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	read, err := client.Get(ctx, resGroup, name, "")
+	read, err := client.Get(ctx, resourceGroup, name, "")
 	if err != nil {
-		return err
+		return fmt.Errorf("Error retrieving Route Table %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
+
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Route Table %q (resource group %q) ID", name, resGroup)
+		return fmt.Errorf("ID was nil for Route Table %q (Resource Group %q)", name, resourceGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -175,24 +176,22 @@ func resourceArmRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := networkSvc.ParseRouteTableResourceID(d.Id())
 	if err != nil {
 		return err
 	}
-	resGroup := id.ResourceGroup
-	name := id.Path["routeTables"]
 
-	resp, err := client.Get(ctx, resGroup, name, "")
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure Route Table %q: %+v", name, err)
+		return fmt.Errorf("Error retrieving Route Table %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resGroup)
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -216,22 +215,20 @@ func resourceArmRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := networkSvc.ParseRouteTableResourceID(d.Id())
 	if err != nil {
 		return err
 	}
-	resGroup := id.ResourceGroup
-	name := id.Path["routeTables"]
 
-	future, err := client.Delete(ctx, resGroup, name)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("Error deleting Route Table %q (Resource Group %q): %+v", name, resGroup, err)
+			return fmt.Errorf("Error deleting Route Table %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of Route Table %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("Error waiting for deletion of Route Table %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -222,7 +222,7 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 			ID: &rtId,
 		}
 
-		parsedRouteTableId, err := networksvc.ParseRouteTableResourceID(rtId)
+		parsedRouteTableId, err := networksvc.ParseRouteTableID(rtId)
 		if err != nil {
 			return err
 		}
@@ -385,7 +385,7 @@ func resourceArmSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("route_table_id"); ok {
 		rtId := v.(string)
-		parsedRouteTableId, err2 := networksvc.ParseRouteTableResourceID(rtId)
+		parsedRouteTableId, err2 := networksvc.ParseRouteTableID(rtId)
 		if err2 != nil {
 			return err2
 		}

--- a/azurerm/resource_arm_subnet.go
+++ b/azurerm/resource_arm_subnet.go
@@ -205,7 +205,7 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 			ID: &nsgId,
 		}
 
-		parsedNsgId, err := networksvc.ParseNetworkSecurityGroupResourceID(nsgId)
+		parsedNsgId, err := networksvc.ParseNetworkSecurityGroupID(nsgId)
 		if err != nil {
 			return err
 		}
@@ -374,7 +374,7 @@ func resourceArmSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("network_security_group_id"); ok {
 		networkSecurityGroupId := v.(string)
-		parsedNetworkSecurityGroupId, err2 := networksvc.ParseNetworkSecurityGroupResourceID(networkSecurityGroupId)
+		parsedNetworkSecurityGroupId, err2 := networksvc.ParseNetworkSecurityGroupID(networkSecurityGroupId)
 		if err2 != nil {
 			return err2
 		}

--- a/azurerm/resource_arm_subnet_network_security_group_association.go
+++ b/azurerm/resource_arm_subnet_network_security_group_association.go
@@ -65,7 +65,7 @@ func resourceArmSubnetNetworkSecurityGroupAssociationCreate(d *schema.ResourceDa
 		return err
 	}
 
-	parsedNetworkSecurityGroupId, err := networkSvc.ParseNetworkSecurityGroupResourceID(networkSecurityGroupId)
+	parsedNetworkSecurityGroupId, err := networkSvc.ParseNetworkSecurityGroupID(networkSecurityGroupId)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func resourceArmSubnetNetworkSecurityGroupAssociationDelete(d *schema.ResourceDa
 	}
 
 	// once we have the network security group id to lock on, lock on that
-	parsedNetworkSecurityGroupId, err := networkSvc.ParseNetworkSecurityGroupResourceID(*props.NetworkSecurityGroup.ID)
+	parsedNetworkSecurityGroupId, err := networkSvc.ParseNetworkSecurityGroupID(*props.NetworkSecurityGroup.ID)
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_subnet_route_table_association.go
+++ b/azurerm/resource_arm_subnet_route_table_association.go
@@ -65,7 +65,7 @@ func resourceArmSubnetRouteTableAssociationCreate(d *schema.ResourceData, meta i
 		return err
 	}
 
-	parsedRouteTableId, err := networkSvc.ParseRouteTableResourceID(routeTableId)
+	parsedRouteTableId, err := networkSvc.ParseRouteTableID(routeTableId)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func resourceArmSubnetRouteTableAssociationDelete(d *schema.ResourceData, meta i
 	}
 
 	// once we have the route table id to lock on, lock on that
-	parsedRouteTableId, err := networkSvc.ParseRouteTableResourceID(*props.RouteTable.ID)
+	parsedRouteTableId, err := networkSvc.ParseRouteTableID(*props.RouteTable.ID)
 	if err != nil {
 		return err
 	}

--- a/azurerm/resource_arm_virtual_hub.go
+++ b/azurerm/resource_arm_virtual_hub.go
@@ -162,21 +162,19 @@ func resourceArmVirtualHubRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.Base.ResourceGroup
-	name := id.Name
 
-	resp, err := client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			log.Printf("[INFO] Virtual Hub %q does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error reading Virtual Hub %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error reading Virtual Hub %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -206,20 +204,18 @@ func resourceArmVirtualHubDelete(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.Base.ResourceGroup
-	name := id.Name
 
-	locks.ByName(name, virtualHubResourceName)
-	defer locks.UnlockByName(name, virtualHubResourceName)
+	locks.ByName(id.Name, virtualHubResourceName)
+	defer locks.UnlockByName(id.Name, virtualHubResourceName)
 
-	future, err := client.Delete(ctx, resourceGroup, name)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Virtual Hub %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error deleting Virtual Hub %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("Error waiting for deleting Virtual Hub %q (Resource Group %q): %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error waiting for deleting Virtual Hub %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/resource_arm_virtual_machine_scale_set_extension.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_extension.go
@@ -118,11 +118,11 @@ func resourceArmVirtualMachineScaleSetExtensionCreate(d *schema.ResourceData, me
 	defer cancel()
 
 	name := d.Get("name").(string)
-	virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Get("virtual_machine_scale_set_id").(string))
+	virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetID(d.Get("virtual_machine_scale_set_id").(string))
 	if err != nil {
 		return err
 	}
-	resourceGroup := virtualMachineScaleSetId.Base.ResourceGroup
+	resourceGroup := virtualMachineScaleSetId.ResourceGroup
 	vmssName := virtualMachineScaleSetId.Name
 
 	if features.ShouldResourcesBeImported() {

--- a/azurerm/resource_arm_virtual_machine_scale_set_extension.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_extension.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	computeSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -26,9 +27,11 @@ func resourceArmVirtualMachineScaleSetExtension() *schema.Resource {
 		Read:   resourceArmVirtualMachineScaleSetExtensionRead,
 		Update: resourceArmVirtualMachineScaleSetExtensionUpdate,
 		Delete: resourceArmVirtualMachineScaleSetExtensionDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := computeSvc.ParseVirtualMachineScaleSetExtensionID(id)
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -195,7 +198,7 @@ func resourceArmVirtualMachineScaleSetExtensionUpdate(d *schema.ResourceData, me
 	ctx, cancel := timeouts.ForUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -257,13 +260,13 @@ func resourceArmVirtualMachineScaleSetExtensionUpdate(d *schema.ResourceData, me
 		Name: utils.String(id.Name),
 		VirtualMachineScaleSetExtensionProperties: &props,
 	}
-	future, err := client.CreateOrUpdate(ctx, id.Base.ResourceGroup, id.VirtualMachineName, id.Name, extension)
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.VirtualMachineName, id.Name, extension)
 	if err != nil {
-		return fmt.Errorf("Error updating Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+		return fmt.Errorf("Error updating Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for update of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for update of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.ResourceGroup, err)
 	}
 
 	return resourceArmVirtualMachineScaleSetExtensionRead(d, meta)
@@ -275,31 +278,31 @@ func resourceArmVirtualMachineScaleSetExtensionRead(d *schema.ResourceData, meta
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	vmss, err := vmssClient.Get(ctx, id.Base.ResourceGroup, id.VirtualMachineName)
+	vmss, err := vmssClient.Get(ctx, id.ResourceGroup, id.VirtualMachineName)
 	if err != nil {
 		if utils.ResponseWasNotFound(vmss.Response) {
-			log.Printf("Virtual Machine Scale Set %q was not found in Resource Group %q - removing Extension from state!", id.VirtualMachineName, id.Base.ResourceGroup)
+			log.Printf("Virtual Machine Scale Set %q was not found in Resource Group %q - removing Extension from state!", id.VirtualMachineName, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Virtual Machine Scale Set %q (Resource Group %q): %+v", id.VirtualMachineName, id.Base.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving Virtual Machine Scale Set %q (Resource Group %q): %+v", id.VirtualMachineName, id.ResourceGroup, err)
 	}
 
-	resp, err := client.Get(ctx, id.Base.ResourceGroup, id.VirtualMachineName, id.Name, "")
+	resp, err := client.Get(ctx, id.ResourceGroup, id.VirtualMachineName, id.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("Extension %q (Virtual Machine Scale Set %q / Resource Group %q) was not found - removing from state!", id.Name, id.VirtualMachineName, id.Base.ResourceGroup)
+			log.Printf("Extension %q (Virtual Machine Scale Set %q / Resource Group %q) was not found - removing from state!", id.Name, id.VirtualMachineName, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.ResourceGroup, err)
 	}
 
 	d.Set("name", id.Name)
@@ -335,22 +338,22 @@ func resourceArmVirtualMachineScaleSetExtensionDelete(d *schema.ResourceData, me
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	future, err := client.Delete(ctx, id.Base.ResourceGroup, id.VirtualMachineName, id.Name)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.VirtualMachineName, id.Name)
 	if err != nil {
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+		return fmt.Errorf("Error deleting Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.ResourceGroup, err)
 	}
 
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.Base.ResourceGroup, err)
+		return fmt.Errorf("Error waiting for deletion of Extension %q (Virtual Machine Scale Set %q / Resource Group %q): %+v", id.Name, id.VirtualMachineName, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_virtual_machine_scale_set_extension_test.go
+++ b/azurerm/resource_arm_virtual_machine_scale_set_extension_test.go
@@ -277,18 +277,18 @@ func testCheckAzureRMVirtualMachineScaleSetExtensionExists(resourceName string) 
 
 		name := rs.Primary.Attributes["name"]
 		virtualMachineScaleSetIdRaw := rs.Primary.Attributes["virtual_machine_scale_set_id"]
-		virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetResourceID(virtualMachineScaleSetIdRaw)
+		virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetID(virtualMachineScaleSetIdRaw)
 		if err != nil {
 			return err
 		}
 
-		resp, err := client.Get(ctx, virtualMachineScaleSetId.Base.ResourceGroup, virtualMachineScaleSetId.Name, name, "")
+		resp, err := client.Get(ctx, virtualMachineScaleSetId.ResourceGroup, virtualMachineScaleSetId.Name, name, "")
 		if err != nil {
 			return fmt.Errorf("Bad: Get on vmScaleSetClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: Extension %q (VirtualMachineScaleSet %q / Resource Group: %q) does not exist", name, virtualMachineScaleSetId.Name, virtualMachineScaleSetId.Base.ResourceGroup)
+			return fmt.Errorf("Bad: Extension %q (VirtualMachineScaleSet %q / Resource Group: %q) does not exist", name, virtualMachineScaleSetId.Name, virtualMachineScaleSetId.ResourceGroup)
 		}
 
 		return err
@@ -306,12 +306,12 @@ func testCheckAzureRMVirtualMachineScaleSetExtensionDestroy(s *terraform.State) 
 
 		name := rs.Primary.Attributes["name"]
 		virtualMachineScaleSetIdRaw := rs.Primary.Attributes["virtual_machine_scale_set_id"]
-		virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetResourceID(virtualMachineScaleSetIdRaw)
+		virtualMachineScaleSetId, err := computeSvc.ParseVirtualMachineScaleSetID(virtualMachineScaleSetIdRaw)
 		if err != nil {
 			return err
 		}
 
-		resp, err := client.Get(ctx, virtualMachineScaleSetId.Base.ResourceGroup, virtualMachineScaleSetId.Name, name, "")
+		resp, err := client.Get(ctx, virtualMachineScaleSetId.ResourceGroup, virtualMachineScaleSetId.Name, name, "")
 
 		if err != nil {
 			return nil

--- a/azurerm/resource_arm_virtual_wan.go
+++ b/azurerm/resource_arm_virtual_wan.go
@@ -163,22 +163,19 @@ func resourceArmVirtualWanRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
-	name := id.Name
-
-	resp, err := client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Virtual WAN %q (Resource Group %q) was not found - removing from state", name, resourceGroup)
+			log.Printf("[DEBUG] Virtual WAN %q (Resource Group %q) was not found - removing from state", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error making Read request on Virtual WAN %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
+	return fmt.Errorf("Error making Read request on Virtual WAN %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -203,22 +200,19 @@ func resourceArmVirtualWanDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
-	name := id.Name
-
-	future, err := client.Delete(ctx, resourceGroup, name)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		// deleted outside of Terraform
 		if response.WasNotFound(future.Response()) {
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting Virtual WAN %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error deleting Virtual WAN %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		if !response.WasNotFound(future.Response()) {
-			return fmt.Errorf("Error waiting for the deletion of Virtual WAN %q (Resource Group %q): %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error waiting for the deletion of Virtual WAN %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 		}
 	}
 

--- a/azurerm/resource_arm_virtual_wan.go
+++ b/azurerm/resource_arm_virtual_wan.go
@@ -171,8 +171,8 @@ func resourceArmVirtualWanRead(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
+		return fmt.Errorf("Error making Read request on Virtual WAN %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	return fmt.Errorf("Error making Read request on Virtual WAN %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)

--- a/azurerm/resource_arm_vpn_gateway.go
+++ b/azurerm/resource_arm_vpn_gateway.go
@@ -191,8 +191,8 @@ func resourceArmVPNGatewayRead(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 
+		return fmt.Errorf("Error retrieving VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	return fmt.Errorf("Error retrieving VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 
 	d.Set("name", resp.Name)
 	d.Set("resource_group_name", id.ResourceGroup)

--- a/azurerm/resource_arm_vpn_gateway.go
+++ b/azurerm/resource_arm_vpn_gateway.go
@@ -180,25 +180,22 @@ func resourceArmVPNGatewayRead(d *schema.ResourceData, meta interface{}) error {
 
 	id, err := networkSvc.ParseVPNGatewayID(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error parsing Azure Resource ID %q: %+v", d.Id(), err)
+		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
-	name := id.Name
-
-	resp, err := client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] VPN Gateway %q was not found in Resource Group %q - removing from state", name, resourceGroup)
+			log.Printf("[DEBUG] VPN Gateway %q was not found in Resource Group %q - removing from state", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving VPN Gateway %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
+	return fmt.Errorf("Error retrieving VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 
 	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -231,19 +228,16 @@ func resourceArmVPNGatewayDelete(d *schema.ResourceData, meta interface{}) error
 
 	id, err := networkSvc.ParseVPNGatewayID(d.Id())
 	if err != nil {
-		return fmt.Errorf("Error parsing Azure Resource ID %q: %+v", d.Id(), err)
+		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
-	name := id.Name
-
-	deleteFuture, err := client.Delete(ctx, resourceGroup, name)
+	deleteFuture, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if response.WasNotFound(deleteFuture.Response()) {
 			return nil
 		}
 
-		return fmt.Errorf("Error deleting VPN Gateway %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error deleting VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	err = deleteFuture.WaitForCompletionRef(ctx, client.Client)
@@ -252,7 +246,7 @@ func resourceArmVPNGatewayDelete(d *schema.ResourceData, meta interface{}) error
 			return nil
 		}
 
-		return fmt.Errorf("Error waiting for deletion of VPN Gateway %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for deletion of VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_vpn_server_configuration.go
+++ b/azurerm/resource_arm_vpn_server_configuration.go
@@ -437,21 +437,19 @@ func resourceArmVPNServerConfigurationRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
-
-	resp, err := client.Get(ctx, resourceGroup, id.Name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] VPN Server Configuration %q was not found in Resource Group %q - removing from state!", id.Name, resourceGroup)
+			log.Printf("[DEBUG] VPN Server Configuration %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Point-To-Site VPN Server Configuration %q (Resource Group %q): %+v", id.Name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Point-To-Site VPN Server Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	d.Set("name", id.Name)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("resource_group_name", id.ResourceGroup)
 
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
@@ -512,15 +510,13 @@ func resourceArmVPNServerConfigurationDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 
-	resourceGroup := id.Base.ResourceGroup
-
-	future, err := client.Delete(ctx, resourceGroup, id.Name)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error deleting VPN Server Configuration %q (Resource Group %q): %+v", id.Name, resourceGroup, err)
+		return fmt.Errorf("Error deleting VPN Server Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of VPN Server Configuration %q (Resource Group %q): %+v", id.Name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for deletion of VPN Server Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/resource_arm_vpn_server_configuration.go
+++ b/azurerm/resource_arm_vpn_server_configuration.go
@@ -445,7 +445,7 @@ func resourceArmVPNServerConfigurationRead(d *schema.ResourceData, meta interfac
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Point-To-Site VPN Server Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving VPN Server Configuration %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	d.Set("name", id.Name)

--- a/azurerm/resource_arm_windows_virtual_machine_scale_set.go
+++ b/azurerm/resource_arm_windows_virtual_machine_scale_set.go
@@ -16,6 +16,7 @@ import (
 	computeSvc "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/base64"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -26,9 +27,12 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 		Read:   resourceArmWindowsVirtualMachineScaleSetRead,
 		Update: resourceArmWindowsVirtualMachineScaleSetUpdate,
 		Delete: resourceArmWindowsVirtualMachineScaleSetDelete,
-		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
-		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := computeSvc.ParseVirtualMachineScaleSetID(id)
+			// TODO: (prior to Beta) look up the VM & confirm this is a Windows VMSS
+			return err
+		}),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
@@ -593,23 +597,20 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 	ctx, cancel := timeouts.ForUpdate(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Name
-	resourceGroup := id.Base.ResourceGroup
-
 	updateInstances := false
 
 	// retrieve
-	existing, err := client.Get(ctx, resourceGroup, name)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 	if existing.VirtualMachineScaleSetProperties == nil {
-		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", name, resourceGroup)
+		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
 	}
 
 	updateProps := compute.VirtualMachineScaleSetUpdateProperties{
@@ -791,26 +792,26 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 
 	update.VirtualMachineScaleSetUpdateProperties = &updateProps
 
-	log.Printf("[DEBUG] Updating Windows Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
-	future, err := client.Update(ctx, resourceGroup, name, update)
+	log.Printf("[DEBUG] Updating Windows Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
 	if err != nil {
-		return fmt.Errorf("Error updating Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error updating Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	log.Printf("[DEBUG] Waiting for update of Windows Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
+	log.Printf("[DEBUG] Waiting for update of Windows Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for update of Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for update of Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	log.Printf("[DEBUG] Updated Windows Virtual Machine Scale Set %q (Resource Group %q).", name, resourceGroup)
+	log.Printf("[DEBUG] Updated Windows Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
 
 	// if we update the SKU, we also need to subsequently roll the instances using the `UpdateInstances` API
 	if updateInstances {
 		if userWantsToRollInstances := d.Get("terraform_should_roll_instances_when_required").(bool); userWantsToRollInstances {
-			log.Printf("[DEBUG] Rolling the VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
+			log.Printf("[DEBUG] Rolling the VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 			instancesClient := meta.(*ArmClient).Compute.VMScaleSetVMsClient
-			instances, err := instancesClient.ListComplete(ctx, resourceGroup, name, "", "", "")
+			instances, err := instancesClient.ListComplete(ctx, id.ResourceGroup, id.Name, "", "", "")
 			if err != nil {
-				return fmt.Errorf("Error listing VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+				return fmt.Errorf("Error listing VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 			}
 
 			log.Printf("[DEBUG] Determining instances to roll..")
@@ -838,13 +839,13 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 				ids := compute.VirtualMachineScaleSetVMInstanceRequiredIDs{
 					InstanceIds: &instanceIds,
 				}
-				future, err := client.UpdateInstances(ctx, resourceGroup, name, ids)
+				future, err := client.UpdateInstances(ctx, id.ResourceGroup, id.Name, ids)
 				if err != nil {
-					return fmt.Errorf("Error updating Instance %q (Windows VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error updating Instance %q (Windows VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 
 				if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("Error waiting for update of Instance %q (Windows VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error waiting for update of Instance %q (Windows VM Scale Set %q / Resource Group %q) to the Latest Configuration: %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 				log.Printf("[DEBUG] Updated Instance %q to the Latest Configuration.", instanceId)
 
@@ -853,20 +854,20 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 				reimageInput := &compute.VirtualMachineScaleSetReimageParameters{
 					InstanceIds: &instanceIds,
 				}
-				reimageFuture, err := client.Reimage(ctx, resourceGroup, name, reimageInput)
+				reimageFuture, err := client.Reimage(ctx, id.ResourceGroup, id.Name, reimageInput)
 				if err != nil {
-					return fmt.Errorf("Error reimaging Instance %q (Windows VM Scale Set %q / Resource Group %q): %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error reimaging Instance %q (Windows VM Scale Set %q / Resource Group %q): %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 
 				if err = reimageFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("Error waiting for reimage of Instance %q (Windows VM Scale Set %q / Resource Group %q): %+v", instanceId, name, resourceGroup, err)
+					return fmt.Errorf("Error waiting for reimage of Instance %q (Windows VM Scale Set %q / Resource Group %q): %+v", instanceId, id.Name, id.ResourceGroup, err)
 				}
 				log.Printf("[DEBUG] Reimaged Instance %q..", instanceId)
 			}
 
-			log.Printf("[DEBUG] Rolled the VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q).", name, resourceGroup)
+			log.Printf("[DEBUG] Rolled the VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
 		} else {
-			log.Printf("[DEBUG] Terraform wants to roll the VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q) - but user has opted out - skipping..", name, resourceGroup)
+			log.Printf("[DEBUG] Terraform wants to roll the VM Instances for Windows Virtual Machine Scale Set %q (Resource Group %q) - but user has opted out - skipping..", id.Name, id.ResourceGroup)
 		}
 	}
 
@@ -878,27 +879,24 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 	ctx, cancel := timeouts.ForRead(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Name
-	resourceGroup := id.Base.ResourceGroup
-
-	resp, err := client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Windows Virtual Machine Scale Set %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			log.Printf("[DEBUG] Windows Virtual Machine Scale Set %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	d.Set("name", name)
-	d.Set("resource_group_name", resourceGroup)
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -923,7 +921,7 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 	}
 
 	if resp.VirtualMachineScaleSetProperties == nil {
-		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", name, resourceGroup)
+		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
 	}
 	props := *resp.VirtualMachineScaleSetProperties
 
@@ -1055,21 +1053,18 @@ func resourceArmWindowsVirtualMachineScaleSetDelete(d *schema.ResourceData, meta
 	ctx, cancel := timeouts.ForDelete(meta.(*ArmClient).StopContext, d)
 	defer cancel()
 
-	id, err := computeSvc.ParseVirtualMachineScaleSetResourceID(d.Id())
+	id, err := computeSvc.ParseVirtualMachineScaleSetID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	name := id.Name
-	resourceGroup := id.Base.ResourceGroup
-
-	resp, err := client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	// Sometimes VMSS's aren't fully deleted when the `Delete` call returns - as such we'll try to scale the cluster
@@ -1085,32 +1080,32 @@ func resourceArmWindowsVirtualMachineScaleSetDelete(d *schema.ResourceData, meta
 		update := compute.VirtualMachineScaleSetUpdate{
 			Sku: resp.Sku,
 		}
-		future, err := client.Update(ctx, resourceGroup, name, update)
+		future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
 		if err != nil {
-			return fmt.Errorf("Error updating number of instances in Windows Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error updating number of instances in Windows Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
 		}
 
 		log.Printf("[DEBUG] Waiting for scaling of instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 		err = future.WaitForCompletionRef(ctx, client.Client)
 		if err != nil {
-			return fmt.Errorf("Error waiting for number of instances in Windows Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error waiting for number of instances in Windows Virtual Machine Scale Set %q (Resource Group %q) to scale to 0: %+v", id.Name, id.ResourceGroup, err)
 		}
 		log.Printf("[DEBUG] Scaled instances to 0 prior to deletion - this helps avoids networking issues within Azure")
 	} else {
 		log.Printf("[DEBUG] Unable to scale instances to `0` since the `sku` block is nil - trying to delete anyway")
 	}
 
-	log.Printf("[DEBUG] Deleting Windows Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
-	future, err := client.Delete(ctx, resourceGroup, name)
+	log.Printf("[DEBUG] Deleting Windows Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error deleting Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	log.Printf("[DEBUG] Waiting for deletion of Windows Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
+	log.Printf("[DEBUG] Waiting for deletion of Windows Virtual Machine Scale Set %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for deletion of Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
-	log.Printf("[DEBUG] Deleted Windows Virtual Machine Scale Set %q (Resource Group %q).", name, resourceGroup)
+	log.Printf("[DEBUG] Deleted Windows Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
 
 	return nil
 }


### PR DESCRIPTION
This PR makes the ID parsing consistent for all of the refactored ID parsers - using a new `pop` method which allows us to reduce the TLOC in each parsing/validation function

It also adds Import Validation for:

- `azurerm_kubernetes_cluster`
- `azurerm_kubernetes_node_pool`
- `azurerm_network_security_group`
- `azurerm_route_table`