### PR TITLE
provider docs: remove deprecated `sidebar_current` YAML property

### DIFF
--- a/website/docs/d/api_management.html.markdown
+++ b/website/docs/d/api_management.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management"
-sidebar_current: "docs-azurerm-datasource-api-management-x"
 description: |-
   Gets information about an existing API Management Service.
 ---

--- a/website/docs/d/api_management_api.html.markdown
+++ b/website/docs/d/api_management_api.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api"
-sidebar_current: "docs-azurerm-datasource-azurerm-api-management-api-x"
 description: |-
   Gets information about an existing API Management API.
 ---

--- a/website/docs/d/api_management_group.html.markdown
+++ b/website/docs/d/api_management_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_group"
-sidebar_current: "docs-azurerm-datasource-api-management-group"
 description: |-
   Gets information about an existing API Management Group.
 ---

--- a/website/docs/d/api_management_product.html.markdown
+++ b/website/docs/d/api_management_product.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_product"
-sidebar_current: "docs-azurerm-datasource-api-management-product"
 description: |-
   Gets information about an existing API Management Product.
 ---

--- a/website/docs/d/api_management_user.html.markdown
+++ b/website/docs/d/api_management_user.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_user"
-sidebar_current: "docs-azurerm-datasource-api-management-user"
 description: |-
   Gets information about an existing API Management User.
 ---

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service"
-sidebar_current: "docs-azurerm-datasource-app-service-x"
 description: |-
   Gets information about an existing App Service.
 ---

--- a/website/docs/d/app_service_certificate.html.markdown
+++ b/website/docs/d/app_service_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_certificate"
-sidebar_current: "docs-azurerm-datasource-app-service-certificate"
 description: |-
   Gets information about an App Service certificate.
 

--- a/website/docs/d/app_service_certificate_order.html.markdown
+++ b/website/docs/d/app_service_certificate_order.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_certificate_order"
-sidebar_current: "docs-azurerm-datasource-app-service-x"
 description: |-
   Gets information about an existing App Service Certificate Order.
 ---

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_plan"
-sidebar_current: "docs-azurerm-datasource-app-service-plan"
 description: |-
   Gets information about an existing App Service Plan.
 ---

--- a/website/docs/d/application_insights.html.markdown
+++ b/website/docs/d/application_insights.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Application Insights"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_insights"
-sidebar_current: "docs-azurerm-datasource-application-insights"
 description: |-
   Gets information about an existing Application Insights component.
 ---

--- a/website/docs/d/application_security_group.html.markdown
+++ b/website/docs/d/application_security_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_security_group"
-sidebar_current: "docs-azurerm-datasource-network-application-security-group"
 description: |-
   Gets information about an existing Application Security Group.
 ---

--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_account"
-sidebar_current: "docs-azurerm-datasource-automation"
 description: |-
   Gets information about an existing Automation Account.
 ---

--- a/website/docs/d/automation_variable_bool.html.markdown
+++ b/website/docs/d/automation_variable_bool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_bool"
-sidebar_current: "docs-azurerm-datasource-automation-variable-bool"
 description: |-
   Gets information about an existing Automation Bool Variable
 ---

--- a/website/docs/d/automation_variable_datetime.html.markdown
+++ b/website/docs/d/automation_variable_datetime.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_datetime"
-sidebar_current: "docs-azurerm-datasource-automation-variable-datetime"
 description: |-
   Gets information about an existing Automation Datetime Variable
 ---

--- a/website/docs/d/automation_variable_int.html.markdown
+++ b/website/docs/d/automation_variable_int.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_int"
-sidebar_current: "docs-azurerm-datasource-automation-variable-int"
 description: |-
   Gets information about an existing Automation Int Variable
 ---

--- a/website/docs/d/automation_variable_string.html.markdown
+++ b/website/docs/d/automation_variable_string.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_string"
-sidebar_current: "docs-azurerm-datasource-automation-variable-string"
 description: |-
   Gets information about an existing Automation String Variable
 ---

--- a/website/docs/d/availability_set.html.markdown
+++ b/website/docs/d/availability_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_availability_set"
-sidebar_current: "docs-azurerm-datasource-availability-set"
 description: |-
   Gets information about an existing Availability Set.
 ---

--- a/website/docs/d/azuread_application.html.markdown
+++ b/website/docs/d/azuread_application.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Azure Active Directory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_application"
-sidebar_current: "docs-azurerm-datasource-azuread-application"
 description: |-
   Gets information about an existing Application within Azure Active Directory.
 ---

--- a/website/docs/d/azuread_service_principal.html.markdown
+++ b/website/docs/d/azuread_service_principal.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Azure Active Directory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_service_principal"
-sidebar_current: "docs-azurerm-datasource-azuread-service-principal"
 description: |-
   Gets information about an existing Service Principal associated with an Application within Azure Active Directory.
 

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_account"
-sidebar_current: "docs-azurerm-datasource-batch-account"
 description: |-
   Get information about an existing Batch Account
 

--- a/website/docs/d/batch_certificate.html.markdown
+++ b/website/docs/d/batch_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_certificate"
-sidebar_current: "docs-azurerm-datasource-batch-certificate"
 description: |-
   Get information about an existing certificate in a Batch Account
 

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_pool"
-sidebar_current: "docs-azurerm-datasource-batch-pool"
 description: |-
   Get information about an existing Azure Batch pool.
 

--- a/website/docs/d/builtin_role_definition.markdown
+++ b/website/docs/d/builtin_role_definition.markdown
@@ -2,7 +2,6 @@
 subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_builtin_role_definition"
-sidebar_current: "docs-azurerm-datasource-builtin-role-definition"
 description: |-
   Get information about an existing built-in Role Definition.
 ---

--- a/website/docs/d/cdn_profile.html.markdown
+++ b/website/docs/d/cdn_profile.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_profile"
-sidebar_current: "docs-azurerm-datasource-cdn-profile"
 description: |-
   Gets information about an existing CDN Profile
 ---

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_client_config"
-sidebar_current: "docs-azurerm-datasource-client-config"
 description: |-
   Gets information about the configuration of the azurerm provider.
 ---

--- a/website/docs/d/container_registry.markdown
+++ b/website/docs/d/container_registry.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_container_registry"
-sidebar_current: "docs-azurerm-datasource-container-registry"
 description: |-
   Get information about an existing Container Registry
 

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_account"
-sidebar_current: "docs-azurerm-datasource-cosmosdb-account"
 description: |-
   Gets information about the specified CosmosDB (formally DocumentDB) Account.
 ---

--- a/website/docs/d/data_factory.html.markdown
+++ b/website/docs/d/data_factory.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory"
-sidebar_current: "docs-azurerm-datasource-data-factory-x"
 description: |-
   Manages an Azure Data Factory (Version 2).
 ---

--- a/website/docs/d/data_lake_store.html.markdown
+++ b/website/docs/d/data_lake_store.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Lake"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_lake_store"
-sidebar_current: "docs-azurerm-datasource-data-lake-store"
 description: |-
   Gets information about an existing Data Lake Store
 

--- a/website/docs/d/dev_test_lab.html.markdown
+++ b/website/docs/d/dev_test_lab.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_lab"
-sidebar_current: "docs-azurerm-datasource-dev-test-lab"
 description: |-
   Gets information about an existing Dev Test Lab.
 ---

--- a/website/docs/d/dev_test_virtual_network.html.markdown
+++ b/website/docs/d/dev_test_virtual_network.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_virtual_network"
-sidebar_current: "docs-azurerm-datasource-dev-test-virtual-network"
 description: |-
   Gets information about an existing Dev Test Lab Virtual Network.
 ---

--- a/website/docs/d/dns_zone.html.markdown
+++ b/website/docs/d/dns_zone.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_zone"
-sidebar_current: "docs-azurerm-datasource-dns-zone"
 description: |-
   Gets information about an existing DNS Zone.
 

--- a/website/docs/d/eventhub_namespace.html.markdown
+++ b/website/docs/d/eventhub_namespace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub_namespace"
-sidebar_current: "docs-azurerm-datasource-eventhub-namespace"
 description: |-
   Gets information about an existing EventHub Namespace.
 ---

--- a/website/docs/d/express_route_circuit.html.markdown
+++ b/website/docs/d/express_route_circuit.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_express_route_circuit"
-sidebar_current: "docs-azurerm-datasource-express-route-circuit"
 description: |-
   Gets information about an existing ExpressRoute circuit.
 ---

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_firewall"
-sidebar_current: "docs-azurerm-datasource-firewall"
 description: |-
   Gets information about an existing Azure Firewall.
 

--- a/website/docs/d/hdinsight_cluster.html.markdown
+++ b/website/docs/d/hdinsight_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_cluster"
-sidebar_current: "docs-azurerm-datasource-hdinsight-cluster"
 description: |-
   Gets information about an existing HDInsight Cluster.
 

--- a/website/docs/d/healthcare_service.html.markdown
+++ b/website/docs/d/healthcare_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Healthcare"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_healthcare_service"
-sidebar_current: "docs-azurerm-datasource-healthcare-service-x"
 description: |-
   Get information about an existing Healthcare Service
 ---

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_image"
-sidebar_current: "docs-azurerm-datasource-image"
 description: |-
   Gets information about an existing Image
 

--- a/website/docs/d/key_vault.html.markdown
+++ b/website/docs/d/key_vault.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault"
-sidebar_current: "docs-azurerm-datasource-key-vault-x"
 description: |-
   Gets information about a Key Vault.
 ---

--- a/website/docs/d/key_vault_access_policy.html.markdown
+++ b/website/docs/d/key_vault_access_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_access_policy"
-sidebar_current: "docs-azurerm-datasource-key-vault-access-policy"
 description: |-
   Get information about the templated Access Policies for Key Vault.
 ---

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_key"
-sidebar_current: "docs-azurerm-datasource-key-vault-key"
 description: |-
   Gets information about an existing Key Vault Key.
 

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_secret"
-sidebar_current: "docs-azurerm-datasource-key-vault-secret"
 description: |-
   Gets information about an existing Key Vault Secret.
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_cluster"
-sidebar_current: "docs-azurerm-data-source-kubernetes-cluster"
 description: |-
   Gets information about an existing Managed Kubernetes Cluster (AKS)
 ---

--- a/website/docs/d/kubernetes_service_versions.html.markdown
+++ b/website/docs/d/kubernetes_service_versions.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_service_versions"
-sidebar_current: "docs-azurerm-datasource-kubernetes-service-versions"
 description: |-
   Gets the available versions of Kubernetes supported by Azure Kubernetes Service.
 ---

--- a/website/docs/d/loadbalancer.html.markdown
+++ b/website/docs/d/loadbalancer.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb"
-sidebar_current: "docs-azurerm-datasource-load-balancer-x"
 description: |-
   Get information about an existing Load Balancer
 

--- a/website/docs/d/loadbalancer_backend_address_pool.html.markdown
+++ b/website/docs/d/loadbalancer_backend_address_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_backend_address_pool"
-sidebar_current: "docs-azurerm-datasource-load-balancer-backend-address-pool"
 description: |-
   Get information about an existing Load Balancer Backend Address Pool
 

--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Log Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_log_analytics_workspace"
-sidebar_current: "docs-azurerm-datasource-oms-log-analytics-workspace"
 description: |-
   Gets information about an existing Log Analytics (formally Operational Insights) Workspace.
 ---

--- a/website/docs/d/logic_app_workflow.html.markdown
+++ b/website/docs/d/logic_app_workflow.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_workflow"
-sidebar_current: "docs-azurerm-data-source-logic-app-workflow"
 description: |-
   Gets information about an existing Logic App Workflow.
 ---

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_managed_disk"
-sidebar_current: "docs-azurerm-datasource-managed-disk"
 description: |-
   Get information about an existing Managed Disk.
 ---

--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_management_group"
-sidebar_current: "docs-azurerm-datasource-management-group"
 description: |-
   Gets information about an existing Management Group.
 ---

--- a/website/docs/d/maps_account.html.markdown
+++ b/website/docs/d/maps_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Maps"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_maps_account"
-sidebar_current: "docs-azurerm-datasource-maps-account"
 description: |-
   Gets information about an existing Azure Maps Account.
 ---

--- a/website/docs/d/monitor_action_group.html.markdown
+++ b/website/docs/d/monitor_action_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_action_group"
-sidebar_current: "docs-azurerm-datasource-monitor-action-group"
 description: |-
   Get information about the specified Action Group.
 ---

--- a/website/docs/d/monitor_diagnostic_categories.html.markdown
+++ b/website/docs/d/monitor_diagnostic_categories.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_diagnostic_categories"
-sidebar_current: "docs-azurerm-datasource-monitor-diagnostic-categories"
 description: |-
   Gets information about an the Monitor Diagnostics Categories supported by an existing Resource.
 

--- a/website/docs/d/monitor_log_profile.html.markdown
+++ b/website/docs/d/monitor_log_profile.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_log_profile"
-sidebar_current: "docs-azurerm-datasource-monitor-log-profile"
 description: |-
   Get information about the specified Log Profile.
 ---

--- a/website/docs/d/mssql_elasticpool.html.markdown
+++ b/website/docs/d/mssql_elasticpool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mssql_elasticpool"
-sidebar_current: "docs-azurerm-datasource-mssql-elasticpool"
 description: |-
   Gets information about an existing SQL elastic pool.
 ---

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nat_gateway"
-sidebar_current: "docs-azurerm-datasource-nat-gateway"
 description: |-
   Gets information about an existing NAT Gateway
 ---

--- a/website/docs/d/netapp_account.html.markdown
+++ b/website/docs/d/netapp_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_account"
-sidebar_current: "docs-azurerm-datasource-netapp-account"
 description: |-
   Gets information about an existing NetApp Account
 ---

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_pool"
-sidebar_current: "docs-azurerm-datasource-netapp-pool"
 description: |-
 Gets information about an existing NetApp Pool
 ---

--- a/website/docs/d/netapp_snapshot.html.markdown
+++ b/website/docs/d/netapp_snapshot.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_snapshot"
-sidebar_current: "docs-azurerm-datasource-netapp-snapshot"
 description: |-
 Gets information about an existing NetApp Snapshot
 ---

--- a/website/docs/d/netapp_volume.html.markdown
+++ b/website/docs/d/netapp_volume.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_volume"
-sidebar_current: "docs-azurerm-datasource-netapp-volume"
 description: |-
 Gets information about an existing NetApp Volume
 ---

--- a/website/docs/d/network_ddos_protection_plan.html.markdown
+++ b/website/docs/d/network_ddos_protection_plan.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_ddos_protection_plan"
-sidebar_current: "docs-azurerm-datasource-network-ddos-protection-plan-x"
 description: |-
   Use this data source to access information about an existing Azure Network DDoS Protection Plan.
 

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_interface"
-sidebar_current: "docs-azurerm-datasource-network-interface"
 description: |-
   Gets information about an existing Network Interface.
 ---

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_security_group"
-sidebar_current: "docs-azurerm-datasource-network-security-group"
 description: |-
   Gets information about an existing Network Security Group.
 ---

