### PR TITLE
New Data Source/Resource: `azurerm_dedicated_host_group`

### DIFF
--- a/azurerm/internal/services/compute/client/client.go
+++ b/azurerm/internal/services/compute/client/client.go
@@ -8,6 +8,7 @@ import (
 
 type Client struct {
 	AvailabilitySetsClient         *compute.AvailabilitySetsClient
+	DedicatedHostGroupsClient      *compute.DedicatedHostGroupsClient
 	DisksClient                    *compute.DisksClient
 	GalleriesClient                *compute.GalleriesClient
 	GalleryImagesClient            *compute.GalleryImagesClient
@@ -29,6 +30,9 @@ type Client struct {
 func NewClient(o *common.ClientOptions) *Client {
 	availabilitySetsClient := compute.NewAvailabilitySetsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&availabilitySetsClient.Client, o.ResourceManagerAuthorizer)
+
+	dedicatedHostGroupsClient := compute.NewDedicatedHostGroupsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&dedicatedHostGroupsClient.Client, o.ResourceManagerAuthorizer)
 
 	disksClient := compute.NewDisksClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&disksClient.Client, o.ResourceManagerAuthorizer)
@@ -80,6 +84,7 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	return &Client{
 		AvailabilitySetsClient:         &availabilitySetsClient,
+		DedicatedHostGroupsClient:      &dedicatedHostGroupsClient,
 		DisksClient:                    &disksClient,
 		GalleriesClient:                &galleriesClient,
 		GalleryImagesClient:            &galleryImagesClient,

--- a/azurerm/internal/services/compute/data_source_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/data_source_dedicated_host_group.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 
@@ -18,6 +19,10 @@ import (
 func dataSourceArmDedicatedHostGroup() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceArmDedicatedHostGroupRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/azurerm/internal/services/compute/data_source_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/data_source_dedicated_host_group.go
@@ -1,0 +1,98 @@
+package compute
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmDedicatedHostGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmDedicatedHostGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[^_\W][\w-.]{0,78}[\w]$`), ""),
+			},
+
+			"location": azure.SchemaLocationForDataSource(),
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"host_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"platform_fault_domain_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"zones": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostGroupsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroupName := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroupName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Dedicated Host Group %q (Resource Group %q) was not found", name, resourceGroupName)
+		}
+		return fmt.Errorf("Error reading Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroupName, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroupName)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+	if props := resp.DedicatedHostGroupProperties; props != nil {
+		if props.Hosts != nil {
+			var hostIds []string
+			for _, item := range *props.Hosts {
+				hostIds = append(hostIds, *item.ID)
+			}
+			if err := d.Set("host_ids", hostIds); err != nil {
+				return fmt.Errorf("Error setting `hosts`: %+v", err)
+			}
+		}
+		d.Set("platform_fault_domain_count", int(*props.PlatformFaultDomainCount))
+	}
+
+	d.Set("zones", utils.FlattenStringSlice(resp.Zones))
+
+	return nil
+}

--- a/azurerm/internal/services/compute/data_source_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/data_source_dedicated_host_group.go
@@ -30,14 +30,6 @@ func dataSourceArmDedicatedHostGroup() *schema.Resource {
 
 			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
 
-			"host_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-
 			"platform_fault_domain_count": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -80,19 +72,10 @@ func dataSourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 	if props := resp.DedicatedHostGroupProperties; props != nil {
-		if props.Hosts != nil {
-			var hostIds []string
-			for _, item := range *props.Hosts {
-				hostIds = append(hostIds, *item.ID)
-			}
-			if err := d.Set("host_ids", hostIds); err != nil {
-				return fmt.Errorf("Error setting `hosts`: %+v", err)
-			}
-		}
 		d.Set("platform_fault_domain_count", int(*props.PlatformFaultDomainCount))
 	}
 
 	d.Set("zones", utils.FlattenStringSlice(resp.Zones))
 
-	return nil
+	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/azurerm/internal/services/compute/data_source_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/data_source_dedicated_host_group.go
@@ -72,7 +72,11 @@ func dataSourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 	if props := resp.DedicatedHostGroupProperties; props != nil {
-		d.Set("platform_fault_domain_count", int(*props.PlatformFaultDomainCount))
+		platformFaultDomainCount := 0
+		if props.PlatformFaultDomainCount != nil {
+			platformFaultDomainCount = int(*props.PlatformFaultDomainCount)
+		}
+		d.Set("platform_fault_domain_count", platformFaultDomainCount)
 	}
 
 	d.Set("zones", utils.FlattenStringSlice(resp.Zones))

--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -16,6 +16,7 @@ func (r Registration) Name() string {
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_availability_set":          dataSourceArmAvailabilitySet(),
+		"azurerm_dedicated_host_group":      dataSourceArmDedicatedHostGroup(),
 		"azurerm_managed_disk":              dataSourceArmManagedDisk(),
 		"azurerm_image":                     dataSourceArmImage(),
 		"azurerm_platform_image":            dataSourceArmPlatformImage(),
@@ -31,6 +32,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	resources := map[string]*schema.Resource{
 		"azurerm_availability_set":                     resourceArmAvailabilitySet(),
+		"azurerm_dedicated_host_group":                 resourceArmDedicatedHostGroup(),
 		"azurerm_image":                                resourceArmImage(),
 		"azurerm_managed_disk":                         resourceArmManagedDisk(),
 		"azurerm_marketplace_agreement":                resourceArmMarketplaceAgreement(),

--- a/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
@@ -1,0 +1,203 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmDedicatedHostGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDedicatedHostGroupCreate,
+		Read:   resourceArmDedicatedHostGroupRead,
+		Update: resourceArmDedicatedHostGroupUpdate,
+		Delete: resourceArmDedicatedHostGroupDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[^_\W][\w-.]{0,78}[\w]$`), ""),
+			},
+
+			"location": azure.SchemaLocation(),
+
+			// There's a bug in the Azure API where this is returned in upper-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/8068
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+
+			"platform_fault_domain_count": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 3),
+			},
+
+			"zones": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[1-9]\d*$`), ""),
+				},
+				// Currently only one endpoint is allowed.
+				// we'll leave this open to enhancement when they add multiple zones support.
+				MaxItems: 1,
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func resourceArmDedicatedHostGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostGroupsClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroupName := d.Get("resource_group_name").(string)
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroupName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for present of existing Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroupName, err)
+			}
+		}
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_dedicated_host_group", *existing.ID)
+		}
+	}
+
+	location := azure.NormalizeLocation(d.Get("location").(string))
+	platformFaultDomainCount := d.Get("platform_fault_domain_count").(int)
+	t := d.Get("tags").(map[string]interface{})
+
+	parameters := compute.DedicatedHostGroup{
+		Location: utils.String(location),
+		DedicatedHostGroupProperties: &compute.DedicatedHostGroupProperties{
+			PlatformFaultDomainCount: utils.Int32(int32(platformFaultDomainCount)),
+		},
+		Tags: tags.Expand(t),
+	}
+	if zones, ok := d.GetOk("zones"); ok {
+		parameters.Zones = utils.ExpandStringSlice(zones.([]interface{}))
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroupName, name, parameters); err != nil {
+		return fmt.Errorf("Error creating Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroupName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroupName, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroupName, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read Dedicated Host Group %q (Resource Group %q) ID", name, resourceGroupName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmDedicatedHostGroupRead(d, meta)
+}
+
+func resourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostGroupsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroupName := id.ResourceGroup
+	name := id.Path["hostGroups"]
+
+	resp, err := client.Get(ctx, resourceGroupName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Dedicated Host Group %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroupName, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroupName)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+	if props := resp.DedicatedHostGroupProperties; props != nil {
+		d.Set("platform_fault_domain_count", int(*props.PlatformFaultDomainCount))
+	}
+	d.Set("zones", utils.FlattenStringSlice(resp.Zones))
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceArmDedicatedHostGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostGroupsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroupName := d.Get("resource_group_name").(string)
+	t := d.Get("tags").(map[string]interface{})
+
+	parameters := compute.DedicatedHostGroupUpdate{
+		Tags: tags.Expand(t),
+	}
+
+	if _, err := client.Update(ctx, resourceGroupName, name, parameters); err != nil {
+		return fmt.Errorf("Error updating Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroupName, err)
+	}
+
+	return resourceArmDedicatedHostGroupRead(d, meta)
+}
+
+func resourceArmDedicatedHostGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostGroupsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	name := id.Path["hostGroups"]
+
+	if _, err := client.Delete(ctx, resourceGroup, name); err != nil {
+		return fmt.Errorf("Error deleting Dedicated Host Group %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
@@ -147,7 +147,11 @@ func resourceArmDedicatedHostGroupRead(d *schema.ResourceData, meta interface{})
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 	if props := resp.DedicatedHostGroupProperties; props != nil {
-		d.Set("platform_fault_domain_count", int(*props.PlatformFaultDomainCount))
+		platformFaultDomainCount := 0
+		if props.PlatformFaultDomainCount != nil {
+			platformFaultDomainCount = int(*props.PlatformFaultDomainCount)
+		}
+		d.Set("platform_fault_domain_count", platformFaultDomainCount)
 	}
 	d.Set("zones", utils.FlattenStringSlice(resp.Zones))
 

--- a/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
@@ -59,18 +59,9 @@ func resourceArmDedicatedHostGroup() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 3),
 			},
 
-			"zones": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[1-9]\d*$`), ""),
-				},
-				// Currently only one endpoint is allowed.
-				// we'll leave this open to enhancement when they add multiple zones support.
-				MaxItems: 1,
-			},
+			// Currently only one endpoint is allowed.
+			// we'll leave this open to enhancement when they add multiple zones support.
+			"zones": azure.SchemaSingleZone(),
 
 			"tags": tags.Schema(),
 		},

