### PR TITLE
azurerm_private_link_service: support for `enable_proxy_protocol`

### DIFF
--- a/azurerm/data_source_private_link_service.go
+++ b/azurerm/data_source_private_link_service.go
@@ -38,6 +38,11 @@ func dataSourceArmPrivateLinkService() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"enable_proxy_protocol": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"visibility_subscription_ids": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -122,6 +127,8 @@ func dataSourceArmPrivateLinkServiceRead(d *schema.ResourceData, meta interface{
 
 	if props := resp.PrivateLinkServiceProperties; props != nil {
 		d.Set("alias", props.Alias)
+		d.Set("enable_proxy_protocol", props.EnableProxyProtocol)
+
 		if props.AutoApproval.Subscriptions != nil {
 			if err := d.Set("auto_approval_subscription_ids", utils.FlattenStringSlice(props.AutoApproval.Subscriptions)); err != nil {
 				return fmt.Errorf("Error setting `auto_approval_subscription_ids`: %+v", err)
@@ -132,12 +139,7 @@ func dataSourceArmPrivateLinkServiceRead(d *schema.ResourceData, meta interface{
 				return fmt.Errorf("Error setting `visibility_subscription_ids`: %+v", err)
 			}
 		}
-		// currently not implemented yet, timeline unknown, exact purpose unknown, maybe coming to a future API near you
-		// if props.Fqdns != nil {
-		// 	if err := d.Set("fqdns", utils.FlattenStringSlice(props.Fqdns)); err != nil {
-		// 		return fmt.Errorf("Error setting `fqdns`: %+v", err)
-		// 	}
-		// }
+
 		if props.IPConfigurations != nil {
 			if err := d.Set("nat_ip_configuration", flattenArmPrivateLinkServiceIPConfiguration(props.IPConfigurations)); err != nil {
 				return fmt.Errorf("Error setting `nat_ip_configuration`: %+v", err)

--- a/azurerm/resource_arm_private_link_service.go
+++ b/azurerm/resource_arm_private_link_service.go
@@ -61,6 +61,11 @@ func resourceArmPrivateLinkService() *schema.Resource {
 				Set: schema.HashString,
 			},
 
+			"enable_proxy_protocol": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"visibility_subscription_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -177,6 +182,7 @@ func resourceArmPrivateLinkServiceCreateUpdate(d *schema.ResourceData, meta inte
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	autoApproval := d.Get("auto_approval_subscription_ids").(*schema.Set).List()
+	enableProxyProtocol := d.Get("enable_proxy_protocol").(bool)
 	primaryIpConfiguration := d.Get("nat_ip_configuration").([]interface{})
 	loadBalancerFrontendIpConfigurations := d.Get("load_balancer_frontend_ip_configuration_ids").(*schema.Set).List()
 	visibility := d.Get("visibility_subscription_ids").(*schema.Set).List()
@@ -188,6 +194,7 @@ func resourceArmPrivateLinkServiceCreateUpdate(d *schema.ResourceData, meta inte
 			AutoApproval: &network.PrivateLinkServicePropertiesAutoApproval{
 				Subscriptions: utils.ExpandStringSlice(autoApproval),
 			},
+			EnableProxyProtocol: utils.Bool(enableProxyProtocol),
 			Visibility: &network.PrivateLinkServicePropertiesVisibility{
 				Subscriptions: utils.ExpandStringSlice(visibility),
 			},
@@ -270,6 +277,8 @@ func resourceArmPrivateLinkServiceRead(d *schema.ResourceData, meta interface{})
 
 	if props := resp.PrivateLinkServiceProperties; props != nil {
 		d.Set("alias", props.Alias)
+		d.Set("enable_proxy_protocol", props.EnableProxyProtocol)
+
 		if err := d.Set("auto_approval_subscription_ids", utils.FlattenStringSlice(props.AutoApproval.Subscriptions)); err != nil {
 			return fmt.Errorf("Error setting `auto_approval_subscription_ids`: %+v", err)
 		}

--- a/website/docs/d/private_link_service.html.markdown
+++ b/website/docs/d/private_link_service.html.markdown
@@ -44,6 +44,8 @@ The following attributes are exported:
 
 * `auto_approval_subscription_ids` - The list of subscription(s) globally unique identifiers that will be auto approved to use the private link service.
 
+* `enable_proxy_protocol` - Does the Private Link Service support the Proxy Protocol?
+
 * `load_balancer_frontend_ip_configuration_ids` - The list of Standard Load Balancer(SLB) resource IDs. The Private Link service is tied to the frontend IP address of a SLB. All traffic destined for the private link service will reach the frontend of the SLB. You can configure SLB rules to direct this traffic to appropriate backend pools where your applications are running.
 
 * `location` - The supported Azure location where the resource exists.

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `auto_approval_subscription_ids` - (Optional) A list of Subscription UUID/GUID's that will be automatically be able to use this Private Link Service.
 
+* `enable_proxy_protocol` - (Optional) Should the Private Link Service support the Proxy Protocol? Defaults to `false`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 
 * `visibility_subscription_ids` - (Optional) A list of Subscription UUID/GUID's that will be able to see this Private Link Service.


### PR DESCRIPTION
This PR adds support for `enable_proxy_protocol` to both the Data Source & Resource for `azurerm_private_link_service`