--- a/website/docs/d/network_watcher.html.markdown
+++ b/website/docs/d/network_watcher.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_watcher"
-sidebar_current: "docs-azurerm-datasource-network-watcher"
 description: |-
   Gets information about an existing Network Watcher.
 ---

--- a/website/docs/d/notification_hub.html.markdown
+++ b/website/docs/d/notification_hub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_notification_hub"
-sidebar_current: "docs-azurerm-datasource-notification-hub-x"
 description: |-
   Gets information about an existing Notification Hub within a Notification Hub Namespace.
 ---

--- a/website/docs/d/notification_hub_namespace.html.markdown
+++ b/website/docs/d/notification_hub_namespace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_notification_hub_namespace"
-sidebar_current: "docs-azurerm-datasource-notification-hub-namespace"
 description: |-
   Gets information about an existing Notification Hub Namespace.
 ---

--- a/website/docs/d/platform_image.html.markdown
+++ b/website/docs/d/platform_image.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_platform_image"
-sidebar_current: "docs-azurerm-datasource-platform-image"
 description: |-
   Gets information about a Platform Image.
 ---

--- a/website/docs/d/policy_definition.markdown
+++ b/website/docs/d/policy_definition.markdown
@@ -2,7 +2,6 @@
 subcategory: "Policy"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_definition"
-sidebar_current: "docs-azurerm-datasource-policy-definition"
 description: |-
   Get information about a Policy Definition.
 ---

--- a/website/docs/d/postgresql_server.html.markdown
+++ b/website/docs/d/postgresql_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_postgresql_server"
-sidebar_current: "docs-azurerm-datasource-postgresql-server"
 description: |-
   Gets information about an existing PostgreSQL Azure Database Server.
 ---

--- a/website/docs/d/private_endpoint_connection.html.markdown
+++ b/website/docs/d/private_endpoint_connection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_endpoint_connection"
-sidebar_current: "docs-azurerm-datasource-private-endpoint-connection"
 description: |-
   Gets the connecton status information about an existing Private Endpoint
 ---

--- a/website/docs/d/private_link_endpoint_connection.html.markdown
+++ b/website/docs/d/private_link_endpoint_connection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_endpoint_connection"
-sidebar_current: "docs-azurerm-datasource-private-endpoint-connection"
 description: |-
   Gets the connecton status information about an existing Private Link Endpoint
 ---

--- a/website/docs/d/private_link_service.html.markdown
+++ b/website/docs/d/private_link_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_service"
-sidebar_current: "docs-azurerm-datasource-private-link-service"
 description: |-
   Use this data source to access information about an existing Private Link Service.
 ---

--- a/website/docs/d/private_link_service_endpoint_connections.html.markdown
+++ b/website/docs/d/private_link_service_endpoint_connections.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_service_endpoint_connections"
-sidebar_current: "docs-azurerm-datasource-private-link-service-endpoint-connections"
 description: |-
   Use this data source to access endpoint connection information about an existing Private Link Service.
 ---

--- a/website/docs/d/proximity_placement_group.html.markdown
+++ b/website/docs/d/proximity_placement_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_proximity_placement_group"
-sidebar_current: "docs-azurerm-datasource-proximity-placement-group"
 description: |-
   Gets information about an existing Proximity Placement Group.
 ---

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ip"
-sidebar_current: "docs-azurerm-datasource-public-ip-x"
 description: |-
   Gets information about an existing Public IP Address.
 

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ip_prefix"
-sidebar_current: "docs-azurerm-datasource-public-ip-prefix-x"
 description: |-
   Gets information about an existing Public IP Prefix.
 

--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ips"
-sidebar_current: "docs-azurerm-datasource-public-ips"
 description: |-
   Gets information about a set of existing Public IP Addresses.
 ---

--- a/website/docs/d/recovery_services_protection_policy_vm.markdown
+++ b/website/docs/d/recovery_services_protection_policy_vm.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_protection_policy_vm"
-sidebar_current: "docs-azurerm-datasource-recovery-services-protection-policy-vm"
 description: |-
   Gets information about an existing Recovery Services VM Protection Policy.
 ---

--- a/website/docs/d/recovery_services_vault.markdown
+++ b/website/docs/d/recovery_services_vault.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_vault"
-sidebar_current: "docs-azurerm-datasource-recovery-services-vault"
 description: |-
   Gets information about an existing Recovery Services Vault.
 ---

--- a/website/docs/d/redis_cache.html.markdown
+++ b/website/docs/d/redis_cache.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Redis"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_redis_cache"
-sidebar_current: "docs-azurerm-datasource-redis-cache"
 description: |-
   Gets information about an existing Azure Redis Cache.
 

--- a/website/docs/d/resource_group.html.markdown
+++ b/website/docs/d/resource_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_resource_group"
-sidebar_current: "docs-azurerm-datasource-resource-group"
 description: |-
   Gets information about an existing Resource Group.
 ---

--- a/website/docs/d/resources.html.markdown
+++ b/website/docs/d/resources.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_resources"
-sidebar_current: "docs-azurerm-datasource-resources"
 description: |-
   Gets information about an existing Resources.
 ---

--- a/website/docs/d/role_definition.markdown
+++ b/website/docs/d/role_definition.markdown
@@ -2,7 +2,6 @@
 subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_role_definition"
-sidebar_current: "docs-azurerm-datasource-role-definition"
 description: |-
   Get information about an existing Role Definition.
 ---

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_route_table"
-sidebar_current: "docs-azurerm-data-source-route-table"
 description: |-
   Gets information about an existing Route Table
 

--- a/website/docs/d/scheduler_job_collection.html.markdown
+++ b/website/docs/d/scheduler_job_collection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Scheduler"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_scheduler_job_collection"
-sidebar_current: "docs-azurerm-datasource-scheduler-job-collection"
 description: |-
   Gets information about an existing Scheduler Job Collection.
 ---

--- a/website/docs/d/servicebus_namespace.html.markdown
+++ b/website/docs/d/servicebus_namespace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace"
-sidebar_current: "docs-azurerm-datasource-servicebus-namespace"
 description: |-
   Gets information about an existing ServiceBus Namespace.
 ---

--- a/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace_authorization_rule"
-sidebar_current: "docs-azurerm-datasource-servicebus-namespace-authorization-rule"
 description: |-
   Gets information about an existing ServiceBus Namespace Authorization Rule.
 ---

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image"
-sidebar_current: "docs-azurerm-datasource-shared-image-x"
 description: |-
   Gets information about an existing Shared Image a Shared Image Gallery.
 

--- a/website/docs/d/shared_image_gallery.html.markdown
+++ b/website/docs/d/shared_image_gallery.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image_gallery"
-sidebar_current: "docs-azurerm-datasource-shared-image-gallery"
 description: |-
   Gets information about an existing Shared Image Gallery.
 

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image_version"
-sidebar_current: "docs-azurerm-datasource-shared-image-version"
 description: |-
   Gets information about an existing Version of a Shared Image within a Shared Image Gallery.
 

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_signalr_service"
-sidebar_current: "docs-azurerm-datasource-signalr-service"
 description: |-
   Gets information about an existing Azure SignalR service.
 ---

--- a/website/docs/d/snapshot.html.markdown
+++ b/website/docs/d/snapshot.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_snapshot"
-sidebar_current: "docs-azurerm-datasource-snapshot"
 description: |-
   Get information about an existing Snapshot
 ---

--- a/website/docs/d/sql_database.html.markdown
+++ b/website/docs/d/sql_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_database"
-sidebar_current: "docs-azurerm-datasource-sql-database"
 description: |-
   Gets information about an existing SQL Azure Database.
 ---

--- a/website/docs/d/sql_server.html.markdown
+++ b/website/docs/d/sql_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_server"
-sidebar_current: "docs-azurerm-datasource-sql-server"
 description: |-
   Gets information about an existing SQL Azure Database Server.
 ---

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account"
-sidebar_current: "docs-azurerm-datasource-storage-account-x"
 description: |-
   Gets information about an existing Storage Account.
 

--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account_blob_container_sas"
-sidebar_current: "docs-azurerm-datasource-storage-account-blob-container-sas"
 description: |-
   Gets a Shared Access Signature (SAS Token) for an existing Storage Account Blob Container.
 

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account_sas"
-sidebar_current: "docs-azurerm-datasource-storage-account-sas"
 description: |-
   Gets a Shared Access Signature (SAS Token) for an existing Storage Account.
 

--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_management_policy"
-sidebar_current: "docs-azurerm-datasource-storage-management-policy"
 description: |-
   Gets information about an existing Storage Management Policy.
 ---

--- a/website/docs/d/stream_analytics_job.html.markdown
+++ b/website/docs/d/stream_analytics_job.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_job"
-sidebar_current: "docs-azurerm-datasource-stream-analytics-job"
 description: |-
   Gets information about an existing Stream Analytics Job.
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subnet"
-sidebar_current: "docs-azurerm-datasource-subnet"
 description: |-
   Gets information about an existing Subnet located within a Virtual Network.
 ---

--- a/website/docs/d/subscription.html.markdown
+++ b/website/docs/d/subscription.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subscription"
-sidebar_current: "docs-azurerm-datasource-subscription-x"
 description: |-
   Gets information about an existing Subscription.
 ---

--- a/website/docs/d/subscriptions.html.markdown
+++ b/website/docs/d/subscriptions.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subscriptions"
-sidebar_current: "docs-azurerm-datasource-subscriptions"
 description: |-
   Get information about the available subscriptions.
 ---

--- a/website/docs/d/traffic_manager_geographical_location.html.markdown
+++ b/website/docs/d/traffic_manager_geographical_location.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_traffic_manager_geographical_location"
-sidebar_current: "docs-azurerm-datasource-traffic-manager-geographical-location"
 description: |-
   Gets information about a specified Traffic Manager Geographical Location within the Geographical Hierarchy.
 

--- a/website/docs/d/user_assigned_identity.html.markdown
+++ b/website/docs/d/user_assigned_identity.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azure_user_assigned_identity"
-sidebar_current: "docs-azurerm-datasource-user-assigned-identity"
 description: |-
   Gets information about an existing User Assigned Identity.
 

--- a/website/docs/d/virtual_hub.html.markdown
+++ b/website/docs/d/virtual_hub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_hub"
-sidebar_current: "docs-azurerm-datasource-virtual-hub"
 description: |-
   Gets information about an existing Virtual Hub
 ---

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_machine"
-sidebar_current: "docs-azurerm-datasource-virtual-machine"
 description: |-
   Gets information about an existing Virtual Machine.
 ---

--- a/website/docs/d/virtual_network.html.markdown
+++ b/website/docs/d/virtual_network.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network"
-sidebar_current: "docs-azurerm-datasource-virtual-network-x"
 description: |-
   Gets information about an existing Virtual Network.
 ---

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network_gateway"
-sidebar_current: "docs-azurerm-datasource-virtual-network-gateway"
 description: |-
   Gets information about an existing Virtual Network Gateway.
 ---

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network_gateway_connection"
-sidebar_current: "docs-azurerm-datasource-virtual-network-gateway-connection"
 description: |-
   Gets information about an existing Virtual Network Gateway Connection.
 ---

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Azure Resource Manager: 2.0 Upgrade Guide"
-sidebar_current: "docs-azurerm-guide-2.0-upgrade"
 description: |-
     Azure Resource Manager: 2.0 Upgrade Guide
 

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Azure Provider: Authenticating via the Azure CLI"
-sidebar_current: "docs-azurerm-guide-authentication-azure-cli"
 description: |-
   This guide will cover how to use the Azure CLI as authentication for the Azure Provider.
 

--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Azure Provider: Authenticating via Managed Identity"
-sidebar_current: "docs-azurerm-guide-authentication-managed-service-identity"
 description: |-
   This guide will cover how to use managed identity for Azure resources as authentication for the Azure Provider.
 

--- a/website/docs/guides/migrating-between-renamed-resources.html.markdown
+++ b/website/docs/guides/migrating-between-renamed-resources.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Azure Provider: Migrating to a renamed resource"
-sidebar_current: "docs-azurerm-migrating-to-a-renamed-resource"
 description: |-
     This page documents how to migrate between two resources in the Azure Provider which have been renamed.
 

--- a/website/docs/guides/migrating-to-azuread.html.markdown
+++ b/website/docs/guides/migrating-to-azuread.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Azure Active Directory: Migrating to the AzureAD Provider"
-sidebar_current: "docs-azurerm-migrating-to-azuread"
 description: |-
   This page documents how to migrate from using the AzureAD resources within this repository to the resources in the new split-out repository.
 

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Azure Provider: Authenticating via a Service Principal and a Client Certificate"
-sidebar_current: "docs-azurerm-guide-authentication-service-principal-client-certificate"
 description: |-
   This guide will cover how to use a Service Principal (Shared Account) with a Client Certificate as authentication for the Azure Provider.
 

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Azure Provider: Authenticating via a Service Principal and a Client Secret"
-sidebar_current: "docs-azurerm-guide-authentication-service-principal-client-secret"
 description: |-
   This guide will cover how to use a Service Principal (Shared Account) with a Client Secret as authentication for the Azure Provider.
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,7 +1,6 @@
 ---
 layout: "azurerm"
 page_title: "Provider: Azure"
-sidebar_current: "docs-azurerm-index"
 description: |-
   The Azure Provider is used to interact with the many resources supported by Azure Resource Manager (also known as AzureRM) through its APIs.
 

--- a/website/docs/r/advanced_threat_protection.html.markdown
+++ b/website/docs/r/advanced_threat_protection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Security Center"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_advanced_threat_protection"
-sidebar_current: "docs-azurerm-resource-azurerm-advanced-threat-protection-x"
 description: |-
   Manages a resources Advanced Threat Protection setting.
 ---

--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Analysis Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_analysis_services_server"
-sidebar_current: "docs-azurerm-resource-analysis_services_server-x"
 description: |-
   Manages an Analysis Services Server.
 ---

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management"
-sidebar_current: "docs-azurerm-resource-api-management-x"
 description: |-
   Manages an API Management Service.
 ---

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api"
-sidebar_current: "docs-azurerm-resource-api-management-api-x"
 description: |-
   Manages an API within an API Management Service.
 ---

--- a/website/docs/r/api_management_api_operation.html.markdown
+++ b/website/docs/r/api_management_api_operation.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api_operation"
-sidebar_current: "docs-azurerm-resource-api-management-api-operation"
 description: |-
   Manages an API Operation within an API Management Service.
 ---

--- a/website/docs/r/api_management_api_operation_policy.html.markdown
+++ b/website/docs/r/api_management_api_operation_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api_operation_policy"
-sidebar_current: "docs-azurerm-resource-api-management-api-operation-policy"
 description: |-
   Manages an API Management API Operation Policy
 ---

