### PR TITLE
r/key_vault: making the `network_acls` block computed

### DIFF
--- a/azurerm/resource_arm_key_vault.go
+++ b/azurerm/resource_arm_key_vault.go
@@ -157,6 +157,7 @@ func resourceArmKeyVault() *schema.Resource {
 			"network_acls": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -471,7 +472,14 @@ func flattenKeyVaultSku(sku *keyvault.Sku) []interface{} {
 
 func flattenKeyVaultNetworkAcls(input *keyvault.NetworkRuleSet) []interface{} {
 	if input == nil {
-		return []interface{}{}
+		return []interface{}{
+			map[string]interface{}{
+				"bypass":                     string(keyvault.AzureServices),
+				"default_action":             string(keyvault.Allow),
+				"ip_rules":                   schema.NewSet(schema.HashString, []interface{}{}),
+				"virtual_network_subnet_ids": schema.NewSet(schema.HashString, []interface{}{}),
+			},
+		}
 	}
 
 	output := make(map[string]interface{})

--- a/azurerm/resource_arm_key_vault_test.go
+++ b/azurerm/resource_arm_key_vault_test.go
@@ -695,7 +695,7 @@ resource "azurerm_key_vault" "test" {
   network_acls {
     default_action             = "Allow"
     bypass                     = "AzureServices"
-    ip_rules                   = ["10.0.0.102/32"]
+    ip_rules                   = ["123.0.0.102/32"]
     virtual_network_subnet_ids = ["${azurerm_subnet.test_a.id}"]
   }
 }


### PR DESCRIPTION
This PR supersedes #4805 by making the `network_acls` block computed with a default value based on the behaviour of the API

```
$ acctests azurerm TestAccAzureRMKeyVault_networkAcls
=== RUN   TestAccAzureRMKeyVault_networkAcls
=== PAUSE TestAccAzureRMKeyVault_networkAcls
=== RUN   TestAccAzureRMKeyVault_networkAclsAllowed
=== PAUSE TestAccAzureRMKeyVault_networkAclsAllowed
=== CONT  TestAccAzureRMKeyVault_networkAcls
--- PASS: TestAccAzureRMKeyVault_networkAcls (347.28s)
=== CONT  TestAccAzureRMKeyVault_networkAclsAllowed
--- PASS: TestAccAzureRMKeyVault_networkAclsAllowed (247.89s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	595.221s
```

Fixes #2164