### PR TITLE
azurerm_storage_account - fix performance issue for accounts that don't support queues 

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1240,6 +1240,10 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// queue is only available for certain tier and kind (as specified below)
+	if resp.Sku == nil {
+		return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): `sku` was nil", name, resourceGrup)
+	}
+	
 	if resp.Sku.Tier == storage.Standard {
 		if resp.Kind == storage.Storage || resp.Kind == storage.StorageV2 {
 			queueClient, err := storageClient.QueuesClient(ctx, *account)

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1241,7 +1241,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 	// queue is only available for certain tier and kind (as specified below)
 	if resp.Sku == nil {
-		return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): `sku` was nil", name, resourceGrup)
+		return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): `sku` was nil", name, resGroup)
 	}
 
 	if resp.Sku.Tier == storage.Standard {

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1239,20 +1239,25 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	queueClient, err := storageClient.QueuesClient(ctx, *account)
-	if err != nil {
-		return fmt.Errorf("Error building Queues Client: %s", err)
-	}
+	// queue is only available for certain tier and kind (as specified below)
+	if resp.Sku.Tier == storage.Standard {
+		if resp.Kind == storage.Storage || resp.Kind == storage.StorageV2 {
+			queueClient, err := storageClient.QueuesClient(ctx, *account)
+			if err != nil {
+				return fmt.Errorf("Error building Queues Client: %s", err)
+			}
 
-	queueProps, err := queueClient.GetServiceProperties(ctx, name)
-	if err != nil {
-		if queueProps.Response.Response != nil && !utils.ResponseWasNotFound(queueProps.Response) {
-			return fmt.Errorf("Error reading queue properties for AzureRM Storage Account %q: %+v", name, err)
+			queueProps, err := queueClient.GetServiceProperties(ctx, name)
+			if err != nil {
+				if queueProps.Response.Response != nil && !utils.ResponseWasNotFound(queueProps.Response) {
+					return fmt.Errorf("Error reading queue properties for AzureRM Storage Account %q: %+v", name, err)
+				}
+			}
+
+			if err := d.Set("queue_properties", flattenQueueProperties(queueProps)); err != nil {
+				return fmt.Errorf("Error setting `queue_properties `for AzureRM Storage Account %q: %+v", name, err)
+			}
 		}
-	}
-
-	if err := d.Set("queue_properties", flattenQueueProperties(queueProps)); err != nil {
-		return fmt.Errorf("Error setting `queue_properties `for AzureRM Storage Account %q: %+v", name, err)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1243,7 +1243,7 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 	if resp.Sku == nil {
 		return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): `sku` was nil", name, resourceGrup)
 	}
-	
+
 	if resp.Sku.Tier == storage.Standard {
 		if resp.Kind == storage.Storage || resp.Kind == storage.StorageV2 {
 			queueClient, err := storageClient.QueuesClient(ctx, *account)


### PR DESCRIPTION
Not all storage account supports queue. Without this condition, user with unsupported kind will suffer a block (for about 10min) while reading the resource. 