### PR TITLE
New Resource: `azurerm_api_management_identity_provider_aad`

### DIFF
--- a/azurerm/internal/services/apimanagement/client/client.go
+++ b/azurerm/internal/services/apimanagement/client/client.go
@@ -18,6 +18,7 @@ type Client struct {
 	DiagnosticClient           *apimanagement.DiagnosticClient
 	GroupClient                *apimanagement.GroupClient
 	GroupUsersClient           *apimanagement.GroupUserClient
+	IdentityProviderClient     *apimanagement.IdentityProviderClient
 	LoggerClient               *apimanagement.LoggerClient
 	OpenIdConnectClient        *apimanagement.OpenIDConnectProviderClient
 	PolicyClient               *apimanagement.PolicyClient
@@ -69,6 +70,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	groupUsersClient := apimanagement.NewGroupUserClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&groupUsersClient.Client, o.ResourceManagerAuthorizer)
+
+	identityProviderClient := apimanagement.NewIdentityProviderClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&identityProviderClient.Client, o.ResourceManagerAuthorizer)
 
 	loggerClient := apimanagement.NewLoggerClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&loggerClient.Client, o.ResourceManagerAuthorizer)
@@ -122,6 +126,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		DiagnosticClient:           &diagnosticClient,
 		GroupClient:                &groupClient,
 		GroupUsersClient:           &groupUsersClient,
+		IdentityProviderClient:     &identityProviderClient,
 		LoggerClient:               &loggerClient,
 		OpenIdConnectClient:        &openIdConnectClient,
 		PolicyClient:               &policyClient,

--- a/azurerm/internal/services/apimanagement/registration.go
+++ b/azurerm/internal/services/apimanagement/registration.go
@@ -38,6 +38,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_api_management_diagnostic":              resourceArmApiManagementDiagnostic(),
 		"azurerm_api_management_group":                   resourceArmApiManagementGroup(),
 		"azurerm_api_management_group_user":              resourceArmApiManagementGroupUser(),
+		"azurerm_api_management_identity_provider_aad":   resourceArmApiManagementIdentityProviderAAD(),
 		"azurerm_api_management_logger":                  resourceArmApiManagementLogger(),
 		"azurerm_api_management_openid_connect_provider": resourceArmApiManagementOpenIDConnectProvider(),
 		"azurerm_api_management_product":                 resourceArmApiManagementProduct(),

--- a/azurerm/internal/services/apimanagement/resource_arm_api_management_identity_provider_aad.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management_identity_provider_aad.go
@@ -41,7 +41,7 @@ func resourceArmApiManagementIdentityProviderAAD() *schema.Resource {
 			"client_id": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validate.NoEmptyStrings,
+				ValidateFunc: validate.GUID,
 			},
 
 			"client_secret": {
@@ -55,7 +55,8 @@ func resourceArmApiManagementIdentityProviderAAD() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validate.GUID,
 				},
 			},
 		},

--- a/azurerm/internal/services/apimanagement/resource_arm_api_management_identity_provider_aad.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management_identity_provider_aad.go
@@ -1,0 +1,170 @@
+package apimanagement
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementIdentityProviderAAD() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementIdentityProviderAADCreateUpdate,
+		Read:   resourceArmApiManagementIdentityProviderAADRead,
+		Update: resourceArmApiManagementIdentityProviderAADCreateUpdate,
+		Delete: resourceArmApiManagementIdentityProviderAADDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"client_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"client_secret": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"allowed_tenants": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementIdentityProviderAADCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	clientID := d.Get("client_id").(string)
+	clientSecret := d.Get("client_secret").(string)
+	allowedTenants := d.Get("allowed_tenants").([]interface{})
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Aad)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Identity Provider %q (API Management Service %q / Resource Group %q): %s", apimanagement.Aad, serviceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management_identity_provider_aad", *existing.ID)
+		}
+	}
+
+	parameters := apimanagement.IdentityProviderContract{
+		IdentityProviderContractProperties: &apimanagement.IdentityProviderContractProperties{
+			ClientID:       utils.String(clientID),
+			ClientSecret:   utils.String(clientSecret),
+			Type:           apimanagement.Aad,
+			AllowedTenants: utils.ExpandStringSlice(allowedTenants),
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, apimanagement.Aad, parameters, ""); err != nil {
+		return fmt.Errorf("Error creating or updating Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.Aad, resourceGroup, serviceName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Aad)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.Aad, resourceGroup, serviceName, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read ID for Identity Provider %q (Resource Group %q / API Management Service %q)", apimanagement.Aad, resourceGroup, serviceName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmApiManagementIdentityProviderAADRead(d, meta)
+}
+
+func resourceArmApiManagementIdentityProviderAADRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	identityProviderName := id.Path["identityProviders"]
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Identity Provider %q (Resource Group %q / API Management Service %q) was not found - removing from state!", identityProviderName, resourceGroup, serviceName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+	}
+
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("api_management_name", serviceName)
+
+	if props := resp.IdentityProviderContractProperties; props != nil {
+		d.Set("client_id", props.ClientID)
+		d.Set("client_secret", props.ClientSecret)
+		d.Set("allowed_tenants", props.AllowedTenants)
+	}
+
+	return nil
+}
+
+func resourceArmApiManagementIdentityProviderAADDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	identityProviderName := id.Path["identityProviders"]
+
+	if resp, err := client.Delete(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName), ""); err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error deleting Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_identity_provider_aad_test.go
+++ b/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_identity_provider_aad_test.go
@@ -107,7 +107,7 @@ func testCheckAzureRMApiManagementIdentityProviderAADExists(resourceName string)
 func testAccAzureRMApiManagementIdentityProviderAAD_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
