### PR TITLE
New resource: Dedicated Host

### DIFF
--- a/azurerm/internal/services/compute/client/client.go
+++ b/azurerm/internal/services/compute/client/client.go
@@ -8,6 +8,7 @@ import (
 
 type Client struct {
 	AvailabilitySetsClient         *compute.AvailabilitySetsClient
+	DedicatedHostsClient           *compute.DedicatedHostsClient
 	DedicatedHostGroupsClient      *compute.DedicatedHostGroupsClient
 	DisksClient                    *compute.DisksClient
 	DiskEncryptionSetsClient       *compute.DiskEncryptionSetsClient
@@ -31,6 +32,9 @@ type Client struct {
 func NewClient(o *common.ClientOptions) *Client {
 	availabilitySetsClient := compute.NewAvailabilitySetsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&availabilitySetsClient.Client, o.ResourceManagerAuthorizer)
+
+	dedicatedHostsClient := compute.NewDedicatedHostsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&dedicatedHostsClient.Client, o.ResourceManagerAuthorizer)
 
 	dedicatedHostGroupsClient := compute.NewDedicatedHostGroupsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&dedicatedHostGroupsClient.Client, o.ResourceManagerAuthorizer)
@@ -88,6 +92,7 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	return &Client{
 		AvailabilitySetsClient:         &availabilitySetsClient,
+		DedicatedHostsClient:           &dedicatedHostsClient,
 		DedicatedHostGroupsClient:      &dedicatedHostGroupsClient,
 		DisksClient:                    &disksClient,
 		DiskEncryptionSetsClient:       &diskEncryptionSetsClient,

--- a/azurerm/internal/services/compute/data_source_dedicated_host.go
+++ b/azurerm/internal/services/compute/data_source_dedicated_host.go
@@ -1,0 +1,72 @@
+package compute
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmDedicatedHost() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmDedicatedHostRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateDedicatedHostName(),
+			},
+
+			"location": azure.SchemaLocationForDataSource(),
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"host_group_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateDedicatedHostGroupName(),
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceArmDedicatedHostRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroupName := d.Get("resource_group_name").(string)
+	hostGroupName := d.Get("host_group_name").(string)
+
+	resp, err := client.Get(ctx, resourceGroupName, hostGroupName, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Dedicated Host %q (Host Group Name %q / Resource Group %q) was not found", name, hostGroupName, resourceGroupName)
+		}
+		return fmt.Errorf("Error reading Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+
+	d.SetId(*resp.ID)
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroupName)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+	d.Set("host_group_name", hostGroupName)
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}

--- a/azurerm/internal/services/compute/parse/dedicated_host.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host.go
@@ -1,0 +1,38 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type DedicatedHostId struct {
+	ResourceGroup string
+	HostGroup     string
+	Name          string
+}
+
+func DedicatedHostID(input string) (*DedicatedHostId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host ID %q: %+v", input, err)
+	}
+
+	server := DedicatedHostId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if server.HostGroup, err = id.PopSegment("hostGroups"); err != nil {
+		return nil, err
+	}
+
+	if server.Name, err = id.PopSegment("hosts"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &server, nil
+}

