### PR TITLE
azurerm_api_management_operation - will no longer panic on missing values in `request` 

### DIFF
--- a/azurerm/internal/services/apimanagement/resource_arm_api_management_api_operation.go
+++ b/azurerm/internal/services/apimanagement/resource_arm_api_management_api_operation.go
@@ -245,7 +245,7 @@ func resourceArmApiManagementApiOperationDelete(d *schema.ResourceData, meta int
 }
 
 func expandApiManagementOperationRequestContract(input []interface{}) (*apimanagement.RequestContract, error) {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Actually fix the panic correctly this time as referenced in [PR 5273](https://github.com/terraform-providers/terraform-provider-azurerm/pull/5273)

The following configuration was providing the following plan:

```
variable "query_parameters" {
  type = list(object({
    name        = string
    type        = string
    description = string
    required    = bool
  }))
  default     = []
  description = "The query parameters definition"
}

resource "azurerm_api_management_api_operation" "test-operation2" {
  operation_id        = "testoperation"
  api_name            = "testEndpoint"
  api_management_name = "${module.api_management.api_management_name}"
  resource_group_name = "${azurerm_resource_group.resource_group.name}"

  display_name = "testOperation2"
  method       = "GET"
  url_template = "/cause/a/crash"
  description  = "An endpoint that will find a bug"

  request {
    dynamic "query_parameter" {
      for_each = var.query_parameters

      content {
        name        = query_parameter.value.name
        type        = query_parameter.value.type
        required    = query_parameter.value.required
        description = query_parameter.value.description
        default_value = ""
        values        = []
      }
    }
  }

  dynamic "template_parameter" {
    for_each = var.url_template_parameters

    content {
      name          = template_parameter.value.name
      type          = template_parameter.value.type
      required      = template_parameter.value.required
      description   = template_parameter.value.description
      default_value = ""
      values        = []
    }
  }
}
```

```
   + resource "azurerm_api_management_api_operation" "test-operation2" {
       + api_management_name = "testapim"
       + api_name            = "test"
       + description         = "An endpoint that will find a bug"
       + display_name        = "testOperation2"
       + id                  = (known after apply)
       + method              = "GET"
       + operation_id        = "testoperation"
       + resource_group_name = "jack-test-rg"
       + url_template        = "/cause/a/crash"

       + request {
         }
     }
```

With the important thing being the empty **request** object. The error handling I added previously did not actually fix this correctly. I confirmed by compiling the provider locally and using the compiled provider.