### PR TITLE
r/storage_account: making the resource group name case sensitive

### DIFF
--- a/azurerm/internal/services/automation/data_source_automation_account.go
+++ b/azurerm/internal/services/automation/data_source_automation_account.go
@@ -25,7 +25,7 @@ func dataSourceArmAutomationAccount() *schema.Resource {
 				Required: true,
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
 
 			"primary_key": {
 				Type:     schema.TypeString,

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -62,7 +62,7 @@ func resourceArmStorageAccount() *schema.Resource {
 				ValidateFunc: ValidateArmStorageAccountName,
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+			"resource_group_name": azure.SchemaResourceGroupName(),
 
 			"location": azure.SchemaLocation(),
 

--- a/azurerm/internal/services/web/data_source_app_service.go
+++ b/azurerm/internal/services/web/data_source_app_service.go
@@ -27,7 +27,7 @@ func dataSourceArmAppService() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
 
 			"location": azure.SchemaLocationForDataSource(),
 


### PR DESCRIPTION
Noticed whilst passing through this was case insensitive when it shouldn't be (afaik) - running the tests (with the changes from #5270) the basic test passes:

```
$ TF_ACC=1 envchain azurerm go test -v ./azurerm/internal/services/storage/tests/ -run=TestAccAzureRMStorageAccount_basic
=== RUN   TestAccAzureRMStorageAccount_basic
=== PAUSE TestAccAzureRMStorageAccount_basic
=== CONT  TestAccAzureRMStorageAccount_basic
--- PASS: TestAccAzureRMStorageAccount_basic (490.60s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/tests	490.642s
```