### PR TITLE
New data source: 'azurerm_signalr_service'

### DIFF
--- a/azurerm/internal/services/signalr/data_source_signalr_service.go
+++ b/azurerm/internal/services/signalr/data_source_signalr_service.go
@@ -1,0 +1,130 @@
+package signalr
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmSignalRService() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmSignalRServiceRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"hostname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"public_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"server_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"primary_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"primary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_access_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceArmSignalRServiceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).SignalR.Client
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] SignalR %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error getting SignalR %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	keys, err := client.ListKeys(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error getting keys of SignalR %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroup)
+
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+
+	if properties := resp.Properties; properties != nil {
+		d.Set("hostname", properties.HostName)
+		d.Set("ip_address", properties.ExternalIP)
+		d.Set("public_port", properties.PublicPort)
+		d.Set("server_port", properties.ServerPort)
+	}
+
+	d.Set("primary_access_key", keys.PrimaryKey)
+	d.Set("primary_connection_string", keys.PrimaryConnectionString)
+	d.Set("secondary_access_key", keys.SecondaryKey)
+	d.Set("secondary_connection_string", keys.SecondaryConnectionString)
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}

--- a/azurerm/internal/services/signalr/data_source_signalr_service.go
+++ b/azurerm/internal/services/signalr/data_source_signalr_service.go
@@ -2,7 +2,6 @@ package signalr
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/azurerm/internal/services/signalr/data_source_signalr_service.go
+++ b/azurerm/internal/services/signalr/data_source_signalr_service.go
@@ -94,9 +94,7 @@ func dataSourceArmSignalRServiceRead(d *schema.ResourceData, meta interface{}) e
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] SignalR %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("SignalR %q was not found in Resource Group %q", name, resourceGroup)
 		}
 		return fmt.Errorf("Error getting SignalR %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}

--- a/azurerm/internal/services/signalr/registration.go
+++ b/azurerm/internal/services/signalr/registration.go
@@ -13,7 +13,9 @@ func (r Registration) Name() string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
-	return map[string]*schema.Resource{}
+	return map[string]*schema.Resource{
+		"azurerm_signalr_service": dataSourceArmSignalRService(),
+	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service

--- a/azurerm/internal/services/signalr/tests/data_source_signalr_service_test.go
+++ b/azurerm/internal/services/signalr/tests/data_source_signalr_service_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccDataSourceAzureRMSignalRService_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_signalr_service", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMSignalRServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMSignalRService_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSignalRServiceExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "hostname"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_port"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "server_port"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "primary_access_key"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "secondary_access_key"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "secondary_connection_string"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMSignalRService_basic(data acceptance.TestData) string {
+	template := testAccAzureRMSignalRService_basic(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_signalr_service" "test" {
+  name                = "${azurerm_signalr_service.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, template)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -411,6 +411,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/providers/azurerm/d/signalr_service.html">azurerm_signalr_service</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/snapshot.html">azurerm_snapshot</a>
                 </li>
 

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -4,7 +4,7 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_signalr_service"
 sidebar_current: "docs-azurerm-datasource-signalr-service"
 description: |-
-  Gets informatino about an existing Azure SignalR service.
+  Gets information about an existing Azure SignalR service.
 ---
 
 # Data Source: azurerm_signalr_service

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_signalr_service"
+sidebar_current: "docs-azurerm-datasource-signalr-service"
+description: |-
+  Gets informatino about an existing Azure SignalR service.
+---
+
+# Data Source: azurerm_signalr_service
+
+Use this data source to access information about an existing Azure SignalR service.
+
+## Example Usage
+
+```hcl
+data "azurerm_signalr_service" "example" {
+  name                = "test-signalr"
+  resource_group_name = "signalr-resource-group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the SignalR service.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the SignalR service is located in.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the SignalR service.
+
+* `hostname` - The FQDN of the SignalR service.
+
+* `ip_address` - The publicly accessible IP of the SignalR service.
+
+* `location` - Specifies the supported Azure location where the SignalR service exists.
+
+* `public_port` - The publicly accessible port of the SignalR service which is designed for browser/client use.
+
+* `server_port` - The publicly accessible port of the SignalR service which is designed for customer server side use.
+
+* `primary_access_key` - The primary access key of the SignalR service.
+
+* `primary_connection_string` - The primary connection string of the SignalR service.
+
+* `secondary_access_key` - The secondary access key of the SignalR service.
+
+* `secondary_connection_string` - The secondary connection string of the SignalR service.


### PR DESCRIPTION
Add data source for _azurerm_signalr_service_

Fix #5247 

--- PASS: TestAccDataSourceAzureRMSignalRService_basic (273.19s)