### PR TITLE
'azurerm_storage_account' - Support for 'blob_properties' 'cors_rule'

### DIFF
--- a/azurerm/helpers/azure/storage_account.go
+++ b/azurerm/helpers/azure/storage_account.go
@@ -1,0 +1,66 @@
+package azure
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func SchemaStorageAccountCorsRule() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 5,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"allowed_origins": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 64,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+				"exposed_headers": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 64,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+				"allowed_headers": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 64,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+				"allowed_methods": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 64,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						ValidateFunc: validation.StringInSlice([]string{
+							"DELETE",
+							"GET",
+							"HEAD",
+							"MERGE",
+							"POST",
+							"OPTIONS",
+							"PUT"}, false),
+					},
+				},
+				"max_age_in_seconds": {
+					Type:         schema.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntBetween(1, 2000000000),
+				},
+			},
+		},
+	}
+}

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1391,7 +1391,7 @@ func expandBlobPropertiesDeleteRetentionPolicy(input []interface{}) *storage.Del
 		Enabled: utils.Bool(false),
 	}
 
-	if input == nil || len(input) == 0 {
+	if len(input) == 0 {
 		return &deleteRetentionPolicy
 	}
 
@@ -1406,7 +1406,7 @@ func expandBlobPropertiesDeleteRetentionPolicy(input []interface{}) *storage.Del
 func expandBlobPropertiesCors(input []interface{}) *storage.CorsRules {
 	blobCorsRules := storage.CorsRules{}
 
-	if input == nil || len(input) == 0 {
+	if len(input) == 0 {
 		return &blobCorsRules
 	}
 

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1369,21 +1369,30 @@ func expandStorageAccountBypass(networkRule map[string]interface{}) storage.Bypa
 }
 
 func expandBlobProperties(input []interface{}) storage.BlobServiceProperties {
-	blobServiceProperties := storage.BlobServicePropertiesProperties{}
-	blobProperties := storage.BlobServiceProperties{
-		BlobServicePropertiesProperties: &blobServiceProperties,
+	props := storage.BlobServiceProperties{
+		BlobServicePropertiesProperties: &storage.BlobServicePropertiesProperties{
+			Cors: &storage.CorsRules{
+				CorsRules: &[]storage.CorsRule{},
+			},
+			DeleteRetentionPolicy: &storage.DeleteRetentionPolicy{
+				Enabled: utils.Bool(false),
+			},
+		},
 	}
 
 	if len(input) == 0 || input[0] == nil {
-		return blobProperties
+		return props
 	}
 
-	blobAttr := input[0].(map[string]interface{})
+	v := input[0].(map[string]interface{})
 
-	blobServiceProperties.DeleteRetentionPolicy = expandBlobPropertiesDeleteRetentionPolicy(blobAttr["delete_retention_policy"].([]interface{}))
-	blobServiceProperties.Cors = expandBlobPropertiesCors(blobAttr["cors_rule"].([]interface{}))
+	deletePolicyRaw := v["delete_retention_policy"].([]interface{})
+	props.BlobServicePropertiesProperties.DeleteRetentionPolicy = expandBlobPropertiesDeleteRetentionPolicy(deletePolicyRaw)
 
-	return blobProperties
+	corsRaw := v["cors_rule"].([]interface{})
+	props.BlobServicePropertiesProperties.Cors = expandBlobPropertiesCors(corsRaw)
+
+	return props
 }
 
 func expandBlobPropertiesDeleteRetentionPolicy(input []interface{}) *storage.DeleteRetentionPolicy {
@@ -1437,7 +1446,17 @@ func expandBlobPropertiesCors(input []interface{}) *storage.CorsRules {
 
 func expandQueueProperties(input []interface{}) (queues.StorageServiceProperties, error) {
 	var err error
-	properties := queues.StorageServiceProperties{}
+	properties := queues.StorageServiceProperties{
+		Cors: &queues.Cors{
+			CorsRule: []queues.CorsRule{},
+		},
+		HourMetrics: &queues.MetricsConfig{
+			Enabled: false,
+		},
+		MinuteMetrics: &queues.MetricsConfig{
+			Enabled: false,
+		},
+	}
 	if len(input) == 0 {
 		return properties, nil
 	}

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
@@ -1399,8 +1399,8 @@ resource "azurerm_storage_account" "test" {
       allowed_headers    = ["x-tempo-*"]
       allowed_methods    = ["GET", "PUT"]
       max_age_in_seconds = "500"
-	}
-	
+    }
+
     delete_retention_policy {
       days = 300
     }
@@ -1431,16 +1431,16 @@ resource "azurerm_storage_account" "test" {
       allowed_headers    = ["*"]
       allowed_methods    = ["GET"]
       max_age_in_seconds = "2000000000"
-	}
-	
+    }
+
     cors_rule {
       allowed_origins    = ["http://www.test.com"]
       exposed_headers    = ["x-tempo-*"]
       allowed_headers    = ["*"]
       allowed_methods    = ["PUT"]
       max_age_in_seconds = "1000"
-	}
-	
+    }
+
     delete_retention_policy {
     }
   }

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
@@ -611,6 +611,7 @@ func TestAccAzureRMStorageAccount_blobProperties(t *testing.T) {
 				Config: testAccAzureRMStorageAccount_blobProperties(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "blob_properties.0.cors_rule.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "blob_properties.0.delete_retention_policy.0.days", "300"),
 				),
 			},
@@ -619,6 +620,7 @@ func TestAccAzureRMStorageAccount_blobProperties(t *testing.T) {
 				Config: testAccAzureRMStorageAccount_blobPropertiesUpdated(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "blob_properties.0.cors_rule.#", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "blob_properties.0.delete_retention_policy.0.days", "7"),
 				),
 			},
@@ -1391,6 +1393,14 @@ resource "azurerm_storage_account" "test" {
   account_replication_type = "LRS"
 
   blob_properties {
+    cors_rule {
+      allowed_origins    = ["http://www.example.com"]
+      exposed_headers    = ["x-tempo-*"]
+      allowed_headers    = ["x-tempo-*"]
+      allowed_methods    = ["GET", "PUT"]
+      max_age_in_seconds = "500"
+	}
+	
     delete_retention_policy {
       days = 300
     }
@@ -1415,6 +1425,22 @@ resource "azurerm_storage_account" "test" {
   account_replication_type = "LRS"
 
   blob_properties {
+    cors_rule {
+      allowed_origins    = ["http://www.example.com"]
+      exposed_headers    = ["x-tempo-*", "x-method-*"]
+      allowed_headers    = ["*"]
+      allowed_methods    = ["GET"]
+      max_age_in_seconds = "2000000000"
+	}
+	
+    cors_rule {
+      allowed_origins    = ["http://www.test.com"]
+      exposed_headers    = ["x-tempo-*"]
+      allowed_headers    = ["*"]
+      allowed_methods    = ["PUT"]
+      max_age_in_seconds = "1000"
+	}
+	
     delete_retention_policy {
     }
   }

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -125,6 +125,8 @@ The following arguments are supported:
 
 A `blob_properties` block supports the following:
 
+* `cors_rule` - (Optional) A `cors_rule` block as defined below.
+
 * `delete_retention_policy` - (Optional) A `delete_retention_policy` block as defined below.
 
 ---
@@ -221,7 +223,7 @@ any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 
 A `queue_properties` block supports the following:
 
-* `cors_rule` - (Optional) A `cors_rule` block as defined below.
+* `cors_rule` - (Optional) A `cors_rule` block as defined above.
 
 * `logging` - (Optional) A `logging` block as defined below.
 


### PR DESCRIPTION
This PR adds the ability to set _cors_rule_'s for blob's on the storage account. This will resolve #19

The one question I have is around the Azure Go Storage SDK vs. Giovanni Storage SDK. I chose to use the Azure Go Storage SDK. Do we want to use this or Giovanni? 

Let me know and I can update if needed
 
=== RUN   TestAccAzureRMStorageAccount_blobProperties
=== PAUSE TestAccAzureRMStorageAccount_blobProperties
=== CONT  TestAccAzureRMStorageAccount_blobProperties
--- PASS: TestAccAzureRMStorageAccount_blobProperties (156.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/tests       156.958s