### PR TITLE
Two arguments in Management Group import

### DIFF
--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -59,5 +59,5 @@ The following attributes are exported:
 Management Groups can be imported using the `management group resource id`, e.g.
 
 ```shell
-terraform import azurerm_management_group.example/providers/Microsoft.Management/ManagementGroups/group1
+terraform import azurerm_management_group.example /providers/Microsoft.Management/ManagementGroups/group1
 ```


### PR DESCRIPTION
The example import is missing a space, incorrectly showing the import as having one large argument instead of two.