### PR TITLE
F/virtual machine extension by ID fixes #2456

### DIFF
--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -45,7 +45,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_shared_image":                         resourceArmSharedImage(),
 		"azurerm_snapshot":                             resourceArmSnapshot(),
 		"azurerm_virtual_machine_data_disk_attachment": resourceArmVirtualMachineDataDiskAttachment(),
-		"azurerm_virtual_machine_extension":            resourceArmVirtualMachineExtensions(),
+		"azurerm_virtual_machine_extension":            resourceArmVirtualMachineExtension(),
 		"azurerm_virtual_machine_scale_set":            resourceArmVirtualMachineScaleSet(),
 		"azurerm_virtual_machine":                      resourceArmVirtualMachine(),
 	}

--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
@@ -128,7 +128,9 @@ func resourceArmVirtualMachineExtensionsCreateUpdate(d *schema.ResourceData, met
 			return fmt.Errorf("Error getting Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 
-		location = *virtualMachine.Location
+		if location = *virtualMachine.Location; location == "" {
+			return fmt.Errorf("Error reading location of Virtual Machine %q", virtualMachineName)
+		}
 	} else {
 		if vm, ok := d.GetOk("virtual_machine_name"); !ok {
 			return fmt.Errorf("Error, one of `virtual_machine_name` (deprecated) or `virtual_machine_id` (preferred) required.")

--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
@@ -40,6 +40,7 @@ func resourceArmVirtualMachineExtension() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+
 			// TODO: Remove in 2.0
 			"virtual_machine_name": {
 				Type:       schema.TypeString,
@@ -48,6 +49,7 @@ func resourceArmVirtualMachineExtension() *schema.Resource {
 				ForceNew:   true,
 				Deprecated: "This field has been deprecated in favor of `virtual_machine_id` - will be removed in 2.0 of the Azure Provider",
 			},
+
 			"virtual_machine_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -55,6 +57,7 @@ func resourceArmVirtualMachineExtension() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: ValidateVirtualMachineID,
 			},
+
 			"publisher": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -90,6 +93,7 @@ func resourceArmVirtualMachineExtension() *schema.Resource {
 				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
+
 			// TODO: Remove location and resource_group_name in 2.0
 			"location": {
 				Type:             schema.TypeString,
@@ -100,8 +104,10 @@ func resourceArmVirtualMachineExtension() *schema.Resource {
 				DiffSuppressFunc: azure.SuppressLocationDiff,
 				Deprecated:       "location is no longer used",
 			},
+
 			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(),
-			"tags":                tags.Schema(),
+
+			"tags": tags.Schema(),
 		},
 	}
 }

--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
@@ -91,7 +91,6 @@ func resourceArmVirtualMachineExtension() *schema.Resource {
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
 			// TODO: Remove location and resource_group_name in 2.0
-			//"location":            azure.SchemaLocationDeprecated(),
 			"location": {
 				Type:             schema.TypeString,
 				ForceNew:         true,

--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_extension.go
@@ -17,7 +17,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func resourceArmVirtualMachineExtensions() *schema.Resource {
+func resourceArmVirtualMachineExtension() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmVirtualMachineExtensionsCreateUpdate,
 		Read:   resourceArmVirtualMachineExtensionsRead,
@@ -40,16 +40,21 @@ func resourceArmVirtualMachineExtensions() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
-			// TODO: deprecate these 2/3 in favour of pulling it from the VMSS
-			"location":            azure.SchemaLocation(),
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			// TODO: Remove in 2.0
 			"virtual_machine_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "This field has been deprecated in favor of `virtual_machine_id` - will be removed in 2.0 of the Azure Provider",
 			},
-
+			"virtual_machine_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidateVirtualMachineID,
+			},
 			"publisher": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -85,26 +90,60 @@ func resourceArmVirtualMachineExtensions() *schema.Resource {
 				ValidateFunc:     validation.ValidateJsonString,
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
-
-			"tags": tags.Schema(),
+			// TODO: Remove location and resource_group_name in 2.0
+			"location":            azure.SchemaLocationDeprecated(),
+			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(),
+			"tags":                tags.Schema(),
 		},
 	}
 }
 
 func resourceArmVirtualMachineExtensionsCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Compute.VMExtensionClient
+	vmExtensionClient := meta.(*clients.Client).Compute.VMExtensionClient
+	vmClient := meta.(*clients.Client).Compute.VMClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	name := d.Get("name").(string)
-	vmName := d.Get("virtual_machine_name").(string)
-	resGroup := d.Get("resource_group_name").(string)
+	var virtualMachineName, resourceGroup, location string
+	if virtualMachineId, ok := d.GetOk("virtual_machine_id"); ok {
+		v, err := ParseVirtualMachineID(virtualMachineId.(string))
+		if err != nil {
+			return fmt.Errorf("Error parsing Virtual Machine ID %q: %+v", virtualMachineId, err)
+		}
+
+		virtualMachineName = v.Name
+		resourceGroup = v.ResourceGroup
+
+		virtualMachine, err := vmClient.Get(ctx, resourceGroup, virtualMachineName, "")
+		if err != nil {
+			return fmt.Errorf("Error getting Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
+
+		location = *virtualMachine.Location
+
+	} else {
+		if vm, ok := d.GetOk("virtual_machine_name"); !ok {
+			return fmt.Errorf("Error, one of `virtual_machine_name` (deprecated) or `virtual_machine_id` (preferred) required.")
+		} else {
+			virtualMachineName = vm.(string)
+			resourceGroup = d.Get("resource_group_name").(string)
+			if resourceGroup == "" {
+				return fmt.Errorf("`resource_group_name` must be specified if `virtual_machine_id` is not used")
+			}
+
+			location = azure.NormalizeLocation(d.Get("location").(string))
+			if location == "" {
+				return fmt.Errorf("`location` must be specified if `virtual_machine_id` is not used")
+			}
+		}
+	}
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
-		existing, err := client.Get(ctx, resGroup, vmName, name, "")
+		existing, err := vmExtensionClient.Get(ctx, resourceGroup, virtualMachineName, name, "")
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Extension %q (Virtual Machine %q / Resource Group %q): %s", name, vmName, resGroup, err)
+				return fmt.Errorf("Error checking for presence of existing Extension %q (Virtual Machine %q / Resource Group %q): %s", name, virtualMachineName, resourceGroup, err)
 			}
 		}
 
@@ -113,7 +152,6 @@ func resourceArmVirtualMachineExtensionsCreateUpdate(d *schema.ResourceData, met
 		}
 	}
 
