### PR TITLE
Add new resource & data source: azurerm_disk_encryption_set

### DIFF
--- a/azurerm/internal/services/compute/client/client.go
+++ b/azurerm/internal/services/compute/client/client.go
@@ -10,6 +10,7 @@ type Client struct {
 	AvailabilitySetsClient         *compute.AvailabilitySetsClient
 	DedicatedHostGroupsClient      *compute.DedicatedHostGroupsClient
 	DisksClient                    *compute.DisksClient
+	DiskEncryptionSetsClient       *compute.DiskEncryptionSetsClient
 	GalleriesClient                *compute.GalleriesClient
 	GalleryImagesClient            *compute.GalleryImagesClient
 	GalleryImageVersionsClient     *compute.GalleryImageVersionsClient
@@ -36,6 +37,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	disksClient := compute.NewDisksClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&disksClient.Client, o.ResourceManagerAuthorizer)
+
+	diskEncryptionSetsClient := compute.NewDiskEncryptionSetsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&diskEncryptionSetsClient.Client, o.ResourceManagerAuthorizer)
 
 	galleriesClient := compute.NewGalleriesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&galleriesClient.Client, o.ResourceManagerAuthorizer)
@@ -86,6 +90,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		AvailabilitySetsClient:         &availabilitySetsClient,
 		DedicatedHostGroupsClient:      &dedicatedHostGroupsClient,
 		DisksClient:                    &disksClient,
+		DiskEncryptionSetsClient:       &diskEncryptionSetsClient,
 		GalleriesClient:                &galleriesClient,
 		GalleryImagesClient:            &galleryImagesClient,
 		GalleryImageVersionsClient:     &galleryImageVersionsClient,