--- a/website/docs/r/api_management_api_policy.html.markdown
+++ b/website/docs/r/api_management_api_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api_policy"
-sidebar_current: "docs-azurerm-resource-api-management-api-policy"
 description: |-
   Manages an API Management API Policy
 ---

--- a/website/docs/r/api_management_api_schema.html.markdown
+++ b/website/docs/r/api_management_api_schema.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api_schema"
-sidebar_current: "docs-azurerm-resource-api-management-api-schema"
 description: |-
   Manages an API Schema within an API Management Service.
 ---

--- a/website/docs/r/api_management_api_version_set.html.markdown
+++ b/website/docs/r/api_management_api_version_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_api_version_set"
-sidebar_current: "docs-azurerm-resource-api-management-api-version-set"
 description: |-
   Manages an API Version Set within an API Management Service.
 ---

--- a/website/docs/r/api_management_authorization_server.html.markdown
+++ b/website/docs/r/api_management_authorization_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_authorization_server"
-sidebar_current: "docs-azurerm-resource-api-management-authorization-server"
 description: |-
   Manages an Authorization Server within an API Management Service.
 ---

--- a/website/docs/r/api_management_backend.html.markdown
+++ b/website/docs/r/api_management_backend.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_backend"
-sidebar_current: "docs-azurerm-resource-api-management-backend-x"
 description: |-
   Manages a backend within an API Management Service.
 ---

--- a/website/docs/r/api_management_certificate.html.markdown
+++ b/website/docs/r/api_management_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_certificate"
-sidebar_current: "docs-azurerm-resource-api-management-certificate"
 description: |-
   Manages an Certificate within an API Management Service.
 ---

--- a/website/docs/r/api_management_diagnostic.html.markdown
+++ b/website/docs/r/api_management_diagnostic.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_diagnostic"
-sidebar_current: "docs-azurerm-resource-api-management-diagnostic"
 description: |-
   Manages an API Management Service Diagnostic.
 ---

--- a/website/docs/r/api_management_group.html.markdown
+++ b/website/docs/r/api_management_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_group"
-sidebar_current: "docs-azurerm-resource-api-management-group-x"
 description: |-
   Manages an API Management Group.
 ---

--- a/website/docs/r/api_management_group_user.html.markdown
+++ b/website/docs/r/api_management_group_user.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_group_user"
-sidebar_current: "docs-azurerm-resource-api-management-group-user"
 description: |-
   Manages an API Management User Assignment to a Group.
 ---

--- a/website/docs/r/api_management_identity_provider_aad.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aad.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_aad"
-sidebar_current: "docs-azurerm-resource-api-management-identity-provider-aad"
 description: |-
   Manages an API Management AAD Identity Provider.
 ---

--- a/website/docs/r/api_management_identity_provider_google.html.markdown
+++ b/website/docs/r/api_management_identity_provider_google.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_google"
-sidebar_current: "docs-azurerm-resource-api-management-identity-provider-google"
 description: |-
   Manages an API Management Google Identity Provider.
 ---

--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_logger"
-sidebar_current: "docs-azurerm-resource-api-management-logger"
 description: |-
   Manages a Logger within an API Management Service.
 ---

--- a/website/docs/r/api_management_openid_connect_provider.html.markdown
+++ b/website/docs/r/api_management_openid_connect_provider.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_openid_connect_provider"
-sidebar_current: "docs-azurerm-resource-api-management-openid-connect-provider"
 description: |-
   Manages an OpenID Connect Provider within a API Management Service.
 ---

--- a/website/docs/r/api_management_product.html.markdown
+++ b/website/docs/r/api_management_product.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_product"
-sidebar_current: "docs-azurerm-resource-api-management-product-x"
 description: |-
   Manages an API Management Product.
 ---

--- a/website/docs/r/api_management_product_api.html.markdown
+++ b/website/docs/r/api_management_product_api.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_product_api"
-sidebar_current: "docs-azurerm-resource-api-management-product-api"
 description: |-
   Manages an API Management API Assignment to a Product.
 ---

--- a/website/docs/r/api_management_product_group.html.markdown
+++ b/website/docs/r/api_management_product_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_product_group"
-sidebar_current: "docs-azurerm-resource-api-management-product-group"
 description: |-
   Manages an API Management Product Assignment to a Group.
 ---

--- a/website/docs/r/api_management_product_policy.html.markdown
+++ b/website/docs/r/api_management_product_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_product_policy"
-sidebar_current: "docs-azurerm-resource-api-management-product-policy"
 description: |-
   Manages an API Management Product Policy
 ---

--- a/website/docs/r/api_management_property.html.markdown
+++ b/website/docs/r/api_management_property.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_property"
-sidebar_current: "docs-azurerm-resource-api-management-property-x"
 description: |-
   Manages an API Management Property.
 ---

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_subscription"
-sidebar_current: "docs-azurerm-resource-api-management-subscription"
 description: |-
   Manages a Subscription within a API Management Service.
 ---

--- a/website/docs/r/api_management_user.html.markdown
+++ b/website/docs/r/api_management_user.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_user"
-sidebar_current: "docs-azurerm-resource-api-management-user"
 description: |-
   Manages an API Management User.
 ---

--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Configuration"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_configuration"
-sidebar_current: "docs-azurerm-resource-app-configuration"
 description: |-
   Manages an Azure App Configuration.
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service"
-sidebar_current: "docs-azurerm-resource-app-service-x"
 description: |-
   Manages an App Service (within an App Service Plan).
 

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_active_slot"
-sidebar_current: "docs-azurerm-resource-app-service-active-slot"
 description: |-
   Promotes an App Service Slot to Production within an App Service
 

--- a/website/docs/r/app_service_certificate.html.markdown
+++ b/website/docs/r/app_service_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_certificate"
-sidebar_current: "docs-azurerm-resource-app-service-certificate"
 description: |-
   Manages an App Service certificate.
 

--- a/website/docs/r/app_service_certificate_order.html.markdown
+++ b/website/docs/r/app_service_certificate_order.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_certificate_order"
-sidebar_current: "docs-azurerm-resource-app-service-certificate-order"
 description: |-
   Manages an App Service Certificate Order.
 

--- a/website/docs/r/app_service_custom_hostname_binding.html.markdown
+++ b/website/docs/r/app_service_custom_hostname_binding.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_custom_hostname_binding"
-sidebar_current: "docs-azurerm-resource-app-service-custom-hostname-binding"
 description: |-
   Manages a Hostname Binding within an App Service.
 

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_plan"
-sidebar_current: "docs-azurerm-resource-app-service-plan"
 description: |-
   Manages an App Service Plan component.
 ---

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_slot"
-sidebar_current: "docs-azurerm-resource-app-service-slot"
 description: |-
   Manages an App Service Slot (within an App Service).
 

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_source_control_token"
-sidebar_current: "docs-azurerm-resource-app-service-source-control-token"
 description: |-
   Manages an App Service source control token.
 

--- a/website/docs/r/app_service_virtual_network_association.html.markdown
+++ b/website/docs/r/app_service_virtual_network_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_app_service_virtual_network_swift_connection"
-sidebar_current: "docs-azurerm-resource-app-service-virtual-network-association"
 description: |-
   Manages an App Service Virtual Network Association.
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_gateway"
-sidebar_current: "docs-azurerm-resource-network-application-gateway"
 description: |-
   Manages an Application Gateway.
 ---

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Application Insights"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_insights"
-sidebar_current: "docs-azurerm-resource-application-insights-x"
 description: |-
   Manages an Application Insights component.
 ---

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Application Insights"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_insights_analytics_item"
-sidebar_current: "docs-azurerm-resource-application-insights-x"
 description: |-
   Manages an Application Insights Analytics Item component.
 ---

--- a/website/docs/r/application_insights_api_key.html.markdown
+++ b/website/docs/r/application_insights_api_key.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Application Insights"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_insights_api_key"
-sidebar_current: "docs-azurerm-resource-application-insights-api-key"
 description: |-
   Manages an Application Insights API key.
 ---

--- a/website/docs/r/application_insights_web_test.html.markdown
+++ b/website/docs/r/application_insights_web_test.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Application Insights"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_insights_web_test"
-sidebar_current: "docs-azurerm-resource-application-insights-web-test"
 description: |-
   Manages an Application Insights WebTest.
 ---

--- a/website/docs/r/application_security_group.html.markdown
+++ b/website/docs/r/application_security_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_application_security_group"
-sidebar_current: "docs-azurerm-resource-network-application-security-group"
 description: |-
   Manages an Application Security Group.
 ---

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_account"
-sidebar_current: "docs-azurerm-resource-automation-account"
 description: |-
   Manages a Automation Account.
 ---

--- a/website/docs/r/automation_certificate.html.markdown
+++ b/website/docs/r/automation_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_certificate"
-sidebar_current: "docs-azurerm-resource-automation-certificate"
 description: |-
   Manages an Automation Certificate.
 ---

--- a/website/docs/r/automation_credential.html.markdown
+++ b/website/docs/r/automation_credential.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_credential"
-sidebar_current: "docs-azurerm-resource-automation-credential"
 description: |-
   Manages a Automation Credential.
 ---

--- a/website/docs/r/automation_dsc_configuration.html.markdown
+++ b/website/docs/r/automation_dsc_configuration.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_dsc_configuration"
-sidebar_current: "docs-azurerm-resource-automation-dsc-configuration"
 description: |-
   Manages a Automation DSC Configuration.
 ---

--- a/website/docs/r/automation_dsc_nodeconfiguration.html.markdown
+++ b/website/docs/r/automation_dsc_nodeconfiguration.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_dsc_nodeconfiguration"
-sidebar_current: "docs-azurerm-resource-automation-dsc-nodeconfiguration"
 description: |-
   Manages a Automation DSC Node Configuration.
 ---

--- a/website/docs/r/automation_job_schedule.html.markdown
+++ b/website/docs/r/automation_job_schedule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_job_schedule"
-sidebar_current: "docs-azurerm-resource-automation-job-schedule"
 description: |-
   Links an Automation Runbook and Schedule.
 ---

--- a/website/docs/r/automation_module.html.markdown
+++ b/website/docs/r/automation_module.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_module"
-sidebar_current: "docs-azurerm-resource-automation-module"
 description: |-
   Manages a Automation Module.
 ---

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_runbook"
-sidebar_current: "docs-azurerm-resource-automation-runbook"
 description: |-
   Manages a Automation Runbook.
 ---

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_schedule"
-sidebar_current: "docs-azurerm-resource-automation-schedule"
 description: |-
   Manages a Automation Schedule.
 ---

--- a/website/docs/r/automation_variable_bool.html.markdown
+++ b/website/docs/r/automation_variable_bool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_bool"
-sidebar_current: "docs-azurerm-resource-automation-variable-bool"
 description: |-
   Manages a boolean variable in Azure Automation.
 ---

--- a/website/docs/r/automation_variable_datetime.html.markdown
+++ b/website/docs/r/automation_variable_datetime.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_datetime"
-sidebar_current: "docs-azurerm-resource-automation-variable-datetime"
 description: |-
   Manages a date/time variable in Azure Automation.
 ---

--- a/website/docs/r/automation_variable_int.html.markdown
+++ b/website/docs/r/automation_variable_int.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_int"
-sidebar_current: "docs-azurerm-resource-automation-variable-int"
 description: |-
   Manages a integer variable in Azure Automation.
 ---

--- a/website/docs/r/automation_variable_string.html.markdown
+++ b/website/docs/r/automation_variable_string.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_string"
-sidebar_current: "docs-azurerm-resource-automation-variable-string"
 description: |-
   Manages a string variable in Azure Automation.
 ---

--- a/website/docs/r/autoscale_setting.html.markdown
+++ b/website/docs/r/autoscale_setting.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_autoscale_setting"
-sidebar_current: "docs-azurerm-resource-monitor-autoscale-setting"
 description: |-
     Manages an AutoScale Setting which can be applied to Virtual Machine Scale Sets, App Services and other scalable resources.
 ---

--- a/website/docs/r/availability_set.html.markdown
+++ b/website/docs/r/availability_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_availability_set"
-sidebar_current: "docs-azurerm-resource-compute-availability-set"
 description: |-
   Manages an availability set for virtual machines.
 

--- a/website/docs/r/azuread_application.html.markdown
+++ b/website/docs/r/azuread_application.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Azure Active Directory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_application"
-sidebar_current: "docs-azurerm-resource-azuread-application"
 description: |-
   Manages an Application within Azure Active Directory.
 

--- a/website/docs/r/azuread_service_principal.html.markdown
+++ b/website/docs/r/azuread_service_principal.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Azure Active Directory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_service_principal"
-sidebar_current: "docs-azurerm-resource-azuread-service-principal-x"
 description: |-
   Manages a Service Principal associated with an Application within Azure Active Directory.
 

--- a/website/docs/r/azuread_service_principal_password.html.markdown
+++ b/website/docs/r/azuread_service_principal_password.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Azure Active Directory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_azuread_service_principal_password"
-sidebar_current: "docs-azurerm-resource-azuread-service-principal-password"
 description: |-
   Manages a Password associated with a Service Principal within Azure Active Directory.
 

--- a/website/docs/r/backup_container_storage_account.html.markdown
+++ b/website/docs/r/backup_container_storage_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_backup_container_storage_account"
-sidebar_current: "docs-azurerm-backup-container-storage-account"
 description: |-
     Manages a storage account container in an Azure Recovery Vault
 ---

--- a/website/docs/r/backup_policy_file_share.markdown
+++ b/website/docs/r/backup_policy_file_share.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_backup_policy_file_share"
-sidebar_current: "docs-azurerm-backup-policy-file-share"
 description: |-
   Manages an Azure File Share Backup Policy.
 ---

--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_backup_policy_vm"
-sidebar_current: "docs-azurerm-backup-policy-vm"
 description: |-
   Manages an Azure Backup VM Backup Policy.
 ---

--- a/website/docs/r/backup_protected_file_share.markdown
+++ b/website/docs/r/backup_protected_file_share.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_backup_protected_file_share"
-sidebar_current: "docs-azurerm-backup-protected-vm"
 description: |-
   Manages an Azure Backup Protected File Share.
 ---

--- a/website/docs/r/backup_protected_vm.markdown
+++ b/website/docs/r/backup_protected_vm.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_backup_protected_vm"
-sidebar_current: "docs-azurerm-backup-protected-vm"
 description: |-
   Manages an Azure Backup Protected VM.
 ---

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_bastion_host"
-sidebar_current: "docs-azurerm-resource-bastion-host-x"
 description: |-
   Manages a Bastion Host Instance.
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_account"
-sidebar_current: "docs-azurerm-resource-batch-account"
 description: |-
   Manages an Azure Batch account.
 

