### PR TITLE
refactor: moving the config builder / introducing the `acceptance` package

### DIFF
--- a/azurerm/config.go
+++ b/azurerm/config.go
@@ -2,107 +2,27 @@ package azurerm
 
 import (
 	"context"
-	"fmt"
-	"time"
 
-	"github.com/hashicorp/go-azure-helpers/authentication"
-	"github.com/hashicorp/go-azure-helpers/sender"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 )
 
-// ArmClient contains the handles to all the specific Azure Resource Manager
-// resource classes' respective clients.
 type ArmClient struct {
 	// inherit the fields from the parent, so that we should be able to set/access these at either level
 	clients.Client
 }
 
-type armClientBuilder struct {
-	authConfig                  *authentication.Config
-	skipProviderRegistration    bool
-	terraformVersion            string
-	partnerId                   string
-	disableCorrelationRequestID bool
-	disableTerraformPartnerID   bool
-}
+func getArmClient(ctx context.Context, builder clients.ClientBuilder) (*ArmClient, error) {
+	// NOTE: this only needs to exist until ArmClient is removed
+	//		 at this point this method can disappear along
+	//	  	 with the rest of this file
 
-// getArmClient is a helper method which returns a fully instantiated
-// *ArmClient based on the Config's current settings.
-func getArmClient(ctx context.Context, builder armClientBuilder) (*ArmClient, error) {
-	env, err := authentication.DetermineEnvironment(builder.authConfig.Environment)
+	innerClient, err := clients.Build(ctx, builder)
 	if err != nil {
 		return nil, err
-	}
-
-	// client declarations:
-	account, err := clients.NewResourceManagerAccount(ctx, *builder.authConfig, *env)
-	if err != nil {
-		return nil, fmt.Errorf("Error building account: %+v", err)
 	}
 
 	client := ArmClient{
-		Client: clients.Client{
-			Account: account,
-		},
+		Client: *innerClient,
 	}
-
-	oauthConfig, err := builder.authConfig.BuildOAuthConfig(env.ActiveDirectoryEndpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	// OAuthConfigForTenant returns a pointer, which can be nil.
-	if oauthConfig == nil {
-		return nil, fmt.Errorf("Unable to configure OAuthConfig for tenant %s", builder.authConfig.TenantID)
-	}
-
-	sender := sender.BuildSender("AzureRM")
-
-	// Resource Manager endpoints
-	endpoint := env.ResourceManagerEndpoint
-	auth, err := builder.authConfig.GetAuthorizationToken(sender, oauthConfig, env.TokenAudience)
-	if err != nil {
-		return nil, err
-	}
-
-	// Graph Endpoints
-	graphEndpoint := env.GraphEndpoint
-	graphAuth, err := builder.authConfig.GetAuthorizationToken(sender, oauthConfig, graphEndpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	// Storage Endpoints
-	storageAuth, err := builder.authConfig.GetAuthorizationToken(sender, oauthConfig, env.ResourceIdentifiers.Storage)
-	if err != nil {
-		return nil, err
-	}
-
-	// Key Vault Endpoints
-	keyVaultAuth := builder.authConfig.BearerAuthorizerCallback(sender, oauthConfig)
-
-	o := &common.ClientOptions{
-		SubscriptionId:              builder.authConfig.SubscriptionID,
-		TenantID:                    builder.authConfig.TenantID,
-		PartnerId:                   builder.partnerId,
-		TerraformVersion:            builder.terraformVersion,
-		GraphAuthorizer:             graphAuth,
-		GraphEndpoint:               graphEndpoint,
-		KeyVaultAuthorizer:          keyVaultAuth,
-		ResourceManagerAuthorizer:   auth,
-		ResourceManagerEndpoint:     endpoint,
-		StorageAuthorizer:           storageAuth,
-		PollingDuration:             180 * time.Minute,
-		SkipProviderReg:             builder.skipProviderRegistration,
-		DisableCorrelationRequestID: builder.disableCorrelationRequestID,
-		DisableTerraformPartnerID:   builder.disableTerraformPartnerID,
-		Environment:                 *env,
-	}
-
-	if err := client.Client.Build(o); err != nil {
-		return nil, fmt.Errorf("Error building Client: %+v", err)
-	}
-
 	return &client, nil
 }

--- a/azurerm/internal/acceptance/client_data.go
+++ b/azurerm/internal/acceptance/client_data.go
@@ -1,0 +1,34 @@
+package acceptance
+
+import "os"
+
+type ClientData struct {
+	// ClientID is the UUID of the Service Principal being used to connect to Azure
+	ClientID string
+
+	// ClientSecret is the Client Secret being used to connect to Azure
+	ClientSecret string
+
+	// SubscriptionID is the UUID of the Azure Subscription where tests are being run
+	SubscriptionID string
+
+	// TenantID is the UUID of the Azure Tenant where tests are being run
+	TenantID string
+
+	// Are we connected as a Service Principal
+	// this exists for allowing folks to run the test suite via other
+	// credentials in the future; but requires code changes first
+	IsServicePrincipal bool
+}
+
+// Client returns a struct containing information about the Client being
+// used to connect to Azure
+func (td TestData) Client() ClientData {
+	return ClientData{
+		ClientID:           os.Getenv("ARM_CLIENT_ID"),
+		ClientSecret:       os.Getenv("ARM_CLIENT_SECRET"),
+		IsServicePrincipal: true,
+		SubscriptionID:     os.Getenv("ARM_SUBSCRIPTION_ID"),
+		TenantID:           os.Getenv("ARM_TENANT_ID"),
+	}
+}

--- a/azurerm/internal/acceptance/data.go
+++ b/azurerm/internal/acceptance/data.go
@@ -11,8 +11,8 @@ import (
 )
 
 type TestData struct {
-	// Location is a set of Azure Regions which should be used for this Test
-	Location Regions
+	// Locations is a set of Azure Regions which should be used for this Test
+	Locations Regions
 
 	// RandomString is a random integer which is unique to this test case
 	RandomInteger int
@@ -58,9 +58,9 @@ func BuildTestData(t *testing.T, resourceType string, resourceLabel string) Test
 	}
 
 	if features.UseDynamicTestLocations() {
-		testData.Location = SupportedLocations()
+		testData.Locations = availableLocations()
 	} else {
-		testData.Location = Regions{
+		testData.Locations = Regions{
 			Primary:   Location(),
 			Secondary: AltLocation(),
 			Ternary:   AltLocation2(),

--- a/azurerm/internal/acceptance/data.go
+++ b/azurerm/internal/acceptance/data.go
@@ -1,0 +1,71 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+type TestData struct {
+	// Location is a set of Azure Regions which should be used for this Test
+	Location Regions
+
+	// RandomString is a random integer which is unique to this test case
+	RandomInteger int
+
+	// RandomString is a random 5 character string is unique to this test case
+	RandomString string
+
+	// ResourceName is the fully qualified resource name, comprising of the
+	// resource type and then the resource label
+	// e.g. `azurerm_resource_group.test`
+	ResourceName string
+
+	// Environment is a struct containing Details about the Azure Environment
+	// that we're running against
+	Environment azure.Environment
+
+	// EnvironmentName is the name of the Azure Environment where we're running
+	EnvironmentName string
+
+	// resourceType is the Terraform Resource Type - `azurerm_resource_group`
+	resourceType string
+
+	// resourceLabel is the local used for the resource - generally "test""
+	resourceLabel string
+}
+
+// BuildTestData generates some test data for the given resource
+func BuildTestData(t *testing.T, resourceType string, resourceLabel string) TestData {
+	env, err := Environment()
+	if err != nil {
+		t.Fatalf("Error retrieving Environment: %+v", err)
+	}
+
+	testData := TestData{
+		RandomInteger:   tf.AccRandTimeInt(),
+		RandomString:    acctest.RandString(5),
+		ResourceName:    fmt.Sprintf("%s.%s", resourceType, resourceLabel),
+		Environment:     *env,
+		EnvironmentName: EnvironmentName(),
+
+		resourceType:  resourceType,
+		resourceLabel: resourceLabel,
+	}
+
+	if features.UseDynamicTestLocations() {
+		testData.Location = SupportedLocations()
+	} else {
+		testData.Location = Regions{
+			Primary:   Location(),
+			Secondary: AltLocation(),
+			Ternary:   AltLocation2(),
+		}
+	}
+
+	return testData
+}

--- a/azurerm/internal/acceptance/deprecated.go
+++ b/azurerm/internal/acceptance/deprecated.go
@@ -1,0 +1,18 @@
+package acceptance
+
+import "os"
+
+// Functions in this file are provided for compatibility purposes - but will eventually be deprecated
+// Developers should instead switch to using the `BuildTestData` method to obtain Test/Client Data
+
+func Location() string {
+	return os.Getenv("ARM_TEST_LOCATION")
+}
+
+func AltLocation() string {
+	return os.Getenv("ARM_TEST_LOCATION_ALT")
+}
+
+func AltLocation2() string {
+	return os.Getenv("ARM_TEST_LOCATION_ALT2")
+}

--- a/azurerm/internal/acceptance/locations.go
+++ b/azurerm/internal/acceptance/locations.go
@@ -1,0 +1,53 @@
+package acceptance
+
+import (
+	"math/rand"
+	"os"
+	"time"
+)
+
+// Regions is a list of Azure Regions which can be used for test purposes
+type Regions struct {
+	// Primary is the Primary/Default Azure Region which should be used for testing
+	Primary string
+
+	// Secondary is the Secondary Azure Region which should be used for testing
+	Secondary string
+
+	// Ternary is the Ternary Azure Region which should be used for testing
+	Ternary string
+}
+
+// SupportedLocations returns a struct containing a random set of regions
+// this will return a randomly ordered set of locations - and as such must be cached
+// this allows us to distribute the test suite across Azure to provide more stable tests
+func SupportedLocations() Regions {
+	locations := []string{
+		os.Getenv("ARM_TEST_LOCATION"),
+		os.Getenv("ARM_TEST_LOCATION_ALT"),
+		os.Getenv("ARM_TEST_LOCATION_ALT2"),
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(locations), func(i, j int) {
+		locations[i], locations[j] = locations[j], locations[i]
+	})
+
+	return Regions{
+		Primary:   locations[0],
+		Secondary: locations[1],
+		Ternary:   locations[2],
+	}
+}
+
+func Location() string {
+	return os.Getenv("ARM_TEST_LOCATION")
+}
+
+func AltLocation() string {
+	return os.Getenv("ARM_TEST_LOCATION_ALT")
+}
+
+func AltLocation2() string {
+	return os.Getenv("ARM_TEST_LOCATION_ALT2")
+}

--- a/azurerm/internal/acceptance/locations.go
+++ b/azurerm/internal/acceptance/locations.go
@@ -39,15 +39,3 @@ func SupportedLocations() Regions {
 		Ternary:   locations[2],
 	}
 }
-
-func Location() string {
-	return os.Getenv("ARM_TEST_LOCATION")
-}
-
-func AltLocation() string {
-	return os.Getenv("ARM_TEST_LOCATION_ALT")
-}
-
-func AltLocation2() string {
-	return os.Getenv("ARM_TEST_LOCATION_ALT2")
-}

--- a/azurerm/internal/acceptance/locations.go
+++ b/azurerm/internal/acceptance/locations.go
@@ -18,10 +18,10 @@ type Regions struct {
 	Ternary string
 }
 
-// SupportedLocations returns a struct containing a random set of regions
+// availableLocations returns a struct containing a random set of regions
 // this will return a randomly ordered set of locations - and as such must be cached
 // this allows us to distribute the test suite across Azure to provide more stable tests
-func SupportedLocations() Regions {
+func availableLocations() Regions {
 	locations := []string{
 		os.Getenv("ARM_TEST_LOCATION"),
 		os.Getenv("ARM_TEST_LOCATION_ALT"),

--- a/azurerm/internal/acceptance/steps.go
+++ b/azurerm/internal/acceptance/steps.go
@@ -1,0 +1,58 @@
+package acceptance
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+type DisappearsStepData struct {
+	// Config is a function which returns the Terraform Configuration which should be used for this step
+	Config func(data TestData) string
+
+	// CheckExists is a function which confirms that the given Resource in
+	// the state exists
+	CheckExists func(resourceName string) resource.TestCheckFunc
+
+	// Destroy is a function which looks up the given Resource in the State
+	// and then ensures that it's deleted
+	Destroy func(resourceName string) resource.TestCheckFunc
+}
+
+// DisappearsStep returns a Test Step which first confirms the resource exists
+// then destroys it, and expects that the plan at the end of this should show
+// that the resource needs to be created (since it's been destroyed)
+func (td TestData) DisappearsStep(data DisappearsStepData) resource.TestStep {
+	config := data.Config(td)
+	return resource.TestStep{
+		Config: config,
+		Check: resource.ComposeTestCheckFunc(
+			data.CheckExists(td.ResourceName),
+			data.Destroy(td.ResourceName),
+		),
+		ExpectNonEmptyPlan: true,
+	}
+}
+
+// ImportStep returns a Test Step which Imports the Resource, optionally
+// ignoring any fields which may not be imported (for example, as they're
+// not returned from the API)
+func (td TestData) ImportStep(ignore ...string) resource.TestStep {
+	step := resource.TestStep{
+		ResourceName:      td.ResourceName,
+		ImportState:       true,
+		ImportStateVerify: true,
+	}
+
+	if len(ignore) > 0 {
+		step.ImportStateVerifyIgnore = ignore
+	}
+
+	return step
+}
+
+// RequiresImportErrorStep returns a Test Step which expects a Requires Import
+// error to be returned when running this step
+func (td TestData) RequiresImportErrorStep(configBuilder func(data TestData) string) resource.TestStep {
+	config := configBuilder(td)
+	return resource.TestStep{
+		Config:      config,
+		ExpectError: RequiresImportError(td.resourceType),
+	}
+}

--- a/azurerm/internal/acceptance/testing.go
+++ b/azurerm/internal/acceptance/testing.go
@@ -35,18 +35,6 @@ func PreCheck(t *testing.T) {
 	}
 }
 
-func Location() string {
-	return os.Getenv("ARM_TEST_LOCATION")
-}
-
-func AltLocation() string {
-	return os.Getenv("ARM_TEST_LOCATION_ALT")
-}
-
-func AltLocation2() string {
-	return os.Getenv("ARM_TEST_LOCATION_ALT2")
-}
-
 func EnvironmentName() string {
 	envName, exists := os.LookupEnv("ARM_ENVIRONMENT")
 	if !exists {

--- a/azurerm/internal/clients/builder.go
+++ b/azurerm/internal/clients/builder.go
@@ -1,0 +1,96 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/authentication"
+	"github.com/hashicorp/go-azure-helpers/sender"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
+)
+
+type ClientBuilder struct {
+	AuthConfig                  *authentication.Config
+	DisableCorrelationRequestID bool
+	DisableTerraformPartnerID   bool
+	PartnerId                   string
+	SkipProviderRegistration    bool
+	TerraformVersion            string
+}
+
+func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
+	env, err := authentication.DetermineEnvironment(builder.AuthConfig.Environment)
+	if err != nil {
+		return nil, err
+	}
+
+	// client declarations:
+	account, err := NewResourceManagerAccount(ctx, *builder.AuthConfig, *env)
+	if err != nil {
+		return nil, fmt.Errorf("Error building account: %+v", err)
+	}
+
+	client := Client{
+		Account: account,
+	}
+
+	oauthConfig, err := builder.AuthConfig.BuildOAuthConfig(env.ActiveDirectoryEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// OAuthConfigForTenant returns a pointer, which can be nil.
+	if oauthConfig == nil {
+		return nil, fmt.Errorf("Unable to configure OAuthConfig for tenant %s", builder.AuthConfig.TenantID)
+	}
+
+	sender := sender.BuildSender("AzureRM")
+
+	// Resource Manager endpoints
+	endpoint := env.ResourceManagerEndpoint
+	auth, err := builder.AuthConfig.GetAuthorizationToken(sender, oauthConfig, env.TokenAudience)
+	if err != nil {
+		return nil, err
+	}
+
+	// Graph Endpoints
+	graphEndpoint := env.GraphEndpoint
+	graphAuth, err := builder.AuthConfig.GetAuthorizationToken(sender, oauthConfig, graphEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Storage Endpoints
+	storageAuth, err := builder.AuthConfig.GetAuthorizationToken(sender, oauthConfig, env.ResourceIdentifiers.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	// Key Vault Endpoints
+	keyVaultAuth := builder.AuthConfig.BearerAuthorizerCallback(sender, oauthConfig)
+
+	o := &common.ClientOptions{
+		SubscriptionId:              builder.AuthConfig.SubscriptionID,
+		TenantID:                    builder.AuthConfig.TenantID,
+		PartnerId:                   builder.PartnerId,
+		TerraformVersion:            builder.TerraformVersion,
+		GraphAuthorizer:             graphAuth,
+		GraphEndpoint:               graphEndpoint,
+		KeyVaultAuthorizer:          keyVaultAuth,
+		ResourceManagerAuthorizer:   auth,
+		ResourceManagerEndpoint:     endpoint,
+		StorageAuthorizer:           storageAuth,
+		PollingDuration:             180 * time.Minute,
+		SkipProviderReg:             builder.SkipProviderRegistration,
+		DisableCorrelationRequestID: builder.DisableCorrelationRequestID,
+		DisableTerraformPartnerID:   builder.DisableTerraformPartnerID,
+		Environment:                 *env,
+	}
+
+	if err := client.Build(ctx, o); err != nil {
+		return nil, fmt.Errorf("Error building Client: %+v", err)
+	}
+
+	return &client, nil
+}

--- a/azurerm/internal/clients/client.go
+++ b/azurerm/internal/clients/client.go
@@ -136,7 +136,11 @@ type Client struct {
 	Web              *web.Client
 }
 
-func (client *Client) Build(o *common.ClientOptions) error {
+// NOTE: it should be possible for this method to become Private once the top level Client's removed
+
+func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error {
+	client.StopContext = ctx
+
 	client.AnalysisServices = analysisServices.NewClient(o)
 	client.ApiManagement = apiManagement.NewClient(o)
 	client.AppConfiguration = appConfiguration.NewClient(o)

--- a/azurerm/internal/features/dynamic_test_locations.go
+++ b/azurerm/internal/features/dynamic_test_locations.go
@@ -1,0 +1,20 @@
+package features
+
+import (
+	"os"
+	"strings"
+)
+
+// UseDynamicTestLocations returns whether or not the Acceptance Test data should use
+// dynamic values for test locations
+//
+// In practice this means that of the available test locations, the primary, secondary
+// and ternary locations will change dynamically for each test
+//
+// The primary benefit of this is to distribute the tests across Azure Regions,
+// to improve the overall reliability. In time this'll become the default value.
+//
+// It's possible to opt into this by setting `ARM_PROVIDER_DYNAMIC_TEST` to `true`.
+func UseDynamicTestLocations() bool {
+	return strings.EqualFold(os.Getenv("ARM_PROVIDER_DYNAMIC_TEST"), "true")
+}

--- a/azurerm/internal/features/dynamic_test_locations_test.go
+++ b/azurerm/internal/features/dynamic_test_locations_test.go
@@ -1,0 +1,55 @@
+package features
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDynamicTestLocations(t *testing.T) {
+	testData := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "unset",
+			value:    "",
+			expected: false,
+		},
+		{
+			name:     "disabled lower-case",
+			value:    "false",
+			expected: false,
+		},
+		{
+			name:     "disabled upper-case",
+			value:    "FALSE",
+			expected: false,
+		},
+		{
+			name:     "enabled lower-case",
+			value:    "true",
+			expected: true,
+		},
+		{
+			name:     "enabled upper-case",
+			value:    "TRUE",
+			expected: true,
+		},
+		{
+			name:     "invalid",
+			value:    "pandas",
+			expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Test %q..", v.name)
+
+		os.Setenv("ARM_PROVIDER_DYNAMIC_TEST", v.value)
+		actual := UseDynamicTestLocations()
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/azurerm/provider.go
+++ b/azurerm/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -722,13 +723,13 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 		}
 
 		skipProviderRegistration := d.Get("skip_provider_registration").(bool)
-		clientBuilder := armClientBuilder{
-			authConfig:                  config,
-			skipProviderRegistration:    skipProviderRegistration,
-			terraformVersion:            terraformVersion,
-			partnerId:                   d.Get("partner_id").(string),
-			disableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
-			disableTerraformPartnerID:   d.Get("disable_terraform_partner_id").(bool),
+		clientBuilder := clients.ClientBuilder{
+			AuthConfig:                  config,
+			SkipProviderRegistration:    skipProviderRegistration,
+			TerraformVersion:            terraformVersion,
+			PartnerId:                   d.Get("partner_id").(string),
+			DisableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
+			DisableTerraformPartnerID:   d.Get("disable_terraform_partner_id").(bool),
 		}
 		client, err := getArmClient(p.StopContext(), clientBuilder)
 		if err != nil {
@@ -737,7 +738,6 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 		// TODO: clean this up when ArmClient is removed
 		client.StopContext = p.StopContext()
-		client.Client.StopContext = p.StopContext()
 
 		// replaces the context between tests
 		p.MetaReset = func() error {

--- a/azurerm/required_resource_providers_test.go
+++ b/azurerm/required_resource_providers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/go-azure-helpers/resourceproviders"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
@@ -14,14 +15,14 @@ func TestAccAzureRMEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 		return
 	}
 
-	builder := armClientBuilder{
-		authConfig:                  config,
-		terraformVersion:            "0.0.0",
-		partnerId:                   "",
-		disableCorrelationRequestID: true,
-		disableTerraformPartnerID:   false,
+	builder := clients.ClientBuilder{
+		AuthConfig:                  config,
+		TerraformVersion:            "0.0.0",
+		PartnerId:                   "",
+		DisableCorrelationRequestID: true,
+		DisableTerraformPartnerID:   false,
 		// this test intentionally checks all the RP's are registered - so this is intentional
-		skipProviderRegistration: true,
+		SkipProviderRegistration: true,
 	}
 	armClient, err := getArmClient(context.Background(), builder)
 	if err != nil {

--- a/azurerm/resource_arm_container_registry_migrate_test.go
+++ b/azurerm/resource_arm_container_registry_migrate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAccAzureRMContainerRegistryMigrateState(t *testing.T) {
@@ -21,13 +22,13 @@ func TestAccAzureRMContainerRegistryMigrateState(t *testing.T) {
 		return
 	}
 
-	builder := armClientBuilder{
-		authConfig:                  config,
-		terraformVersion:            "0.0.0",
-		partnerId:                   "",
-		disableCorrelationRequestID: true,
-		disableTerraformPartnerID:   false,
-		skipProviderRegistration:    false,
+	builder := clients.ClientBuilder{
+		AuthConfig:                  config,
+		TerraformVersion:            "0.0.0",
+		PartnerId:                   "",
+		DisableCorrelationRequestID: true,
+		DisableTerraformPartnerID:   false,
+		SkipProviderRegistration:    false,
 	}
 	client, err := getArmClient(context.Background(), builder)
 	if err != nil {

--- a/azurerm/resource_arm_data_lake_store_file_migration_test.go
+++ b/azurerm/resource_arm_data_lake_store_file_migration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 // NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
@@ -17,13 +18,13 @@ func TestAccAzureRMDataLakeStoreFileMigrateState(t *testing.T) {
 		return
 	}
 
-	builder := armClientBuilder{
-		authConfig:                  config,
-		terraformVersion:            "0.0.0",
-		partnerId:                   "",
-		disableCorrelationRequestID: true,
-		disableTerraformPartnerID:   false,
-		skipProviderRegistration:    false,
+	builder := clients.ClientBuilder{
+		AuthConfig:                  config,
+		TerraformVersion:            "0.0.0",
+		PartnerId:                   "",
+		DisableCorrelationRequestID: true,
+		DisableTerraformPartnerID:   false,
+		SkipProviderRegistration:    false,
 	}
 	client, err := getArmClient(context.Background(), builder)
 	if err != nil {

--- a/azurerm/resource_arm_resource_group_test.go
+++ b/azurerm/resource_arm_resource_group_test.go
@@ -187,7 +187,7 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
 }
-`, testData.RandomInteger, testData.Location.Primary)
+`, testData.RandomInteger, testData.Locations.Primary)
 }
 
 func testAccAzureRMResourceGroup_requiresImport(testData acceptance.TestData) string {
@@ -213,7 +213,7 @@ resource "azurerm_resource_group" "test" {
     cost_center = "MSFT"
   }
 }
-`, testData.RandomInteger, testData.Location.Primary)
+`, testData.RandomInteger, testData.Locations.Primary)
 }
 
 func testAccAzureRMResourceGroup_withTagsUpdated(testData acceptance.TestData) string {
@@ -226,5 +226,5 @@ resource "azurerm_resource_group" "test" {
     environment = "staging"
   }
 }
-`, testData.RandomInteger, testData.Location.Primary)
+`, testData.RandomInteger, testData.Locations.Primary)
 }

--- a/azurerm/resource_arm_resource_group_test.go
+++ b/azurerm/resource_arm_resource_group_test.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
 func TestAccAzureRMResourceGroup_basic(t *testing.T) {
-	resourceName := "azurerm_resource_group.test"
-	ri := tf.AccRandTimeInt()
+	testData := acceptance.BuildTestData(t, "azurerm_resource_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,16 +20,12 @@ func TestAccAzureRMResourceGroup_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMResourceGroup_basic(ri, testLocation()),
+				Config: testAccAzureRMResourceGroup_basic(testData),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMResourceGroupExists(resourceName),
+					testCheckAzureRMResourceGroupExists(testData.ResourceName),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testData.ImportStep(),
 		},
 	})
 }
@@ -41,8 +36,7 @@ func TestAccAzureRMResourceGroup_requiresImport(t *testing.T) {
 		return
 	}
 
-	resourceName := "azurerm_resource_group.test"
-	ri := tf.AccRandTimeInt()
+	testData := acceptance.BuildTestData(t, "azurerm_resource_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,46 +44,35 @@ func TestAccAzureRMResourceGroup_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMResourceGroup_basic(ri, testLocation()),
+				Config: testAccAzureRMResourceGroup_basic(testData),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMResourceGroupExists(resourceName),
+					testCheckAzureRMResourceGroupExists(testData.ResourceName),
 				),
 			},
-			{
-				Config:      testAccAzureRMResourceGroup_requiresImport(ri, testLocation()),
-				ExpectError: testRequiresImportError("azurerm_resource_group"),
-			},
+			testData.RequiresImportErrorStep(testAccAzureRMResourceGroup_requiresImport),
 		},
 	})
 }
 
 func TestAccAzureRMResourceGroup_disappears(t *testing.T) {
-	resourceName := "azurerm_resource_group.test"
-	ri := tf.AccRandTimeInt()
+	testData := acceptance.BuildTestData(t, "azurerm_resource_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMResourceGroup_basic(ri, testLocation()),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMResourceGroupExists(resourceName),
-					testCheckAzureRMResourceGroupDisappears(resourceName),
-				),
-				ExpectNonEmptyPlan: true,
-			},
+			testData.DisappearsStep(acceptance.DisappearsStepData{
+				Config:      testAccAzureRMResourceGroup_basic,
+				CheckExists: testCheckAzureRMResourceGroupExists,
+				Destroy:     testCheckAzureRMResourceGroupDisappears,
+			}),
 		},
 	})
 }
 
 func TestAccAzureRMResourceGroup_withTags(t *testing.T) {
-	resourceName := "azurerm_resource_group.test"
-	ri := tf.AccRandTimeInt()
-	location := testLocation()
-	preConfig := testAccAzureRMResourceGroup_withTags(ri, location)
-	postConfig := testAccAzureRMResourceGroup_withTagsUpdated(ri, location)
+	testData := acceptance.BuildTestData(t, "azurerm_resource_group", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -97,32 +80,24 @@ func TestAccAzureRMResourceGroup_withTags(t *testing.T) {
 		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: preConfig,
+				Config: testAccAzureRMResourceGroup_withTags(testData),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMResourceGroupExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tags.environment", "Production"),
-					resource.TestCheckResourceAttr(resourceName, "tags.cost_center", "MSFT"),
+					testCheckAzureRMResourceGroupExists(testData.ResourceName),
+					resource.TestCheckResourceAttr(testData.ResourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(testData.ResourceName, "tags.environment", "Production"),
+					resource.TestCheckResourceAttr(testData.ResourceName, "tags.cost_center", "MSFT"),
 				),
 			},
+			testData.ImportStep(),
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: postConfig,
+				Config: testAccAzureRMResourceGroup_withTagsUpdated(testData),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMResourceGroupExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.environment", "staging"),
+					testCheckAzureRMResourceGroupExists(testData.ResourceName),
+					resource.TestCheckResourceAttr(testData.ResourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(testData.ResourceName, "tags.environment", "staging"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testData.ImportStep(),
 		},
 	})
 }
@@ -206,16 +181,17 @@ func testCheckAzureRMResourceGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMResourceGroup_basic(rInt int, location string) string {
+func testAccAzureRMResourceGroup_basic(testData acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
 }
-`, rInt, location)
+`, testData.RandomInteger, testData.Location.Primary)
 }
 
-func testAccAzureRMResourceGroup_requiresImport(rInt int, location string) string {
+func testAccAzureRMResourceGroup_requiresImport(testData acceptance.TestData) string {
+	template := testAccAzureRMResourceGroup_basic(testData)
 	return fmt.Sprintf(`
 %s
 
@@ -223,10 +199,10 @@ resource "azurerm_resource_group" "import" {
   name     = "${azurerm_resource_group.test.name}"
   location = "${azurerm_resource_group.test.location}"
 }
-`, testAccAzureRMResourceGroup_basic(rInt, location))
+`, template)
 }
 
-func testAccAzureRMResourceGroup_withTags(rInt int, location string) string {
+func testAccAzureRMResourceGroup_withTags(testData acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -237,10 +213,10 @@ resource "azurerm_resource_group" "test" {
     cost_center = "MSFT"
   }
 }
-`, rInt, location)
+`, testData.RandomInteger, testData.Location.Primary)
 }
 
-func testAccAzureRMResourceGroup_withTagsUpdated(rInt int, location string) string {
+func testAccAzureRMResourceGroup_withTagsUpdated(testData acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
@@ -250,5 +226,5 @@ resource "azurerm_resource_group" "test" {
     environment = "staging"
   }
 }
-`, rInt, location)
+`, testData.RandomInteger, testData.Location.Primary)
 }

--- a/azurerm/resource_arm_storage_blob_migration_test.go
+++ b/azurerm/resource_arm_storage_blob_migration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 // NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
@@ -17,13 +18,13 @@ func TestAccAzureRMStorageBlobMigrateState(t *testing.T) {
 		return
 	}
 
-	builder := armClientBuilder{
-		authConfig:                  config,
-		terraformVersion:            "0.0.0",
-		partnerId:                   "",
-		disableCorrelationRequestID: true,
-		disableTerraformPartnerID:   false,
-		skipProviderRegistration:    false,
+	builder := clients.ClientBuilder{
+		AuthConfig:                  config,
+		TerraformVersion:            "0.0.0",
+		PartnerId:                   "",
+		DisableCorrelationRequestID: true,
+		DisableTerraformPartnerID:   false,
+		SkipProviderRegistration:    false,
 	}
 	client, err := getArmClient(context.Background(), builder)
 	if err != nil {

--- a/azurerm/resource_arm_storage_container_migration_test.go
+++ b/azurerm/resource_arm_storage_container_migration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 // NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
@@ -17,13 +18,13 @@ func TestAccAzureRMStorageContainerMigrateState(t *testing.T) {
 		return
 	}
 
-	builder := armClientBuilder{
-		authConfig:                  config,
-		terraformVersion:            "0.0.0",
-		partnerId:                   "",
-		disableCorrelationRequestID: true,
-		disableTerraformPartnerID:   false,
-		skipProviderRegistration:    false,
+	builder := clients.ClientBuilder{
+		AuthConfig:                  config,
+		TerraformVersion:            "0.0.0",
+		PartnerId:                   "",
+		DisableCorrelationRequestID: true,
+		DisableTerraformPartnerID:   false,
+		SkipProviderRegistration:    false,
 	}
 	client, err := getArmClient(context.Background(), builder)
 	if err != nil {

--- a/azurerm/resource_arm_storage_queue_migration_test.go
+++ b/azurerm/resource_arm_storage_queue_migration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 // NOTE: this is intentionally an acceptance test (and we're not explicitly setting the env)
@@ -17,13 +18,13 @@ func TestAccAzureRMStorageQueueMigrateState(t *testing.T) {
 		return
 	}
 
-	builder := armClientBuilder{
-		authConfig:                  config,
-		terraformVersion:            "0.0.0",
-		partnerId:                   "",
-		disableCorrelationRequestID: true,
-		disableTerraformPartnerID:   false,
-		skipProviderRegistration:    false,
+	builder := clients.ClientBuilder{
+		AuthConfig:                  config,
+		TerraformVersion:            "0.0.0",
+		PartnerId:                   "",
+		DisableCorrelationRequestID: true,
+		DisableTerraformPartnerID:   false,
+		SkipProviderRegistration:    false,
 	}
 	client, err := getArmClient(context.Background(), builder)
 	if err != nil {


### PR DESCRIPTION
This PR introduces the new `acceptance` package which will replace the existing test infrastructure; the general intention is to reduce boilerplate where possible. In order to demonstrate this I've updated the tests for the Resource Group resource to use this new pattern - which I believe should suffice for now.

In addition this PR moves most of the logic of `config.go` out of the main package - which should enable the final steps required to move Data Sources & Resources.

Finally, this also introduces a feature toggle for Dynamic Test Locations; which allows us to dynamically distribute our test load across Azure Regions, to better distribute this across Azure; however at this time this is feature toggled off by default.

Tests pass:

```
$ acctests azurerm TestAccAzureRMResourceGroup_
=== RUN   TestAccAzureRMResourceGroup_basic
=== PAUSE TestAccAzureRMResourceGroup_basic
=== RUN   TestAccAzureRMResourceGroup_requiresImport
--- SKIP: TestAccAzureRMResourceGroup_requiresImport (0.00s)
    resource_arm_resource_group_test.go:35: Skipping since resources aren't required to be imported
=== RUN   TestAccAzureRMResourceGroup_disappears
=== PAUSE TestAccAzureRMResourceGroup_disappears
=== RUN   TestAccAzureRMResourceGroup_withTags
=== PAUSE TestAccAzureRMResourceGroup_withTags
=== CONT  TestAccAzureRMResourceGroup_basic
--- PASS: TestAccAzureRMResourceGroup_basic (78.66s)
=== CONT  TestAccAzureRMResourceGroup_withTags
--- PASS: TestAccAzureRMResourceGroup_withTags (99.51s)
=== CONT  TestAccAzureRMResourceGroup_disappears
--- PASS: TestAccAzureRMResourceGroup_disappears (67.29s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	245.525s
```