--- a/azurerm/internal/services/compute/parse/dedicated_host_test.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_test.go
@@ -6,60 +6,60 @@ import (
 
 func TestDedicatedHostID(t *testing.T) {
 	testData := []struct {
-		Name          string
-		Input         string
-		ExpectedOK    bool
-		ExpectedValue *DedicatedHostId
+		Name   string
+		Input  string
+		Error  bool
+		Expect *DedicatedHostId
 	}{
 		{
-			Name:       "Empty",
-			Input:      "",
-			ExpectedOK: false,
+			Name:  "Empty",
+			Input: "",
+			Error: true,
 		},
 		{
-			Name:       "No Resource Groups Segment",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000",
-			ExpectedOK: false,
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
 		},
 		{
-			Name:       "No Resource Groups Value",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
-			ExpectedOK: false,
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
 		},
 		{
-			Name:       "Resource Group ID",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
-			ExpectedOK: false,
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Error: true,
 		},
 		{
-			Name:       "Missing Host Group Value",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/",
-			ExpectedOK: false,
+			Name:  "Missing Host Group Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/",
+			Error: true,
 		},
 		{
-			Name:       "Host Group ID",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/",
-			ExpectedOK: false,
+			Name:  "Host Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/",
+			Error: true,
 		},
 		{
-			Name:       "Missing Host Value",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/",
-			ExpectedOK: false,
+			Name:  "Missing Host Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/",
+			Error: true,
 		},
 		{
-			Name:       "Host ID",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/host1",
-			ExpectedOK: true,
-			ExpectedValue: &DedicatedHostId{
+			Name:  "Host ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/host1",
+			Error: false,
+			Expect: &DedicatedHostId{
 				ResourceGroup: "resGroup1",
 				HostGroup:     "group1",
 				Name:          "host1",
 			},
 		},
 		{
-			Name:       "Wrong Casing",
-			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/Hosts/host1",
-			ExpectedOK: false,
+			Name:  "Wrong Casing",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/Hosts/host1",
+			Error: true,
 		},
 	}
 
@@ -68,23 +68,23 @@ func TestDedicatedHostID(t *testing.T) {
 
 		actual, err := DedicatedHostID(v.Input)
 		if err != nil {
-			if v.ExpectedOK == false {
+			if v.Error {
 				continue
 			}
 
 			t.Fatalf("Expected a value but got an error: %s", err)
 		}
 
-		if actual.Name != v.ExpectedValue.Name {
-			t.Fatalf("Expected %q but got %q for Name", v.ExpectedValue.Name, actual.Name)
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
 		}
 
-		if actual.HostGroup != v.ExpectedValue.HostGroup {
-			t.Fatalf("Expected %q but got %q for HostGroup", v.ExpectedValue.HostGroup, actual.HostGroup)
+		if actual.HostGroup != v.Expect.HostGroup {
+			t.Fatalf("Expected %q but got %q for HostGroup", v.Expect.HostGroup, actual.HostGroup)
 		}
 
-		if actual.ResourceGroup != v.ExpectedValue.ResourceGroup {
-			t.Fatalf("Expected %q but got %q for Resource Group", v.ExpectedValue.ResourceGroup, actual.ResourceGroup)
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
 		}
 	}
 }

--- a/azurerm/internal/services/compute/parse/dedicated_host_test.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host_test.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestDedicatedHostID(t *testing.T) {
+	testData := []struct {
+		Name          string
+		Input         string
+		ExpectedOK    bool
+		ExpectedValue *DedicatedHostId
+	}{
+		{
+			Name:       "Empty",
+			Input:      "",
+			ExpectedOK: false,
+		},
+		{
+			Name:       "No Resource Groups Segment",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000",
+			ExpectedOK: false,
+		},
+		{
+			Name:       "No Resource Groups Value",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			ExpectedOK: false,
+		},
+		{
+			Name:       "Resource Group ID",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			ExpectedOK: false,
+		},
+		{
+			Name:       "Missing Host Group Value",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/",
+			ExpectedOK: false,
+		},
+		{
+			Name:       "Host Group ID",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/",
+			ExpectedOK: false,
+		},
+		{
+			Name:       "Missing Host Value",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/",
+			ExpectedOK: false,
+		},
+		{
+			Name:       "Host ID",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/host1",
+			ExpectedOK: true,
+			ExpectedValue: &DedicatedHostId{
+				ResourceGroup: "resGroup1",
+				HostGroup:     "group1",
+				Name:          "host1",
+			},
+		},
+		{
+			Name:       "Wrong Casing",
+			Input:      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/hostGroups/group1/Hosts/host1",
+			ExpectedOK: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := DedicatedHostID(v.Input)
+		if err != nil {
+			if v.ExpectedOK == false {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.ExpectedValue.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.ExpectedValue.Name, actual.Name)
+		}
+
+		if actual.HostGroup != v.ExpectedValue.HostGroup {
+			t.Fatalf("Expected %q but got %q for HostGroup", v.ExpectedValue.HostGroup, actual.HostGroup)
+		}
+
+		if actual.ResourceGroup != v.ExpectedValue.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.ExpectedValue.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -16,6 +16,7 @@ func (r Registration) Name() string {
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_availability_set":          dataSourceArmAvailabilitySet(),
+		"azurerm_dedicated_host":            dataSourceArmDedicatedHost(),
 		"azurerm_dedicated_host_group":      dataSourceArmDedicatedHostGroup(),
 		"azurerm_disk_encryption_set":       dataSourceArmDiskEncryptionSet(),
 		"azurerm_managed_disk":              dataSourceArmManagedDisk(),
@@ -34,6 +35,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	resources := map[string]*schema.Resource{
 		"azurerm_availability_set":                     resourceArmAvailabilitySet(),
+		"azurerm_dedicated_host":                       resourceArmDedicatedHost(),
 		"azurerm_dedicated_host_group":                 resourceArmDedicatedHostGroup(),
 		"azurerm_disk_encryption_set":                  resourceArmDiskEncryptionSet(),
 		"azurerm_image":                                resourceArmImage(),

--- a/azurerm/internal/services/compute/resource_arm_dedicated_host.go
+++ b/azurerm/internal/services/compute/resource_arm_dedicated_host.go
@@ -1,0 +1,252 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/response"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmDedicatedHost() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDedicatedHostCreate,
+		Read:   resourceArmDedicatedHostRead,
+		Update: resourceArmDedicatedHostUpdate,
+		Delete: resourceArmDedicatedHostDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateDedicatedHostName(),
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"host_group_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateDedicatedHostGroupName(),
+			},
+
+			// In order to follow convention for both protal and azure cli, `sku` here means
+			// sku name only.
+			"sku": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"DSv3-Type1",
+					"ESv3-Type1",
+					"FSv2-Type2",
+				}, false),
+			},
+
+			"platform_fault_domain": {
+				Type:     schema.TypeInt,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"auto_replace_on_failure": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"license_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.DedicatedHostLicenseTypesNone),
+					string(compute.DedicatedHostLicenseTypesWindowsServerHybrid),
+					string(compute.DedicatedHostLicenseTypesWindowsServerPerpetual),
+				}, false),
+				Default: string(compute.DedicatedHostLicenseTypesNone),
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func resourceArmDedicatedHostCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostsClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroupName := d.Get("resource_group_name").(string)
+	hostGroupName := d.Get("host_group_name").(string)
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroupName, hostGroupName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for present of existing Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+			}
+		}
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_dedicated_host", *existing.ID)
+		}
+	}
+
+	location := azure.NormalizeLocation(d.Get("location").(string))
+	t := d.Get("tags").(map[string]interface{})
+	parameters := compute.DedicatedHost{
+		Location: utils.String(location),
+		DedicatedHostProperties: &compute.DedicatedHostProperties{
+			AutoReplaceOnFailure: utils.Bool(d.Get("auto_replace_on_failure").(bool)),
+			LicenseType:          compute.DedicatedHostLicenseTypes(d.Get("license_type").(string)),
+		},
+		Sku: &compute.Sku{
+			Name: utils.String(d.Get("sku").(string)),
+		},
+		Tags: tags.Expand(t),
+	}
+	if platformFaultDomain, ok := d.GetOk("platform_fault_domain"); ok {
+		parameters.DedicatedHostProperties.PlatformFaultDomain = utils.Int32(int32(platformFaultDomain.(int)))
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroupName, hostGroupName, name, parameters)
+	if err != nil {
+		return fmt.Errorf("Error creating Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for creation of Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroupName, hostGroupName, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read Dedicated Host %q (Host Group Name %q / Resource Group %q) ID", name, hostGroupName, resourceGroupName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmDedicatedHostRead(d, meta)
+}
+
+func resourceArmDedicatedHostRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroupName := id.ResourceGroup
+	hostGroupName := id.Path["hostGroups"]
+	name := id.Path["hosts"]
+
+	resp, err := client.Get(ctx, resourceGroupName, hostGroupName, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Dedicated Host %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resourceGroupName)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*location))
+	}
+	d.Set("host_group_name", hostGroupName)
+	d.Set("sku", resp.Sku.Name)
+	if props := resp.DedicatedHostProperties; props != nil {
+		d.Set("platform_fault_domain", props.PlatformFaultDomain)
+		d.Set("auto_replace_on_failure", props.AutoReplaceOnFailure)
+		d.Set("license_type", props.LicenseType)
+	}
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceArmDedicatedHostUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostsClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroupName := d.Get("resource_group_name").(string)
+	hostGroupName := d.Get("host_group_name").(string)
+	t := d.Get("tags").(map[string]interface{})
+
+	parameters := compute.DedicatedHostUpdate{
+		DedicatedHostProperties: &compute.DedicatedHostProperties{
+			AutoReplaceOnFailure: utils.Bool(d.Get("auto_replace_on_failure").(bool)),
+			LicenseType:          compute.DedicatedHostLicenseTypes(d.Get("license_type").(string)),
+		},
+		Tags: tags.Expand(t),
+	}
+
+	future, err := client.Update(ctx, resourceGroupName, hostGroupName, name, parameters)
+	if err != nil {
+		return fmt.Errorf("Error updating Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for update of Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+
+	return resourceArmDedicatedHostRead(d, meta)
+}
+
+func resourceArmDedicatedHostDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.DedicatedHostsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroupName := id.ResourceGroup
+	hostGroupName := id.Path["hostGroups"]
+	name := id.Path["hosts"]
+
+	future, err := client.Delete(ctx, resourceGroupName, hostGroupName, name)
+	if err != nil {
+		return fmt.Errorf("Error deleting Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		if !response.WasNotFound(future.Response()) {
+			return fmt.Errorf("Error waiting for deleting Dedicated Host %q (Host Group Name %q / Resource Group %q): %+v", name, hostGroupName, resourceGroupName, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/compute/resource_arm_dedicated_host.go
+++ b/azurerm/internal/services/compute/resource_arm_dedicated_host.go
@@ -63,8 +63,6 @@ func resourceArmDedicatedHost() *schema.Resource {
 				ValidateFunc: validateDedicatedHostGroupName(),
 			},
 
-			// In order to follow convention for both protal and azure cli, `sku_name` here means
-			// sku name only.
 			"sku_name": {
 				Type:     schema.TypeString,
 				ForceNew: true,

--- a/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
+++ b/azurerm/internal/services/compute/resource_arm_dedicated_host_group.go
@@ -3,7 +3,6 @@ package compute
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -43,7 +42,7 @@ func resourceArmDedicatedHostGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[^_\W][\w-.]{0,78}[\w]$`), ""),
+				ValidateFunc: validateDedicatedHostGroupName(),
 			},
 
 			"location": azure.SchemaLocation(),

--- a/azurerm/internal/services/compute/tests/data_source_dedicated_host_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_dedicated_host_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
@@ -21,10 +19,7 @@ func TestAccDataSourceAzureRMDedicatedHost_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceDedicatedHost_basic(data),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "sku", "DSv3-Type1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesNone)),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "id"),
 				),
 			},
 		},

--- a/azurerm/internal/services/compute/tests/data_source_dedicated_host_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_dedicated_host_test.go
@@ -1,0 +1,45 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAzureRMDedicatedHost_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_dedicated_host", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDedicatedHost_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "sku", "DSv3-Type1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesNone)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDedicatedHost_basic(data acceptance.TestData) string {
+	config := testAccAzureRMDedicatedHost_basic(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_dedicated_host" "test" {
+  name                = azurerm_dedicated_host.test.name
+  resource_group_name = azurerm_dedicated_host.test.resource_group_name
+  host_group_name     = azurerm_dedicated_host.test.host_group_name
+}
+`, config)
+}

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
@@ -167,25 +167,25 @@ func testCheckAzureRMDedicatedHostDestroy(s *terraform.State) error {
 func testAccAzureRMDedicatedHost_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name		= "acctestRG-compute-%d"
-  location	= "%s"
+  name     = "acctestRG-compute-%d"
+  location = "%s"
 }
 
 resource "azurerm_dedicated_host_group" "test" {
-  name 								= "acctestDHG-compute-%s"
-  resource_group_name 				= azurerm_resource_group.test.name
-  location							= azurerm_resource_group.test.location
-  platform_fault_domain_count 		= 2
+  name                        = "acctestDHG-compute-%s"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
 }
 
 
 resource "azurerm_dedicated_host" "test" {
-  name							= "acctestDH-compute-%s"
-  location						= azurerm_resource_group.test.location
-  resource_group_name 			= azurerm_resource_group.test.name
-  host_group_name				= azurerm_dedicated_host_group.test.name
-  sku							= "DSv3-Type1"
-  platform_fault_domain			= 1
+  name                  = "acctestDH-compute-%s"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  host_group_name       = azurerm_dedicated_host_group.test.name
+  sku                   = "DSv3-Type1"
+  platform_fault_domain = 1
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
@@ -198,22 +198,22 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dedicated_host_group" "test" {
-  name								= "acctestDHG-compute-%s"
-  resource_group_name				= azurerm_resource_group.test.name
-  location							= azurerm_resource_group.test.location
-  platform_fault_domain_count		= 2
+  name                        = "acctestDHG-compute-%s"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
 }
 
 
 resource "azurerm_dedicated_host" "test" {
-  name							= "acctestDH-compute-%s"
-  location						= azurerm_resource_group.test.location
-  resource_group_name 			= azurerm_resource_group.test.name
-  host_group_name				= azurerm_dedicated_host_group.test.name
-  sku							= "DSv3-Type1"
-  platform_fault_domain			= 1
-  license_type					= "Windows_Server_Hybrid"
-  auto_replace_on_failure		= false
+  name                    = "acctestDH-compute-%s"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  host_group_name         = azurerm_dedicated_host_group.test.name
+  sku                     = "DSv3-Type1"
+  platform_fault_domain   = 1
+  license_type            = "Windows_Server_Hybrid"
+  auto_replace_on_failure = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
 }
@@ -222,11 +222,11 @@ func testAccAzureRMDedicatedHost_requiresImport(data acceptance.TestData) string
 	return fmt.Sprintf(`
 %s
 resource "azurerm_dedicated_host" "import" {
-  name                = azurerm_dedicated_host.test.name
-  resource_group_name = azurerm_dedicated_host.test.resource_group_name
-  location            = azurerm_dedicated_host.test.location
-  host_group_name     = azurerm_dedicated_host.test.host_group_name
-  sku                 = azurerm_dedicated_host.test.sku
+  name                  = azurerm_dedicated_host.test.name
+  resource_group_name   = azurerm_dedicated_host.test.resource_group_name
+  location              = azurerm_dedicated_host.test.location
+  host_group_name       = azurerm_dedicated_host.test.host_group_name
+  sku                   = azurerm_dedicated_host.test.sku
   platform_fault_domain = azurerm_dedicated_host.test.platform_fault_domain
 }
 `, testAccAzureRMDedicatedHost_basic(data))

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
@@ -2,8 +2,9 @@ package tests
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
@@ -178,7 +178,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dedicated_host_group" "test" {
-  name                        = "acctestDHG-compute-%s"
+  name                        = "acctest-DHG-%s"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   platform_fault_domain_count = 2
@@ -186,7 +186,7 @@ resource "azurerm_dedicated_host_group" "test" {
 
 
 resource "azurerm_dedicated_host" "test" {
-  name                  = "acctestDH-compute-%s"
+  name                  = "acctest-DH-%s"
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   host_group_name       = azurerm_dedicated_host_group.test.name
@@ -204,7 +204,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_dedicated_host_group" "test" {
-  name                        = "acctestDHG-compute-%s"
+  name                        = "acctest-DHG-%s"
   resource_group_name         = azurerm_resource_group.test.name
   location                    = azurerm_resource_group.test.location
   platform_fault_domain_count = 2
@@ -212,7 +212,7 @@ resource "azurerm_dedicated_host_group" "test" {
 
 
 resource "azurerm_dedicated_host" "test" {
-  name                    = "acctestDH-compute-%s"
+  name                    = "acctest-DH-%s"
   location                = azurerm_resource_group.test.location
   resource_group_name     = azurerm_resource_group.test.name
   host_group_name         = azurerm_dedicated_host_group.test.name

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 
@@ -51,9 +51,7 @@ func TestAccAzureRMDedicatedHost_complete(t *testing.T) {
 				Config: testAccAzureRMDedicatedHost_complete(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDedicatedHostExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesNone)),
-					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "sku", "DSv3-Type1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesWindowsServerHybrid)),
 					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "false"),
@@ -214,7 +212,7 @@ resource "azurerm_dedicated_host" "test" {
   host_group_name				= azurerm_dedicated_host_group.test.name
   sku							= "DSv3-Type1"
   platform_fault_domain			= 1
-  license_type					= Windows_Server_Hybrid
+  license_type					= "Windows_Server_Hybrid"
   auto_replace_on_failure		= false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)

--- a/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_dedicated_host_test.go
@@ -1,0 +1,235 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMDedicatedHost_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDedicatedHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDedicatedHost_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesNone)),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku", "DSv3-Type1"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDedicatedHost_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDedicatedHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDedicatedHost_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesNone)),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "platform_fault_domain", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku", "DSv3-Type1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesWindowsServerHybrid)),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "false"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDedicatedHost_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDedicatedHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDedicatedHost_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesNone)),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "true"),
+				),
+			},
+			{
+				Config: testAccAzureRMDedicatedHost_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "license_type", string(compute.DedicatedHostLicenseTypesWindowsServerHybrid)),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_replace_on_failure", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMDedicatedHost_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_dedicated_host", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDedicatedHostDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDedicatedHost_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDedicatedHostExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMDedicatedHost_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMDedicatedHostExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Dedicated Host not found: %s", resourceName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		hostGroupName := rs.Primary.Attributes["host_group_name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DedicatedHostsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		if resp, err := client.Get(ctx, resourceGroupName, hostGroupName, name, ""); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Dedicated Host %q (Host Group Name %q / Resource Group %q) does not exist", name, hostGroupName, resourceGroupName)
+			}
+			return fmt.Errorf("Bad: Get on Compute.DedicatedHostsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMDedicatedHostDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.DedicatedHostsClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_dedicated_host" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroupName := rs.Primary.Attributes["resource_group_name"]
+		hostGroupName := rs.Primary.Attributes["host_group_name"]
+
+		if resp, err := client.Get(ctx, resourceGroupName, hostGroupName, name, ""); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Get on Compute.DedicatedHostsClient: %+v", err)
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMDedicatedHost_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name		= "acctestRG-compute-%d"
+  location	= "%s"
+}
+
+resource "azurerm_dedicated_host_group" "test" {
+  name 								= "acctestDHG-compute-%s"
+  resource_group_name 				= azurerm_resource_group.test.name
+  location							= azurerm_resource_group.test.location
+  platform_fault_domain_count 		= 2
+}
+
+
+resource "azurerm_dedicated_host" "test" {
+  name							= "acctestDH-compute-%s"
+  location						= azurerm_resource_group.test.location
+  resource_group_name 			= azurerm_resource_group.test.name
+  host_group_name				= azurerm_dedicated_host_group.test.name
+  sku							= "DSv3-Type1"
+  platform_fault_domain			= 1
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMDedicatedHost_complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-compute-%d"
+  location = "%s"
+}
+
+resource "azurerm_dedicated_host_group" "test" {
+  name								= "acctestDHG-compute-%s"
+  resource_group_name				= azurerm_resource_group.test.name
+  location							= azurerm_resource_group.test.location
+  platform_fault_domain_count		= 2
+}
+
+
+resource "azurerm_dedicated_host" "test" {
+  name							= "acctestDH-compute-%s"
+  location						= azurerm_resource_group.test.location
+  resource_group_name 			= azurerm_resource_group.test.name
+  host_group_name				= azurerm_dedicated_host_group.test.name
+  sku							= "DSv3-Type1"
+  platform_fault_domain			= 1
+  license_type					= Windows_Server_Hybrid
+  auto_replace_on_failure		= false
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMDedicatedHost_requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_dedicated_host" "import" {
+  name                = azurerm_dedicated_host.test.name
+  resource_group_name = azurerm_dedicated_host.test.resource_group_name
+  location            = azurerm_dedicated_host.test.location
+  host_group_name     = azurerm_dedicated_host.test.host_group_name
+  sku                 = azurerm_dedicated_host.test.sku
+  platform_fault_domain = azurerm_dedicated_host.test.platform_fault_domain
+}
+`, testAccAzureRMDedicatedHost_basic(data))
+}

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func ValidateLinuxName(i interface{}, k string) (warnings []string, errors []error) {
@@ -102,4 +104,12 @@ func validateDiskSizeGB(v interface{}, _ string) (warnings []string, errors []er
 			"The `disk_size_gb` can only be between 0 and 32767"))
 	}
 	return warnings, errors
+}
+
+func validateDedicatedHostGroupName() func(i interface{}, k string) (warnings []string, errors []error) {
+	return validation.StringMatch(regexp.MustCompile(`^[^_\W][\w-.]{0,78}[\w]$`), "")
+}
+
+func validateDedicatedHostName() func(i interface{}, k string) (warnings []string, errors []error) {
+	return validateDedicatedHostGroupName()
 }

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -171,6 +171,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/providers/azurerm/d/dedicated_host.html">azurerm_dedicated_host</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/dedicated_host_group.html">azurerm_dedicated_host_group</a>
                 </li>
 
@@ -887,6 +891,10 @@
               <ul class="nav">
                 <li>
                   <a href="/docs/providers/azurerm/r/availability_set.html">azurerm_availability_set</a>
+                </li>
+
+                <li>
+                  <a href="/docs/providers/azurerm/r/dedicated_host.html">azurerm_dedicated_host</a>
                 </li>
 
                 <li>

--- a/website/docs/d/dedicated_host.html.markdown
+++ b/website/docs/d/dedicated_host.html.markdown
@@ -1,0 +1,47 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dedicated_host"
+sidebar_current: "docs-azurerm-datasource-dedicated-host"
+description: |-
+  Gets information about an existing Dedicated Host
+---
+
+# Data Source: azurerm_dedicated_host
+
+Use this data source to access information about an existing Dedicated Host.
+
+## Example Usage
+
+```hcl
+data "azurerm_dedicated_host" "example" {
+  name                = "example-dh"
+  resource_group_name = "example-rg"
+  host_group_name     = "example-dhg"
+}
+
+output "dedicated_host_id" {
+  value = "${data.azurerm_dedicated_host.example.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the Dedicated Host.
+
+* `resource_group_name` - (Required) Specifies the name of the resource group the Dedicated Host is located in.
+
+* `host_group_name` - (Required) Specifies the name of the Dedicated Host Group the Dedicated Host is located in.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of Dedicated Host.
+
+* `location` - The location where the Dedicated Host exists.
+
+* `tags` - A mapping of tags assigned to the Dedicated Host.
+

--- a/website/docs/d/dedicated_host.html.markdown
+++ b/website/docs/d/dedicated_host.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dedicated_host"
-sidebar_current: "docs-azurerm-datasource-dedicated-host"
 description: |-
   Gets information about an existing Dedicated Host
 ---

--- a/website/docs/r/dedicated_host.html.markdown
+++ b/website/docs/r/dedicated_host.html.markdown
@@ -2,7 +2,6 @@
 subcategory: "Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_dedicated_host"
-sidebar_current: "docs-azurerm-resource-dedicated-host"
 description: |-
   Manage an Dedicated Host.
 ---

--- a/website/docs/r/dedicated_host.html.markdown
+++ b/website/docs/r/dedicated_host.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_dedicated_host"
+sidebar_current: "docs-azurerm-resource-dedicated-host"
+description: |-
+  Manage an Dedicated Host.
+---
+
+# azurerm_dedicated_host
+
+Manage an Dedicated Host.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "West US"
+}
+
+resource "azurerm_dedicated_host_group" "example" {
+  name                                = "example-dhg"
+  resource_group_name                 = azurerm_resource_group.example.name
+  location                            = azurerm_resource_group.example.location
+  platform_fault_domain_count         = 2
+}
+
+
+resource "azurerm_dedicated_host" "example" {
+  name                                = "example-dh"
+  location                            = azurerm_resource_group.example.location
+  resource_group_name                 = azurerm_resource_group.example.name
+  host_group_name                     = azurerm_dedicated_host_group.example.name
+  sku                                 = "DSv3-Type1"
+  platform_fault_domain               = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specify the name of the Dedicated Host. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the Dedicated Host. Changing this forces a new resource to be created.
+
+* `location` - (Required) Specify the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+* `host_group_name` - (Required) Specify the name of the Dedicated Host Group in which to create the Dedicated Host. Changing this forces a new resource to be created.
+
+* `sku` - (Required) Specify the sku name of the Dedicated Host. Possible values are `DSv3-Type1`, `ESv3-Type1`, `FSv2-Type2`. Changing this forces a new resource to be created.
+
+* `platform_fault_domain` - (Required) Specify the fault domain of the Dedicated Host Group in which to create the Dedicated Host. Changing this forces a new resource to be created.
+
+* `auto_replace_on_failure` - (Optional) Specifies whether the Dedicated Host should be replaced automatically in case of a failure. The value is defaulted to `true` when not provided.
+
+* `license_type` - (Optional) Specifies the software license type that will be applied to the VMs deployed on the Dedicated Host. Possible values are: `None`, `Windows_Server_Hybrid`, `Windows_Server_Perpetual`. The value is defaulted to `None` when not provided.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Dedicated Host.
+
+## Import
+
+Dedicated Host can be imported using the `resource id`, e.g.
+
+```shell
+$ terraform import azurerm_dedicated_host.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/hostGroups/group1/hosts/host1
+```

--- a/website/docs/r/dedicated_host.html.markdown
+++ b/website/docs/r/dedicated_host.html.markdown
@@ -20,20 +20,20 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_dedicated_host_group" "example" {
-  name                                = "example-dhg"
-  resource_group_name                 = azurerm_resource_group.example.name
-  location                            = azurerm_resource_group.example.location
-  platform_fault_domain_count         = 2
+  name                        = "example-dhg"
+  resource_group_name         = azurerm_resource_group.example.name
+  location                    = azurerm_resource_group.example.location
+  platform_fault_domain_count = 2
 }
 
 
 resource "azurerm_dedicated_host" "example" {
-  name                                = "example-dh"
-  location                            = azurerm_resource_group.example.location
-  resource_group_name                 = azurerm_resource_group.example.name
-  host_group_name                     = azurerm_dedicated_host_group.example.name
-  sku                                 = "DSv3-Type1"
-  platform_fault_domain               = 1
+  name                  = "example-dh"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  host_group_name       = azurerm_dedicated_host_group.example.name
+  sku                   = "DSv3-Type1"
+  platform_fault_domain = 1
 }
 ```
 

--- a/website/docs/r/dedicated_host.html.markdown
+++ b/website/docs/r/dedicated_host.html.markdown
@@ -31,7 +31,7 @@ resource "azurerm_dedicated_host" "example" {
   location              = azurerm_resource_group.example.location
   resource_group_name   = azurerm_resource_group.example.name
   host_group_name       = azurerm_dedicated_host_group.example.name
-  sku                   = "DSv3-Type1"
+  sku_name              = "DSv3-Type1"
   platform_fault_domain = 1
 }
 ```
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `host_group_name` - (Required) Specify the name of the Dedicated Host Group in which to create the Dedicated Host. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Specify the sku name of the Dedicated Host. Possible values are `DSv3-Type1`, `ESv3-Type1`, `FSv2-Type2`. Changing this forces a new resource to be created.
+* `sku_name` - (Required) Specify the sku name of the Dedicated Host. Possible values are `DSv3-Type1`, `ESv3-Type1`, `FSv2-Type2`. Changing this forces a new resource to be created.
 
 * `platform_fault_domain` - (Required) Specify the fault domain of the Dedicated Host Group in which to create the Dedicated Host. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
New resource dedicated host.

Note:

1. Because of the broken delete api on dedicated host (Azure/azure-rest-api-specs#8137), we introduced a work around here.
2. Each subscription in azure has limit quota for dedicated host, hence you might encounter quota out of limit when running acctest in parallel, in which case just limit the parallelism by passing `-parallel=N` into `go test`