### PR TITLE
Recovery Services: adding their own CheckDestroy functions

### DIFF
--- a/azurerm/resource_arm_recovery_services_fabric_test.go
+++ b/azurerm/resource_arm_recovery_services_fabric_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
@@ -98,8 +97,8 @@ func testCheckAzureRMRecoveryFabricDestroy(s *terraform.State) error {
 		vaultName := rs.Primary.Attributes["recovery_vault_name"]
 		resourceGroup := rs.Primary.Attributes["name"]
 
-		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.FabricClient(resourceGroupName, vaultName)
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		client := testAccProvider.Meta().(*clients.Client).RecoveryServices.FabricClient(resourceGroupName, vaultName)
+		ctx := testAccProvider.Meta().(*clients.Client).StopContext
 
 		resp, err := client.Get(ctx, resourceGroup)
 		if err != nil {

--- a/azurerm/resource_arm_recovery_services_fabric_test.go
+++ b/azurerm/resource_arm_recovery_services_fabric_test.go
@@ -8,23 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAccAzureRMRecoveryFabric_basic(t *testing.T) {
-	resourceGroupName := "azurerm_resource_group.test"
-	vaultName := "azurerm_recovery_services_vault.test"
 	resourceName := "azurerm_recovery_services_fabric.test"
 	ri := tf.AccRandTimeInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		CheckDestroy: testCheckAzureRMRecoveryFabricDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMRecoveryFabric_basic(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRecoveryFabricExists(resourceGroupName, vaultName, resourceName),
+					testCheckAzureRMRecoveryFabricExists(resourceName),
 				),
 			},
 			{
@@ -59,25 +59,17 @@ resource "azurerm_recovery_services_fabric" "test" {
 `, rInt, location, rInt, rInt)
 }
 
-func testCheckAzureRMRecoveryFabricExists(resourceGroupStateName, vaultStateName string, resourceStateName string) resource.TestCheckFunc {
+func testCheckAzureRMRecoveryFabricExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		resourceGroupState, ok := s.RootModule().Resources[resourceGroupStateName]
+		state, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceGroupStateName)
-		}
-		vaultState, ok := s.RootModule().Resources[vaultStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", vaultStateName)
-		}
-		fabricState, ok := s.RootModule().Resources[resourceStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroupName := resourceGroupState.Primary.Attributes["name"]
-		vaultName := vaultState.Primary.Attributes["name"]
-		fabricName := fabricState.Primary.Attributes["name"]
+		resourceGroupName := state.Primary.Attributes["resource_group_name"]
+		vaultName := state.Primary.Attributes["recovery_vault_name"]
+		fabricName := state.Primary.Attributes["name"]
 
 		// Ensure fabric exists in API
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.FabricClient(resourceGroupName, vaultName)
@@ -94,4 +86,30 @@ func testCheckAzureRMRecoveryFabricExists(resourceGroupStateName, vaultStateName
 
 		return nil
 	}
+}
+
+func testCheckAzureRMRecoveryFabricDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_recovery_services_fabric" {
+			continue
+		}
+
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		vaultName := rs.Primary.Attributes["recovery_vault_name"]
+		resourceGroup := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.FabricClient(resourceGroupName, vaultName)
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		resp, err := client.Get(ctx, resourceGroup)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Recovery Services Fabric still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
 }

--- a/azurerm/resource_arm_recovery_services_network_mapping_test.go
+++ b/azurerm/resource_arm_recovery_services_network_mapping_test.go
@@ -113,6 +113,7 @@ func testCheckAzureRMRecoveryNetworkMappingExists(resourceName string) resource.
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.NetworkMappingClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
+		// TODO Fix Bad: networkMapping error
 		resp, err := client.Get(ctx, fabricName, networkName, mappingName)
 		if err != nil {
 			if resp.Response.StatusCode == http.StatusNotFound {

--- a/azurerm/resource_arm_recovery_services_network_mapping_test.go
+++ b/azurerm/resource_arm_recovery_services_network_mapping_test.go
@@ -102,26 +102,24 @@ func testCheckAzureRMRecoveryNetworkMappingExists(resourceName string) resource.
 		vaultName := state.Primary.Attributes["recovery_vault_name"]
 		fabricName := state.Primary.Attributes["source_recovery_fabric_name"]
 		networkId := state.Primary.Attributes["source_network_id"]
-		networkName := func() string {
-			id, err := azure.ParseAzureResourceID(networkId)
-			if err != nil {
-				return ""
-			}
-
-			return id.Path["virtualNetworks"]
-		}()
 		mappingName := state.Primary.Attributes["name"]
+
+		id, err := azure.ParseAzureResourceID(networkId)
+		if err != nil {
+			return err
+		}
+		networkName := id.Path["virtualNetworks"]
 
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.NetworkMappingClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, fabricName, networkName, mappingName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on networkMappingClient: %+v", err)
-		}
+			if resp.Response.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("Bad: networkMapping: %q (network %q) does not exist", mappingName, networkName)
+			}
 
-		if resp.Response.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: networkMapping: %q does not exist", mappingName)
+			return fmt.Errorf("Bad: Get on networkMappingClient: %+v", err)
 		}
 
 		return nil
@@ -138,15 +136,13 @@ func testCheckAzureRMRecoveryNetworkMappingDestroy(s *terraform.State) error {
 		vaultName := rs.Primary.Attributes["recovery_vault_name"]
 		fabricName := rs.Primary.Attributes["source_recovery_fabric_name"]
 		networkId := rs.Primary.Attributes["source_network_id"]
-		networkName := func() string {
-			id, err := azure.ParseAzureResourceID(networkId)
-			if err != nil {
-				return ""
-			}
-
-			return id.Path["virtualNetworks"]
-		}()
 		mappingName := rs.Primary.Attributes["name"]
+
+		id, err := azure.ParseAzureResourceID(networkId)
+		if err != nil {
+			return err
+		}
+		networkName := id.Path["virtualNetworks"]
 
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.NetworkMappingClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext

--- a/azurerm/resource_arm_recovery_services_protection_container_mapping_test.go
+++ b/azurerm/resource_arm_recovery_services_protection_container_mapping_test.go
@@ -11,22 +11,18 @@ import (
 )
 
 func TestAccAzureRMRecoveryProtectionContainerMapping_basic(t *testing.T) {
-	resourceGroupName := "azurerm_resource_group.test1"
-	vaultName := "azurerm_recovery_services_vault.test"
-	fabricName := "azurerm_recovery_services_fabric.test1"
-	protectionContainerName := "azurerm_recovery_services_protection_container.test1"
 	resourceName := "azurerm_recovery_services_protection_container_mapping.test"
 	ri := tf.AccRandTimeInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		CheckDestroy: testCheckAzureRMRecoveryProtectionContainerMappingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMRecoveryProtectionContainerMapping_basic(ri, testLocation(), testAltLocation()),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRecoveryProtectionContainerMappingExists(resourceGroupName, vaultName, fabricName, protectionContainerName, resourceName),
+					testCheckAzureRMRecoveryProtectionContainerMappingExists(resourceName),
 				),
 			},
 			{
@@ -101,35 +97,19 @@ resource "azurerm_recovery_services_protection_container_mapping" "test" {
 `, rInt, location, rInt, rInt, rInt, altLocation, rInt, rInt, rInt, rInt)
 }
 
-func testCheckAzureRMRecoveryProtectionContainerMappingExists(resourceGroupStateName, vaultStateName string, resourceStateName string, protectionContainerStateName string, protectionContainerStateMappingName string) resource.TestCheckFunc {
+func testCheckAzureRMRecoveryProtectionContainerMappingExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		resourceGroupState, ok := s.RootModule().Resources[resourceGroupStateName]
+		state, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceGroupStateName)
-		}
-		vaultState, ok := s.RootModule().Resources[vaultStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", vaultStateName)
-		}
-		fabricState, ok := s.RootModule().Resources[resourceStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
-		}
-		protectionContainerState, ok := s.RootModule().Resources[protectionContainerStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
-		}
-		protectionContainerMappingState, ok := s.RootModule().Resources[protectionContainerStateMappingName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", protectionContainerStateMappingName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroupName := resourceGroupState.Primary.Attributes["name"]
-		vaultName := vaultState.Primary.Attributes["name"]
-		fabricName := fabricState.Primary.Attributes["name"]
-		protectionContainerName := protectionContainerState.Primary.Attributes["name"]
-		mappingName := protectionContainerMappingState.Primary.Attributes["name"]
+		resourceGroupName := state.Primary.Attributes["resource_group_name"]
+		vaultName := state.Primary.Attributes["recovery_vault_name"]
+		fabricName := state.Primary.Attributes["recovery_fabric_name"]
+		protectionContainerName := state.Primary.Attributes["recovery_source_protection_container_name"]
+		mappingName := state.Primary.Attributes["name"]
 
 		// Ensure mapping exists in API
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.ContainerMappingClient(resourceGroupName, vaultName)
@@ -146,4 +126,33 @@ func testCheckAzureRMRecoveryProtectionContainerMappingExists(resourceGroupState
 
 		return nil
 	}
+}
+
+func testCheckAzureRMRecoveryProtectionContainerMappingDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_recovery_services_protection_container_mapping" {
+			continue
+		}
+
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		vaultName := rs.Primary.Attributes["recovery_vault_name"]
+		fabricName := rs.Primary.Attributes["recovery_fabric_name"]
+		protectionContainerName := rs.Primary.Attributes["recovery_source_protection_container_name"]
+		mappingName := rs.Primary.Attributes["name"]
+
+		// Ensure mapping exists in API
+		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.ContainerMappingClient(resourceGroupName, vaultName)
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := client.Get(ctx, fabricName, protectionContainerName, mappingName)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Container Mapping still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
 }

