### PR TITLE
Create MongoDB v3.6 with azurerm_cosmosdb_account (#4757)

### DIFF
--- a/azurerm/internal/services/cosmos/resource_arm_cosmosdb_account.go
+++ b/azurerm/internal/services/cosmos/resource_arm_cosmosdb_account.go
@@ -211,6 +211,7 @@ func resourceArmCosmosDbAccount() *schema.Resource {
 								"EnableTable",
 								"EnableGremlin",
 								"EnableCassandra",
+								"EnableMongo",
 								"EnableAggregationPipeline",
 								"MongoDBv3.4",
 								"mongoEnableDocLevelTTL",
@@ -397,21 +398,6 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	//for some reason capabilities doesn't always work on create, so lets patch it
-	//tracked: https://github.com/Azure/azure-sdk-for-go/issues/2864
-	future, err := client.Patch(ctx, resourceGroup, name, documentdb.DatabaseAccountPatchParameters{
-		DatabaseAccountPatchProperties: &documentdb.DatabaseAccountPatchProperties{
-			Capabilities: account.Capabilities,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("Error Patching CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-
-	if err := future.WaitForCompletionRef(context.Background(), client.Client); err != nil {
-		return fmt.Errorf("Error waiting on patch future CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-
 	id := resp.ID
 	if id == nil {
 		return fmt.Errorf("Cannot read CosmosDB Account '%s' (resource group %s) ID", name, resourceGroup)
@@ -548,21 +534,6 @@ func resourceArmCosmosDbAccountUpdate(d *schema.ResourceData, meta interface{}) 
 	id := (*upsertResponse).ID
 	if id == nil {
 		return fmt.Errorf("Cannot read CosmosDB Account '%s' (resource group %s) ID", name, resourceGroup)
-	}
-
-	//for some reason capabilities doesn't always work on create, so lets patch it
-	//tracked: https://github.com/Azure/azure-sdk-for-go/issues/2864
-	future, err := client.Patch(ctx, resourceGroup, name, documentdb.DatabaseAccountPatchParameters{
-		DatabaseAccountPatchProperties: &documentdb.DatabaseAccountPatchProperties{
-			Capabilities: account.Capabilities,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("Error Patching CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
-	}
-
-	if err := future.WaitForCompletionRef(context.Background(), client.Client); err != nil {
-		return fmt.Errorf("Error waiting on patch future CosmosDB Account %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	d.SetId(*id)

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 `capabilities` Configures the capabilities to enable for this Cosmos DB account:
 
-* `name` - (Required) The capability to enable - Possible values are `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableTable`, `MongoDBv3.4`, and `mongoEnableDocLevelTTL`.
+* `name` - (Required) The capability to enable - Possible values are `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`,`EnableMongo`, `EnableTable`, `MongoDBv3.4`, and `mongoEnableDocLevelTTL`.
 
 **NOTE:** The `prefix` and `failover_priority` fields of a location cannot be changed for the location with a failover priority of `0`.
 


### PR DESCRIPTION
Fixes #4757 for service/cosmosdb

FWIW, in #4757 are also validations mentioned. I'm looking into implementing these, but I'm not sure wheter these should be here in a custom validate function or not. If they should be here, the question is if I should break the existing contract to implement these (with more validations) in the schema:

```
"capabilities": {
	Type:     schema.TypeSet,
	Optional: true,
	Elem: &schema.Resource{
		Schema: map[string]*schema.Schema{
			"EnableMongo": {
				Type:     schema.TypeBool,
				Optional: true,
				Default:  false,
			},
..
```