### PR TITLE
Correct / Clarify App Service Certificate Documentation

### DIFF
--- a/website/docs/r/app_service_certificate.html.markdown
+++ b/website/docs/r/app_service_certificate.html.markdown
@@ -50,7 +50,13 @@ The following arguments are supported:
 
 * `key_vault_secret_id` - (Optional) The ID of the Key Vault secret. Changing this forces a new resource to be created.
 
--> **NOTE:** If using `key_vault_secret_id`, the WebApp Service Resource Principal ID `abfa0a7c-a6b6-4736-8310-5855508787cd` with object_id `f8daea97-62e7-4026-becf-13c2ea98e8b4` of  must have 'Secret -> get' and 'Certificate -> get' permissions on the Key Vault containing the certificate.  (Source: [App Service Blog](https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html))
+-> **NOTE:** If using `key_vault_secret_id`, the WebApp Service Resource Principal ID `abfa0a7c-a6b6-4736-8310-5855508787cd` must have 'Secret -> get' and 'Certificate -> get' permissions on the Key Vault containing the certificate. (Source: [App Service Blog](https://azure.github.io/AppService/2016/05/24/Deploying-Azure-Web-App-Certificate-through-Key-Vault.html)) If you use Terraform to create the access policy you have to specify the Object ID of this Principal. This Object ID can be retrieved via following data reference, since it is different in every AAD Tenant:
+
+```hcl
+data "azuread_service_principal" "MicrosoftWebApp" {
+  application_id = "abfa0a7c-a6b6-4736-8310-5855508787cd"
+}
+```
 
 ## Attributes Reference
 


### PR DESCRIPTION
Hi,
I made a mistake in my last doc update. It turns out that the Object ID is different in each Azure Active Directory Tenant. Therefore the comment is incorrect and can lead to more confusion. I tried to make it clearer that the Object ID is needed, especially if the KeyVault access policy is created with Terraform AzureRM and that the correct information can be retrieved by the AAD Service Principal Data Source, this works for every Tenant.

Sorry for any inconvenience this caused.