### PR TITLE
New data source: 'azurerm_iothub_dps'

### DIFF
--- a/azurerm/internal/services/iothub/data_source_iothub_dps.go
+++ b/azurerm/internal/services/iothub/data_source_iothub_dps.go
@@ -1,0 +1,93 @@
+package iothub
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmIotHubDPS() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIotHubDPSRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.IoTHubName,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(), // azure.SchemaResourceGroupNameDiffSuppress(),
+
+			"location": azure.SchemaLocationForDataSource(),
+
+			"allocation_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"device_provisioning_host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"id_scope": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"service_operations_host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func dataSourceIotHubDPSRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).IoTHub.DPSResourceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	resp, err := client.Get(ctx, name, resourceGroup)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: IoT Device Provisioning Service %q (Resource Group %q) was not found", name, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving IoT Device Provisioning Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.SetId(*resp.ID)
+
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+
+	if props := resp.Properties; props != nil {
+		d.Set("service_operations_host_name", props.ServiceOperationsHostName)
+		d.Set("device_provisioning_host_name", props.DeviceProvisioningHostName)
+		d.Set("id_scope", props.IDScope)
+		d.Set("allocation_policy", props.AllocationPolicy)
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}

--- a/azurerm/internal/services/iothub/data_source_iothub_dps.go
+++ b/azurerm/internal/services/iothub/data_source_iothub_dps.go
@@ -28,7 +28,7 @@ func dataSourceArmIotHubDPS() *schema.Resource {
 				ValidateFunc: validate.IoTHubName,
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(), // azure.SchemaResourceGroupNameDiffSuppress(),
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
 
 			"location": azure.SchemaLocationForDataSource(),
 

--- a/azurerm/internal/services/iothub/registration.go
+++ b/azurerm/internal/services/iothub/registration.go
@@ -13,7 +13,9 @@ func (r Registration) Name() string {
 
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
-	return map[string]*schema.Resource{}
+	return map[string]*schema.Resource{
+		"azurerm_iothub_dps": dataSourceArmIotHubDPS(),
+	}
 }
 
 // SupportedResources returns the supported Resources supported by this Service

--- a/azurerm/internal/services/iothub/tests/data_source_iothub_dps_test.go
+++ b/azurerm/internal/services/iothub/tests/data_source_iothub_dps_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccDataSourceAzureRMIotHubDPS_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_iothub_dps", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMIotHubDPSDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMIotHubDPS_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(data.ResourceName, "allocation_policy"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "device_provisioning_host_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "id_scope"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "service_operations_host_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMIotHubDPS_basic(data acceptance.TestData) string {
+	template := testAccAzureRMIotHubDPS_basic(data)
+
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_iothub_dps" "test" {
+	name 				= "${azurerm_iothub_dps.test.name}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`, template)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -199,6 +199,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/d/iothub_dps.html">azurerm_iothub_dps</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/image.html">azurerm_image</a>
                 </li>
 

--- a/website/docs/d/iothub_dps.html.markdown
+++ b/website/docs/d/iothub_dps.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_dps"
-sidebar_current: "docs-azurerm-datasource-iothub-dps"
 description: |-
   Gets information about an existing IoT Hub Device Provisioning Service.
 ---

--- a/website/docs/d/iothub_dps.html.markdown
+++ b/website/docs/d/iothub_dps.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "IoT Hub"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_iothub_dps"
+sidebar_current: "docs-azurerm-datasource-iothub-dps"
+description: |-
+  Gets information about an existing IoT Hub Device Provisioning Service.
+---
+
+# Data Source: azurerm_iothub_dps
+
+Use this data source to access information about an existing IotHub Device Provisioning Service.
+
+## Example Usage
+
+```hcl
+data "azurerm_iothub_dps" "example" {
+  name                = "iot_hub_dps_test"
+  resource_group_name = "iothub_dps_rg"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Iot Device Provisioning Service resource.
+
+* `resource_group_name` - (Required) The name of the resource group under which the Iot Device Provisioning Service is located in.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the IoT Device Provisioning Service.
+
+* `location` - Specifies the supported Azure location where the IoT Device Provisioning Service exists.
+
+* `allocation_policy` - The allocation policy of the IoT Device Provisioning Service.
+
+* `device_provisioning_host_name` - The device endpoint of the IoT Device Provisioning Service.
+
+* `id_scope` - The unique identifier of the IoT Device Provisioning Service.
+
+* `service_operations_host_name` - The service endpoint of the IoT Device Provisioning Service.


### PR DESCRIPTION
Add the 'azurerm_iothub_dps' data source. 

I chose not to include the **SKU** property as I didn't think it was too critical for a data source. I imagine that the more important values would be the ones included. I can easily add it if you think it's required.