--- a/website/docs/r/batch_application.html.markdown
+++ b/website/docs/r/batch_application.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_application"
-sidebar_current: "docs-azurerm-resource-batch-application"
 description: |-
   Manages Azure Batch Application instance.
 ---

--- a/website/docs/r/batch_certificate.html.markdown
+++ b/website/docs/r/batch_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_certificate"
-sidebar_current: "docs-azurerm-resource-batch-certificate"
 description: |-
   Manages a certificate in an Azure Batch account.
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Batch"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_batch_pool"
-sidebar_current: "docs-azurerm-resource-batch-pool"
 description: |-
   Manages an Azure Batch pool.
 

--- a/website/docs/r/bot_channel_email.markdown
+++ b/website/docs/r/bot_channel_email.markdown
@@ -2,7 +2,6 @@
 subcategory: "Bot"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_bot_channel_email"
-sidebar_current: "docs-azurerm-resource-bot-channel-email"
 description: |-
   Manages a Email integration for a Bot Channel
 ---

--- a/website/docs/r/bot_channel_ms_teams.markdown
+++ b/website/docs/r/bot_channel_ms_teams.markdown
@@ -2,7 +2,6 @@
 subcategory: "Bot"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_bot_channel_ms_teams"
-sidebar_current: "docs-azurerm-resource-bot-channel-ms-teams"
 description: |-
   Manages an MS Teams integration for a Bot Channel
 ---

--- a/website/docs/r/bot_channel_slack.markdown
+++ b/website/docs/r/bot_channel_slack.markdown
@@ -2,7 +2,6 @@
 subcategory: "Bot"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_bot_channel_slack"
-sidebar_current: "docs-azurerm-resource-bot-channel-slack"
 description: |-
   Manages a Slack integration for a Bot Channel
 ---

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -2,7 +2,6 @@
 subcategory: "Bot"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_bot_channels_registration"
-sidebar_current: "docs-azurerm-resource-bot_channels_registration"
 description: |-
   Manages a Bot Channels Registration.
 ---

--- a/website/docs/r/bot_connection.markdown
+++ b/website/docs/r/bot_connection.markdown
@@ -2,7 +2,6 @@
 subcategory: "Bot"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_bot_connection"
-sidebar_current: "docs-azurerm-resource-bot-connection"
 description: |-
   Manages a Bot Connection.
 ---

--- a/website/docs/r/bot_web_app.markdown
+++ b/website/docs/r/bot_web_app.markdown
@@ -2,7 +2,6 @@
 subcategory: "Bot"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_bot_web_app"
-sidebar_current: "docs-azurerm-resource-bot-web-app"
 description: |-
   Manages a Web App Bot.
 ---

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_endpoint"
-sidebar_current: "docs-azurerm-resource-cdn-endpoint"
 description: |-
   Manages a CDN Endpoint.
 

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_profile"
-sidebar_current: "docs-azurerm-resource-cdn-profile"
 description: |-
   Manages a CDN Profile to create a collection of CDN Endpoints.
 ---

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Cognitive Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cognitive_account"
-sidebar_current: "docs-azurerm-resource-cognitive-account"
 description: |-
   Manages a Cognitive Services Account.
 ---

--- a/website/docs/r/connection_monitor.html.markdown
+++ b/website/docs/r/connection_monitor.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_connection_monitor"
-sidebar_current: "docs-azurerm-resource-connection-monitor"
 description: |-
   Configures a Connection Monitor to monitor communication between a Virtual Machine and an endpoint using a Network Watcher.
 

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_container_group"
-sidebar_current: "docs-azurerm-resource-container-group"
 description: |-
   Create as an Azure Container Group instance.
 ---

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_container_registry"
-sidebar_current: "docs-azurerm-resource-container-registry"
 description: |-
   Manages an Azure Container Registry.
 

--- a/website/docs/r/container_registry_webhook.html.markdown
+++ b/website/docs/r/container_registry_webhook.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_container_registry_webhook"
-sidebar_current: "docs-azurerm-resource-container-registry-webhook"
 description: |-
   Manages an Azure Container Registry Webhook.
 

--- a/website/docs/r/container_service.html.markdown
+++ b/website/docs/r/container_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_container_service"
-sidebar_current: "docs-azurerm-resource-container-service"
 description: |-
   Manages an Azure Container Service instance.
 ---

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_account"
-sidebar_current: "docs-azurerm-resource-cosmosdb-account"
 description: |-
   Manages a CosmosDB (formally DocumentDB) Account.
 ---

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_cassandra_keyspace"
-sidebar_current: "docs-azurerm-resource-cosmosdb-cassandra-keyspace"
 description: |-
   Manages a Cassandra KeySpace within a Cosmos DB Account.
 ---

--- a/website/docs/r/cosmosdb_gremlin_database.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_gremlin_database"
-sidebar_current: "docs-azurerm-resource-cosmosdb-gremlin-database"
 description: |-
   Manages a Gremlin Database within a Cosmos DB Account.
 ---

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_mongo_collection"
-sidebar_current: "docs-azurerm-resource-cosmosdb-mongo-collection"
 description: |-
   Manages a Mongo Collection within a Cosmos DB Account.
 ---

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_mongo_database"
-sidebar_current: "docs-azurerm-resource-cosmosdb-mongo-database"
 description: |-
   Manages a Mongo Database within a Cosmos DB Account.
 ---

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_sql_container"
-sidebar_current: "docs-azurerm-resource-cosmosdb-sql-container"
 description: |-
   Manages a SQL Container within a Cosmos DB Account.
 ---

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_sql_database"
-sidebar_current: "docs-azurerm-resource-cosmosdb-sql-database"
 description: |-
   Manages a SQL Database within a Cosmos DB Account.
 ---

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "CosmosDB (DocumentDB)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cosmosdb_table"
-sidebar_current: "docs-azurerm-resource-cosmosdb-table"
 description: |-
   Manages a Table within a Cosmos DB Account.
 ---

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Portal"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dashboard"
-sidebar_current: "docs-azurerm-resource-portal-dashboards"
 description: |-
   Manages a shared dashboard in the Azure Portal.
 ---

--- a/website/docs/r/data_factory.html.markdown
+++ b/website/docs/r/data_factory.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory"
-sidebar_current: "docs-azurerm-resource-data-factory-x"
 description: |-
   Manages an Azure Data Factory (Version 2).
 ---

--- a/website/docs/r/data_factory_dataset_mysql.html.markdown
+++ b/website/docs/r/data_factory_dataset_mysql.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_dataset_mysql"
-sidebar_current: "docs-azurerm-resource-data-factory-dataset-mysql"
 description: |-
   Manages a MySQL Dataset inside a Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_dataset_postgresql.html.markdown
+++ b/website/docs/r/data_factory_dataset_postgresql.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_dataset_postgresql"
-sidebar_current: "docs-azurerm-resource-data-factory-dataset-postgresql"
 description: |-
   Manages a PostgreSQL Dataset inside a Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_dataset_sql_server_table.html.markdown
+++ b/website/docs/r/data_factory_dataset_sql_server_table.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_dataset_sql_server_table"
-sidebar_current: "docs-azurerm-resource-data-factory-dataset-sql-server-table"
 description: |-
   Manages a SQL Server Table Dataset inside a Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_integration_runtime_managed"
-sidebar_current: "docs-azurerm_data_factory_integration_runtime_managed"
 description: |-
   Manages an Azure Data Factory Managed Integration Runtime.
 ---

--- a/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
+++ b/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_data_lake_storage_gen2"
-sidebar_current: "docs-azurerm-resource-data-factory-linked-service-data-lake-storage-gen2"
 description: |-
   Manages a Linked Service (connection) between Data Lake Storage Gen2 and Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_linked_service_mysql.html.markdown
+++ b/website/docs/r/data_factory_linked_service_mysql.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_mysql"
-sidebar_current: "docs-azurerm-resource-data-factory-linked-service-mysql"
 description: |-
   Manages a Linked Service (connection) between MySQL and Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_linked_service_postgresql.html.markdown
+++ b/website/docs/r/data_factory_linked_service_postgresql.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_postgresql"
-sidebar_current: "docs-azurerm-resource-data-factory-linked-service-postgresql"
 description: |-
   Manages a Linked Service (connection) between PostgreSQL and Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_linked_service_sql_server.html.markdown
+++ b/website/docs/r/data_factory_linked_service_sql_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_sql_server"
-sidebar_current: "docs-azurerm-resource-data-factory-linked-service-sql-server"
 description: |-
   Manages a Linked Service (connection) between a SQL Server and Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_pipeline.html.markdown
+++ b/website/docs/r/data_factory_pipeline.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_pipeline"
-sidebar_current: "docs-azurerm-resource-data-factory-pipeline"
 description: |-
   Manages a Pipeline inside a Azure Data Factory.
 ---

--- a/website/docs/r/data_factory_trigger_schedule.html.markdown
+++ b/website/docs/r/data_factory_trigger_schedule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Factory"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_factory_trigger_schedule"
-sidebar_current: "docs-azurerm-resource-data-factory-trigger-schedule"
 description: |-
   Manages a Trigger Schedule inside a Azure Data Factory.
 ---

--- a/website/docs/r/data_lake_analytics_account.html.markdown
+++ b/website/docs/r/data_lake_analytics_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Lake"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_lake_analytics_account"
-sidebar_current: "docs-azurerm-resource-data-lake-analytics-account"
 description: |-
   Manages an Azure Data Lake Analytics Account.
 ---

--- a/website/docs/r/data_lake_analytics_firewall_rule.html.markdown
+++ b/website/docs/r/data_lake_analytics_firewall_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Lake"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_lake_analytics_firewall_rule"
-sidebar_current: "docs-azurerm-resource-data-lake-analytics-firewall-rule"
 description: |-
   Manages a Azure Data Lake Analytics Firewall Rule.
 ---

--- a/website/docs/r/data_lake_store.html.markdown
+++ b/website/docs/r/data_lake_store.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Lake"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_lake_store"
-sidebar_current: "docs-azurerm-resource-data-lake-store-x"
 description: |-
   Manages an Azure Data Lake Store.
 ---

--- a/website/docs/r/data_lake_store_file.html.markdown
+++ b/website/docs/r/data_lake_store_file.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Lake"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_lake_store_file"
-sidebar_current: "docs-azurerm-resource-data-lake-store-file"
 description: |-
   Manages a Azure Data Lake Store File.
 ---

--- a/website/docs/r/data_lake_store_firewall_rule.html.markdown
+++ b/website/docs/r/data_lake_store_firewall_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Lake"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_data_lake_store_firewall_rule"
-sidebar_current: "docs-azurerm-resource-data-lake-store-firewall-rule"
 description: |-
   Manages a Azure Data Lake Store Firewall Rule.
 ---

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Databricks"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_databricks_workspace"
-sidebar_current: "docs-azurerm-resource-databricks-workspace"
 description: |-
   Manages a Databricks Workspace
 ---

--- a/website/docs/r/ddos_protection_plan.html.markdown
+++ b/website/docs/r/ddos_protection_plan.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_ddos_protection_plan"
-sidebar_current: "docs-azurerm-resource-ddos-protection-plan-x"
 description: |-
   Manages an Azure DDoS Protection Plan.
 

--- a/website/docs/r/dev_test_lab.html.markdown
+++ b/website/docs/r/dev_test_lab.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_lab"
-sidebar_current: "docs-azurerm-resource-dev-test-lab"
 description: |-
   Manages a Dev Test Lab.
 ---

--- a/website/docs/r/dev_test_linux_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_linux_virtual_machine.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_linux_virtual_machine"
-sidebar_current: "docs-azurerm-resource-dev-test-linux-virtual-machine"
 description: |-
   Manages a Linux Virtual Machine within a Dev Test Lab.
 ---

--- a/website/docs/r/dev_test_policy.html.markdown
+++ b/website/docs/r/dev_test_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_policy"
-sidebar_current: "docs-azurerm-resource-dev-test-policy"
 description: |-
   Manages a Policy within a Dev Test Policy Set.
 ---

--- a/website/docs/r/dev_test_schedule.html.markdown
+++ b/website/docs/r/dev_test_schedule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_schedule"
-sidebar_current: "docs-azurerm-dev-test-schedule"
 description: |-
     Manages automated startup and shutdown schedules for Azure Dev Test Lab.
 ---

--- a/website/docs/r/dev_test_virtual_network.html.markdown
+++ b/website/docs/r/dev_test_virtual_network.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_virtual_network"
-sidebar_current: "docs-azurerm-resource-dev-test-virtual-network"
 description: |-
   Manages a Virtual Network within a Dev Test Lab.
 ---

--- a/website/docs/r/dev_test_windows_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_windows_virtual_machine.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Dev Test"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dev_test_windows_virtual_machine"
-sidebar_current: "docs-azurerm-resource-dev-test-windows-virtual-machine"
 description: |-
   Manages a Windows Virtual Machine within a Dev Test Lab.
 ---

--- a/website/docs/r/devspace_controller.html.markdown
+++ b/website/docs/r/devspace_controller.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DevSpace"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_devspace_controller"
-sidebar_current: "docs-azurerm-resource-devspace-controller"
 description: |-
   Manages a DevSpace Controller.
 ---

--- a/website/docs/r/dns_a_record.html.markdown
+++ b/website/docs/r/dns_a_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_a_record"
-sidebar_current: "docs-azurerm-resource-dns-a-record"
 description: |-
   Manages a DNS A Record.
 ---

--- a/website/docs/r/dns_aaaa_record.html.markdown
+++ b/website/docs/r/dns_aaaa_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_aaaa_record"
-sidebar_current: "docs-azurerm-resource-dns-aaaa-record"
 description: |-
   Manages a DNS AAAA Record.
 ---

--- a/website/docs/r/dns_caa_record.html.markdown
+++ b/website/docs/r/dns_caa_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_caa_record"
-sidebar_current: "docs-azurerm-resource-dns-caa-record"
 description: |-
   Manages a DNS CAA Record.
 ---

--- a/website/docs/r/dns_cname_record.html.markdown
+++ b/website/docs/r/dns_cname_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_cname_record"
-sidebar_current: "docs-azurerm-resource-dns-cname-record"
 description: |-
   Manages a DNS CNAME Record.
 ---

--- a/website/docs/r/dns_mx_record.html.markdown
+++ b/website/docs/r/dns_mx_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_mx_record"
-sidebar_current: "docs-azurerm-resource-dns-mx-record"
 description: |-
   Manages a DNS MX Record.
 ---

--- a/website/docs/r/dns_ns_record.html.markdown
+++ b/website/docs/r/dns_ns_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_ns_record"
-sidebar_current: "docs-azurerm-resource-dns-ns-record"
 description: |-
   Manages a DNS NS Record.
 ---

--- a/website/docs/r/dns_ptr_record.html.markdown
+++ b/website/docs/r/dns_ptr_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_ptr_record"
-sidebar_current: "docs-azurerm-resource-dns-ptr-record"
 description: |-
   Manages a DNS PTR Record.
 ---