--- a/azurerm/internal/services/compute/tests/data_source_dedicated_host_group_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_dedicated_host_group_test.go
@@ -35,8 +35,8 @@ func testAccDataSourceDedicatedHostGroup_basic(data acceptance.TestData) string 
 %s
 
 data "azurerm_dedicated_host_group" "test" {
-  resource_group_name 	= "${azurerm_dedicated_host_group.test.resource_group_name}"
   name           		= "${azurerm_dedicated_host_group.test.name}"
+  resource_group_name 	= "${azurerm_dedicated_host_group.test.resource_group_name}"
 }
 `, config)
 }

--- a/azurerm/internal/services/compute/tests/data_source_dedicated_host_group_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_dedicated_host_group_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAzureRMDedicatedHostGroup_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_dedicated_host_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDedicatedHostGroup_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostGroupExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "zones.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "zones.0", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain_count", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDedicatedHostGroup_basic(data acceptance.TestData) string {
+	config := testAccAzureRMDedicatedHostGroup_complete(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_dedicated_host_group" "test" {
+  resource_group_name 	= "${azurerm_dedicated_host_group.test.resource_group_name}"
+  name           		= "${azurerm_dedicated_host_group.test.name}"
+}
+`, config)
+}

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_group_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_group_test.go
@@ -137,15 +137,16 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dedicated_host_group" "test" {
+  name							= "acctestDHG-compute-%d"
   resource_group_name			= "${azurerm_resource_group.test.name}"
