### PR TITLE
r/shared_image_version - support for the storage_account_type property

### DIFF
--- a/azurerm/data_source_shared_image_version.go
+++ b/azurerm/data_source_shared_image_version.go
@@ -64,6 +64,11 @@ func dataSourceArmSharedImageVersion() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+
+						"storage_account_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -143,6 +148,8 @@ func flattenSharedImageVersionDataSourceTargetRegions(input *[]compute.TargetReg
 			if v.RegionalReplicaCount != nil {
 				output["regional_replica_count"] = int(*v.RegionalReplicaCount)
 			}
+
+			output["storage_account_type"] = v.StorageAccountType
 
 			results = append(results, output)
 		}

--- a/azurerm/data_source_shared_image_version.go
+++ b/azurerm/data_source_shared_image_version.go
@@ -51,7 +51,7 @@ func dataSourceArmSharedImageVersion() *schema.Resource {
 			},
 
 			"target_region": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -149,7 +149,7 @@ func flattenSharedImageVersionDataSourceTargetRegions(input *[]compute.TargetReg
 				output["regional_replica_count"] = int(*v.RegionalReplicaCount)
 			}
 
-			output["storage_account_type"] = v.StorageAccountType
+			output["storage_account_type"] = string(v.StorageAccountType)
 
 			results = append(results, output)
 		}

--- a/azurerm/data_source_shared_image_version_test.go
+++ b/azurerm/data_source_shared_image_version_test.go
@@ -40,35 +40,12 @@ func TestAccDataSourceAzureRMSharedImageVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "target_region.0.storage_account_type", "Standard_LRS"),
 				),
 			},
