### PR TITLE
Use EightFullStopZero for azurerm_mysql_server version validation

### DIFF
--- a/azurerm/internal/services/mysql/resource_arm_mysql_server.go
+++ b/azurerm/internal/services/mysql/resource_arm_mysql_server.go
@@ -140,7 +140,7 @@ func resourceArmMySqlServer() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(mysql.FiveFullStopSix),
 					string(mysql.FiveFullStopSeven),
-					"8.0", //TODO: Update to EightFullStopZero ServerVersion constant when available in Azure Go SDK https://github.com/Azure/azure-rest-api-specs/pull/7864
+					string(mysql.EightFullStopZero),
 				}, true),
 				DiffSuppressFunc: suppress.CaseDifference,
 				ForceNew:         true,


### PR DESCRIPTION
Updates the validation for `azurerm_mysql_server`'s [`version`](https://www.terraform.io/docs/providers/azurerm/r/mysql_server.html#version) option to use the Azure SDK's  `EightFullStopZero` constant instead of `"8.0"`.