+  name     = "acctestRG-api-%d"
   location = "%s"
 }
 

--- a/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_identity_provider_aad_test.go
+++ b/azurerm/internal/services/apimanagement/tests/resource_arm_api_management_identity_provider_aad_test.go
@@ -1,0 +1,146 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMApiManagementIdentityProviderAAD_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aad", "test")
+	config := testAccAzureRMApiManagementIdentityProviderAAD_basic(data)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderAADDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderAADExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderAAD_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aad", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderAADDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderAAD_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderAADExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementIdentityProviderAAD_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementIdentityProviderAADDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_identity_provider_aad" {
+			continue
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Aad)
+
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+	return nil
+}
+
+func testCheckAzureRMApiManagementIdentityProviderAADExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Aad)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Aad, resourceGroup, serviceName)
+			}
+			return fmt.Errorf("Bad: Get on apiManagementIdentityProviderClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApiManagementIdentityProviderAAD_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_aad" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  client_id           = "aadclientid"
+  client_secret       = "aadsecret"
+  allowed_tenants     = ["%s"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
+}
+
+func testAccAzureRMApiManagementIdentityProviderAAD_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementIdentityProviderAAD_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_identity_provider_aad" "import" {
+  resource_group_name = "${azurerm_api_management_identity_provider_aad.test.resource_group_name}"
+  api_management_name = "${azurerm_api_management_identity_provider_aad.test.api_management_name}"
+  client_id           = "${azurerm_api_management_identity_provider_aad.test.client_id}"
+  client_secret	      = "${azurerm_api_management_identity_provider_aad.test.client_secret}"
+  allowed_tenants     = "${azurerm_api_management_identity_provider_aad.test.allowed_tenants}"
+}
+`, template)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -562,6 +562,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/api_management_identity_provider_aad.html">azurerm_api_management_identity_provider_aad</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_logger.html">azurerm_api_management_logger</a>
                 </li>
 

--- a/website/docs/r/api_management_identity_provider_aad.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aad.html.markdown
@@ -21,18 +21,18 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_api_management" "example" {
   name                = "example-apim"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
   publisher_name      = "My Company"
   publisher_email     = "company@terraform.io"
   sku_name            = "Developer_1"
 }
 
-resource "azurerm_api_management_identity_provider_aad" "test" {
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  api_management_name = "${azurerm_api_management.test.name}"
-  client_id           = "aadclientid"
-  client_secret       = "aadsecret"
+resource "azurerm_api_management_identity_provider_aad" "example" {
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  api_management_name = "${azurerm_api_management.example.name}"
+  client_id           = "00000000-0000-0000-0000-000000000000"
+  client_secret       = "00000000000000000000000000000000"
   allowed_tenants     = ["00000000-0000-0000-0000-000000000000"]
 }
 ```

--- a/website/docs/r/api_management_identity_provider_aad.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aad.html.markdown
@@ -14,12 +14,12 @@ Manages an API Management AAD Identity Provider.
 ## Example Usage
 
 ```hcl
-resource "azurerm_resource_group" "test" {
+resource "azurerm_resource_group" "example" {
   name     = "example-resources"
   location = "West Europe"
 }
 
-resource "azurerm_api_management" "test" {
+resource "azurerm_api_management" "example" {
   name                = "example-apim"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -64,5 +64,5 @@ In addition to all arguments above, the following attributes are exported:
 API Management AAD Identity Provider can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_identity_provider_aad.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/aad
+terraform import azurerm_api_management_identity_provider_aad.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/aad
 ```

--- a/website/docs/r/api_management_identity_provider_aad.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aad.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "API Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_aad"
+sidebar_current: "docs-azurerm-resource-api-management-identity-provider-aad"
+description: |-
+  Manages an API Management AAD Identity Provider.
+---
+
+# azurerm_api_management_identity_provider_aad
+
+Manages an API Management AAD Identity Provider.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "example-apim"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_aad" "test" {
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  api_management_name = "${azurerm_api_management.test.name}"
+  client_id           = "aadclientid"
+  client_secret       = "aadsecret"
+  allowed_tenants     = ["00000000-0000-0000-0000-000000000000"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `api_management_name` - (Required) The Name of the API Management Service where this AAD Identity Provider should be created. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+
+* `client_id` - (Required) Client Id of the Application in the AAD Identity Provider.
+
+* `client_secret` - (Required) Client secret of the Application in the AAD Identity Provider.
+
+* `allowed_tenants` - (Required) List of allowed AAD Tenants.
+
+---
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the API Management AAD Identity Provider.
+
+## Import
+
+API Management AAD Identity Provider can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_identity_provider_aad.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/aad
+```


### PR DESCRIPTION
Partially addresses: #5044  

Adds the `azurerm_api_management_identity_provider_aad` resource.

```
=== RUN   TestAccAzureRMApiManagementIdentityProviderAAD_basic
=== PAUSE TestAccAzureRMApiManagementIdentityProviderAAD_basic
=== CONT  TestAccAzureRMApiManagementIdentityProviderAAD_basic
--- PASS: TestAccAzureRMApiManagementIdentityProviderAAD_basic (1989.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/tests 1989.82
```