-			{
-				Config: testAccDataSourceSharedImageVersion_zrs(rInt, location, username, password, hostname),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "managed_image_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "target_region.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "target_region.0.storage_account_type", "Standard_ZRS"),
-				),
-			},
 		},
 	})
 }
 
 func testAccDataSourceSharedImageVersion_basic(rInt int, location, username, password, hostname string) string {
 	template := testAccAzureRMSharedImageVersion_imageVersion(rInt, location, username, password, hostname)
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_shared_image_version" "test" {
-  name                = "${azurerm_shared_image_version.test.name}"
-  gallery_name        = "${azurerm_shared_image_version.test.gallery_name}"
-  image_name          = "${azurerm_shared_image_version.test.image_name}"
-  resource_group_name = "${azurerm_shared_image_version.test.resource_group_name}"
-}
-`, template)
-}
-
-func testAccDataSourceSharedImageVersion_zrs(rInt int, location, username, password, hostname string) string {
-	template := testAccAzureRMSharedImageVersion_imageVersionStorageAccountType(rInt, location, username, password, hostname, "Standard_ZRS")
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/data_source_shared_image_version_test.go
+++ b/azurerm/data_source_shared_image_version_test.go
@@ -37,6 +37,16 @@ func TestAccDataSourceAzureRMSharedImageVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "managed_image_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "target_region.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "target_region.0.storage_account_type", "Standard_LRS"),
+				),
+			},
+			{
+				Config: testAccDataSourceSharedImageVersion_zrs(rInt, location, username, password, hostname),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "managed_image_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "target_region.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "target_region.0.storage_account_type", "Standard_ZRS"),
 				),
 			},
 		},
@@ -45,6 +55,20 @@ func TestAccDataSourceAzureRMSharedImageVersion_basic(t *testing.T) {
 
 func testAccDataSourceSharedImageVersion_basic(rInt int, location, username, password, hostname string) string {
 	template := testAccAzureRMSharedImageVersion_imageVersion(rInt, location, username, password, hostname)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_shared_image_version" "test" {
+  name                = "${azurerm_shared_image_version.test.name}"
+  gallery_name        = "${azurerm_shared_image_version.test.gallery_name}"
+  image_name          = "${azurerm_shared_image_version.test.image_name}"
+  resource_group_name = "${azurerm_shared_image_version.test.resource_group_name}"
+}
+`, template)
+}
+
+func testAccDataSourceSharedImageVersion_zrs(rInt int, location, username, password, hostname string) string {
+	template := testAccAzureRMSharedImageVersion_imageVersionZrs(rInt, location, username, password, hostname)
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/data_source_shared_image_version_test.go
+++ b/azurerm/data_source_shared_image_version_test.go
@@ -68,7 +68,7 @@ data "azurerm_shared_image_version" "test" {
 }
 
 func testAccDataSourceSharedImageVersion_zrs(rInt int, location, username, password, hostname string) string {
-	template := testAccAzureRMSharedImageVersion_imageVersionZrs(rInt, location, username, password, hostname)
+	template := testAccAzureRMSharedImageVersion_imageVersionStorageAccountType(rInt, location, username, password, hostname, "Standard_ZRS")
 	return fmt.Sprintf(`
 %s
 

--- a/azurerm/resource_arm_shared_image_version.go
+++ b/azurerm/resource_arm_shared_image_version.go
@@ -86,6 +86,7 @@ func resourceArmSharedImageVersion() *schema.Resource {
 						"storage_account_type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 					},

--- a/azurerm/resource_arm_shared_image_version.go
+++ b/azurerm/resource_arm_shared_image_version.go
@@ -290,7 +290,7 @@ func flattenSharedImageVersionTargetRegions(input *[]compute.TargetRegion) []int
 				output["regional_replica_count"] = int(*v.RegionalReplicaCount)
 			}
 
-			output["storage_account_type"] = v.StorageAccountType
+			output["storage_account_type"] = string(v.StorageAccountType)
 
 			results = append(results, output)
 		}

--- a/azurerm/resource_arm_shared_image_version.go
+++ b/azurerm/resource_arm_shared_image_version.go
@@ -267,7 +267,7 @@ func expandSharedImageVersionTargetRegions(d *schema.ResourceData) *[]compute.Ta
 		output := compute.TargetRegion{
 			Name:                 utils.String(name),
 			RegionalReplicaCount: utils.Int32(int32(regionalReplicaCount)),
-			StorageAccountType:   compute.StorageAccountType(string(storageAccountType)),
+			StorageAccountType:   compute.StorageAccountType(storageAccountType),
 		}
 		results = append(results, output)
 	}

--- a/azurerm/resource_arm_shared_image_version.go
+++ b/azurerm/resource_arm_shared_image_version.go
@@ -82,6 +82,12 @@ func resourceArmSharedImageVersion() *schema.Resource {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
+
+						"storage_account_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 					},
 				},
 			},
@@ -256,10 +262,12 @@ func expandSharedImageVersionTargetRegions(d *schema.ResourceData) *[]compute.Ta
 
 		name := input["name"].(string)
 		regionalReplicaCount := input["regional_replica_count"].(int)
+		storageAccountType := input["storage_account_type"].(string)
 
 		output := compute.TargetRegion{
 			Name:                 utils.String(name),
 			RegionalReplicaCount: utils.Int32(int32(regionalReplicaCount)),
+			StorageAccountType:   compute.StorageAccountType(string(storageAccountType)),
 		}
 		results = append(results, output)
 	}
@@ -281,6 +289,8 @@ func flattenSharedImageVersionTargetRegions(input *[]compute.TargetRegion) []int
 			if v.RegionalReplicaCount != nil {
 				output["regional_replica_count"] = int(*v.RegionalReplicaCount)
 			}
+
+			output["storage_account_type"] = v.StorageAccountType
 
 			results = append(results, output)
 		}

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -45,6 +45,23 @@ func TestAccAzureRMSharedImageVersion_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccAzureRMSharedImageVersion_imageVersion(ri, testLocation(), userName, password, hostName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSharedImageVersionExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_image_id"),
+					resource.TestCheckResourceAttr(resourceName, "target_region.#", "1"),
+				),
+			},
+			{
+				Config: testAccAzureRMSharedImageVersion_imageVersionZrs(ri, testLocation(), userName, password, hostName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSharedImageVersionExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "managed_image_id"),
+					resource.TestCheckResourceAttr(resourceName, "target_region.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "target_region.0.storage_account_type", "Standard_ZRS"),
+				),
+			},
+			{
 				Config: testAccAzureRMSharedImageVersion_imageVersionUpdated(ri, testLocation(), testAltLocation(), userName, password, hostName),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSharedImageVersionExists(resourceName),

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -62,7 +62,7 @@ func TestAccAzureRMSharedImageVersion_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMSharedImageVersion_storageAccountType(t *testing.T) {
+func TestAccAzureRMSharedImageVersion_storageAccountTypeLrs(t *testing.T) {
 	resourceName := "azurerm_shared_image_version.test"
 
 	ri := tf.AccRandTimeInt()
@@ -96,6 +96,39 @@ func TestAccAzureRMSharedImageVersion_storageAccountType(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMSharedImageVersion_storageAccountTypeZrs(t *testing.T) {
+	resourceName := "azurerm_shared_image_version.test"
+
+	ri := tf.AccRandTimeInt()
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
+	userName := "testadmin"
+	password := "Password1234!"
+	hostName := fmt.Sprintf("tftestcustomimagesrc%d", ri)
+	sshPort := "22"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSharedImageVersionDestroy,
+		Steps: []resource.TestStep{
+			{
+				// need to create a vm and then reference it in the image creation
+				Config:  testAccAzureRMSharedImageVersion_setup(ri, testLocation(), userName, password, hostName),
+				Destroy: false,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureVMExists("azurerm_virtual_machine.testsource", true),
+					testGeneralizeVMImage(resourceGroup, "testsource", userName, password, hostName, sshPort, testLocation()),
+				),
+			},
+			{
 				Config: testAccAzureRMSharedImageVersion_imageVersionStorageAccountType(ri, testLocation(), userName, password, hostName, "Standard_ZRS"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSharedImageVersionExists(resourceName),
@@ -103,7 +136,7 @@ func TestAccAzureRMSharedImageVersion_storageAccountType(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "target_region.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "target_region.0.storage_account_type", "Standard_ZRS"),
 				),
-			},
+			},			
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -87,7 +87,7 @@ func TestAccAzureRMSharedImageVersion_storageAccountType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMSharedImageVersion_imageVersionLrs(ri, testLocation(), userName, password, hostName),
+				Config: testAccAzureRMSharedImageVersion_imageVersionStorageAccountType(ri, testLocation(), userName, password, hostName, "Standard_LRS"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSharedImageVersionExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_image_id"),
@@ -96,7 +96,7 @@ func TestAccAzureRMSharedImageVersion_storageAccountType(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMSharedImageVersion_imageVersionZrs(ri, testLocation(), userName, password, hostName),
+				Config: testAccAzureRMSharedImageVersion_imageVersionStorageAccountType(ri, testLocation(), userName, password, hostName, "Standard_ZRS"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSharedImageVersionExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_image_id"),
@@ -270,7 +270,7 @@ resource "azurerm_shared_image_version" "test" {
 `, template)
 }
 
-func testAccAzureRMSharedImageVersion_imageVersionLrs(rInt int, location, username, password, hostname string) string {
+func testAccAzureRMSharedImageVersion_imageVersionStorageAccountType(rInt int, location, username, password, hostname string, storageAccountType string) string {
 	template := testAccAzureRMSharedImageVersion_provision(rInt, location, username, password, hostname)
 	return fmt.Sprintf(`
 %s
@@ -286,32 +286,12 @@ resource "azurerm_shared_image_version" "test" {
   target_region {
     name                   = "${azurerm_resource_group.test.location}"
 	regional_replica_count = 1
-	storage_account_type   = "Standard_LRS"
+	storage_account_type   = "%s"
   }
 }
 `, template)
 }
-func testAccAzureRMSharedImageVersion_imageVersionZrs(rInt int, location, username, password, hostname string) string {
-	template := testAccAzureRMSharedImageVersion_provision(rInt, location, username, password, hostname)
-	return fmt.Sprintf(`
-%s
 
-resource "azurerm_shared_image_version" "test" {
-  name                = "0.0.1"
-  gallery_name        = "${azurerm_shared_image_gallery.test.name}"
-  image_name          = "${azurerm_shared_image.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-  managed_image_id    = "${azurerm_image.test.id}"
-
-  target_region {
-    name                   = "${azurerm_resource_group.test.location}"
-	regional_replica_count = 1
-	storage_account_type   = "Standard_ZRS"
-  }
-}
-`, template)
-}
 func testAccAzureRMSharedImageVersion_requiresImport(rInt int, location, username, password, hostname string) string {
 	return fmt.Sprintf(`
 %s

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -92,7 +92,6 @@ func TestAccAzureRMSharedImageVersion_storageAccountTypeLrs(t *testing.T) {
 					testCheckAzureRMSharedImageVersionExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_image_id"),
 					resource.TestCheckResourceAttr(resourceName, "target_region.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "target_region.0.storage_account_type", "Standard_LRS"),
 				),
 			},
 			{
@@ -134,7 +133,6 @@ func TestAccAzureRMSharedImageVersion_storageAccountTypeZrs(t *testing.T) {
 					testCheckAzureRMSharedImageVersionExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "managed_image_id"),
 					resource.TestCheckResourceAttr(resourceName, "target_region.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "target_region.0.storage_account_type", "Standard_ZRS"),
 				),
 			},
 			{

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -217,6 +217,27 @@ resource "azurerm_shared_image_version" "test" {
 }
 `, template)
 }
+func testAccAzureRMSharedImageVersion_imageVersionZrs(rInt int, location, username, password, hostname string) string {
+	template := testAccAzureRMSharedImageVersion_provision(rInt, location, username, password, hostname)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_shared_image_version" "test" {
+  name                = "0.0.1"
+  gallery_name        = "${azurerm_shared_image_gallery.test.name}"
+  image_name          = "${azurerm_shared_image.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  managed_image_id    = "${azurerm_image.test.id}"
+
+  target_region {
+    name                   = "${azurerm_resource_group.test.location}"
+	regional_replica_count = 1
+	storage_account_type   = "Standard_ZRS"
+  }
+}
+`, template)
+}
 func testAccAzureRMSharedImageVersion_requiresImport(rInt int, location, username, password, hostname string) string {
 	return fmt.Sprintf(`
 %s

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -289,7 +289,7 @@ resource "azurerm_shared_image_version" "test" {
 	storage_account_type   = "%s"
   }
 }
-`, template)
+`, template, storageAccountType)
 }
 
 func testAccAzureRMSharedImageVersion_requiresImport(rInt int, location, username, password, hostname string) string {

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -45,14 +45,6 @@ func TestAccAzureRMSharedImageVersion_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAzureRMSharedImageVersion_imageVersion(ri, testLocation(), userName, password, hostName),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSharedImageVersionExists(resourceName),
-					resource.TestCheckResourceAttrSet(resourceName, "managed_image_id"),
-					resource.TestCheckResourceAttr(resourceName, "target_region.#", "1"),
-				),
-			},
-			{
 				Config: testAccAzureRMSharedImageVersion_imageVersionZrs(ri, testLocation(), userName, password, hostName),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSharedImageVersionExists(resourceName),

--- a/azurerm/resource_arm_shared_image_version_test.go
+++ b/azurerm/resource_arm_shared_image_version_test.go
@@ -136,7 +136,7 @@ func TestAccAzureRMSharedImageVersion_storageAccountTypeZrs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "target_region.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "target_region.0.storage_account_type", "Standard_ZRS"),
 				),
-			},			
+			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -58,3 +58,5 @@ The `target_region` block exports the following:
 * `name` - The Azure Region in which this Image Version exists.
 
 * `regional_replica_count` - The number of replicas of the Image Version to be created per region.
+
+* `storage_account_type` - The storage account type for the image version.

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -37,6 +37,7 @@ resource "azurerm_shared_image_version" "example" {
   target_region {
     name                   = "${data.azurerm_shared_image.existing.location}"
     regional_replica_count = "5"
+    storage_account_type   = "Standard_LRS"
   }
 }
 ```
@@ -72,6 +73,8 @@ The `target_region` block exports the following:
 * `name` - (Required) The Azure Region in which this Image Version should exist.
 
 * `regional_replica_count` - (Required) The number of replicas of the Image Version to be created per region.
+
+* `storage_account_type` - (Optional) The storage account type for the image version, which defaults to `Standard_LRS`. You can store all of your image version replicas in Zone Redundant Storage by specifying `Standard_ZRS`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR incorporates and supersedes #4865 by making the `storage_account_type` field computed & removing the List assertions from the tests since it's a Set.

Supersedes #4865
Fixes #4833