--- a/azurerm/internal/services/compute/data_source_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/data_source_disk_encryption_set.go
@@ -61,5 +61,5 @@ func dataSourceArmDiskEncryptionSetRead(d *schema.ResourceData, meta interface{}
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
-	return nil
+	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/azurerm/internal/services/compute/data_source_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/data_source_disk_encryption_set.go
@@ -1,0 +1,137 @@
+package compute
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmDiskEncryptionSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmDiskEncryptionSetRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"location": azure.SchemaLocationForDataSource(),
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"active_key": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_vault_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"identity": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"principal_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"previous_keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_vault_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceArmDiskEncryptionSetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Disk Encryption Set %q (Resource Group %q) was not found", name, resourceGroup)
+		}
+		return fmt.Errorf("Error reading Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroup)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+	if encryptionSetProperties := resp.EncryptionSetProperties; encryptionSetProperties != nil {
+		if err := d.Set("active_key", flattenArmDiskEncryptionSetKeyVaultAndKeyReference(encryptionSetProperties.ActiveKey)); err != nil {
+			return fmt.Errorf("Error setting `active_key`: %+v", err)
+		}
+		if err := d.Set("previous_keys", flattenArmDiskEncryptionSetKeyVaultAndKeyReferenceArray(encryptionSetProperties.PreviousKeys)); err != nil {
+			return fmt.Errorf("Error setting `previous_keys`: %+v", err)
+		}
+	}
+	if identity := resp.Identity; identity != nil {
+		if err := d.Set("identity", flattenArmDiskEncryptionSetIdentity(identity)); err != nil {
+			return fmt.Errorf("Error setting `identity`: %+v", err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/compute/data_source_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/data_source_disk_encryption_set.go
@@ -32,62 +32,6 @@ func dataSourceArmDiskEncryptionSet() *schema.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
 
-			"active_key": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key_url": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"source_vault_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
-			"identity": {
-				Type:     schema.TypeList,
-				Computed: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"principal_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"tenant_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
-			"previous_keys": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key_url": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"source_vault_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
-
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -115,19 +59,6 @@ func dataSourceArmDiskEncryptionSetRead(d *schema.ResourceData, meta interface{}
 	d.Set("resource_group_name", resourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
-	}
-	if encryptionSetProperties := resp.EncryptionSetProperties; encryptionSetProperties != nil {
-		if err := d.Set("active_key", flattenArmDiskEncryptionSetKeyVaultAndKeyReference(encryptionSetProperties.ActiveKey)); err != nil {
-			return fmt.Errorf("Error setting `active_key`: %+v", err)
-		}
-		if err := d.Set("previous_keys", flattenArmDiskEncryptionSetKeyVaultAndKeyReferenceArray(encryptionSetProperties.PreviousKeys)); err != nil {
-			return fmt.Errorf("Error setting `previous_keys`: %+v", err)
-		}
-	}
-	if identity := resp.Identity; identity != nil {
-		if err := d.Set("identity", flattenArmDiskEncryptionSetIdentity(identity)); err != nil {
-			return fmt.Errorf("Error setting `identity`: %+v", err)
-		}
 	}
 
 	return nil

--- a/azurerm/internal/services/compute/data_source_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/data_source_disk_encryption_set.go
@@ -18,10 +18,7 @@ func dataSourceArmDiskEncryptionSet() *schema.Resource {
 		Read: dataSourceArmDiskEncryptionSetRead,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Read: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -17,6 +17,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_availability_set":          dataSourceArmAvailabilitySet(),
 		"azurerm_dedicated_host_group":      dataSourceArmDedicatedHostGroup(),
+		"azurerm_disk_encryption_set":       dataSourceArmDiskEncryptionSet(),
 		"azurerm_managed_disk":              dataSourceArmManagedDisk(),
 		"azurerm_image":                     dataSourceArmImage(),
 		"azurerm_platform_image":            dataSourceArmPlatformImage(),
@@ -34,6 +35,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 	resources := map[string]*schema.Resource{
 		"azurerm_availability_set":                     resourceArmAvailabilitySet(),
 		"azurerm_dedicated_host_group":                 resourceArmDedicatedHostGroup(),
+		"azurerm_disk_encryption_set":                  resourceArmDiskEncryptionSet(),
 		"azurerm_image":                                resourceArmImage(),
 		"azurerm_managed_disk":                         resourceArmManagedDisk(),
 		"azurerm_marketplace_agreement":                resourceArmMarketplaceAgreement(),

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -276,14 +276,20 @@ func flattenArmDiskEncryptionSetIdentity(input *compute.EncryptionSetIdentity) [
 		return make([]interface{}, 0)
 	}
 
-	result := make(map[string]interface{})
-
-	result["type"] = string(input.Type)
-	if principalId := input.PrincipalID; principalId != nil {
-		result["principal_id"] = *principalId
+	t := string(input.Type)
+	principalId := ""
+	if input.PrincipalID != nil {
+		principalId = *input.PrincipalID
 	}
-	if tenantId := input.TenantID; tenantId != nil {
-		result["tenant_id"] = *tenantId
+	tenantId := ""
+	if input.TenantID != nil {
+		tenantId = *input.TenantID
 	}
-	return []interface{}{result}
+	return []interface{}{
+		map[string]interface{} {
+			"type": t,
+			"principal_id": principalId,
+			"tenant_id": tenantId,
+		},
+	}
 }

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -42,7 +42,7 @@ func resourceArmDiskEncryptionSet() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: ValidateDiskEncryptionSetName,
+				ValidateFunc: validateDiskEncryptionSetName,
 			},
 
 			"location": azure.SchemaLocation(),

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -113,13 +113,13 @@ func resourceArmDiskEncryptionSetCreateUpdate(d *schema.ResourceData, meta inter
 	keyVaultKeyId := d.Get("key_vault_key_id").(string)
 	keyVaultDetails, err := diskEncryptionSetRetrieveKeyVault(ctx, vaultClient, keyVaultKeyId)
 	if err != nil {
-		return fmt.Errorf("Error validating Key Vault %q (Resource Group %q) for Disk Encryption Set: %+v", err)
+		return fmt.Errorf("Error validating Key Vault Key %q for Disk Encryption Set: %+v", keyVaultKeyId, err)
 	}
 	if !keyVaultDetails.softDeleteEnabled {
-		return fmt.Errorf("Error validating Key Vault %q (Resource Group %q) for Disk Encryption Set: Soft Delete must be enabled but it isn't!", err)
+		return fmt.Errorf("Error validating Key Vault %q (Resource Group %q) for Disk Encryption Set: Soft Delete must be enabled but it isn't!", keyVaultDetails.keyVaultName, keyVaultDetails.resourceGroupName)
 	}
 	if !keyVaultDetails.purgeProtectionEnabled {
-		return fmt.Errorf("Error validating Key Vault %q (Resource Group %q) for Disk Encryption Set: Purge Protection must be enabled but it isn't!", err)
+		return fmt.Errorf("Error validating Key Vault %q (Resource Group %q) for Disk Encryption Set: Purge Protection must be enabled but it isn't!", keyVaultDetails.keyVaultName, keyVaultDetails.resourceGroupName)
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
@@ -260,6 +260,8 @@ func flattenArmDiskEncryptionSetIdentity(input *compute.EncryptionSetIdentity) [
 
 type diskEncryptionSetKeyVault struct {
 	keyVaultId             string
+	resourceGroupName      string
+	keyVaultName           string
 	purgeProtectionEnabled bool
 	softDeleteEnabled      bool
 }
@@ -304,6 +306,8 @@ func diskEncryptionSetRetrieveKeyVault(ctx context.Context, client *keyvault.Vau
 
 	return &diskEncryptionSetKeyVault{
 		keyVaultId:             *keyVaultID,
+		resourceGroupName:      resourceGroup,
+		keyVaultName:           vaultName,
 		purgeProtectionEnabled: purgeProtectionEnabled,
 		softDeleteEnabled:      softDeleteEnabled,
 	}, nil

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -3,7 +3,6 @@ package compute
 import (
 	"context"
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"log"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -1,0 +1,387 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmDiskEncryptionSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDiskEncryptionSetCreateUpdate,
+		Read:   resourceArmDiskEncryptionSetRead,
+		Update: resourceArmDiskEncryptionSetCreateUpdate,
+		Delete: resourceArmDiskEncryptionSetDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidateDiskEncryptionSetName,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"active_key": {
+				Type:     schema.TypeList,
+				Required: true,
+				// the forceNew is enabled because currently key rotation is not supported, you cannot change the key vault and key associated with disk encryption set.
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key_url": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validate.NoEmptyStrings,
+						},
+						"source_vault_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: azure.ValidateResourceID,
+						},
+					},
+				},
+			},
+
+			"identity": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(compute.SystemAssigned),
+							}, false),
+							Default: string(compute.SystemAssigned),
+						},
+						"principal_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tenant_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"previous_keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key_url": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validate.NoEmptyStrings,
+						},
+						"source_vault_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validate.NoEmptyStrings,
+						},
+					},
+				},
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func resourceArmDiskEncryptionSetCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for present of existing Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+			}
+		}
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_disk_encryption_set", *existing.ID)
+		}
+	}
+
+	location := azure.NormalizeLocation(d.Get("location").(string))
+	activeKey := d.Get("active_key").([]interface{})
+	t := d.Get("tags").(map[string]interface{})
+
+	diskEncryptionSet := compute.DiskEncryptionSet{
+		Location: utils.String(location),
+		EncryptionSetProperties: &compute.EncryptionSetProperties{
+			ActiveKey: expandArmDiskEncryptionSetKeyVaultAndKeyReference(activeKey),
+		},
+		Tags: tags.Expand(t),
+	}
+
+	if v, ok := d.GetOk("identity"); ok {
+		diskEncryptionSet.Identity = expandArmDiskEncryptionSetIdentity(v.([]interface{}))
+	} else {
+		diskEncryptionSet.Identity = &compute.EncryptionSetIdentity{
+			Type: compute.SystemAssigned,
+		}
+	}
+
+	// validate whether the keyvault has soft-delete and purge-protection enabled
+	err := validateKeyVaultAndKey(ctx, meta, resourceGroup, diskEncryptionSet.ActiveKey)
+	if err != nil {
+		return fmt.Errorf("Error creating Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, diskEncryptionSet)
+	if err != nil {
+		return fmt.Errorf("Error creating Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for creation of Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read Disk Encryption Set %q (Resource Group %q) ID", name, resourceGroup)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmDiskEncryptionSetRead(d, meta)
+}
+
+func validateKeyVaultAndKey(ctx context.Context, meta interface{}, resourceGroup string, keyVaultAndKey *compute.KeyVaultAndKeyReference) error {
+	armClient := meta.(*clients.Client)
+	if keyVaultAndKey == nil {
+		return nil
+	}
+	if keyVault := keyVaultAndKey.SourceVault; keyVault != nil {
+		if keyVaultId := keyVault.ID; keyVaultId != nil {
+			client := armClient.KeyVault.VaultsClient
+			parsedId, err := azure.ParseAzureResourceID(*keyVaultId)
+			if err != nil {
+				return fmt.Errorf("Error parsing ID for keyvault in Disk Encryption Set: %+v", err)
+			}
+			keyVaultName := parsedId.Path["name"]
+			log.Printf("[INFO] Keyvault name input in Disk Encryption Set: %s", keyVaultName)
+			resp, err := client.Get(ctx, resourceGroup, keyVaultName)
+			if err != nil {
+				return fmt.Errorf("Error reading keyvault %q (Resource Group %q): %+v", keyVaultName, resourceGroup, err)
+			}
+			if props := resp.Properties; props != nil {
+				if softDelete := props.EnableSoftDelete; softDelete != nil {
+					if !*softDelete {
+						return fmt.Errorf("the keyvault in Disk Encryption Set must enable soft delete")
+					}
+				}
+				if purgeProtection := props.EnablePurgeProtection; purgeProtection != nil {
+					if !*purgeProtection {
+						return fmt.Errorf("the keyvault in Disk Encryption Set must enable purge protection")
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func resourceArmDiskEncryptionSetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	name := id.Path["diskEncryptionSets"]
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Disk Encryption Set %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroup)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+	if encryptionSetProperties := resp.EncryptionSetProperties; encryptionSetProperties != nil {
+		if err := d.Set("active_key", flattenArmDiskEncryptionSetKeyVaultAndKeyReference(encryptionSetProperties.ActiveKey)); err != nil {
+			return fmt.Errorf("Error setting `active_key`: %+v", err)
+		}
+		if err := d.Set("previous_keys", flattenArmDiskEncryptionSetKeyVaultAndKeyReferenceArray(encryptionSetProperties.PreviousKeys)); err != nil {
+			return fmt.Errorf("Error setting `previous_keys`: %+v", err)
+		}
+	}
+	if identity := resp.Identity; identity != nil {
+		if err := d.Set("identity", flattenArmDiskEncryptionSetIdentity(identity)); err != nil {
+			return fmt.Errorf("Error setting `identity`: %+v", err)
+		}
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceArmDiskEncryptionSetDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DiskEncryptionSetsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	name := id.Path["diskEncryptionSets"]
+
+	future, err := client.Delete(ctx, resourceGroup, name)
+	if err != nil {
+		if response.WasNotFound(future.Response()) {
+			return nil
+		}
+		return fmt.Errorf("Error deleting Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		if !response.WasNotFound(future.Response()) {
+			return fmt.Errorf("Error waiting for deleting Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
+	}
+
+	return nil
+}
+
+func expandArmDiskEncryptionSetKeyVaultAndKeyReference(input []interface{}) *compute.KeyVaultAndKeyReference {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0].(map[string]interface{})
+
+	sourceVaultId := v["source_vault_id"].(string)
+	keyUrl := v["key_url"].(string)
+
+	result := compute.KeyVaultAndKeyReference{
+		KeyURL: utils.String(keyUrl),
+		SourceVault: &compute.SourceVault{
+			ID: utils.String(sourceVaultId),
+		},
+	}
+	return &result
+}
+
+func expandArmDiskEncryptionSetIdentity(input []interface{}) *compute.EncryptionSetIdentity {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0].(map[string]interface{})
+
+	t := v["type"].(string)
+	result := compute.EncryptionSetIdentity{
+		Type: compute.DiskEncryptionSetIdentityType(t),
+	}
+
+	return &result
+}
+
+func flattenArmDiskEncryptionSetKeyVaultAndKeyReference(input *compute.KeyVaultAndKeyReference) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	result := make(map[string]interface{})
+
+	if keyUrl := input.KeyURL; keyUrl != nil {
+		result["key_url"] = *keyUrl
+	}
+	if sourceVault := input.SourceVault; sourceVault != nil {
+		if sourceVaultId := sourceVault.ID; sourceVaultId != nil {
+			result["source_vault_id"] = *sourceVaultId
+		}
+	}
+
+	return []interface{}{result}
+}
+
+func flattenArmDiskEncryptionSetKeyVaultAndKeyReferenceArray(input *[]compute.KeyVaultAndKeyReference) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, item := range *input {
+		v := make(map[string]interface{})
+
+		if sourceVault := item.SourceVault; sourceVault != nil {
+			if sourceVaultId := sourceVault.ID; sourceVaultId != nil {
+				v["source_vault_id"] = *sourceVaultId
+			}
+		}
+
+		results = append(results, v)
+	}
+
+	return results
+}
+
+func flattenArmDiskEncryptionSetIdentity(input *compute.EncryptionSetIdentity) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	result := make(map[string]interface{})
+
+	result["type"] = string(input.Type)
+	if principalId := input.PrincipalID; principalId != nil {
+		result["principal_id"] = *principalId
+	}
+	if tenantId := input.TenantID; tenantId != nil {
+		result["tenant_id"] = *tenantId
+	}
+	return []interface{}{result}
+}

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -286,10 +286,10 @@ func flattenArmDiskEncryptionSetIdentity(input *compute.EncryptionSetIdentity) [
 		tenantId = *input.TenantID
 	}
 	return []interface{}{
-		map[string]interface{} {
-			"type": t,
+		map[string]interface{}{
+			"type":         t,
 			"principal_id": principalId,
-			"tenant_id": tenantId,
+			"tenant_id":    tenantId,
 		},
 	}
 }

--- a/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
+++ b/azurerm/internal/services/compute/resource_arm_disk_encryption_set.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -142,7 +143,7 @@ func resourceArmDiskEncryptionSetCreateUpdate(d *schema.ResourceData, meta inter
 	diskEncryptionSet.Identity = expandArmDiskEncryptionSetIdentity(d)
 
 	// validate whether the keyvault has soft-delete and purge-protection enabled
-	if err := validateKeyVault(ctx, meta.(*clients.Client), resourceGroup, *keyVaultID); err != nil {
+	if err := validateKeyVault(ctx, meta.(*clients.Client).KeyVault.VaultsClient, resourceGroup, *keyVaultID); err != nil {
 		return fmt.Errorf("Error creating Disk Encryption Set %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
@@ -166,8 +167,7 @@ func resourceArmDiskEncryptionSetCreateUpdate(d *schema.ResourceData, meta inter
 	return resourceArmDiskEncryptionSetRead(d, meta)
 }
 
-func validateKeyVault(ctx context.Context, armClient *clients.Client, resourceGroup string, keyVaultID string) error {
-	client := armClient.KeyVault.VaultsClient
+func validateKeyVault(ctx context.Context, client *keyvault.VaultsClient, resourceGroup string, keyVaultID string) error {
 	parsedId, err := azure.ParseAzureResourceID(keyVaultID)
 	if err != nil {
 		return fmt.Errorf("Error parsing ID for keyvault in Disk Encryption Set: %+v", err)

--- a/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
@@ -10,45 +10,40 @@ import (
 
 func TestAccDataSourceAzureRMDiskEncryptionSet_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_disk_encryption_set", "test")
-	resourceGroup := fmt.Sprintf("acctestRG-%d", data.RandomInteger)
-	vaultName := fmt.Sprintf("vault%d", data.RandomInteger)
-	keyName := fmt.Sprintf("key-%s", data.RandomString)
-	desName := fmt.Sprintf("acctestdes-%d", data.RandomInteger)
-	location := data.Locations.Primary
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
 		CheckDestroy: testCheckAzureRMDiskEncryptionSetDestroy,
 		Steps: []resource.TestStep{
-			// These two steps are used for setting up a valid keyVault, which enables soft-delete and purge protection.
-			// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
 			{
-				Config: testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName),
+				// These two steps are used for setting up a valid keyVault, which enables soft-delete and purge protection.
+				// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
+				Config: testAccAzureRMDiskEncryptionSet_dependencies(data),
 				Check: resource.ComposeTestCheckFunc(
-					enableSoftDeleteAndPurgeProtectionForKeyvault(resourceGroup, vaultName),
+					enableSoftDeleteAndPurgeProtectionForKeyVault("azurerm_key_vault.test"),
 				),
 			},
-			// This step is not negligible, without this step, the final step will fail on refresh complaining `Disk Encryption Set does not exist`
 			{
-				Config: testAccAzureRMDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName),
+				Config: testAccAzureRMDiskEncryptionSet_basic(data),
 			},
 			{
-				Config: testAccDataSourceDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName),
-				Check:  resource.ComposeTestCheckFunc(),
+				Config: testAccDataSourceDiskEncryptionSet_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(data.ResourceName, "location"),
+				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName string) string {
-	config := testAccAzureRMDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName)
+func testAccDataSourceDiskEncryptionSet_basic(data acceptance.TestData) string {
+	config := testAccAzureRMDiskEncryptionSet_basic(data)
 	return fmt.Sprintf(`
 %s
 
 data "azurerm_disk_encryption_set" "test" {
-  resource_group_name = "${azurerm_disk_encryption_set.test.resource_group_name}"
   name                = "${azurerm_disk_encryption_set.test.name}"
+  resource_group_name = "${azurerm_disk_encryption_set.test.resource_group_name}"
 }
 `, config)
 }

--- a/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
@@ -35,15 +35,7 @@ func TestAccDataSourceAzureRMDiskEncryptionSet_basic(t *testing.T) {
 			},
 			{
 				Config: testAccDataSourceDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "identity.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "identity.0.type", "SystemAssigned"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.0.principal_id"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.0.tenant_id"),
-					resource.TestCheckResourceAttr(data.ResourceName, "active_key.#", "1"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "active_key.0.source_vault_id"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "active_key.0.key_url"),
-				),
+				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})

--- a/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccDataSourceAzureRMDiskEncryptionSet_basic(t *testing.T) {
+	dataSourceName := "data.azurerm_disk_encryption_set.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(6)
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
+	vaultName := fmt.Sprintf("vault%d", ri)
+	keyName := fmt.Sprintf("key-%s", rs)
+	desName := fmt.Sprintf("acctestdes-%d", ri)
+	location := acceptance.Location()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDiskEncryptionSetDestroy,
+		Steps: []resource.TestStep{
+			// These two steps are used for setting up a valid keyVault, which enables soft-delete and purge protection.
+			{
+				Config:  testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName),
+				Destroy: false,
+				Check:   resource.ComposeTestCheckFunc(),
+			},
+			// This step is not negligible, without this step, the final step will fail on refresh complaining `Disk Encryption Set does not exist`
+			{
+				PreConfig: func() { enableSoftDeleteAndPurgeProtectionForKeyvault(resourceGroup, vaultName) },
+				Config:    testAccAzureRMDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName),
+			},
+			{
+				Config: testAccDataSourceDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "identity.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "identity.0.type", "SystemAssigned"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "identity.0.principal_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "identity.0.tenant_id"),
+					resource.TestCheckResourceAttr(dataSourceName, "active_key.#", "1"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "active_key.0.source_vault_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "active_key.0.key_url"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName string) string {
+	config := testAccAzureRMDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_disk_encryption_set" "test" {
+  resource_group_name = "${azurerm_disk_encryption_set.test.resource_group_name}"
+  name                = "${azurerm_disk_encryption_set.test.name}"
+}
+`, config)
+}

--- a/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_disk_encryption_set_test.go
@@ -26,10 +26,12 @@ func TestAccDataSourceAzureRMDiskEncryptionSet_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMDiskEncryptionSetDestroy,
 		Steps: []resource.TestStep{
 			// These two steps are used for setting up a valid keyVault, which enables soft-delete and purge protection.
+			// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
 			{
-				Config:  testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName),
-				Destroy: false,
-				Check:   resource.ComposeTestCheckFunc(),
+				Config: testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName),
+				Check: resource.ComposeTestCheckFunc(
+					enableSoftDeleteAndPurgeProtectionForKeyvault(resourceGroup, vaultName),
+				),
 			},
 			// This step is not negligible, without this step, the final step will fail on refresh complaining `Disk Encryption Set does not exist`
 			{

--- a/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
@@ -38,8 +38,7 @@ func TestAccAzureRMDiskEncryptionSet_basic(t *testing.T) {
 				Config: testAccAzureRMDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDiskEncryptionSetExists(data.ResourceName),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "active_key.0.source_vault_id"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "active_key.0.key_url"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "key_vault_key_uri"),
 				),
 			},
 			data.ImportStep(),
@@ -184,7 +183,7 @@ resource "azurerm_key_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
-  sku_name                = "premium"
+  sku_name            = "premium"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -227,7 +226,6 @@ resource "azurerm_disk_encryption_set" "test" {
   location            = azurerm_resource_group.test.location
 
   key_vault_key_uri = azurerm_key_vault_key.test.id
-  }
 }
 `, resourceGroup, location, vaultName, keyName, desName)
 }

--- a/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
@@ -2,8 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"log"
 	"testing"
 
@@ -12,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 

--- a/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
@@ -1,0 +1,243 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"log"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMDiskEncryptionSet_basic(t *testing.T) {
+	resourceName := "azurerm_disk_encryption_set.test"
+	ri := tf.AccRandTimeInt()
+	rs := acctest.RandString(6)
+	resourceGroup := fmt.Sprintf("acctestRG-%d", ri)
+	vaultName := fmt.Sprintf("vault%d", ri)
+	keyName := fmt.Sprintf("key-%s", rs)
+	desName := fmt.Sprintf("acctestdes-%d", ri)
+	location := acceptance.Location()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDiskEncryptionSetDestroy,
+		Steps: []resource.TestStep{
+			// This test step is temporary due to freezing of functions in keyVault.
+			// After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
+			{
+				Config:  testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName),
+				Destroy: false,
+				Check:   resource.ComposeTestCheckFunc(),
+			},
+			{
+				PreConfig: func() { enableSoftDeleteAndPurgeProtectionForKeyvault(resourceGroup, vaultName) },
+				Config:    testAccAzureRMDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDiskEncryptionSetExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "active_key.0.source_vault_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "active_key.0.key_url"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMDiskEncryptionSetExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Disk Encryption Set not found: %s", resourceName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DiskEncryptionSetsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		if resp, err := client.Get(ctx, resourceGroup, name); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Disk Encryption Set %q (Resource Group %q) does not exist", name, resourceGroup)
+			}
+			return fmt.Errorf("Bad: Get on Compute.DiskEncryptionSetsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMDiskEncryptionSetDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DiskEncryptionSetsClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_disk_encryption_set" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		if resp, err := client.Get(ctx, resourceGroup, name); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Get on Compute.DiskEncryptionSetsClient: %+v", err)
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func enableSoftDeleteAndPurgeProtectionForKeyvault(resourceGroup, vaultName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		armClient := acceptance.AzureProvider.Meta().(*clients.Client)
+		client := armClient.KeyVault.VaultsClient
+		ctx := armClient.StopContext
+		vaultPatch := keyvault.VaultPatchParameters{
+			Properties: &keyvault.VaultPatchProperties{
+				EnableSoftDelete:      utils.Bool(true),
+				EnablePurgeProtection: utils.Bool(true),
+			},
+		}
+		log.Printf("[LOG] Updating")
+		_, err := client.Update(ctx, resourceGroup, vaultName, vaultPatch)
+		if err != nil {
+			return fmt.Errorf("Bad: error when updating Keyvault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
+		}
+		return nil
+	}
+}
+
+func testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName string) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "%s"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name                = "premium"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.service_principal_object_id
+
+    key_permissions = [
+      "create",
+      "delete",
+      "get",
+      "update",
+    ]
+
+    secret_permissions = [
+      "get",
+      "delete",
+      "set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+`, resourceGroup, location, vaultName, keyName)
+}
+
+func testAccAzureRMDiskEncryptionSet_basic(resourceGroup, location, vaultName, keyName, desName string) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "%s"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name                = "premium"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.service_principal_object_id
+
+    key_permissions = [
+      "create",
+      "delete",
+      "get",
+      "update",
+    ]
+
+    secret_permissions = [
+      "get",
+      "delete",
+      "set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_disk_encryption_set" "test" {
+  name                = "%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  active_key {
+    source_vault_id = azurerm_key_vault.test.id
+    key_url         = azurerm_key_vault_key.test.id
+  }
+}
+`, resourceGroup, location, vaultName, keyName, desName)
+}

--- a/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
@@ -31,11 +31,10 @@ func TestAccAzureRMDiskEncryptionSet_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMDiskEncryptionSetDestroy,
 		Steps: []resource.TestStep{
 			// This test step is temporary due to freezing of functions in keyVault.
-			// After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
+			// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
 			{
-				Config:  testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName),
-				Destroy: false,
-				Check:   resource.ComposeTestCheckFunc(),
+				Config: testAccPrepareKeyvaultAndKey(resourceGroup, location, vaultName, keyName),
+				Check:  resource.ComposeTestCheckFunc(),
 			},
 			{
 				PreConfig: func() { enableSoftDeleteAndPurgeProtectionForKeyvault(resourceGroup, vaultName) },
@@ -114,7 +113,7 @@ func enableSoftDeleteAndPurgeProtectionForKeyvault(resourceGroup, vaultName stri
 				EnablePurgeProtection: utils.Bool(true),
 			},
 		}
-		log.Printf("[LOG] Updating")
+		log.Printf("[DEBUG] Enabling Soft Delete & Purge Protection on Key Vault %q (Resource Group %q)..", vaultName, resourceGroup)
 		_, err := client.Update(ctx, resourceGroup, vaultName, vaultPatch)
 		if err != nil {
 			return fmt.Errorf("Bad: error when updating Keyvault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
@@ -234,9 +233,7 @@ resource "azurerm_disk_encryption_set" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 
-  active_key {
-    source_vault_id = azurerm_key_vault.test.id
-    key_url         = azurerm_key_vault_key.test.id
+  key_vault_key_uri = azurerm_key_vault_key.test.id
   }
 }
 `, resourceGroup, location, vaultName, keyName, desName)

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -76,3 +76,18 @@ func validateName(maxLength int) func(i interface{}, k string) (warnings []strin
 		return
 	}
 }
+
+func ValidateDiskEncryptionSetName(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+		return
+	}
+
+	// Supported characters for the name are a-z, A-Z, 0-9 and _. The maximum name length is 80 characters.
+	// despite the swagger says the constraint above, but a name that contains hyphens will also pass.
+	if matched := regexp.MustCompile(`^[a-zA-Z0-9_-]{1,80}$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%s must be between 1 - 80 characters long, and contains only a-z, A-Z, 0-9 and _", k))
+	}
+	return
+}

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -77,16 +77,19 @@ func validateName(maxLength int) func(i interface{}, k string) (warnings []strin
 	}
 }
 
-func ValidateDiskEncryptionSetName(i interface{}, k string) (warnings []string, errors []error) {
+func validateDiskEncryptionSetName(i interface{}, k string) (warnings []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
 		return
 	}
 
-	// Supported characters for the name are a-z, A-Z, 0-9 and _. The maximum name length is 80 characters.
-	// despite the swagger says the constraint above, but a name that contains hyphens will also pass.
-	if matched := regexp.MustCompile(`^[a-zA-Z0-9_-]{1,80}$`).Match([]byte(v)); !matched {
+	// Swagger says: Supported characters for the name are a-z, A-Z, 0-9 and _. The maximum name length is 80 characters.
+	// Confirmed with the service team, they gave me a regex: ^[^_\W][\w-._]{0,79}(?<![-.])$
+	// This means the name can contain a-z, A-Z, 0-9, underscore, dot or hyphen, and must not starts with a underscore or any other non-word characters (underscore is considered as word character)
+	// additionally, the name cannot end with hyphen or dot.
+	// Golang regex does not support "negative look ahead" (aka `?<!`), therefore I transformed this regex to the following regular expression.
+	if matched := regexp.MustCompile(`^[^_\W][\w-._]{0,78}\w$`).Match([]byte(v)); !matched {
 		errors = append(errors, fmt.Errorf("%s must be between 1 - 80 characters long, and contains only a-z, A-Z, 0-9 and _", k))
 	}
 	return

--- a/azurerm/internal/services/compute/validation_test.go
+++ b/azurerm/internal/services/compute/validation_test.go
@@ -254,3 +254,81 @@ func TestParseVirtualMachineScaleSetID(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateDiskEncryptionSetName(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// empty
+			input:    "",
+			expected: false,
+		},
+		{
+			//basic example
+			input:    "hello",
+			expected: true,
+		},
+		{
+			// can't start with an underscore
+			input:    "_hello",
+			expected: false,
+		},
+		{
+			// can't start with dot
+			input:    ".hello",
+			expected: false,
+		},
+		{
+			// dot in middle
+			input:    "hello.world",
+			expected: true,
+		},
+		{
+			// hyphen in middle
+			input:    "hello-world",
+			expected: true,
+		},
+		{
+			// can't end with hyphen
+			input:    "helloworld-",
+			expected: false,
+		},
+		{
+			// can't contain an exclamation mark
+			input:    "hello!",
+			expected: false,
+		},
+		{
+			// can't end with dot
+			input:    "hello.",
+			expected: false,
+		},
+		{
+			// underscore at end
+			input:    "helloworld_",
+			expected: true,
+		},
+		{
+			// 80 characters
+			input:    "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde",
+			expected: true,
+		},
+		{
+			// 81 characters
+			input:    "abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdef",
+			expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q...", v.input)
+
+		_, errors := validateDiskEncryptionSetName(v.input, "name")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -183,6 +183,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/providers/azurerm/d/disk_encryption_set.html">azurerm_disk_encryption_set</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/eventhub_namespace.html">azurerm_eventhub_namespace</a>
                 </li>
 
@@ -846,6 +850,10 @@
 
                 <li>
                   <a href="/docs/providers/azurerm/r/dedicated_host_group.html">azurerm_dedicated_host_group</a>
+                </li>
+
+                <li>
+                  <a href="/docs/providers/azurerm/r/disk_encryption_set.html">azurerm_disk_encryption_set</a>
                 </li>
 
                 <li>

--- a/website/docs/d/disk_encryption_set.html.markdown
+++ b/website/docs/d/disk_encryption_set.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_disk_encryption_set"
+sidebar_current: "docs-azurerm-datasource-disk-encryption-set"
+description: |-
+  Gets information about an existing Disk Encryption Set
+---
+
+# Data Source: azurerm_disk_encryption_set
+
+Use this data source to access information about an existing Disk Encryption Set.
+
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Disk Encryption Set exists.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Disk Encryption Set exists.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - Resource Id
+
+* `location` - Resource location
+
+* `active_key` - One `active_key` block defined below.
+
+* `identity` - A `identity` block defined below.
+
+* `previous_keys` - One or more `previous_key` block defined below.
+
+* `tags` - Resource tags
+
+
+---
+
+The `active_key` block contains the following:
+
+* `source_vault_id` - The resource id of the KeyVault containing the key or secret which the Disk Encryption Set is using.
+
+* `key_url` - The URL pointing to a key or secret in KeyVault.
+
+---
+
+The `identity` block contains the following:
+
+* `type` - The type of Managed Service Identity used by this Disk Encryption Set. Only SystemAssigned is supported.
+
+* `principal_id` - The object ID of the Managed Service Identity created by Azure.
+
+* `tenant_id` - The tenant ID of the Managed Service Identity created by Azure.
+
+---
+
+The `previous_key` block contains the following:
+
+* `source_vault_id` - The resource id of the KeyVault containing the key or secret which the Disk Encryption Set is using.
+
+* `key_url` - The URL pointing to a key or secret in KeyVault.

--- a/website/docs/d/disk_encryption_set.html.markdown
+++ b/website/docs/d/disk_encryption_set.html.markdown
@@ -26,41 +26,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - Resource Id
+* `id` - The ID of the Disk Encryption Set.
 
-* `location` - Resource location
+* `location` - The location where the Disk Encryption Set exists.
 
-* `active_key` - One `active_key` block defined below.
-
-* `identity` - A `identity` block defined below.
-
-* `previous_keys` - One or more `previous_key` block defined below.
-
-* `tags` - Resource tags
-
-
----
-
-The `active_key` block contains the following:
-
-* `source_vault_id` - The resource id of the KeyVault containing the key or secret which the Disk Encryption Set is using.
-
-* `key_url` - The URL pointing to a key or secret in KeyVault.
-
----
-
-The `identity` block contains the following:
-
-* `type` - The type of Managed Service Identity used by this Disk Encryption Set. Only SystemAssigned is supported.
-
-* `principal_id` - The object ID of the Managed Service Identity created by Azure.
-
-* `tenant_id` - The tenant ID of the Managed Service Identity created by Azure.
-
----
-
-The `previous_key` block contains the following:
-
-* `source_vault_id` - The resource id of the KeyVault containing the key or secret which the Disk Encryption Set is using.
-
-* `key_url` - The URL pointing to a key or secret in KeyVault.
+* `tags` - A mapping of tags assigned to the Disk Encryption Set.

--- a/website/docs/d/disk_encryption_set.html.markdown
+++ b/website/docs/d/disk_encryption_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_disk_encryption_set"
-sidebar_current: "docs-azurerm-datasource-disk-encryption-set"
 description: |-
   Gets information about an existing Disk Encryption Set
 ---

--- a/website/docs/d/disk_encryption_set.html.markdown
+++ b/website/docs/d/disk_encryption_set.html.markdown
@@ -11,8 +11,6 @@ description: |-
 
 Use this data source to access information about an existing Disk Encryption Set.
 
-
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -20,7 +18,6 @@ The following arguments are supported:
 * `name` - (Required) The name of the Disk Encryption Set exists.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Disk Encryption Set exists.
-
 
 ## Attributes Reference
 

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -1,0 +1,140 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_disk_encryption_set"
+sidebar_current: "docs-azurerm-resource-disk-encryption-set"
+description: |-
+  Manage Azure DiskEncryptionSet instance.
+---
+
+# azurerm_disk_encryption_set
+
+Manage an Azure DiskEncryptionSet instance.
+
+-> **NOTE:** The DiskEncryptionSet service is currently in public preview and are only available in a limited set of regions. 
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "des-example-rg"
+  location = "westus2"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "des-example-keyvault"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name                = "premium"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.service_principal_object_id
+
+    key_permissions = [
+      "create",
+      "get",
+      "delete",
+      "list",
+      "wrapkey",
+      "unwrapkey",
+      "get",
+    ]
+
+    secret_permissions = [
+      "get",
+      "delete",
+      "set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "des-example-key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_disk_encryption_set" "test" {
+  name                = "des"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  active_key {
+    source_vault_id = azurerm_key_vault.test.id
+    key_url         = azurerm_key_vault_key.test.id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the disk encryption set that is being created. The name can't be changed after the disk encryption set is created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) Specifies the name of the Resource Group in which the Disk Encryption Set should exist. Changing this forces a new resource to be created.
+
+* `location` - (Required) Specifies the Azure Region where the Disk Encryption Set exists. Changing this forces a new resource to be created.
+
+* `active_key` - (Required) One `active_key` block defined below.
+
+* `identity` - (Optional) A `identity` block defined below.
+
+* `tags` - (Optional) A mapping of tags to assign to the Disk Encryption Set.
+
+---
+
+The `active_key` block supports the following:
+
+* `source_vault_id` - (Required) Specifies the resource ID of the KeyVault containing the key or secret.
+
+* `key_url` - (Required) Specifies the URL pointing to a key or secret in KeyVault.
+
+-> **NOTE** Access to the KeyVault must be granted for this Disk Encryption Set, if you want to further use this Disk Encryption Set in a Managed Disk or Virtual Machine, or Virtual Machine Scale Set. For instructions, please refer to the doc of [Server side encryption of Azure managed disks](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption).
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `previous_keys` - One or more `previous_key` block defined below.
+
+* `id` - The ID of the Disk Encryption Set.
+
+---
+
+A `identity` block supports the following:
+
+* `type` - (Required) The Managed Service Identity Type of this Disk Encryption Set. The possible value is `SystemAssigned` (where Azure will generate a Service Principal for you).
+
+~> **NOTE:** When `type` is set to `SystemAssigned`, identity the Principal ID can be retrieved after the Disk Encryption Set has been created. See [documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview) for additional information.
+
+---
+
+The `previous_key` block contains the following:
+
+* `source_vault_id` - (Required) Specifies the resource ID of the KeyVault containing the key or secret.
+
+* `key_url` - (Required) Specifies the URL pointing to a key or secret in KeyVault.
+
+## Import
+
+Disk Encryption Set can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_disk_encryption_set.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/diskEncryptionSets/des1
+```

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages a Disk Encryption Set.
 
--> **NOTE:** The Disk Encryption Sets are currently in Public Preview and are only available in a limited set of regions: West Central US, Canada Central and North Europe. 
+-> **NOTE**: Disk Encryption Sets are in Public Preview and at this time is only available in `Canada Central`, `North Europe` and `West Central US` regions - [more information can be found in the preview documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption). 
 
 -> **NOTE:** At this time the Key Vault used to store the Active Key for this Disk Encryption Set must have both Soft Delete & Purge Protection enabled - which are not yet supported by Terraform - instead you can configure this using [a provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) or [the `azurerm_template_deployment` resource](https://www.terraform.io/docs/providers/azurerm/r/template_deployment.html).
 
@@ -30,8 +30,7 @@ resource "azurerm_key_vault" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-
-  sku_name                = "premium"
+  sku_name            = "premium"
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
@@ -75,8 +74,7 @@ resource "azurerm_disk_encryption_set" "example" {
   name                = "des"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-
-  key_vault_key_uri   = azurerm_key_vault_key.example.id
+  key_vault_key_id    = azurerm_key_vault_key.example.id
 }
 ```
 
@@ -90,13 +88,19 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the Azure Region where the Disk Encryption Set exists. Changing this forces a new resource to be created.
 
-* `key_vault_key_uri` - (Required) Specifies the URL to a Key Vault Key (either from a Key Vault Key, or the Key URL for the Key Vault Secret).
+* `key_vault_key_id` - (Required) Specifies the URL to a Key Vault Key (either from a Key Vault Key, or the Key URL for the Key Vault Secret).
 
 -> **NOTE** Access to the KeyVault must be granted for this Disk Encryption Set, if you want to further use this Disk Encryption Set in a Managed Disk or Virtual Machine, or Virtual Machine Scale Set. For instructions, please refer to the doc of [Server side encryption of Azure managed disks](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption).
 
 * `identity` - (Optional) A `identity` block defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the Disk Encryption Set.
+
+---
+
+A `identity` block supports the following:
+
+* `type` - (Required) The Type of Identity which should be used for this Disk Encryption Set. At this time the only possible value is `SystemAssigned`.
 
 ## Attributes Reference
 
@@ -108,13 +112,13 @@ The following attributes are exported:
 
 A `identity` block exports the following:
 
-* `type` - (Required) The Managed Service Identity Type of this Disk Encryption Set. The possible value is `SystemAssigned` (where Azure will generate a Service Principal for you).
+* `principal_id` - The (Client) ID of the Service Principal.
 
-~> **NOTE:** When `type` is set to `SystemAssigned`, identity the Principal ID can be retrieved after the Disk Encryption Set has been created. See [documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview) for additional information.
+* `tenant_id` - The ID of the Tenant the Service Principal is assigned in.
 
 ## Import
 
-Disk Encryption Set can be imported using the `resource id`, e.g.
+Disk Encryption Sets can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_disk_encryption_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/diskEncryptionSets/encryptionSet1

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -4,29 +4,31 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_disk_encryption_set"
 sidebar_current: "docs-azurerm-resource-disk-encryption-set"
 description: |-
-  Manage Azure DiskEncryptionSet instance.
+  Manages a Disk Encryption Set.
 ---
 
 # azurerm_disk_encryption_set
 
-Manage an Azure DiskEncryptionSet instance.
+Manages a Disk Encryption Set.
 
--> **NOTE:** The DiskEncryptionSet service is currently in public preview and are only available in a limited set of regions. 
+-> **NOTE:** The Disk Encryption Sets are currently in Public Preview and are only available in a limited set of regions. 
+
+-> **NOTE:** At this time the Key Vault used to store the Active Key for this Disk Encryption Set must have both Soft Delete & Purge Protection enabled - which are not yet supported by Terraform - instead you can configure this using [a provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) or [the `azurerm_template_deployment` resource](https://www.terraform.io/docs/providers/azurerm/r/template_deployment.html).
 
 ## Example Usage
 
 ```hcl
 data "azurerm_client_config" "current" {}
 
-resource "azurerm_resource_group" "test" {
-  name     = "des-example-rg"
-  location = "westus2"
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
 }
 
-resource "azurerm_key_vault" "test" {
+resource "azurerm_key_vault" "example" {
   name                = "des-example-keyvault"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
 
   sku_name                = "premium"
@@ -53,9 +55,9 @@ resource "azurerm_key_vault" "test" {
   }
 }
 
-resource "azurerm_key_vault_key" "test" {
+resource "azurerm_key_vault_key" "example" {
   name         = "des-example-key"
-  key_vault_id = azurerm_key_vault.test.id
+  key_vault_id = azurerm_key_vault.example.id
   key_type     = "RSA"
   key_size     = 2048
 
@@ -69,14 +71,12 @@ resource "azurerm_key_vault_key" "test" {
   ]
 }
 
-resource "azurerm_disk_encryption_set" "test" {
+resource "azurerm_disk_encryption_set" "example" {
   name                = "des"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 
-  active_key {
-    source_vault_id = azurerm_key_vault.test.id
-    key_url         = azurerm_key_vault_key.test.id
+  key_vault_key_uri   = azurerm_key_vault_key.example.id
   }
 }
 ```
@@ -85,56 +85,38 @@ resource "azurerm_disk_encryption_set" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the disk encryption set that is being created. The name can't be changed after the disk encryption set is created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Disk Encryption Set. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group in which the Disk Encryption Set should exist. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Disk Encryption Set should exist. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the Azure Region where the Disk Encryption Set exists. Changing this forces a new resource to be created.
 
-* `active_key` - (Required) One `active_key` block defined below.
+* `key_vault_key_uri` - (Required) Specifies the URL to a Key Vault Key (either from a Key Vault Key, or the Key URL for the Key Vault Secret).
+
+-> **NOTE** Access to the KeyVault must be granted for this Disk Encryption Set, if you want to further use this Disk Encryption Set in a Managed Disk or Virtual Machine, or Virtual Machine Scale Set. For instructions, please refer to the doc of [Server side encryption of Azure managed disks](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption).
 
 * `identity` - (Optional) A `identity` block defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the Disk Encryption Set.
 
----
-
-The `active_key` block supports the following:
-
-* `source_vault_id` - (Required) Specifies the resource ID of the KeyVault containing the key or secret.
-
-* `key_url` - (Required) Specifies the URL pointing to a key or secret in KeyVault.
-
--> **NOTE** Access to the KeyVault must be granted for this Disk Encryption Set, if you want to further use this Disk Encryption Set in a Managed Disk or Virtual Machine, or Virtual Machine Scale Set. For instructions, please refer to the doc of [Server side encryption of Azure managed disks](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption).
-
 ## Attributes Reference
 
 The following attributes are exported:
-
-* `previous_keys` - One or more `previous_key` block defined below.
 
 * `id` - The ID of the Disk Encryption Set.
 
 ---
 
-A `identity` block supports the following:
+A `identity` block exports the following:
 
 * `type` - (Required) The Managed Service Identity Type of this Disk Encryption Set. The possible value is `SystemAssigned` (where Azure will generate a Service Principal for you).
 
 ~> **NOTE:** When `type` is set to `SystemAssigned`, identity the Principal ID can be retrieved after the Disk Encryption Set has been created. See [documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview) for additional information.
-
----
-
-The `previous_key` block contains the following:
-
-* `source_vault_id` - (Required) Specifies the resource ID of the KeyVault containing the key or secret.
-
-* `key_url` - (Required) Specifies the URL pointing to a key or secret in KeyVault.
 
 ## Import
 
 Disk Encryption Set can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_disk_encryption_set.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/diskEncryptionSets/des1
+terraform import azurerm_disk_encryption_set.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/diskEncryptionSets/encryptionSet1
 ```

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_disk_encryption_set"
-sidebar_current: "docs-azurerm-resource-disk-encryption-set"
 description: |-
   Manages a Disk Encryption Set.
 ---

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Manages a Disk Encryption Set.
 
--> **NOTE:** The Disk Encryption Sets are currently in Public Preview and are only available in a limited set of regions. 
+-> **NOTE:** The Disk Encryption Sets are currently in Public Preview and are only available in a limited set of regions: West Central US, Canada Central and North Europe. 
 
 -> **NOTE:** At this time the Key Vault used to store the Active Key for this Disk Encryption Set must have both Soft Delete & Purge Protection enabled - which are not yet supported by Terraform - instead you can configure this using [a provisioner](https://www.terraform.io/docs/provisioners/local-exec.html) or [the `azurerm_template_deployment` resource](https://www.terraform.io/docs/providers/azurerm/r/template_deployment.html).
 
@@ -77,7 +77,6 @@ resource "azurerm_disk_encryption_set" "example" {
   location            = azurerm_resource_group.example.location
 
   key_vault_key_uri   = azurerm_key_vault_key.example.id
-  }
 }
 ```
 


### PR DESCRIPTION
This is part of update of the [SSE-CMK feature](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption), adding a new resource and a data source: `azurerm_disk_encryption_set`.

This feature requires Keyvault to enable `enable_soft_delete` and `enable_purge_protection`, which are both not implemented in terraform. And the creation of `azurerm_disk_encryption_set` depends on those two switches, otherwise the service will return errors complaining about this.
Therefore I did some workaround in the test of `azurerm_disk_encryption_set`. I will change the workaround back when these two features are implemented in `azurerm_key_vault`.

Currently the fields that could accept user input in a DiskEncryptionSet is all required, therefore I do not put a complete test, since all the fields are covered in the basic test.