--- a/website/docs/r/dns_srv_record.html.markdown
+++ b/website/docs/r/dns_srv_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_srv_record"
-sidebar_current: "docs-azurerm-resource-dns-srv-record"
 description: |-
   Manages a DNS SRV Record.
 ---

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_txt_record"
-sidebar_current: "docs-azurerm-resource-dns-txt-record"
 description: |-
   Manages a DNS TXT Record.
 ---

--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dns_zone"
-sidebar_current: "docs-azurerm-resource-dns-zone"
 description: |-
   Manages a DNS Zone.
 ---

--- a/website/docs/r/eventgrid_domain.html.markdown
+++ b/website/docs/r/eventgrid_domain.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventgrid_domain"
-sidebar_current: "docs-azurerm-resource-messaging-eventgrid-domain"
 description: |-
   Manages an EventGrid Domain
 

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventgrid_event_subscription"
-sidebar_current: "docs-azurerm-resource-messaging-eventgrid-event-subscription"
 description: |-
   Manages an EventGrid Event Subscription
 

--- a/website/docs/r/eventgrid_topic.html.markdown
+++ b/website/docs/r/eventgrid_topic.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventgrid_topic"
-sidebar_current: "docs-azurerm-resource-messaging-eventgrid-topic"
 description: |-
   Manages an EventGrid Topic
 

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub"
-sidebar_current: "docs-azurerm-resource-messaging-eventhub-x"
 description: |-
   Manages a Event Hubs as a nested resource within an Event Hubs namespace.
 ---

--- a/website/docs/r/eventhub_authorization_rule.html.markdown
+++ b/website/docs/r/eventhub_authorization_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub_authorization_rule"
-sidebar_current: "docs-azurerm-resource-messaging-eventhub-authorization-rule"
 description: |-
   Manages a Event Hubs authorization Rule within an Event Hub.
 ---

--- a/website/docs/r/eventhub_consumer_group.html.markdown
+++ b/website/docs/r/eventhub_consumer_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub_consumer_group"
-sidebar_current: "docs-azurerm-resource-messaging-eventhub-consumer-group"
 description: |-
   Manages a Event Hubs Consumer Group as a nested resource within an Event Hub.
 ---

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub_namespace"
-sidebar_current: "docs-azurerm-resource-messaging-eventhub-namespace-x"
 description: |-
   Manages an EventHub Namespace.
 ---

--- a/website/docs/r/eventhub_namespace_authorization_rule.html.markdown
+++ b/website/docs/r/eventhub_namespace_authorization_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub_namespace_authorization_rule"
-sidebar_current: "docs-azurerm-resource-messaging-eventhub-namespace-authorization-rule"
 description: |-
   Manages an Authorization Rule for an Event Hub Namespace.
 ---

--- a/website/docs/r/eventhub_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/eventhub_namespace_disaster_recovery_config.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_eventhub_namespace_disaster_recovery_config"
-sidebar_current: "docs-azurerm-resource-messaging-eventhub-namespace-disaster-recovery-config"
 description: |-
   Manages an Disaster Recovery Config for an Event Hub Namespace.
 ---

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_express_route_circuit"
-sidebar_current: "docs-azurerm-resource-network-express-route-circuit-x"
 description: |-
   Manages an ExpressRoute circuit.
 ---

--- a/website/docs/r/express_route_circuit_authorization.html.markdown
+++ b/website/docs/r/express_route_circuit_authorization.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_express_route_circuit_authorization"
-sidebar_current: "docs-azurerm-resource-network-express-route-circuit-authorization"
 description: |-
   Manages an ExpressRoute Circuit Authorization.
 ---

--- a/website/docs/r/express_route_circuit_peering.html.markdown
+++ b/website/docs/r/express_route_circuit_peering.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_express_route_circuit_peering"
-sidebar_current: "docs-azurerm-resource-network-express-route-circuit-peering"
 description: |-
   Manages an ExpressRoute Circuit Peering.
 ---

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_firewall"
-sidebar_current: "docs-azurerm-resource-network-firewall-x"
 description: |-
   Manages an Azure Firewall.
 

--- a/website/docs/r/firewall_application_rule_collection.html.markdown
+++ b/website/docs/r/firewall_application_rule_collection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_firewall_application_rule_collection"
-sidebar_current: "docs-azurerm-resource-network-firewall-application-rule-collection"
 description: |-
   Manages an Application Rule Collection within an Azure Firewall.
 

--- a/website/docs/r/firewall_nat_rule_collection.html.markdown
+++ b/website/docs/r/firewall_nat_rule_collection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_firewall_nat_rule_collection"
-sidebar_current: "docs-azurerm-resource-network-firewall-nat-rule-collection"
 description: |-
   Manages a NAT Rule Collection within an Azure Firewall.
 

--- a/website/docs/r/firewall_network_rule_collection.html.markdown
+++ b/website/docs/r/firewall_network_rule_collection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_firewall_network_rule_collection"
-sidebar_current: "docs-azurerm-resource-network-firewall-network-rule-collection"
 description: |-
   Manages a Network Rule Collection within an Azure Firewall.
 

--- a/website/docs/r/front_door.html.markdown
+++ b/website/docs/r/front_door.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Front Door"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor"
-sidebar_current: "docs-azurerm-resource-front-door"
 description: |-
   Manages an Azure Front Door instance.
 ---

--- a/website/docs/r/front_door_firewall_policy.html.markdown
+++ b/website/docs/r/front_door_firewall_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Front Door"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_firewall_policy"
-sidebar_current: "docs-azurerm-resource-front-door-firewall-policy"
 description: |-
   Manages an Azure Front Door Web Application Firewall Policy instance.
 ---

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "App Service (Web Apps)"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_function_app"
-sidebar_current: "docs-azurerm-resource-app-service-function-app"
 description: |-
   Manages a Function App.
 

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_hadoop_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-hadoop-cluster"
 description: |-
   Manages a HDInsight Hadoop Cluster.
 ---

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_hbase_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-hbase-cluster"
 description: |-
   Manages a HDInsight HBase Cluster.
 ---

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_interactive_query_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-interactive-query-cluster"
 description: |-
   Manages a HDInsight Interactive Query Cluster.
 ---

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_kafka_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-kafka-cluster"
 description: |-
   Manages a HDInsight Kafka Cluster.
 ---

--- a/website/docs/r/hdinsight_ml_services_cluster.html.markdown
+++ b/website/docs/r/hdinsight_ml_services_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_ml_services_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-ml-services-cluster"
 description: |-
   Manages a HDInsight ML Services Cluster.
 ---

--- a/website/docs/r/hdinsight_rserver_cluster.html.markdown
+++ b/website/docs/r/hdinsight_rserver_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_rserver_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-rserver-cluster"
 description: |-
   Manages a HDInsight RServer Cluster.
 ---

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_spark_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-spark-cluster"
 description: |-
   Manages a HDInsight Spark Cluster.
 ---

--- a/website/docs/r/hdinsight_storm_cluster.html.markdown
+++ b/website/docs/r/hdinsight_storm_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "HDInsight"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_hdinsight_storm_cluster"
-sidebar_current: "docs-azurerm-resource-hdinsight-storm-cluster"
 description: |-
   Manages a HDInsight Storm Cluster.
 ---

--- a/website/docs/r/healthcare_service.html.markdown
+++ b/website/docs/r/healthcare_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Healthcare"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_healthcare_service"
-sidebar_current: "docs-azurerm-resource-healthcare-service-x"
 description: |-
   Manages a Healthcare Service.
 ---

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_image"
-sidebar_current: "docs-azurerm-resource-compute-image"
 description: |-
   Manages a custom virtual machine image that can be used to create virtual machines.
 ---

--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub"
-sidebar_current: "docs-azurerm-iothub-x"
 description: |-
   Manages an IotHub
 ---

--- a/website/docs/r/iothub_consumer_group.html.markdown
+++ b/website/docs/r/iothub_consumer_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_consumer_group"
-sidebar_current: "docs-azurerm-resource-iothub-consumer-group"
 description: |-
   Manages a Consumer Group within an IotHub
 ---

--- a/website/docs/r/iothub_dps.html.markdown
+++ b/website/docs/r/iothub_dps.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_dps"
-sidebar_current: "docs-azurerm-resource-iothub-dps-x"
 description: |-
   Manages an IoT Device Provisioning Service.
 ---

--- a/website/docs/r/iothub_dps_certificate.html.markdown
+++ b/website/docs/r/iothub_dps_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_dps_certificate"
-sidebar_current: "docs-azurerm-resource-iothub-dps_certificate"
 description: |-
   Manages an IoT Device Provisioning Service Certificate.
 ---

--- a/website/docs/r/iothub_dps_shared_access_policy.html.markdown
+++ b/website/docs/r/iothub_dps_shared_access_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_dps_shared_access_policy"
-sidebar_current: "docs-azurerm-resource-iothub-dps-shared-access-policy-x"
 description: |-
   Manages an IotHub Device Provisioning Service Shared Access Policy
 ---

--- a/website/docs/r/iothub_endpoint_eventhub.html.markdown
+++ b/website/docs/r/iothub_endpoint_eventhub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_eventhub"
-sidebar_current: "docs-azurerm-resource-messaging-iothub-endpoint-eventhub"
 description: |-
   Manages an IotHub EventHub Endpoint
 ---

--- a/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_servicebus_queue"
-sidebar_current: "docs-azurerm-resource-messaging-iothub-servicebus-queue"
 description: |-
   Manages an IotHub ServiceBus Queue Endpoint
 ---

--- a/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_servicebus_topic"
-sidebar_current: "docs-azurerm-resource-messaging-iothub-servicebus-topic"
 description: |-
   Manages an IotHub ServiceBus Topic Endpoint
 ---

--- a/website/docs/r/iothub_endpoint_storage_container.html.markdown
+++ b/website/docs/r/iothub_endpoint_storage_container.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_storage_container"
-sidebar_current: "docs-azurerm-resource-messaging-iothub-endpoint-storage-container"
 description: |-
   Manages an IotHub Storage Container Endpoint
 ---

--- a/website/docs/r/iothub_fallback_route.html.markdown
+++ b/website/docs/r/iothub_fallback_route.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_fallback_route"
-sidebar_current: "docs-azurerm-resource-messaging-iothub-fallback-route-x"
 description: |-
   Manages an IotHub Fallback Route
 ---

--- a/website/docs/r/iothub_route.html.markdown
+++ b/website/docs/r/iothub_route.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_route"
-sidebar_current: "docs-azurerm-resource-messaging-iothub-route-x"
 description: |-
   Manages an IotHub Route
 ---

--- a/website/docs/r/iothub_shared_access_policy.html.markdown
+++ b/website/docs/r/iothub_shared_access_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_shared_access_policy"
-sidebar_current: "docs-azurerm-resource-iothub-shared-access-policy-x"
 description: |-
   Manages an IotHub Shared Access Policy
 ---

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault"
-sidebar_current: "docs-azurerm-resource-key-vault-x"
 description: |-
   Manages a Key Vault.
 ---

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_access_policy"
-sidebar_current: "docs-azurerm-resource-key-vault-access-policy"
 description: |-
   Manages a Key Vault Access Policy.
 ---

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_certificate"
-sidebar_current: "docs-azurerm-resource-key-vault-certificate"
 description: |-
   Manages a Key Vault Certificate.
 

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_key"
-sidebar_current: "docs-azurerm-resource-key-vault-key"
 description: |-
   Manages a Key Vault Key.
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_secret"
-sidebar_current: "docs-azurerm-resource-key-vault-secret"
 description: |-
   Manages a Key Vault Secret.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_cluster"
-sidebar_current: "docs-azurerm-resource-container-kubernetes-cluster-x"
 description: |-
   Manages a managed Kubernetes Cluster (also known as AKS / Azure Kubernetes Service)
 ---

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_cluster_node_pool"
-sidebar_current: "docs-azurerm-resource-container-kubernetes-cluster-node-pool"
 description: |-
   Manages a Node Pool within a Kubernetes Cluster
 ---

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Explorer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kusto_cluster"
-sidebar_current: "docs-azurerm-resource-kusto-cluster"
 description: |-
   Manages Kusto (also known as Azure Data Explorer) Cluster
 ---

--- a/website/docs/r/kusto_database.html.markdown
+++ b/website/docs/r/kusto_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Explorer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kusto_database"
-sidebar_current: "docs-azurerm-resource-kusto-database"
 description: |-
   Manages Kusto / Data Explorer Database
 ---

--- a/website/docs/r/kusto_database_principal.html.markdown
+++ b/website/docs/r/kusto_database_principal.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Explorer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kusto_database_principal"
-sidebar_current: "docs-azurerm-resource-kusto-database-principal"
 description: |-
   Manages Kusto / Data Explorer Database Principal
 ---

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Data Explorer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kusto_eventhub_data_connection"
-sidebar_current: "docs-azurerm-resource-kusto-eventhub-data-connection"
 description: |-
   Manages Kusto / Data Explorer EventHub Data Connection
 ---

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Beta"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_linux_virtual_machine_scale_set"
-sidebar_current: "docs-azurerm-resource-linux-virtual-machine-scale-set"
 description: |-
   Manages a Linux Virtual Machine Scale Set.
 ---

--- a/website/docs/r/loadbalancer.html.markdown
+++ b/website/docs/r/loadbalancer.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Load Balancer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb"
-sidebar_current: "docs-azurerm-resource-loadbalancer-x"
 description: |-
   Manages a Load Balancer Resource.
 ---

--- a/website/docs/r/loadbalancer_backend_address_pool.html.markdown
+++ b/website/docs/r/loadbalancer_backend_address_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Load Balancer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_backend_address_pool"
-sidebar_current: "docs-azurerm-resource-loadbalancer-backend-address-pool"
 description: |-
   Manages a Load Balancer Backend Address Pool.
 ---

--- a/website/docs/r/loadbalancer_nat_pool.html.markdown
+++ b/website/docs/r/loadbalancer_nat_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Load Balancer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_nat_pool"
-sidebar_current: "docs-azurerm-resource-loadbalancer-nat-pool"
 description: |-
   Manages a Load Balancer NAT Pool.
 ---

--- a/website/docs/r/loadbalancer_nat_rule.html.markdown
+++ b/website/docs/r/loadbalancer_nat_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Load Balancer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_nat_rule"
-sidebar_current: "docs-azurerm-resource-loadbalancer-nat-rule"
 description: |-
   Manages a Load Balancer NAT Rule.
 ---

--- a/website/docs/r/loadbalancer_outbound_rule.html.markdown
+++ b/website/docs/r/loadbalancer_outbound_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Load Balancer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_outbound_rule"
-sidebar_current: "docs-azurerm-resource-loadbalancer-outbound-rule"
 description: |-
   Manages a Load Balancer Outbound Rule.
 ---