--- a/azurerm/resource_arm_recovery_services_protection_container_test.go
+++ b/azurerm/resource_arm_recovery_services_protection_container_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
@@ -106,8 +105,8 @@ func testCheckAzureRMRecoveryProtectionContainerDestroy(s *terraform.State) erro
 		fabricName := rs.Primary.Attributes["recovery_fabric_name"]
 		protectionContainerName := rs.Primary.Attributes["name"]
 
-		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.ProtectionContainerClient(resourceGroupName, vaultName)
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		client := testAccProvider.Meta().(*clients.Client).RecoveryServices.ProtectionContainerClient(resourceGroupName, vaultName)
+		ctx := testAccProvider.Meta().(*clients.Client).StopContext
 
 		resp, err := client.Get(ctx, fabricName, protectionContainerName)
 		if err != nil {

--- a/azurerm/resource_arm_recovery_services_protection_container_test.go
+++ b/azurerm/resource_arm_recovery_services_protection_container_test.go
@@ -8,24 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAccAzureRMRecoveryProtectionContainer_basic(t *testing.T) {
-	resourceGroupName := "azurerm_resource_group.test"
-	vaultName := "azurerm_recovery_services_vault.test"
-	fabricName := "azurerm_recovery_services_fabric.test"
 	resourceName := "azurerm_recovery_services_protection_container.test"
 	ri := tf.AccRandTimeInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		CheckDestroy: testCheckAzureRMRecoveryProtectionContainerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMRecoveryProtectionContainer_basic(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRecoveryProtectionContainerExists(resourceGroupName, vaultName, fabricName, resourceName),
+					testCheckAzureRMRecoveryProtectionContainerExists(resourceName),
 				),
 			},
 			{
@@ -68,44 +67,57 @@ resource "azurerm_recovery_services_protection_container" "test" {
 `, rInt, location, rInt, rInt, rInt)
 }
 
-func testCheckAzureRMRecoveryProtectionContainerExists(resourceGroupStateName, vaultStateName string, resourceStateName string, protectionContainerStateName string) resource.TestCheckFunc {
+func testCheckAzureRMRecoveryProtectionContainerExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Ensure we have enough information in state to look up in API
-		resourceGroupState, ok := s.RootModule().Resources[resourceGroupStateName]
+		state, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceGroupStateName)
-		}
-		vaultState, ok := s.RootModule().Resources[vaultStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", vaultStateName)
-		}
-		fabricState, ok := s.RootModule().Resources[resourceStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
-		}
-		protectionContainerState, ok := s.RootModule().Resources[protectionContainerStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroupName := resourceGroupState.Primary.Attributes["name"]
-		vaultName := vaultState.Primary.Attributes["name"]
-		fabricName := fabricState.Primary.Attributes["name"]
-		protectionContainerName := protectionContainerState.Primary.Attributes["name"]
+		resourceGroupName := state.Primary.Attributes["resource_group_name"]
+		vaultName := state.Primary.Attributes["recovery_vault_name"]
+		fabricName := state.Primary.Attributes["recovery_fabric_name"]
+		protectionContainerName := state.Primary.Attributes["name"]
 
-		// Ensure fabric exists in API
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.ProtectionContainerClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, fabricName, protectionContainerName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on fabricClient: %+v", err)
+			return fmt.Errorf("Bad: Get on RecoveryServices.ProtectionContainerClient: %+v", err)
 		}
 
 		if resp.Response.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: fabric: %q does not exist", fabricName)
+			return fmt.Errorf("Bad: Protection Container: %q does not exist", fabricName)
 		}
 
 		return nil
 	}
+}
+
+func testCheckAzureRMRecoveryProtectionContainerDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_recovery_services_protection_container" {
+			continue
+		}
+
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		vaultName := rs.Primary.Attributes["recovery_vault_name"]
+		fabricName := rs.Primary.Attributes["recovery_fabric_name"]
+		protectionContainerName := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.ProtectionContainerClient(resourceGroupName, vaultName)
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		resp, err := client.Get(ctx, fabricName, protectionContainerName)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Protection Container Client still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
 }

--- a/azurerm/resource_arm_recovery_services_replicated_vm_test.go
+++ b/azurerm/resource_arm_recovery_services_replicated_vm_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
@@ -254,8 +253,8 @@ func testCheckAzureRMRecoveryReplicatedVmDestroy(s *terraform.State) error {
 		protectionContainerName := rs.Primary.Attributes["source_recovery_protection_container_name"]
 		replicationName := rs.Primary.Attributes["name"]
 
-		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.ReplicationMigrationItemsClient(resourceGroupName, vaultName)
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		client := testAccProvider.Meta().(*clients.Client).RecoveryServices.ReplicationMigrationItemsClient(resourceGroupName, vaultName)
+		ctx := testAccProvider.Meta().(*clients.Client).StopContext
 
 		resp, err := client.Get(ctx, fabricName, protectionContainerName, replicationName)
 		if err != nil {

--- a/azurerm/resource_arm_recovery_services_replicated_vm_test.go
+++ b/azurerm/resource_arm_recovery_services_replicated_vm_test.go
@@ -8,25 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAccAzureRMRecoveryReplicatedVm_basic(t *testing.T) {
-	resourceGroupName := "azurerm_resource_group.test2"
-	vaultName := "azurerm_recovery_services_vault.test"
-	fabricName := "azurerm_recovery_services_fabric.test1"
-	protectionContainerName := "azurerm_recovery_services_protection_container.test1"
 	replicationName := "azurerm_recovery_replicated_vm.test"
 	ri := tf.AccRandTimeInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		CheckDestroy: testCheckAzureRMRecoveryReplicatedVmDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMRecoveryReplicatedVm_basic(ri, testLocation(), testAltLocation()),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRecoveryReplicatedVmExists(resourceGroupName, vaultName, fabricName, protectionContainerName, replicationName),
+					testCheckAzureRMRecoveryReplicatedVmExists(replicationName),
 				),
 			},
 			{
@@ -215,49 +213,59 @@ resource "azurerm_recovery_replicated_vm" "test" {
 `, rInt, location, rInt, altLocation, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
 }
 
-func testCheckAzureRMRecoveryReplicatedVmExists(resourceGroupStateName, vaultStateName string, resourceStateName string, protectionContainerStateName string, replicationStateName string) resource.TestCheckFunc {
+func testCheckAzureRMRecoveryReplicatedVmExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Ensure we have enough information in state to look up in API
-		resourceGroupState, ok := s.RootModule().Resources[resourceGroupStateName]
+		state, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceGroupStateName)
-		}
-		vaultState, ok := s.RootModule().Resources[vaultStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", vaultStateName)
-		}
-		fabricState, ok := s.RootModule().Resources[resourceStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
-		}
-		protectionContainerState, ok := s.RootModule().Resources[protectionContainerStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
-		}
-		replicationState, ok := s.RootModule().Resources[replicationStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", replicationStateName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroupName := resourceGroupState.Primary.Attributes["name"]
-		vaultName := vaultState.Primary.Attributes["name"]
-		fabricName := fabricState.Primary.Attributes["name"]
-		protectionContainerName := protectionContainerState.Primary.Attributes["name"]
-		replicationName := replicationState.Primary.Attributes["name"]
+		resourceGroupName := state.Primary.Attributes["resource_group_name"]
+		vaultName := state.Primary.Attributes["recovery_vault_name"]
+		fabricName := state.Primary.Attributes["source_recovery_fabric_name"]
+		protectionContainerName := state.Primary.Attributes["source_recovery_protection_container_name"]
+		replicationName := state.Primary.Attributes["name"]
 
-		// Ensure mapping exists in API
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.ReplicationMigrationItemsClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, fabricName, protectionContainerName, replicationName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on replicationVmClient: %+v", err)
+			return fmt.Errorf("Bad: Get on RecoveryServices.ReplicationMigrationItemsClient: %+v", err)
 		}
 
 		if resp.Response.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: fabric: %q does not exist", fabricName)
+			return fmt.Errorf("Bad: Recovery Services Replicated VM: %q does not exist", fabricName)
 		}
 
 		return nil
 	}
