### PR TITLE
`azurerm_network_watcher_flow_log` - support for `version`

### DIFF
--- a/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
+++ b/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
@@ -149,7 +149,7 @@ func resourceArmNetworkWatcherFlowLog() *schema.Resource {
 			"version": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      1,
+				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 2),
 			},
 		},
@@ -264,7 +264,10 @@ func resourceArmNetworkWatcherFlowLogRead(d *schema.ResourceData, meta interface
 
 	if props := fli.FlowLogProperties; props != nil {
 		d.Set("enabled", props.Enabled)
-		d.Set("version", props.Format.Version)
+
+		if format := props.Format; format != nil {
+			d.Set("version", format.Version)
+		}
 
 		// Azure API returns "" when flow log is disabled
 		// Don't overwrite to prevent storage account ID diff when that is the case

--- a/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
+++ b/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
@@ -145,6 +145,13 @@ func resourceArmNetworkWatcherFlowLog() *schema.Resource {
 					},
 				},
 			},
+
+			"version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				ValidateFunc: validation.IntBetween(1, 2),
+			},
 		},
 	}
 }
@@ -171,6 +178,7 @@ func resourceArmNetworkWatcherFlowLogCreateUpdate(d *schema.ResourceData, meta i
 	networkSecurityGroupID := d.Get("network_security_group_id").(string)
 	storageAccountID := d.Get("storage_account_id").(string)
 	enabled := d.Get("enabled").(bool)
+	version := d.Get("version").(int)
 
 	parameters := network.FlowLogInformation{
 		TargetResourceID: &networkSecurityGroupID,
@@ -178,6 +186,9 @@ func resourceArmNetworkWatcherFlowLogCreateUpdate(d *schema.ResourceData, meta i
 			StorageID:       &storageAccountID,
 			Enabled:         &enabled,
 			RetentionPolicy: expandAzureRmNetworkWatcherFlowLogRetentionPolicy(d),
+			Format: &network.FlowLogFormatParameters{
+				Version: utils.Int32(int32(version)),
+			},
 		},
 	}
 
@@ -253,6 +264,7 @@ func resourceArmNetworkWatcherFlowLogRead(d *schema.ResourceData, meta interface
 
 	if props := fli.FlowLogProperties; props != nil {
 		d.Set("enabled", props.Enabled)
+		d.Set("version", props.Format.Version)
 
 		// Azure API returns "" when flow log is disabled
 		// Don't overwrite to prevent storage account ID diff when that is the case

--- a/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
+++ b/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
@@ -178,7 +178,6 @@ func resourceArmNetworkWatcherFlowLogCreateUpdate(d *schema.ResourceData, meta i
 	networkSecurityGroupID := d.Get("network_security_group_id").(string)
 	storageAccountID := d.Get("storage_account_id").(string)
 	enabled := d.Get("enabled").(bool)
-	version := d.Get("version").(int)
 
 	parameters := network.FlowLogInformation{
 		TargetResourceID: &networkSecurityGroupID,
@@ -186,14 +185,19 @@ func resourceArmNetworkWatcherFlowLogCreateUpdate(d *schema.ResourceData, meta i
 			StorageID:       &storageAccountID,
 			Enabled:         &enabled,
 			RetentionPolicy: expandAzureRmNetworkWatcherFlowLogRetentionPolicy(d),
-			Format: &network.FlowLogFormatParameters{
-				Version: utils.Int32(int32(version)),
-			},
 		},
 	}
 
 	if _, ok := d.GetOk("traffic_analytics"); ok {
 		parameters.FlowAnalyticsConfiguration = expandAzureRmNetworkWatcherFlowLogTrafficAnalytics(d)
+	}
+
+	if version, ok := d.GetOk("version"); ok {
+		format := &network.FlowLogFormatParameters{
+			Version: utils.Int32(int32(version.(int))),
+		}
+
+		parameters.FlowLogProperties.Format = format
 	}
 
 	future, err := client.SetFlowLogConfiguration(ctx, resourceGroupName, networkWatcherName, parameters)

--- a/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
@@ -540,7 +540,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   network_security_group_id = "${azurerm_network_security_group.test.id}"
   storage_account_id        = "${azurerm_storage_account.test.id}"
   enabled                   = true
-  version					= %d
+  version                   = %d
 
   retention_policy {
     enabled = true
@@ -548,7 +548,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
   }
 
   traffic_analytics {
-    enabled               = false
+    enabled               = true
     workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
     workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
     workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"

--- a/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
@@ -527,32 +527,32 @@ func testAccAzureRMNetworkWatcherFlowLog_versionConfig(data acceptance.TestData,
 %s
 
 resource "azurerm_log_analytics_workspace" "test" {
-	name                = "acctestLAW-%d"
-	location            = "${azurerm_resource_group.test.location}"
-	resource_group_name = "${azurerm_resource_group.test.name}"
-	sku                 = "PerGB2018"
+  name                = "acctestLAW-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "PerGB2018"
 }
 
 resource "azurerm_network_watcher_flow_log" "test" {
-	network_watcher_name = "${azurerm_network_watcher.test.name}"
-	resource_group_name  = "${azurerm_resource_group.test.name}"
+  network_watcher_name = "${azurerm_network_watcher.test.name}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
 
-	network_security_group_id = "${azurerm_network_security_group.test.id}"
-	storage_account_id        = "${azurerm_storage_account.test.id}"
-	enabled                   = true
-	version					  = %d
+  network_security_group_id = "${azurerm_network_security_group.test.id}"
+  storage_account_id        = "${azurerm_storage_account.test.id}"
+  enabled                   = true
+  version					= %d
 
-	retention_policy {
-	enabled = true
-	days    = 7
-	}
+  retention_policy {
+    enabled = true
+    days    = 7
+  }
 
-	traffic_analytics {
-	enabled               = true
-	workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
-	workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
-	workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"
-	}
+  traffic_analytics {
+    enabled               = false
+    workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
+    workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
+    workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"
+  }
 }
 `, testAccAzureRMNetworkWatcherFlowLog_prerequisites(data), data.RandomInteger, version)
 }

--- a/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
@@ -267,6 +267,34 @@ func testAccAzureRMNetworkWatcherFlowLog_trafficAnalytics(t *testing.T) {
 	})
 }
 
+func testAccAzureRMNetworkWatcherFlowLog_version(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_watcher_flow_log", "test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMNetworkWatcherDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkWatcherFlowLog_versionConfig(data, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkWatcherFlowLogExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "version", "1"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMNetworkWatcherFlowLog_versionConfig(data, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkWatcherFlowLogExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "version", "2"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMNetworkWatcherFlowLogExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.WatcherClient
@@ -492,4 +520,39 @@ resource "azurerm_network_watcher_flow_log" "test" {
   }
 }
 `, testAccAzureRMNetworkWatcherFlowLog_prerequisites(data), data.RandomInteger)
+}
+
+func testAccAzureRMNetworkWatcherFlowLog_versionConfig(data acceptance.TestData, version int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_workspace" "test" {
+	name                = "acctestLAW-%d"
+	location            = "${azurerm_resource_group.test.location}"
+	resource_group_name = "${azurerm_resource_group.test.name}"
+	sku                 = "PerGB2018"
+}
+
+resource "azurerm_network_watcher_flow_log" "test" {
+	network_watcher_name = "${azurerm_network_watcher.test.name}"
+	resource_group_name  = "${azurerm_resource_group.test.name}"
+
+	network_security_group_id = "${azurerm_network_security_group.test.id}"
+	storage_account_id        = "${azurerm_storage_account.test.id}"
+	enabled                   = true
+	version					  = %d
+
+	retention_policy {
+	enabled = true
+	days    = 7
+	}
+
+	traffic_analytics {
+	enabled               = true
+	workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
+	workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
+	workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"
+	}
+}
+`, testAccAzureRMNetworkWatcherFlowLog_prerequisites(data), data.RandomInteger, version)
 }

--- a/azurerm/internal/services/network/tests/resource_arm_network_watcher_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_watcher_test.go
@@ -73,6 +73,7 @@ func TestAccAzureRMNetworkWatcher(t *testing.T) {
 			"retentionPolicy":      testAccAzureRMNetworkWatcherFlowLog_retentionPolicy,
 			"updateStorageAccount": testAccAzureRMNetworkWatcherFlowLog_updateStorageAccount,
 			"trafficAnalytics":     testAccAzureRMNetworkWatcherFlowLog_trafficAnalytics,
+			"version":              testAccAzureRMNetworkWatcherFlowLog_version,
 		},
 	}
 

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `traffic_analytics` - (Optional) A `traffic_analytics` block as documented below.
 
-* `version` - (Optional) The version (revision) of the flow log. POssible values are `1` and `2`.
+* `version` - (Optional) The version (revision) of the flow log. Possible values are `1` and `2`.
 
 ---
 

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -88,6 +88,8 @@ The following arguments are supported:
 
 * `traffic_analytics` - (Optional) A `traffic_analytics` block as documented below.
 
+* `version` - (Optional) The version (revision) of the flow log.
+
 ---
 
 * `retention_policy` supports the following:

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `traffic_analytics` - (Optional) A `traffic_analytics` block as documented below.
 
-* `version` - (Optional) The version (revision) of the flow log.
+* `version` - (Optional) The version (revision) of the flow log. POssible values are `1` and `2`.
 
 ---
 


### PR DESCRIPTION
Fixes #5403

Adds the `version` argument for the `azurerm_network_watcher_flow_log` resource.