--- a/website/docs/r/loadbalancer_probe.html.markdown
+++ b/website/docs/r/loadbalancer_probe.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Load Balancer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_probe"
-sidebar_current: "docs-azurerm-resource-loadbalancer-probe"
 description: |-
   Manages a Load Balancer Probe Resource.
 ---

--- a/website/docs/r/loadbalancer_rule.html.markdown
+++ b/website/docs/r/loadbalancer_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Load Balancer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_lb_rule"
-sidebar_current: "docs-azurerm-resource-loadbalancer-rule"
 description: |-
   Manages a Load Balancer Rule.
 ---

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_local_network_gateway"
-sidebar_current: "docs-azurerm-resource-network-local-network-gateway"
 description: |-
   Manages a local network gateway connection over which specific connections can be configured.
 ---

--- a/website/docs/r/log_analytics_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_linked_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Log Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_log_analytics_linked_service"
-sidebar_current: "docs-azurerm-log-analytics-linked-service"
 description: |-
   Manages a Log Analytics (formally Operational Insights) Linked Service.
 ---

--- a/website/docs/r/log_analytics_solution.html.markdown
+++ b/website/docs/r/log_analytics_solution.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Log Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_log_analytics_solution"
-sidebar_current: "docs-azurerm-log-analytics-solution"
 description: |-
   Manages a Log Analytics (formally Operational Insights) Solution.
 ---

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Log Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_log_analytics_workspace"
-sidebar_current: "docs-azurerm-log-analytics-workspace-x"
 description: |-
   Manages a Log Analytics (formally Operational Insights) Workspace.
 ---

--- a/website/docs/r/log_analytics_workspace_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_workspace_linked_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Log Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_log_analytics_workspace_linked_service"
-sidebar_current: "docs-azurerm-log-analytics-workspace-linked-service"
 description: |-
   Manages a Log Analytics (formally Operational Insights) Linked Service.
 ---

--- a/website/docs/r/logic_app_action_custom.html.markdown
+++ b/website/docs/r/logic_app_action_custom.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_action_custom"
-sidebar_current: "docs-azurerm-resource-logic-app-action-custom"
 description: |-
   Manages a Custom Action within a Logic App Workflow
 ---

--- a/website/docs/r/logic_app_action_http.html.markdown
+++ b/website/docs/r/logic_app_action_http.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_action_http"
-sidebar_current: "docs-azurerm-resource-logic-app-action-http"
 description: |-
   Manages an HTTP Action within a Logic App Workflow
 ---

--- a/website/docs/r/logic_app_trigger_custom.html.markdown
+++ b/website/docs/r/logic_app_trigger_custom.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_trigger_custom"
-sidebar_current: "docs-azurerm-resource-logic-app-trigger-custom"
 description: |-
   Manages a Custom Trigger within a Logic App Workflow
 ---

--- a/website/docs/r/logic_app_trigger_http_request.html.markdown
+++ b/website/docs/r/logic_app_trigger_http_request.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_trigger_http_request"
-sidebar_current: "docs-azurerm-resource-logic-app-trigger-http-request"
 description: |-
   Manages a HTTP Request Trigger within a Logic App Workflow
 ---

--- a/website/docs/r/logic_app_trigger_recurrence.html.markdown
+++ b/website/docs/r/logic_app_trigger_recurrence.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_trigger_recurrence"
-sidebar_current: "docs-azurerm-resource-logic-app-trigger-recurrence"
 description: |-
   Manages a Recurrence Trigger within a Logic App Workflow
 ---

--- a/website/docs/r/logic_app_workflow.html.markdown
+++ b/website/docs/r/logic_app_workflow.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Logic App"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_logic_app_workflow"
-sidebar_current: "docs-azurerm-resource-logic-app-workflow"
 description: |-
   Manages a Logic App Workflow.
 ---

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_managed_disk"
-sidebar_current: "docs-azurerm-resource-compute-managed-disk"
 description: |-
   Manages a Managed Disk.
 ---

--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_management_group"
-sidebar_current: "docs-azurerm-management-group"
 description: |-
   Manages a Management Group.
 ---

--- a/website/docs/r/management_lock.html.markdown
+++ b/website/docs/r/management_lock.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_management_lock"
-sidebar_current: "docs-azurerm-resource-management-lock"
 description: |-
   Manages a Management Lock which is scoped to a Subscription, Resource Group or Resource.
 

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Maps"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_maps_account"
-sidebar_current: "docs-azurerm-resource-maps-account"
 description: |-
   Manages an Azure Maps Account.
 ---

--- a/website/docs/r/mariadb_configuration.html.markdown
+++ b/website/docs/r/mariadb_configuration.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mariadb_configuration"
-sidebar_current: "docs-azurerm-resource-database-mariadb-configuration"
 description: |-
   Sets a MariaDB Configuration value on a MariaDB Server.
 ---

--- a/website/docs/r/mariadb_database.html.markdown
+++ b/website/docs/r/mariadb_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mariadb_database"
-sidebar_current: "docs-azurerm-resource-database-mariadb-database"
 description: |-
   Manages a MariaDB Database within a MariaDB Server.
 ---

--- a/website/docs/r/mariadb_firewall_rule.html.markdown
+++ b/website/docs/r/mariadb_firewall_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mariadb_firewall_rule"
-sidebar_current: "docs-azurerm-resource-database-mariadb-firewall-rule"
 description: |-
   Manages a Firewall Rule for a MariaDB Server.
 ---

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mariadb_server"
-sidebar_current: "docs-azurerm-resource-database-mariadb-server"
 description: |-
   Manages a MariaDB Server.
 ---

--- a/website/docs/r/mariadb_virtual_network_rule.html.markdown
+++ b/website/docs/r/mariadb_virtual_network_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mariadb_virtual_network_rule"
-sidebar_current: "docs-azurerm-resource-database-mariadb-virtual-network-rule"
 description: |-
   Manages a MariaDB Virtual Network Rule.
 ---

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_marketplace_agreement"
-sidebar_current: "docs-azurerm-resource-compute-marketplace-agreement"
 description: |-
   Allows accepting the Legal Terms for a Marketplace Image.
 ---

--- a/website/docs/r/media_services_account.html.markdown
+++ b/website/docs/r/media_services_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Media"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_media_services_account"
-sidebar_current: "docs-azurerm-resource-media-media-services-account"
 description: |-
   Manages a Media Services Account.
 ---

--- a/website/docs/r/metric_alertrule.html.markdown
+++ b/website/docs/r/metric_alertrule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_metric_alertrule"
-sidebar_current: "docs-azurerm-resource-monitor-metric-alertrule"
 description: |-
   Manages a metric-based alert rule.
 

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_action_group"
-sidebar_current: "docs-azurerm-resource-monitor-action-group"
 description: |-
   Manages an Action Group within Azure Monitor
 

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_activity_log_alert"
-sidebar_current: "docs-azurerm-resource-monitor-activity-log-alert"
 description: |-
   Manages an Activity Log Alert within Azure Monitor
 ---

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_autoscale_setting"
-sidebar_current: "docs-azurerm-resource-monitor-autoscale-setting"
 description: |-
     Manages an AutoScale Setting which can be applied to Virtual Machine Scale Sets, App Services and other scalable resources.
 ---

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_diagnostic_setting"
-sidebar_current: "docs-azurerm-resource-monitor-diagnostic-setting"
 description: |-
   Manages a Diagnostic Setting for an existing Resource.
 

--- a/website/docs/r/monitor_log_profile.html.markdown
+++ b/website/docs/r/monitor_log_profile.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_log_profile"
-sidebar_current: "docs-azurerm-resource-monitor-log-profile"
 description: |-
   Manages a Log Profile.
 ---

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_metric_alert"
-sidebar_current: "docs-azurerm-resource-monitor-metric-alert-x"
 description: |-
   Manages a Metric Alert within Azure Monitor
 ---

--- a/website/docs/r/monitor_metric_alertrule.html.markdown
+++ b/website/docs/r/monitor_metric_alertrule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Monitor"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_monitor_metric_alertrule"
-sidebar_current: "docs-azurerm-resource-monitor-metric-alertrule"
 description: |-
   Manages a metric-based alert rule in Azure Monitor.
 

--- a/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
+++ b/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mssql_database_vulnerability_assessment_rule_baseline"
-sidebar_current: "docs-azurerm-resource-database-vulnerability-assessment-rule-baseline-x"
 description: |-
   Manages a Database Vulnerability Assessment Rule Baseline.
 

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mssql_elasticpool"
-sidebar_current: "docs-azurerm-resource-database-mssql-elasticpool"
 description: |-
   Manages a SQL Elastic Pool.
 ---

--- a/website/docs/r/mssql_server_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_server_security_alert_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mssql_server_security_alert_policy"
-sidebar_current: "docs-azurerm-resource-database-mssql-server-security-alert-policy-x"
 description: |-
   Manages a Security Alert Policy for a MS SQL Server.
 

--- a/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mssql_server_vulnerability_assessment"
-sidebar_current: "docs-azurerm-resource-database-mssql-server-vulnerability-assessment-x"
 description: |-
   Manages the Vulnerability Assessment for a MS SQL Server.
 

--- a/website/docs/r/mysql_configuration.html.markdown
+++ b/website/docs/r/mysql_configuration.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mysql_configuration"
-sidebar_current: "docs-azurerm-resource-database-mysql-configuration"
 description: |-
   Sets a MySQL Configuration value on a MySQL Server.
 ---

--- a/website/docs/r/mysql_database.html.markdown
+++ b/website/docs/r/mysql_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mysql_database"
-sidebar_current: "docs-azurerm-resource-database-mysql-database"
 description: |-
   Manages a MySQL Database within a MySQL Server.
 ---

--- a/website/docs/r/mysql_firewall_rule.html.markdown
+++ b/website/docs/r/mysql_firewall_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mysql_firewall_rule"
-sidebar_current: "docs-azurerm-resource-database-mysql-firewall-rule"
 description: |-
   Manages a Firewall Rule for a MySQL Server.
 ---

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mysql_server"
-sidebar_current: "docs-azurerm-resource-database-mysql-server"
 description: |-
   Manages a MySQL Server.
 

--- a/website/docs/r/mysql_virtual_network_rule.html.markdown
+++ b/website/docs/r/mysql_virtual_network_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_mysql_virtual_network_rule"
-sidebar_current: "docs-azurerm-resource-database-mysql-virtual-network-rule"
 description: |-
   Manages a MySQL Virtual Network Rule.
 ---

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_nat_gateway"
-sidebar_current: "docs-azurerm-resource-nat-gateway"
 description: |-
   Manages a Azure NAT Gateway.
 ---

--- a/website/docs/r/netapp_account.html.markdown
+++ b/website/docs/r/netapp_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_account"
-sidebar_current: "docs-azurerm-resource-netapp-account"
 description: |-
   Manages a NetApp Account.
 ---

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_pool"
-sidebar_current: "docs-azurerm-resource-netapp-pool"
 description: |-
   Manages a Pool within a NetApp Account.
 ---

--- a/website/docs/r/netapp_snapshot.html.markdown
+++ b/website/docs/r/netapp_snapshot.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_snapshot"
-sidebar_current: "docs-azurerm-resource-netapp-snapshot"
 description: |-
   Manages a NetApp Snapshot.
 ---

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "NetApp"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_netapp_volume"
-sidebar_current: "docs-azurerm-resource-netapp-volume"
 description: |-
   Manages a NetApp Volume.
 ---

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_connection_monitor"
-sidebar_current: "docs-azurerm-resource-network-connection-monitor"
 description: |-
   Configures a Network Connection Monitor to monitor communication between a Virtual Machine and an endpoint using a Network Watcher.
 

--- a/website/docs/r/network_ddos_protection_plan.html.markdown
+++ b/website/docs/r/network_ddos_protection_plan.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_ddos_protection_plan"
-sidebar_current: "docs-azurerm-resource-network-ddos-protection-plan-x"
 description: |-
   Manages an Azure Network DDoS Protection Plan.
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_interface"
-sidebar_current: "docs-azurerm-resource-network-interface-x"
 description: |-
   Manages a Network Interface located in a Virtual Network, usually attached to a Virtual Machine.
 

--- a/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_interface_application_gateway_backend_address_pool_association"
-sidebar_current: "docs-azurerm-resource-network-interface-application-gateway-backend-address-pool-association"
 description: |-
   Manages the association between a Network Interface and a Application Gateway's Backend Address Pool.
 

--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_interface_application_security_group_association"
-sidebar_current: "docs-azurerm-resource-network-interface-application-security-group-association"
 description: |-
   Manages the association between a Network Interface and a Application Security Group
 

--- a/website/docs/r/network_interface_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_backend_address_pool_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_interface_backend_address_pool_association"
-sidebar_current: "docs-azurerm-resource-network-interface-backend-address-pool-association"
 description: |-
   Manages the association between a Network Interface and a Load Balancer's Backend Address Pool.
 

--- a/website/docs/r/network_interface_nat_rule_association.html.markdown
+++ b/website/docs/r/network_interface_nat_rule_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_interface_nat_rule_association"
-sidebar_current: "docs-azurerm-resource-network-interface-nat-rule-association"
 description: |-
   Manages the association between a Network Interface and a Load Balancer's NAT Rule.
 

--- a/website/docs/r/network_packet_capture.html.markdown
+++ b/website/docs/r/network_packet_capture.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_packet_capture"
-sidebar_current: "docs-azurerm-resource-network-packet-capture"
 description: |-
   Configures Packet Capturing against a Virtual Machine using a Network Watcher.
 

--- a/website/docs/r/network_profile.html.markdown
+++ b/website/docs/r/network_profile.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_profile"
-sidebar_current: "docs-azurerm-resource-network-profile-x"
 description: |-
   Manages an Azure Network Profile.
 

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_security_group"
-sidebar_current: "docs-azurerm-resource-network-security-group"
 description: |-
   Manages a network security group that contains a list of network security rules. Network security groups enable inbound or outbound traffic to be enabled or denied.
 

--- a/website/docs/r/network_security_rule.html.markdown
+++ b/website/docs/r/network_security_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_security_rule"
-sidebar_current: "docs-azurerm-resource-network-security-rule"
 description: |-
   Manages a Network Security Rule.
 

--- a/website/docs/r/network_watcher.html.markdown
+++ b/website/docs/r/network_watcher.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_watcher"
-sidebar_current: "docs-azurerm-resource-network-watcher"
 description: |-
   Manages a Network Watcher.
 

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_network_watcher_flow_log"
-sidebar_current: "docs-azurerm-resource-network-watcher-flow-log"
 description: |-
   Manages a Network Watcher Flow Log.
 

--- a/website/docs/r/notification_hub.html.markdown
+++ b/website/docs/r/notification_hub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_notification_hub"
-sidebar_current: "docs-azurerm-resource-messaging-notification-hub-x"
 description: |-
   Manages a Notification Hub within a Notification Hub Namespace.
 