+}
+
+func testCheckAzureRMRecoveryReplicatedVmDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_recovery_replicated_vm" {
+			continue
+		}
+
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		vaultName := rs.Primary.Attributes["recovery_vault_name"]
+		fabricName := rs.Primary.Attributes["source_recovery_fabric_name"]
+		protectionContainerName := rs.Primary.Attributes["source_recovery_protection_container_name"]
+		replicationName := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.ReplicationMigrationItemsClient(resourceGroupName, vaultName)
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		resp, err := client.Get(ctx, fabricName, protectionContainerName, replicationName)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Recovery Services Replicated VM still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
 }

--- a/azurerm/resource_arm_recovery_services_replication_policy_test.go
+++ b/azurerm/resource_arm_recovery_services_replication_policy_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
@@ -98,8 +97,8 @@ func testCheckAzureRMRecoveryReplicationPolicyDestroy(s *terraform.State) error 
 		vaultName := rs.Primary.Attributes["recovery_vault_name"]
 		policyName := rs.Primary.Attributes["name"]
 
-		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.ReplicationPoliciesClient(resourceGroup, vaultName)
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		client := testAccProvider.Meta().(*clients.Client).RecoveryServices.ReplicationPoliciesClient(resourceGroup, vaultName)
+		ctx := testAccProvider.Meta().(*clients.Client).StopContext
 
 		resp, err := client.Get(ctx, policyName)
 		if err != nil {

--- a/azurerm/resource_arm_recovery_services_replication_policy_test.go
+++ b/azurerm/resource_arm_recovery_services_replication_policy_test.go
@@ -8,23 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
 func TestAccAzureRMRecoveryReplicationPolicy_basic(t *testing.T) {
-	resourceGroupName := "azurerm_resource_group.test"
-	vaultName := "azurerm_recovery_services_vault.test"
 	resourceName := "azurerm_recovery_services_replication_policy.test"
 	ri := tf.AccRandTimeInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		CheckDestroy: testCheckAzureRMRecoveryReplicationPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMRecoveryReplicationPolicy_basic(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMRecoveryReplicationPolicyExists(resourceGroupName, vaultName, resourceName),
+					testCheckAzureRMRecoveryReplicationPolicyExists(resourceName),
 				),
 			},
 			{
@@ -60,39 +60,56 @@ resource "azurerm_recovery_services_replication_policy" "test" {
 `, rInt, location, rInt, rInt)
 }
 
-func testCheckAzureRMRecoveryReplicationPolicyExists(resourceGroupStateName, vaultStateName string, policyStateName string) resource.TestCheckFunc {
+func testCheckAzureRMRecoveryReplicationPolicyExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		resourceGroupState, ok := s.RootModule().Resources[resourceGroupStateName]
+		state, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceGroupStateName)
-		}
-		vaultState, ok := s.RootModule().Resources[vaultStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", vaultStateName)
-		}
-		policyState, ok := s.RootModule().Resources[policyStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", policyStateName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroupName := resourceGroupState.Primary.Attributes["name"]
-		vaultName := vaultState.Primary.Attributes["name"]
-		policyName := policyState.Primary.Attributes["name"]
+		resourceGroupName := state.Primary.Attributes["resource_group_name"]
+		vaultName := state.Primary.Attributes["recovery_vault_name"]
+		policyName := state.Primary.Attributes["name"]
 
-		// Ensure fabric exists in API
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.ReplicationPoliciesClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
 		resp, err := client.Get(ctx, policyName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on fabricClient: %+v", err)
+			return fmt.Errorf("Bad: Get on RecoveryServices.ReplicationPoliciesClient: %+v", err)
 		}
 
 		if resp.Response.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: fabric: %q does not exist", policyName)
+			return fmt.Errorf("Bad: Replication Policies: %q does not exist", policyName)
 		}
 
 		return nil
 	}
+}
+
+func testCheckAzureRMRecoveryReplicationPolicyDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_recovery_services_replication_policy" {
+			continue
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		vaultName := rs.Primary.Attributes["recovery_vault_name"]
+		policyName := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.ReplicationPoliciesClient(resourceGroup, vaultName)
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		resp, err := client.Get(ctx, policyName)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Replication Policy still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
 }

--- a/azurerm/resource_arm_site_recovery_fabric_test.go
+++ b/azurerm/resource_arm_site_recovery_fabric_test.go
@@ -11,20 +11,18 @@ import (
 )
 
 func TestAccAzureRMSiteRecoveryFabric_basic(t *testing.T) {
-	resourceGroupName := "azurerm_resource_group.test"
-	vaultName := "azurerm_recovery_services_vault.test"
 	resourceName := "azurerm_site_recovery_fabric.test"
 	ri := tf.AccRandTimeInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		CheckDestroy: testCheckAzureRMSiteRecoveryFabricDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMSiteRecoveryFabric_basic(ri, testLocation()),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSiteRecoveryFabricExists(resourceGroupName, vaultName, resourceName),
+					testCheckAzureRMSiteRecoveryFabricExists(resourceName),
 				),
 			},
 			{
@@ -59,27 +57,18 @@ resource "azurerm_site_recovery_fabric" "test" {
 `, rInt, location, rInt, rInt)
 }
 
-func testCheckAzureRMSiteRecoveryFabricExists(resourceGroupStateName, vaultStateName string, resourceStateName string) resource.TestCheckFunc {
+func testCheckAzureRMSiteRecoveryFabricExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		resourceGroupState, ok := s.RootModule().Resources[resourceGroupStateName]
+		state, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceGroupStateName)
-		}
-		vaultState, ok := s.RootModule().Resources[vaultStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", vaultStateName)
-		}
-		fabricState, ok := s.RootModule().Resources[resourceStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceStateName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroupName := resourceGroupState.Primary.Attributes["name"]
-		vaultName := vaultState.Primary.Attributes["name"]
-		fabricName := fabricState.Primary.Attributes["name"]
+		resourceGroupName := state.Primary.Attributes["resource_group_name"]
+		vaultName := state.Primary.Attributes["recovery_vault_name"]
+		fabricName := state.Primary.Attributes["name"]
 
-		// Ensure fabric exists in API
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.FabricClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
@@ -94,4 +83,30 @@ func testCheckAzureRMSiteRecoveryFabricExists(resourceGroupStateName, vaultState
 
 		return nil
 	}
+}
+
+func testCheckAzureRMSiteRecoveryFabricDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_site_recovery_fabric" {
+			continue
+		}
+
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		vaultName := rs.Primary.Attributes["recovery_vault_name"]
+		fabricName := rs.Primary.Attributes["name"]
+
+		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.FabricClient(resourceGroupName, vaultName)
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := client.Get(ctx, fabricName)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Fabric still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
 }