-  name							= "acctestDHG-compute-%s"
   location						= "${azurerm_resource_group.test.location}"
   platform_fault_domain_count	= 2
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func testAccAzureRMDedicatedHostGroup_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMDedicatedHostGroup_basic(data)
 	return fmt.Sprintf(`
 %s
 resource "azurerm_dedicated_host_group" "import" {
@@ -154,7 +155,7 @@ resource "azurerm_dedicated_host_group" "import" {
   location						= "${azurerm_dedicated_host_group.test.location}"
   platform_fault_domain_count	= 2
 }
-`, testAccAzureRMDedicatedHostGroup_basic(data))
+`, template)
 }
 
 func testAccAzureRMDedicatedHostGroup_complete(data acceptance.TestData) string {
@@ -165,8 +166,8 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dedicated_host_group" "test" {
+  name							= "acctestDHG-compute-%d"
   resource_group_name			= "${azurerm_resource_group.test.name}"
-  name							= "acctestDHG-compute-%s"
   location						= "${azurerm_resource_group.test.location}"
   platform_fault_domain_count	= 2
   zones = ["1"]
@@ -174,5 +175,5 @@ resource "azurerm_dedicated_host_group" "test" {
     ENV = "prod"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_group_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_group_test.go
@@ -53,9 +53,7 @@ func TestAccAzureRMDedicatedHostGroup_requiresImport(t *testing.T) {
 					testCheckAzureRMDedicatedHostGroupExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(func(data acceptance.TestData) string {
-				return testAccAzureRMDedicatedHostGroup_requiresImport(data)
-			}),
+			data.RequiresImportErrorStep(testAccAzureRMDedicatedHostGroup_requiresImport),
 		},
 	})
 }
@@ -139,10 +137,10 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dedicated_host_group" "test" {
-  resource_group_name 			= "${azurerm_resource_group.test.name}"
-  name 							= "acctestDHG-compute-%s"
-  location            			= "${azurerm_resource_group.test.location}"
-  platform_fault_domain_count 	= 2
+  resource_group_name			= "${azurerm_resource_group.test.name}"
+  name							= "acctestDHG-compute-%s"
+  location						= "${azurerm_resource_group.test.location}"
+  platform_fault_domain_count	= 2
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -151,10 +149,10 @@ func testAccAzureRMDedicatedHostGroup_requiresImport(data acceptance.TestData) s
 	return fmt.Sprintf(`
 %s
 resource "azurerm_dedicated_host_group" "import" {
-  resource_group_name = "${azurerm_dedicated_host_group.test.resource_group_name}"
-  name                = "${azurerm_dedicated_host_group.test.name}"
-  location            = "${azurerm_dedicated_host_group.test.location}"
-  platform_fault_domain_count 	= 2
+  resource_group_name			= "${azurerm_dedicated_host_group.test.resource_group_name}"
+  name							= "${azurerm_dedicated_host_group.test.name}"
+  location						= "${azurerm_dedicated_host_group.test.location}"
+  platform_fault_domain_count	= 2
 }
 `, testAccAzureRMDedicatedHostGroup_basic(data))
 }
@@ -167,10 +165,10 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dedicated_host_group" "test" {
-  resource_group_name 			= "${azurerm_resource_group.test.name}"
-  name 							= "acctestDHG-compute-%s"
-  location            			= "${azurerm_resource_group.test.location}"
-  platform_fault_domain_count 	= 2
+  resource_group_name			= "${azurerm_resource_group.test.name}"
+  name							= "acctestDHG-compute-%s"
+  location						= "${azurerm_resource_group.test.location}"
+  platform_fault_domain_count	= 2
   zones = ["1"]
   tags = {
     ENV = "prod"

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_group_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_group_test.go
@@ -1,0 +1,180 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMDedicatedHostGroup_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDedicatedHostGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDedicatedHostGroup_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostGroupExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDedicatedHostGroup_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDedicatedHostGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDedicatedHostGroup_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostGroupExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(func(data acceptance.TestData) string {
+				return testAccAzureRMDedicatedHostGroup_requiresImport(data)
+			}),
+		},
+	})
+}
+
+func TestAccAzureRMDedicatedHostGroup_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDedicatedHostGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDedicatedHostGroup_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostGroupExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "zones.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "zones.0", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain_count", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "tags.ENV", "prod"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testCheckAzureRMDedicatedHostGroupExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Dedicated Host Group not found: %s", resourceName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DedicatedHostGroupsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		if resp, err := client.Get(ctx, resourceGroup, name); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Dedicated Host Group %q (Resource Group %q) does not exist", name, resourceGroup)
+			}
+			return fmt.Errorf("Bad: Get on Compute.DedicatedHostGroupsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMDedicatedHostGroupDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DedicatedHostGroupsClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_dedicated_host_group" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		if resp, err := client.Get(ctx, resourceGroup, name); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Get on Compute.DedicatedHostGroupsClient: %+v", err)
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMDedicatedHostGroup_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-compute-%d"
+  location = "%s"
+}
+
+resource "azurerm_dedicated_host_group" "test" {
+  resource_group_name 			= "${azurerm_resource_group.test.name}"
+  name 							= "acctestDHG-compute-%s"
+  location            			= "${azurerm_resource_group.test.location}"
+  platform_fault_domain_count 	= 2
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMDedicatedHostGroup_requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_dedicated_host_group" "import" {
+  resource_group_name = "${azurerm_dedicated_host_group.test.resource_group_name}"
+  name                = "${azurerm_dedicated_host_group.test.name}"
+  location            = "${azurerm_dedicated_host_group.test.location}"
+  platform_fault_domain_count 	= 2
+}
+`, testAccAzureRMDedicatedHostGroup_basic(data))
+}
+
+func testAccAzureRMDedicatedHostGroup_complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-compute-%d"
+  location = "%s"
+}
+
+resource "azurerm_dedicated_host_group" "test" {
+  resource_group_name 			= "${azurerm_resource_group.test.name}"
+  name 							= "acctestDHG-compute-%s"
+  location            			= "${azurerm_resource_group.test.location}"
+  platform_fault_domain_count 	= 2
+  zones = ["1"]
+  tags = {
+    ENV = "prod"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -171,6 +171,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/providers/azurerm/d/dedicated_host_group.html">azurerm_dedicated_host_group</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/dev_test_lab.html">azurerm_dev_test_lab</a>
                 </li>
 
@@ -834,6 +838,10 @@
               <ul class="nav">
                 <li>
                   <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
+                </li>
+
+                <li>
+                  <a href="/docs/providers/azurerm/r/dedicated_host_group.html">azurerm_dedicated_host_group</a>
                 </li>
 
                 <li>

--- a/website/docs/d/dedicated_host_group.html.markdown
+++ b/website/docs/d/dedicated_host_group.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dedicated_host_group"
+sidebar_current: "docs-azurerm-datasource-dedicated-host-group"
+description: |-
+  Gets information about an existing Dedicated Host Group
+---
+
+# Data Source: azurerm_dedicated_host_group
+
+Use this data source to access information about an existing Dedicated Host Group.
+
+
+## Example Usage
+
+```hcl
+data "azurerm_dedicated_host_group" "example" {
+  resource_group_name = "example-rg"
+  name                = "example-dedicated-host-group" 
+}
+
+output "id" {
+  value = data.azurerm_dedicated_host_group.example.id
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Dedicated Host Group.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the Dedicated Host Group is located in.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Dedicated Host Group.
+
+* `location` - The Azure location where the Dedicated Host Group exists.
+
+* `host_ids` - A list of ID of all dedicated hosts in the Dedicated Host Group.
+
+* `platform_fault_domain_count` - Number of fault domains that the Dedicated Host Group can span.
+
+* `zones` - Availability Zone the Dedicated Host Group is scoped. Only single zone is supported. If it is absent, it means the group is using all zones in the region.
+
+* `tags` - A mapping of tags assigned to the resource.

--- a/website/docs/d/dedicated_host_group.html.markdown
+++ b/website/docs/d/dedicated_host_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dedicated_host_group"
-sidebar_current: "docs-azurerm-datasource-dedicated-host-group"
 description: |-
   Gets information about an existing Dedicated Host Group
 ---
@@ -10,7 +9,6 @@ description: |-
 # Data Source: azurerm_dedicated_host_group
 
 Use this data source to access information about an existing Dedicated Host Group.
-
 
 ## Example Usage
 
@@ -24,7 +22,6 @@ output "id" {
   value = data.azurerm_dedicated_host_group.example.id
 }
 ```
-
 
 ## Argument Reference
 
@@ -43,10 +40,8 @@ The following attributes are exported:
 
 * `location` - The Azure location where the Dedicated Host Group exists.
 
-* `host_ids` - A list of ID of all dedicated hosts in the Dedicated Host Group.
+* `platform_fault_domain_count` - The number of fault domains that the Dedicated Host Group spans.
 
-* `platform_fault_domain_count` - Number of fault domains that the Dedicated Host Group can span.
-
-* `zones` - Availability Zone the Dedicated Host Group is scoped. Only single zone is supported. If it is absent, it means the group is using all zones in the region.
+* `zones` - The Availability Zones in which this Dedicated Host Group is located.
 
 * `tags` - A mapping of tags assigned to the resource.

--- a/website/docs/d/dedicated_host_group.html.markdown
+++ b/website/docs/d/dedicated_host_group.html.markdown
@@ -14,8 +14,8 @@ Use this data source to access information about an existing Dedicated Host Grou
 
 ```hcl
 data "azurerm_dedicated_host_group" "example" {
+  name                = "example-dedicated-host-group"
   resource_group_name = "example-rg"
-  name                = "example-dedicated-host-group" 
 }
 
 output "id" {

--- a/website/docs/r/dedicated_host_group.html.markdown
+++ b/website/docs/r/dedicated_host_group.html.markdown
@@ -19,9 +19,9 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_dedicated_host_group" "example" {
+  name                        = "example-dedicated-host-group"
   resource_group_name         = "${azurerm_resource_group.example.name}"
   location                    = "${azurerm_resource_group.example.location}"
-  name                        = "example-dedicated-host-group-compute"
   platform_fault_domain_count = 1
 }
 ```

--- a/website/docs/r/dedicated_host_group.html.markdown
+++ b/website/docs/r/dedicated_host_group.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dedicated_host_group"
+sidebar_current: "docs-azurerm-resource-dedicated-host-group"
+description: |-
+  Manage Azure DedicatedHostGroup instance.
+---
+
+# azurerm_dedicated_host_group
+
+Manage a Azure Dedicated Host Group instance.
+
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg-compute"
+  location = "West Europe"
+}
+
+resource "azurerm_dedicated_host_group" "example" {
+  resource_group_name         = "${azurerm_resource_group.example.name}"
+  location                    = "${azurerm_resource_group.example.location}"
+  name                        = "example-dedicated-host-group-compute"
+  platform_fault_domain_count = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Dedicated Host Group. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the Dedicated Host Group is located in. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure location where the Dedicated Host Group exists. Changing this forces a new resource to be created.
+
+* `platform_fault_domain_count` - (Required) Number of fault domains that the host group can span. Changing this forces a new resource to be created.
+
+* `zones` - (Optional) Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone. Changing this forces a new resource to be created. 
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Dedicated Host Group.
+
+## Import
+
+Dedicated Host Group can be imported using the `resource id`, e.g.
+
+```shell
+$ terraform import azurerm_dedicated_host_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example-rg/providers/Microsoft.Compute/hostGroups/group1
+```

--- a/website/docs/r/dedicated_host_group.html.markdown
+++ b/website/docs/r/dedicated_host_group.html.markdown
@@ -2,15 +2,13 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dedicated_host_group"
-sidebar_current: "docs-azurerm-resource-dedicated-host-group"
 description: |-
-  Manage Azure DedicatedHostGroup instance.
+  Manage a Dedicated Host Group.
 ---
 
 # azurerm_dedicated_host_group
 
-Manage a Azure Dedicated Host Group instance.
-
+Manage a Dedicated Host Group.
 
 ## Example Usage
 
@@ -38,9 +36,9 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure location where the Dedicated Host Group exists. Changing this forces a new resource to be created.
 
-* `platform_fault_domain_count` - (Required) Number of fault domains that the host group can span. Changing this forces a new resource to be created.
+* `platform_fault_domain_count` - (Required) The number of fault domains that the Dedicated Host Group spans. Changing this forces a new resource to be created.
 
-* `zones` - (Optional) Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone. Changing this forces a new resource to be created. 
+* `zones` - (Optional) A list of Availability Zones in which the Dedicated Host Group should be located. Changing this forces a new resource to be created. 
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Add new resource `dedicated_host_group`, which belongs to Compute Provider.

> A host group is a resource that represents a collection of dedicated hosts. You create a host group in a region and an availability zone, and add hosts to it.

Please refer to this [link](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/dedicated-hosts#groups-hosts-and-vms) for more info.