--- a/website/docs/r/notification_hub_authorization_rule.html.markdown
+++ b/website/docs/r/notification_hub_authorization_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_notification_hub_authorization_rule"
-sidebar_current: "docs-azurerm-resource-messaging-notification-hub-authorization-rule"
 description: |-
   Manages an Authorization Rule associated with a Notification Hub within a Notification Hub Namespace.
 

--- a/website/docs/r/notification_hub_namespace.html.markdown
+++ b/website/docs/r/notification_hub_namespace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_notification_hub_namespace"
-sidebar_current: "docs-azurerm-resource-messaging-notification-hub-namespace"
 description: |-
   Manages a Notification Hub Namespace.
 

--- a/website/docs/r/packet_capture.html.markdown
+++ b/website/docs/r/packet_capture.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_packet_capture"
-sidebar_current: "docs-azurerm-resource-packet-capture"
 description: |-
   Configures Packet Capturing against a Virtual Machine using a Network Watcher.
 

--- a/website/docs/r/point_to_site_vpn_gateway.html.markdown
+++ b/website/docs/r/point_to_site_vpn_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_point_to_site_vpn_gateway"
-sidebar_current: "docs-azurerm-resource-network-point-to-site-vpn-gateway"
 description: |-
   Manages a Point-to-Site VPN Gateway.
 

--- a/website/docs/r/policy_assignment.html.markdown
+++ b/website/docs/r/policy_assignment.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Policy"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_assignment"
-sidebar_current: "docs-azurerm-resource-policy-assignment"
 description: |-
   Configures the specified Policy Definition at the specified Scope.
 ---

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Policy"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_definition"
-sidebar_current: "docs-azurerm-resource-policy-definition"
 description: |-
   Manages a policy rule definition. Policy definitions do not take effect until they are assigned to a scope using a Policy Assignment.
 ---

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Policy"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_policy_set_definition"
-sidebar_current: "docs-azurerm-resource-policy-set-definition"
 description: |-
   Manages a policy set definition.
 ---

--- a/website/docs/r/postgresql_configuration.html.markdown
+++ b/website/docs/r/postgresql_configuration.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_postgresql_configuration"
-sidebar_current: "docs-azurerm-resource-database-postgresql-configuration"
 description: |-
   Sets a PostgreSQL Configuration value on a PostgreSQL Server.
 ---

--- a/website/docs/r/postgresql_database.html.markdown
+++ b/website/docs/r/postgresql_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_postgresql_database"
-sidebar_current: "docs-azurerm-resource-database-postgresql-database"
 description: |-
   Manages a PostgreSQL Database within a PostgreSQL Server.
 ---

--- a/website/docs/r/postgresql_firewall_rule.html.markdown
+++ b/website/docs/r/postgresql_firewall_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_postgresql_firewall_rule"
-sidebar_current: "docs-azurerm-resource-database-postgresql-firewall-rule"
 description: |-
   Manages a Firewall Rule for a PostgreSQL Server.
 ---

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_postgresql_server"
-sidebar_current: "docs-azurerm-resource-database-postgresql-server"
 description: |-
   Manages a PostgreSQL Server.
 ---

--- a/website/docs/r/postgresql_virtual_network_rule.html.markdown
+++ b/website/docs/r/postgresql_virtual_network_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_postgresql_virtual_network_rule"
-sidebar_current: "docs-azurerm-resource-database-postgresql-virtual-network-rule"
 description: |-
   Manages a PostgreSQL Virtual Network Rule.
 ---

--- a/website/docs/r/private_dns_a_record.html.markdown
+++ b/website/docs/r/private_dns_a_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_a_record"
-sidebar_current: "docs-azurerm-resource-private-dns-a-record"
 description: |-
   Manages a Private DNS A Record.
 ---

--- a/website/docs/r/private_dns_aaaa_record.html.markdown
+++ b/website/docs/r/private_dns_aaaa_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_aaaa_record"
-sidebar_current: "docs-azurerm-resource-private-dns-aaaa-record"
 description: |-
   Manages a Private DNS AAAA Record.
 ---

--- a/website/docs/r/private_dns_cname_record.html.markdown
+++ b/website/docs/r/private_dns_cname_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_cname_record"
-sidebar_current: "docs-azurerm-resource-private-dns-cname-record"
 description: |-
   Manages a Private DNS CNAME Record.
 ---

--- a/website/docs/r/private_dns_mx_record.html.markdown
+++ b/website/docs/r/private_dns_mx_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_mx_record"
-sidebar_current: "docs-azurerm-resource-private-dns-mx-record"
 description: |-
   Manages a Private DNS MX Record.
 ---

--- a/website/docs/r/private_dns_ptr_record.html.markdown
+++ b/website/docs/r/private_dns_ptr_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_ptr_record"
-sidebar_current: "docs-azurerm-resource-private-dns-ptr-record"
 description: |-
   Manages a Private DNS PTR Record.
 ---

--- a/website/docs/r/private_dns_srv_record.html.markdown
+++ b/website/docs/r/private_dns_srv_record.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_srv_record"
-sidebar_current: "docs-azurerm-resource-private-dns-srv-record"
 description: |-
   Manages a Private DNS SRV Record.
 ---

--- a/website/docs/r/private_dns_zone.html.markdown
+++ b/website/docs/r/private_dns_zone.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_zone"
-sidebar_current: "docs-azurerm-resource-private-dns-zone"
 description: |-
   Manages a Private DNS Zone.
 ---

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Private DNS"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_dns_zone_virtual_network_link"
-sidebar_current: "docs-azurerm-resource-private-dns-zone-virtual-network-link"
 description: |-
   Manages a Private DNS Zone Virtual Network Link.
 ---

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_endpoint"
-sidebar_current: "docs-azurerm-resource-private-endpoint"
 description: |-
   Manages an Private Endpoint.
 ---

--- a/website/docs/r/private_link_endpoint.html.markdown
+++ b/website/docs/r/private_link_endpoint.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_endpoint"
-sidebar_current: "docs-azurerm-resource-private-endpoint"
 description: |-
   Manages an Endpoint within a Private Link Service.
 ---

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_private_link_service"
-sidebar_current: "docs-azurerm-resource-private-link-service"
 description: |-
   Manages a Private Link Service.
 ---

--- a/website/docs/r/proximity_placement_group.html.markdown
+++ b/website/docs/r/proximity_placement_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_proximity_placement_group"
-sidebar_current: "docs-azurerm-resource-compute-proximity-placement-group"
 description: |-
   Manages a proximity placement group for virtual machines, virtual machine scale sets and availability sets.
 

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ip"
-sidebar_current: "docs-azurerm-resource-network-public-ip"
 description: |-
   Manages a Public IP Address.
 ---

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_public_ip_prefix"
-sidebar_current: "docs-azurerm-resource-network-public-ip-prefix"
 description: |-
   Manages a Public IP Prefix.
 ---

--- a/website/docs/r/recovery_network_mapping.html.markdown
+++ b/website/docs/r/recovery_network_mapping.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_network_mapping"
-sidebar_current: "docs-azurerm-recovery-network-mapping"
 description: |-
     Manages a site recovery network mapping on Azure.
 ---

--- a/website/docs/r/recovery_services_fabric.html.markdown
+++ b/website/docs/r/recovery_services_fabric.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_fabric"
-sidebar_current: "docs-azurerm-recovery-services-fabric"
 description: |-
     Manages a site recovery services fabric on Azure.
 ---

--- a/website/docs/r/recovery_services_protected_vm.markdown
+++ b/website/docs/r/recovery_services_protected_vm.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_protected_vm"
-sidebar_current: "docs-azurerm-recovery-services-protected-vm"
 description: |-
   Manages an Recovery Services Protected VM.
 ---

--- a/website/docs/r/recovery_services_protection_container.html.markdown
+++ b/website/docs/r/recovery_services_protection_container.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_protection_container"
-sidebar_current: "docs-azurerm-recovery-services-protection-container"
 description: |-
     Manages a site recovery services protection container on Azure.
 ---

--- a/website/docs/r/recovery_services_protection_container_mapping.html.markdown
+++ b/website/docs/r/recovery_services_protection_container_mapping.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_protection_container_mapping"
-sidebar_current: "docs-azurerm-recovery-services-protection-container-mapping"
 description: |-
     Manages a site recovery services protection container mappings on Azure.
 ---

--- a/website/docs/r/recovery_services_protection_policy_vm.markdown
+++ b/website/docs/r/recovery_services_protection_policy_vm.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_protection_policy_vm"
-sidebar_current: "docs-azurerm-recovery-services-protection-policy-vm"
 description: |-
   Manages an Recovery Services VM Protection Policy.
 ---

--- a/website/docs/r/recovery_services_replicated_vm.html.markdown
+++ b/website/docs/r/recovery_services_replicated_vm.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_replicated_vm"
-sidebar_current: "docs-azurerm-recovery-replicated-vm"
 description: |-
     Manages a site recovery services protection container mappings on Azure.
 ---

--- a/website/docs/r/recovery_services_replication_policy.html.markdown
+++ b/website/docs/r/recovery_services_replication_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_replication_policy"
-sidebar_current: "docs-azurerm-recovery-services-replication-policy"
 description: |-
     Manages a site recovery services replication policy on Azure.
 ---

--- a/website/docs/r/recovery_services_vault.markdown
+++ b/website/docs/r/recovery_services_vault.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_recovery_services_vault"
-sidebar_current: "docs-azurerm-recovery-services-vault"
 description: |-
   Manages a Recovery Services Vault.
 ---

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Redis"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_redis_cache"
-sidebar_current: "docs-azurerm-redis-cache"
 description: |-
   Manages a Redis Cache
 

--- a/website/docs/r/redis_firewall_rule.html.markdown
+++ b/website/docs/r/redis_firewall_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Redis"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_redis_firewall_rule"
-sidebar_current: "docs-azurerm-redis-firewall-rule"
 description: |-
   Manages a Firewall Rule associated with a Redis Cache.
 

--- a/website/docs/r/relay_hybrid_connection.html.markdown
+++ b/website/docs/r/relay_hybrid_connection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_relay_hybrid_connection"
-sidebar_current: "docs-azurerm-resource-messaging-relay-hybrid-connection"
 description: |-
   Manages an Azure Relay Hybrid Connection.
 

--- a/website/docs/r/relay_namespace.html.markdown
+++ b/website/docs/r/relay_namespace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_relay_namespace"
-sidebar_current: "docs-azurerm-resource-messaging-relay-namespace"
 description: |-
   Manages an Azure Relay Namespace.
 

--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Base"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_resource_group"
-sidebar_current: "docs-azurerm-resource-resource-group"
 description: |-
     Manages a resource group on Azure.
 ---

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_role_assignment"
-sidebar_current: "docs-azurerm-resource-authorization-role-assignment"
 description: |-
   Assigns a given Principal (User or Application) to a given Role.
 

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_role_definition"
-sidebar_current: "docs-azurerm-resource-authorization-role-definition"
 description: |-
   Manages a custom Role Definition.
 

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_route"
-sidebar_current: "docs-azurerm-resource-network-route-x"
 description: |-
   Manages a Route within a Route Table.
 ---

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_route_table"
-sidebar_current: "docs-azurerm-resource-network-route-table"
 description: |-
   Manages a Route Table
 

--- a/website/docs/r/scheduler_job.html.markdown
+++ b/website/docs/r/scheduler_job.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Scheduler"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_scheduler_job"
-sidebar_current: "docs-azurerm-resource-scheduler-job-x"
 description: |-
   Manages a Scheduler Job.
 ---

--- a/website/docs/r/scheduler_job_collection.html.markdown
+++ b/website/docs/r/scheduler_job_collection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Scheduler"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_scheduler_job_collection"
-sidebar_current: "docs-azurerm-resource-scheduler-job-collection"
 description: |-
   Manages a Scheduler Job Collection.
 ---

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Search"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_search_service"
-sidebar_current: "docs-azurerm-resource-search-service"
 description: |-
   Manages a Search Service.
 ---

--- a/website/docs/r/security_center_contact.markdown
+++ b/website/docs/r/security_center_contact.markdown
@@ -2,7 +2,6 @@
 subcategory: "Security Center"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_security_center_contact"
-sidebar_current: "docs-azurerm-security-center-contact"
 description: |-
     Manages the subscription's Security Center Contact.
 ---

--- a/website/docs/r/security_center_subscription_pricing.markdown
+++ b/website/docs/r/security_center_subscription_pricing.markdown
@@ -2,7 +2,6 @@
 subcategory: "Security Center"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_security_center_subscription_pricing"
-sidebar_current: "docs-azurerm-security-center-subscription-pricing"
 description: |-
     Manages the Pricing Tier for Azure Security Center in the current subscription.
 ---

--- a/website/docs/r/security_center_workspace.markdown
+++ b/website/docs/r/security_center_workspace.markdown
@@ -2,7 +2,6 @@
 subcategory: "Security Center"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_security_center_workspace"
-sidebar_current: "docs-azurerm-security-center-workspace"
 description: |-
     Manages the subscription's Security Center Workspace.
 ---

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Service Fabric"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_service_fabric_cluster"
-sidebar_current: "docs-azurerm-resource-service-fabric-cluster"
 description: |-
   Manages a Service Fabric Cluster.
 ---

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-namespace-x"
 description: |-
   Manages a ServiceBus Namespace.
 ---

--- a/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_namespace_authorization_rule"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-namespace-authorization-rule"
 description: |-
   Manages a ServiceBus Namespace authorization Rule within a ServiceBus.
 ---

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_queue"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-queue-x"
 description: |-
   Manages a ServiceBus Queue.
 ---

--- a/website/docs/r/servicebus_queue_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_queue_authorization_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_queue_authorization_rule"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-queue-authorization-rule"
 description: |-
   Manages an Authorization Rule for a ServiceBus Queue.
 ---

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_subscription"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-subscription-x"
 description: |-
   Manages a ServiceBus Subscription.
 ---

--- a/website/docs/r/servicebus_subscription_rule.html.markdown
+++ b/website/docs/r/servicebus_subscription_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_subscription_rule"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-subscription-rule"
 description: |-
   Manages a ServiceBus Subscription Rule.
 ---

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_topic"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-topic-x"
 description: |-
   Manages a ServiceBus Topic.
 ---

--- a/website/docs/r/servicebus_topic_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_topic_authorization_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_servicebus_topic_authorization_rule"
-sidebar_current: "docs-azurerm-resource-messaging-servicebus-topic-authorization-rule"
 description: |-
   Manages a ServiceBus Topic authorization Rule within a ServiceBus Topic.
 ---

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image"
-sidebar_current: "docs-azurerm-resource-compute-shared-image-x"
 description: |-
   Manages a Shared Image within a Shared Image Gallery.
 