--- a/azurerm/resource_arm_site_recovery_network_mapping_test.go
+++ b/azurerm/resource_arm_site_recovery_network_mapping_test.go
@@ -113,6 +113,7 @@ func testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceName string) resou
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.NetworkMappingClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
+		// TODO Fix Bad: networkMapping error
 		resp, err := client.Get(ctx, fabricName, networkName, mappingName)
 		if err != nil {
 			if resp.Response.StatusCode == http.StatusNotFound {

--- a/azurerm/resource_arm_site_recovery_network_mapping_test.go
+++ b/azurerm/resource_arm_site_recovery_network_mapping_test.go
@@ -7,26 +7,23 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 )
 
 func TestAccAzureRMSiteRecoveryNetworkMapping_basic(t *testing.T) {
-	resourceGroupName := "azurerm_resource_group.test"
-	vaultName := "azurerm_recovery_services_vault.test"
-	fabricName := "azurerm_site_recovery_fabric.test1"
-	networkName := "azurerm_virtual_network.test1"
 	resourceName := "azurerm_site_recovery_network_mapping.test"
 	ri := tf.AccRandTimeInt()
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		CheckDestroy: testCheckAzureRMSiteRecoveryNetworkMappingDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMSiteRecoveryNetworkMapping_basic(ri, testLocation(), testAltLocation()),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceGroupName, vaultName, fabricName, networkName, resourceName),
+					testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceName),
 				),
 			},
 			{
@@ -93,37 +90,28 @@ resource "azurerm_site_recovery_network_mapping" "test" {
 `, rInt, location, rInt, rInt, rInt, altLocation, rInt, rInt, rInt)
 }
 
-func testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceGroupStateName, vaultStateName string, fabricStateName string, networkStateName string, networkStateMappingName string) resource.TestCheckFunc {
+func testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
-		resourceGroupState, ok := s.RootModule().Resources[resourceGroupStateName]
+		state, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmt.Errorf("Not found: %s", resourceGroupStateName)
-		}
-		vaultState, ok := s.RootModule().Resources[vaultStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", vaultStateName)
-		}
-		fabricState, ok := s.RootModule().Resources[fabricStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", fabricStateName)
-		}
-		networkState, ok := s.RootModule().Resources[networkStateName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", fabricStateName)
-		}
-		networkMappingState, ok := s.RootModule().Resources[networkStateMappingName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", networkStateMappingName)
+			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroupName := resourceGroupState.Primary.Attributes["name"]
-		vaultName := vaultState.Primary.Attributes["name"]
-		fabricName := fabricState.Primary.Attributes["name"]
-		networkName := networkState.Primary.Attributes["name"]
-		mappingName := networkMappingState.Primary.Attributes["name"]
+		resourceGroupName := state.Primary.Attributes["resource_group_name"]
+		vaultName := state.Primary.Attributes["recovery_vault_name"]
+		fabricName := state.Primary.Attributes["source_recovery_fabric_name"]
+		networkId := state.Primary.Attributes["source_network_id"]
+		networkName := func() string {
+			id, err := azure.ParseAzureResourceID(networkId)
+			if err != nil {
+				return ""
+			}
 
-		// Ensure mapping exists in API
+			return id.Path["virtualNetworks"]
+		}()
+		mappingName := state.Primary.Attributes["name"]
+
 		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.NetworkMappingClient(resourceGroupName, vaultName)
 		ctx := testAccProvider.Meta().(*ArmClient).StopContext
 
@@ -138,4 +126,40 @@ func testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceGroupStateName, va
 
 		return nil
 	}
+}
+
+func testCheckAzureRMSiteRecoveryNetworkMappingDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_site_recovery_network_mapping" {
+			continue
+		}
+
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		vaultName := rs.Primary.Attributes["recovery_vault_name"]
+		fabricName := rs.Primary.Attributes["source_recovery_fabric_name"]
+		networkId := rs.Primary.Attributes["source_network_id"]
+		networkName := func() string {
+			id, err := azure.ParseAzureResourceID(networkId)
+			if err != nil {
+				return ""
+			}
+
+			return id.Path["virtualNetworks"]
+		}()
+		mappingName := rs.Primary.Attributes["name"]
+
+		client := testAccProvider.Meta().(*ArmClient).RecoveryServices.NetworkMappingClient(resourceGroupName, vaultName)
+		ctx := testAccProvider.Meta().(*ArmClient).StopContext
+
+		resp, err := client.Get(ctx, fabricName, networkName, mappingName)
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Network Mapping still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Noticed while refactoring that the Recovery Services resources that the tests for this don't use their own CheckDestroy function - as such this PR introduces that so that we can split this apart.

~Dependent on #5191 - will rebase once that one's merged~ no longer dependent