### PR TITLE
azurerm_logic_app_trigger_recurrence - support for start_time

### DIFF
--- a/azurerm/internal/services/logic/resource_arm_logic_app_trigger_recurrence.go
+++ b/azurerm/internal/services/logic/resource_arm_logic_app_trigger_recurrence.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 )
 
 func resourceArmLogicAppTriggerRecurrence() *schema.Resource {
@@ -59,6 +60,12 @@ func resourceArmLogicAppTriggerRecurrence() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+
+			"start_time": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.RFC3339Time,
+			},
 		},
 	}
 }
@@ -70,6 +77,10 @@ func resourceArmLogicAppTriggerRecurrenceCreateUpdate(d *schema.ResourceData, me
 			"interval":  d.Get("interval").(int),
 		},
 		"type": "Recurrence",
+	}
+
+	if v, ok := d.GetOk("start_time"); ok {
+		trigger["recurrence"].(map[string]interface{})["startTime"] = v.(string)
 	}
 
 	logicAppId := d.Get("logic_app_id").(string)
@@ -123,6 +134,10 @@ func resourceArmLogicAppTriggerRecurrenceRead(d *schema.ResourceData, meta inter
 
 	if interval := recurrence["interval"]; interval != nil {
 		d.Set("interval", int(interval.(float64)))
+	}
+
+	if startTime := recurrence["startTime"]; startTime != nil {
+		d.Set("start_time", startTime.(string))
 	}
 
 	return nil

--- a/azurerm/internal/services/logic/tests/resource_arm_logic_app_trigger_recurrence_test.go
+++ b/azurerm/internal/services/logic/tests/resource_arm_logic_app_trigger_recurrence_test.go
@@ -192,6 +192,26 @@ func TestAccAzureRMLogicAppTriggerRecurrence_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLogicAppTriggerRecurrence_startTime(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_logic_app_trigger_recurrence", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogicAppWorkflowDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogicAppTriggerRecurrence_startTime(data, "2020-01-01T01:02:03Z"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogicAppTriggerExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_time", "2020-01-01T01:02:03Z"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testAccAzureRMLogicAppTriggerRecurrence_basic(data acceptance.TestData, frequency string, interval int) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
@@ -212,6 +232,29 @@ resource "azurerm_logic_app_trigger_recurrence" "test" {
   interval     = %d
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, frequency, interval)
+}
+
+func testAccAzureRMLogicAppTriggerRecurrence_startTime(data acceptance.TestData, startTime string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_logic_app_workflow" "test" {
+  name                = "acctestlaw-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_logic_app_trigger_recurrence" "test" {
+  name         = "frequency-trigger"
+  logic_app_id = "${azurerm_logic_app_workflow.test.id}"
+  frequency    = "Month"
+  interval     = 1
+  start_time   = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, startTime)
 }
 
 func testAccAzureRMLogicAppTriggerRecurrence_requiresImport(data acceptance.TestData, frequency string, interval int) string {

--- a/website/docs/r/logic_app_trigger_recurrence.html.markdown
+++ b/website/docs/r/logic_app_trigger_recurrence.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `interval` - (Required) Specifies interval used for the Frequency, for example a value of `4` for `interval` and `hour` for `frequency` would run the Trigger every 4 hours.
 
-* `start_time` - (Optional) Specifies the start date and time for this Trigger (Y-m-d'T'H:M:S'Z').
+* `start_time` - (Optional) Specifies the start date and time for this trigger in RFC3339 format: `2000-01-02T03:04:05Z`.
 
 ## Attributes Reference
 

--- a/website/docs/r/logic_app_trigger_recurrence.html.markdown
+++ b/website/docs/r/logic_app_trigger_recurrence.html.markdown
@@ -47,6 +47,8 @@ The following arguments are supported:
 
 * `interval` - (Required) Specifies interval used for the Frequency, for example a value of `4` for `interval` and `hour` for `frequency` would run the Trigger every 4 hours.
 
+* `start_time` - (Optional) Specifies the start date and time for this Trigger (Y-m-d'T'H:M:S'Z').
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Partially Addresses: #4316

Adds the `start_time` option to the `logic_app_trigger_recurrence` resource.

```
=== RUN   TestAccAzureRMLogicAppTriggerRecurrence_startTime
=== PAUSE TestAccAzureRMLogicAppTriggerRecurrence_startTime
=== CONT  TestAccAzureRMLogicAppTriggerRecurrence_startTime
--- PASS: TestAccAzureRMLogicAppTriggerRecurrence_startTime (82.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/logic/tests 82.786s
```