### PR TITLE
Fix parallel acctest race on `Provider`

### DIFF
--- a/azurerm/internal/acceptance/data.go
+++ b/azurerm/internal/acceptance/data.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -14,6 +15,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 )
+
+var once sync.Once
 
 type TestData struct {
 	// Locations is a set of Azure Regions which should be used for this Test
@@ -46,13 +49,15 @@ type TestData struct {
 
 // BuildTestData generates some test data for the given resource
 func BuildTestData(t *testing.T, resourceType string, resourceLabel string) TestData {
-	azureProvider := provider.AzureProvider().(*schema.Provider)
+	once.Do(func() {
+		azureProvider := provider.AzureProvider().(*schema.Provider)
 
-	AzureProvider = azureProvider
-	SupportedProviders = map[string]terraform.ResourceProvider{
-		"azurerm": azureProvider,
-		"azuread": azuread.Provider().(*schema.Provider),
-	}
+		AzureProvider = azureProvider
+		SupportedProviders = map[string]terraform.ResourceProvider{
+			"azurerm": azureProvider,
+			"azuread": azuread.Provider().(*schema.Provider),
+		}
+	})
 
 	env, err := Environment()
 	if err != nil {


### PR DESCRIPTION
Current implementation of acctest has an concurrent race issue against `Provider` initializaton.

## Reproduce Steps

### Method 1

Specify more than one acctests to run in serialized manner(i.e. specify `-parallel=1), as long as they are defined as parallel test.

E.g. invoke following command:

```bash
$ make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-parallel=1 -run TestAccAzureRMVirtualNetwork_basic'
```

which will run against `TestAccAzureRMVirtualNetwork_basic` and `TestAccAzureRMVirtualNetwork_basicUpdate` in serialized order.

### Method 2

Take `VNet` as example, add a long sleep at `PreCheck()` of the `TestAccAzureRMVirtualNetwork_basicUpdate` test, then run both tests in full parallel, as:

```bash
$ make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMVirtualNetwork_basic'
```

## Expected Result

Test pass.

## Actual Result

Almost everytime, test panic at `testXXXExists()`, actually when trying to get the `meta` from provider, which got a `nil`, and a dereference on it causes panic.

## Reason

At the begining of each test, it invokes `acceptance.BuildTestData()`, which then do following:

```go
azureProvider := provider.AzureProvider().(*schema.Provider)

AzureProvider = azureProvider
SupportedProviders = map[string]terraform.ResourceProvider{
    "azurerm": azureProvider,
    "azuread": azuread.Provider().(*schema.Provider),
}
```

which will set `acceptance.AzureProvider` and `acceptance.SupportedProviders` every time, with a new value (though the content should be same). Let's call it *global provider*.

After this, each test will run the test (we only focus on parallel test) like below:

```go
resource.ParallelTest(t, resource.TestCase{
    PreCheck: func() { acceptance.PreCheck(t) },
    Providers:    acceptance.SupportedProviders, // *
    CheckDestroy: testCheckAzureRMXXXDestroy,
    Steps: []resource.TestStep{
        {
            Config: testAccAzureRMVXXX_basic(data),
            Check: resource.ComposeTestCheckFunc(
                testCheckAzureRMXXXExists(data.ResourceName),
                //...
            ),
        },
        data.ImportStep(),
    },
}
```

The line I comment with `*` is important: Although the test case might not run at this point, because of parallelism throttle. However, the 2nd parameter of `resource.ParallelTest()` has been constructed and passed in, which means the `Providers` field holds whatever value of `acceptance.SupportedProviders` at that moment, in which case it is *likely* to be the one set by `acceptance.BuildTestData`. Let's call this *actual provider*.

The usage of two providers, for our case, is as below:

- *global provider*: During test exists/destroy, we need to get meta(client handler) from it. 
- *actual provider*: Used exclusively in test (in tf sdk level), which will be registerd to GRPC server and be used to accept the client handler.

So we can see, if those two providers are different, which means the client is set to *actual provider*, while we are trying to get it from *global provider*, then we have that issue.

The reason why they might differ is because the *global provider* is overriden by every test.

The reason why this doesn't happen frequently in full parallel test might because the timing: say one test A has inconsistent providers, as long as the current *global provider*, which is a *actual provider* for another test B, is set with client in that test B(duration 1) before test A finish resource provision(duration 2) and try to test exist/destroy of the resource. Here *duration 1* << *duration 2*, which largely reduce the possibility to reproduce this issue in full parallel tests.

## Fix

Actually in `acceptance.BuildTestData()`, we do not need to initialize provider for every test. We can just make sure it is initialized once but no more. 
