### PR TITLE
Update kubernetes_cluster documentation

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -446,5 +446,5 @@ provider "kubernetes" {
 Managed Kubernetes Clusters can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_kubernetes_cluster.cluster1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1
+terraform import azurerm_kubernetes_cluster.cluster1 /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1
 ```


### PR DESCRIPTION
Add Terraform import note for using `azurerm_kubernetes_cluster_node_pool` resource.

`azurerm_kubernetes_cluster_node_pool` get `kubernetes_cluster_id` from cloud is using /resourcegroup/ section, but example import command from Terraform document is using /resourceGroup/, it will cause forces replacement loop.

So I think to add this note to document maybe can help other user to avoid this situation.