### PR TITLE
Fix output name error: 2-vms-loadbalancer-lbrules

### DIFF
--- a/examples/virtual-machines/2-vms-loadbalancer-lbrules/outputs.tf
+++ b/examples/virtual-machines/2-vms-loadbalancer-lbrules/outputs.tf
@@ -6,6 +6,6 @@ output "vm_fqdn" {
   value = "${azurerm_public_ip.lbpip.fqdn}"
 }
 
-output "VMs RDP acces" {
+output "vms_rdp_access" {
   value = "${formatlist("RDP_URL=%v:%v", azurerm_public_ip.lbpip.fqdn, azurerm_lb_nat_rule.tcp.*.frontend_port)}"
 }


### PR DESCRIPTION
Changed output name of RDP_URL.
Output name can include letters, numbers, underscores (_), and hyphens (-), NOT space.