-	location := azure.NormalizeLocation(d.Get("location").(string))
 	publisher := d.Get("publisher").(string)
 	extensionType := d.Get("type").(string)
 	typeHandlerVersion := d.Get("type_handler_version").(string)
@@ -147,22 +185,22 @@ func resourceArmVirtualMachineExtensionsCreateUpdate(d *schema.ResourceData, met
 		extension.VirtualMachineExtensionProperties.ProtectedSettings = &protectedSettings
 	}
 
-	future, err := client.CreateOrUpdate(ctx, resGroup, vmName, name, extension)
+	future, err := vmExtensionClient.CreateOrUpdate(ctx, resourceGroup, virtualMachineName, name, extension)
 	if err != nil {
 		return err
 	}
 
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+	if err = future.WaitForCompletionRef(ctx, vmExtensionClient.Client); err != nil {
 		return err
 	}
 
-	read, err := client.Get(ctx, resGroup, vmName, name, "")
+	read, err := vmExtensionClient.Get(ctx, resourceGroup, virtualMachineName, name, "")
 	if err != nil {
 		return err
 	}
 
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read  Virtual Machine Extension %s (resource group %s) ID", name, resGroup)
+		return fmt.Errorf("Cannot read  Virtual Machine Extension %s (resource group %s) ID", name, resourceGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -175,13 +213,13 @@ func resourceArmVirtualMachineExtensionsRead(d *schema.ResourceData, meta interf
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := ParseVirtualMachineExtensionID(d.Id())
 	if err != nil {
 		return err
 	}
 	resGroup := id.ResourceGroup
-	vmName := id.Path["virtualMachines"]
-	name := id.Path["extensions"]
+	vmName := id.VirtualMachine
+	name := id.Name
 
 	resp, err := client.Get(ctx, resGroup, vmName, name, "")
 
@@ -198,6 +236,8 @@ func resourceArmVirtualMachineExtensionsRead(d *schema.ResourceData, meta interf
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 	d.Set("virtual_machine_name", vmName)
+
+	d.Set("virtual_machine_id", "")
 	d.Set("resource_group_name", resGroup)
 
 	if props := resp.VirtualMachineExtensionProperties; props != nil {

--- a/azurerm/internal/services/compute/tests/resource_arm_virtual_machine_extension_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_virtual_machine_extension_test.go
@@ -36,6 +36,7 @@ func TestAccAzureRMVirtualMachineExtension_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(data.ResourceName, "settings", regexp.MustCompile("whoami")),
 				),
 			},
+			data.ImportStep("protected_settings"),
 		},
 	})
 }
@@ -64,6 +65,7 @@ func TestAccAzureRMVirtualMachineExtension_deprecated(t *testing.T) {
 					resource.TestMatchResourceAttr(data.ResourceName, "settings", regexp.MustCompile("whoami")),
 				),
 			},
+			data.ImportStep("protected_settings"),
 		},
 	})
 }
@@ -294,7 +296,7 @@ SETTINGS
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-// TODO: Remove in 2.0
+// TODO: Remove in 2.0 - this test config covers the name & location inputs
 func testAccAzureRMVirtualMachineExtension_deprecated(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -107,9 +107,7 @@ resource "azurerm_virtual_machine" "example" {
 
 resource "azurerm_virtual_machine_extension" "example" {
   name                 = "hostname"
-  location             = "${azurerm_resource_group.example.location}"
-  resource_group_name  = "${azurerm_resource_group.example.name}"
-  virtual_machine_name = "${azurerm_virtual_machine.example.name}"
+  virtual_machine_id   = "${azurerm_virtual_machine.example.id}"
   publisher            = "Microsoft.Azure.Extensions"
   type                 = "CustomScript"
   type_handler_version = "2.0"
@@ -133,15 +131,19 @@ The following arguments are supported:
 * `name` - (Required) The name of the virtual machine extension peering. Changing
     this forces a new resource to be created.
 
-* `location` - (Required) The location where the extension is created. Changing
+* `location` - (Optional / **Deprecated**) The location where the extension is created. Changing
     this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Optional / **Deprecated**) The name of the resource group in which to
     create the virtual network. Changing this forces a new resource to be
     created.
 
-* `virtual_machine_name` - (Required) The name of the virtual machine. Changing
+* `virtual_machine_name` - (Optional / **Deprecated**) The name of the virtual machine. Changing
     this forces a new resource to be created.
+    
+* `virtual_machine_id` - (Optional) The resource ID of the virtual machine. This value replaces 
+    `location`, `resource_group_name` and `virtual_machine_name`. Changing this forces a new 
+    resource to be created
 
 * `publisher` - (Required) The publisher of the extension, available publishers
     can be found by using the Azure CLI.


### PR DESCRIPTION
This change updates the VM extension resource to use the `virtual_machine_id` and deprecates the use of `virtual_machine_name`. 