### PR TITLE
azurerm_function_app: convert `connection_string`s from a `TypList` to a `TypeSet` (#3596)

### DIFF
--- a/azurerm/internal/services/web/resource_arm_function_app.go
+++ b/azurerm/internal/services/web/resource_arm_function_app.go
@@ -800,7 +800,7 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 }
 
 func expandFunctionAppConnectionStrings(d *schema.ResourceData) map[string]*web.ConnStringValueTypePair {
-	input := d.Get("connection_string").(*schema.Set).([]interface{})
+	input := d.Get("connection_string").(*schema.Set).List()
 	output := make(map[string]*web.ConnStringValueTypePair, len(input))
 
 	for _, v := range input {

--- a/azurerm/internal/services/web/resource_arm_function_app.go
+++ b/azurerm/internal/services/web/resource_arm_function_app.go
@@ -800,7 +800,7 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 }
 
 func expandFunctionAppConnectionStrings(d *schema.ResourceData) map[string]*web.ConnStringValueTypePair {
-	input := d.Get("connection_string").([]interface{})
+	input := d.Get("connection_string").(*schema.Set).([]interface{})
 	output := make(map[string]*web.ConnStringValueTypePair, len(input))
 
 	for _, v := range input {

--- a/azurerm/internal/services/web/resource_arm_function_app.go
+++ b/azurerm/internal/services/web/resource_arm_function_app.go
@@ -97,7 +97,7 @@ func resourceArmFunctionApp() *schema.Resource {
 			},
 
 			"connection_string": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{


### PR DESCRIPTION
Converted function app connection strings to Set, as it was previously done for app service
#3596

Fixes #3596