--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image_gallery"
-sidebar_current: "docs-azurerm-resource-compute-shared-image-gallery"
 description: |-
   Manages a Shared Image Gallery.
 

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_shared_image_version"
-sidebar_current: "docs-azurerm-resource-compute-shared-image-version"
 description: |-
   Manages a Version of a Shared Image within a Shared Image Gallery.
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_signalr_service"
-sidebar_current: "docs-azurerm-resource-messaging-signalr-service"
 description: |-
   Manages an Azure SignalR service.
 ---

--- a/website/docs/r/site_recovery_fabric.html.markdown
+++ b/website/docs/r/site_recovery_fabric.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_fabric"
-sidebar_current: "docs-azurerm-site-recovery-replication-fabric"
 description: |-
     Manages a Site Recovery Replication Fabric on Azure.
 ---

--- a/website/docs/r/site_recovery_network_mapping.html.markdown
+++ b/website/docs/r/site_recovery_network_mapping.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_network_mapping"
-sidebar_current: "docs-azurerm-site-recovery-network-mapping"
 description: |-
     Manages a site recovery network mapping on Azure.
 ---

--- a/website/docs/r/site_recovery_protection_container.html.markdown
+++ b/website/docs/r/site_recovery_protection_container.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_protection_container"
-sidebar_current: "docs-azurerm-site-recovery-protection-container"
 description: |-
     Manages a site recovery services protection container on Azure.
 ---

--- a/website/docs/r/site_recovery_protection_container_mapping.html.markdown
+++ b/website/docs/r/site_recovery_protection_container_mapping.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_protection_container_mapping"
-sidebar_current: "docs-azurerm-recovery-services-protection-container-mapping"
 description: |-
     Manages a Site Recovery protection container mapping on Azure.
 ---

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_replicated_vm"
-sidebar_current: "docs-azurerm-site-recovery-replicated-vm"
 description: |-
     Manages a VM protected with Azure Site Recovery on Azure.
 ---

--- a/website/docs/r/site_recovery_replication_policy.html.markdown
+++ b/website/docs/r/site_recovery_replication_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_replication_policy"
-sidebar_current: "docs-azurerm-site-recovery-replication-policy"
 description: |-
     Manages an Azure Site Recovery replication policy on Azure.
 ---

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_snapshot"
-sidebar_current: "docs-azurerm-resource-compute-snapshot"
 description: |-
   Manages a Disk Snapshot.
 

--- a/website/docs/r/sql_active_directory_administrator.markdown
+++ b/website/docs/r/sql_active_directory_administrator.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource manager: azurerm_sql_active_directory_administrator"
-sidebar_current: "docs-azurerm-resource-database-sql-administrator"
 description: |-
   Manages an Active Directory administrator on a SQL server
 ---

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_database"
-sidebar_current: "docs-azurerm-resource-database-sql-database"
 description: |-
   Manages a SQL Database.
 ---

--- a/website/docs/r/sql_elasticpool.html.markdown
+++ b/website/docs/r/sql_elasticpool.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_elasticpool"
-sidebar_current: "docs-azurerm-resource-database-sql-elasticpool"
 description: |-
   Manages a SQL Elastic Pool.
 ---

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_failover_group"
-sidebar_current: "docs-azurerm-resource-database-sql-fail_over_group"
 description: |-
   Manages a SQL Failover Group.
 ---

--- a/website/docs/r/sql_firewall_rule.html.markdown
+++ b/website/docs/r/sql_firewall_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_firewall_rule"
-sidebar_current: "docs-azurerm-resource-database-sql-firewall-rule"
 description: |-
   Manages a SQL Firewall Rule.
 ---

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_server"
-sidebar_current: "docs-azurerm-resource-database-sql-server"
 description: |-
   Manages a SQL Azure Database Server.
 

--- a/website/docs/r/sql_virtual_network_rule.html.markdown
+++ b/website/docs/r/sql_virtual_network_rule.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Database"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_sql_virtual_network_rule"
-sidebar_current: "docs-azurerm-resource-database-sql-virtual-network-rule"
 description: |-
   Manages a SQL Virtual Network Rule.
 ---

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account"
-sidebar_current: "docs-azurerm-resource-storage-account"
 description: |-
   Manages a Azure Storage Account.
 ---

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_account_network_rules"
-sidebar_current: "docs-azurerm-resource-storage-account-network-rules"
 description: |-
   Manages network rules inside of a Azure Storage Account.
 ---

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_blob"
-sidebar_current: "docs-azurerm-resource-storage-blob"
 description: |-
   Manages a Blob within a Storage Container.
 ---

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_container"
-sidebar_current: "docs-azurerm-resource-storage-container"
 description: |-
   Manages a Container within an Azure Storage Account.
 ---

--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_data_lake_gen2_filesystem"
-sidebar_current: "docs-azurerm-resource-storage-data-lake-gen2-filesystem"
 description: |-
   Manages a Data Lake Gen2 File System within an Azure Storage Account.
 ---

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_management_policy"
-sidebar_current: "docs-azurerm-resource-storage-management-policy"
 description: |-
   Manages an Azure Storage Account Management Policy.
 ---

--- a/website/docs/r/storage_queue.html.markdown
+++ b/website/docs/r/storage_queue.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_queue"
-sidebar_current: "docs-azurerm-resource-storage-queue"
 description: |-
   Manages a Queue within an Azure Storage Account.
 ---

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_share"
-sidebar_current: "docs-azurerm-resource-storage-share-x"
 description: |-
   Manages a File Share within Azure Storage.
 ---

--- a/website/docs/r/storage_share_directory.html.markdown
+++ b/website/docs/r/storage_share_directory.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_share_directory"
-sidebar_current: "docs-azurerm-resource-storage-share-directory"
 description: |-
   Manages a Directory within an Azure Storage File Share.
 ---

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_table"
-sidebar_current: "docs-azurerm-resource-storage-table-x"
 description: |-
   Manages a Table within an Azure Storage Account.
 ---

--- a/website/docs/r/storage_table_entity.html.markdown
+++ b/website/docs/r/storage_table_entity.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Storage"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_storage_table_entity"
-sidebar_current: "docs-azurerm-resource-storage-table-entity"
 description: |-
   Manages an Entity within a Table in an Azure Storage Account.
 ---

--- a/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_function_javascript_udf"
-sidebar_current: "docs-azurerm-resource-stream-analytics-function-javascript-udf"
 description: |-
   Manages a JavaScript UDF Function within Stream Analytics Streaming Job.
 ---

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_job"
-sidebar_current: "docs-azurerm-resource-stream-analytics-job"
 description: |-
   Manages a Stream Analytics Job.
 ---

--- a/website/docs/r/stream_analytics_output_blob.html.markdown
+++ b/website/docs/r/stream_analytics_output_blob.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_output_blob"
-sidebar_current: "docs-azurerm-resource-stream-analytics-output-blob"
 description: |-
   Manages a Stream Analytics Output to Blob Storage.
 ---

--- a/website/docs/r/stream_analytics_output_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_output_eventhub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_output_eventhub"
-sidebar_current: "docs-azurerm-resource-stream-analytics-output-eventhub"
 description: |-
   Manages a Stream Analytics Output to an EventHub.
 ---

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_output_mssql"
-sidebar_current: "docs-azurerm-resource-stream-analytics-output-mssql"
 description: |-
   Manages a Stream Analytics Output to Microsoft SQL Server Database.
 ---

--- a/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_output_servicebus_queue"
-sidebar_current: "docs-azurerm-resource-stream-analytics-output-servicebus-queue"
 description: |-
   Manages a Stream Analytics Output to a ServiceBus Queue.
 ---

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_output_servicebus_topic"
-sidebar_current: "docs-azurerm-resource-stream-analytics-output-servicebus-topic"
 description: |-
   Manages a Stream Analytics Output to a ServiceBus Topic.
 ---

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_reference_input_blob"
-sidebar_current: "docs-azurerm-resource-stream-analytics-reference-input-blob"
 description: |-
   Manages a Stream Analytics Reference Input Blob.
 ---

--- a/website/docs/r/stream_analytics_stream_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_blob.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_stream_input_blob"
-sidebar_current: "docs-azurerm-resource-stream-analytics-stream-input-blob"
 description: |-
   Manages a Stream Analytics Stream Input Blob.
 ---

--- a/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_stream_input_eventhub"
-sidebar_current: "docs-azurerm-resource-stream-analytics-stream-input-eventhub"
 description: |-
   Manages a Stream Analytics Stream Input EventHub.
 ---

--- a/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Stream Analytics"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_stream_analytics_stream_input_iothub"
-sidebar_current: "docs-azurerm-resource-stream-analytics-stream-input-iothub"
 description: |-
   Manages a Stream Analytics Stream Input IoTHub.
 ---

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subnet"
-sidebar_current: "docs-azurerm-resource-network-subnet-x"
 description: |-
   Manages a subnet. Subnets represent network segments within the IP space defined by the virtual network.
 

--- a/website/docs/r/subnet_nat_gateway_association.html.markdown
+++ b/website/docs/r/subnet_nat_gateway_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subnet_nat_gateway_association"
-sidebar_current: "docs-azurerm-resource-network-subnet-nat-gateway-association"
 description: |-
   Associates a [NAT Gateway](nat_gateway.html) with a [Subnet](subnet.html) within a [Virtual Network](virtual_network.html).
 ---

--- a/website/docs/r/subnet_network_security_group_association.html.markdown
+++ b/website/docs/r/subnet_network_security_group_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subnet_network_security_group_association"
-sidebar_current: "docs-azurerm-resource-network-subnet-network-security-group-association"
 description: |-
   Associates a [Network Security Group](network_security_group.html) with a [Subnet](subnet.html) within a [Virtual Network](virtual_network.html).
 

--- a/website/docs/r/subnet_route_table_association.html.markdown
+++ b/website/docs/r/subnet_route_table_association.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_subnet_route_table_association"
-sidebar_current: "docs-azurerm-resource-network-subnet-route-table-association"
 description: |-
   Associates a [Route Table](route_table.html) with a [Subnet](subnet.html) within a [Virtual Network](virtual_network.html).
 

--- a/website/docs/r/template_deployment.html.markdown
+++ b/website/docs/r/template_deployment.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Template"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_template_deployment"
-sidebar_current: "docs-azurerm-resource-template-deployment"
 description: |-
   Manages a template deployment of resources.
 ---

--- a/website/docs/r/traffic_manager_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_endpoint.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_traffic_manager_endpoint"
-sidebar_current: "docs-azurerm-resource-network-traffic-manager-endpoint"
 description: |-
   Manages a Traffic Manager Endpoint.
 ---

--- a/website/docs/r/traffic_manager_profile.html.markdown
+++ b/website/docs/r/traffic_manager_profile.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_traffic_manager_profile"
-sidebar_current: "docs-azurerm-resource-network-traffic-manager-profile"
 description: |-
   Manages a Traffic Manager Profile.
 

--- a/website/docs/r/user_assigned_identity.markdown
+++ b/website/docs/r/user_assigned_identity.markdown
@@ -2,7 +2,6 @@
 subcategory: "Authorization"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azure_user_assigned_identity"
-sidebar_current: "docs-azurerm-resource-authorization-user-assigned-identity"
 description: |-
   Manages a new user assigned identity.
 ---

--- a/website/docs/r/virtual_hub.html.markdown
+++ b/website/docs/r/virtual_hub.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_hub"
-sidebar_current: "docs-azurerm-resource-virtual-hub"
 description: |-
   Manages a Virtual Hub within a Virtual WAN.
 ---

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_machine"
-sidebar_current: "docs-azurerm-resource-compute-virtual-machine-x"
 description: |-
   Manages a Virtual Machine.
 ---

--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_machine_data_disk_attachment"
-sidebar_current: "docs-azurerm-resource-compute-virtual-machine-data-disk-attachment"
 description: |-
   Manages attaching a Disk to a Virtual Machine.
 ---

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_machine_extension"
-sidebar_current: "docs-azurerm-resource-compute-virtualmachine-extension"
 description: |-
     Manages a Virtual Machine Extension to provide post deployment
     configuration and run automated tasks.

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_machine_scale_set"
-sidebar_current: "docs-azurerm-resource-compute-virtualmachine-scale-set"
 description: |-
   Manages a Virtual Machine scale set.
 ---

--- a/website/docs/r/virtual_machine_scale_set_extension.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_extension.html.markdown
@@ -2,7 +2,6 @@
 layout: "azurerm"
 subcategory: "Beta"
 page_title: "Azure Resource Manager: azurerm_virtual_machine_scale_set_extension"
-sidebar_current: "docs-azurerm-resource-virtual-machine-scale-set-extension"
 description: |-
   Manages an Extension for a Virtual Machine Scale Set.
 ---

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network"
-sidebar_current: "docs-azurerm-resource-network-virtual-network-x"
 description: |-
   Manages a virtual network including any configured subnets. Each subnet can optionally be configured with a security group to be associated with the subnet.
 ---

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network_gateway"
-sidebar_current: "docs-azurerm-resource-network-virtual-network-gateway-x"
 description: |-
   Manages a virtual network gateway to establish secure, cross-premises connectivity.
 ---

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network_gateway_connection"
-sidebar_current: "docs-azurerm-resource-network-virtual-network-gateway-connection"
 description: |-
   Manages a connection in an existing Virtual Network Gateway.
 ---

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_network_peering"
-sidebar_current: "docs-azurerm-resource-network-virtual-network-peering"
 description: |-
   Manages a virtual network peering which allows resources to access other
   resources in the linked virtual network.

--- a/website/docs/r/virtual_wan.html.markdown
+++ b/website/docs/r/virtual_wan.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_virtual_wan"
-sidebar_current: "docs-azurerm-resource-network-virtual-wan"
 description: |-
   Manages a Virtual WAN.
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_vpn_gateway"
-sidebar_current: "docs-azurerm-network-vpn-gateway"
 description: |-
     Manages a VPN Gateway within a Virtual Hub.
 ---

--- a/website/docs/r/vpn_server_configuration.html.markdown
+++ b/website/docs/r/vpn_server_configuration.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_vpn_server_configuration"
-sidebar_current: "docs-azurerm-network-vpn-server-configuration"
 description: |-
     Manages a VPN Server Configuration.
 ---

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_web_application_firewall_policy"
-sidebar_current: "docs-azurerm-resource-web-application-firewall-policy"
 description: |-
   Manages a Azure Web Application Firewall Policy instance.
 ---

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Beta"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_windows_virtual_machine_scale_set"
-sidebar_current: "docs-azurerm-resource-windows-virtual-machine-scale-set"
 description: |-
   Manages a Windows Virtual Machine Scale Set.
 ---


### PR DESCRIPTION
This PR removes the now [deprecated](https://github.com/hashicorp/terraform-website#yaml-frontmatter) `sidebar_current` YAML property from all docs pages.