### PR TITLE
azurerm_api_management_operation - will no longer panic on missing values in `response`

### DIFF
--- a/azurerm/internal/services/apimanagement/resource_arm_api_management_api_operation.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management_api_operation.go
@@ -250,15 +250,27 @@ func expandApiManagementOperationRequestContract(input []interface{}) (*apimanag
 	}
 
 	vs := input[0].(map[string]interface{})
+	if vs == nil {
+		return nil, fmt.Errorf("Error mapping input")
+	}
 	description := vs["description"].(string)
 
 	headersRaw := vs["header"].([]interface{})
+	if headersRaw == nil {
+		return nil, fmt.Errorf("Error mapping `header`")
+	}
 	headers := azure.ExpandApiManagementOperationParameterContract(headersRaw)
 
 	queryParametersRaw := vs["query_parameter"].([]interface{})
+	if queryParametersRaw == nil {
+		return nil, fmt.Errorf("Error mapping `query_parameter`")
+	}
 	queryParameters := azure.ExpandApiManagementOperationParameterContract(queryParametersRaw)
 
 	representationsRaw := vs["representation"].([]interface{})
+	if representationsRaw == nil {
+		return nil, fmt.Errorf("Error mapping `representation`")
+	}
 	representations, err := azure.ExpandApiManagementOperationRepresentation(representationsRaw)
 	if err != nil {
 		return nil, err

--- a/azurerm/internal/services/apimanagement/resource_arm_api_management_api_operation.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management_api_operation.go
@@ -251,25 +251,25 @@ func expandApiManagementOperationRequestContract(input []interface{}) (*apimanag
 
 	vs := input[0].(map[string]interface{})
 	if vs == nil {
-		return nil, fmt.Errorf("Error mapping input")
+		return nil, nil
 	}
 	description := vs["description"].(string)
 
 	headersRaw := vs["header"].([]interface{})
 	if headersRaw == nil {
-		return nil, fmt.Errorf("Error mapping `header`")
+		headersRaw = []interface{}{}
 	}
 	headers := azure.ExpandApiManagementOperationParameterContract(headersRaw)
 
 	queryParametersRaw := vs["query_parameter"].([]interface{})
 	if queryParametersRaw == nil {
-		return nil, fmt.Errorf("Error mapping `query_parameter`")
+		queryParametersRaw = []interface{}{}
 	}
 	queryParameters := azure.ExpandApiManagementOperationParameterContract(queryParametersRaw)
 
 	representationsRaw := vs["representation"].([]interface{})
 	if representationsRaw == nil {
-		return nil, fmt.Errorf("Error mapping `representation`")
+		representationsRaw = []interface{}{}
 	}
 	representations, err := azure.ExpandApiManagementOperationRepresentation(representationsRaw)
 	if err != nil {


### PR DESCRIPTION
Fix panic in 'azurerm_api_management_operation' 

Recreatd #5243 after the changes to the provider organization. 