### PR TITLE
Add ability to specify test timeout for Acceptance Tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -95,6 +95,9 @@ test-compile:
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
+acctests: fmtcheck
+	TF_ACC=1 go test -v ./azurerm/internal/services/$(SERVICE)/tests/ $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
+
 debugacc: fmtcheck
 	TF_ACC=1 dlv test $(TEST) --headless --listen=:2345 --api-version=2 -- -test.v $(TESTARGS)
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,7 @@
 TEST?=$$(go list ./... |grep -v 'vendor'|grep -v 'examples')
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=azurerm
+TESTTIMEOUT=180m
 
 #make sure we catch schema errors during testing
 TF_SCHEMA_PANIC_ON_ERROR=1
@@ -92,7 +93,7 @@ test-compile:
 	go test -c $(TEST) $(TESTARGS)
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout $(TESTTIMEOUT) -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
 
 debugacc: fmtcheck
 	TF_ACC=1 dlv test $(TEST) --headless --listen=:2345 --api-version=2 -- -test.v $(TESTARGS)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ make test
 The majority of tests in the provider are Acceptance Tests - which provisions real resources in Azure. It's possible to run the entire acceptance test suite by running `make testacc` - however it's likely you'll want to run a subset, which you can do using a prefix, by running:
 
 ```
-make testacc TEST='./azurerm/helpers/azure/' TESTARGS='-run=TestAccAzureRMResourceGroup' TESTTIMEOUT='60m'
+make testacc SERVICE='resource' TESTARGS='-run=TestAccAzureRMResourceGroup' TESTTIMEOUT='60m'
 ```
 
 The following Environment Variables must be set in your shell prior to running acceptance tests:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ make test
 The majority of tests in the provider are Acceptance Tests - which provisions real resources in Azure. It's possible to run the entire acceptance test suite by running `make testacc` - however it's likely you'll want to run a subset, which you can do using a prefix, by running:
 
 ```
-make testacc TESTARGS='-run=TestAccAzureRMResourceGroup'
+make testacc TEST='./azurerm/helpers/azure/' TESTARGS='-run=TestAccAzureRMResourceGroup' TESTTIMEOUT='60m'
 ```
 
 The following Environment Variables must be set in your shell prior to running acceptance tests:


### PR DESCRIPTION
Based off @tombuildsstuff 's comment in Slack, I decided to document this and add the ability to set the test timeout. 