### PR TITLE
refactor: ensuring custom polling methods support custom timeouts

### DIFF
--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_hadoop_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_hadoop_cluster.go
@@ -275,9 +275,15 @@ func resourceArmHDInsightHadoopClusterCreate(d *schema.ResourceData, meta interf
 			Pending:    []string{"AzureVMConfiguration", "Accepted", "HdInsightConfiguration"},
 			Target:     []string{"Running"},
 			Refresh:    hdInsightWaitForReadyRefreshFunc(ctx, client, resourceGroup, name),
-			Timeout:    60 * time.Minute,
 			MinTimeout: 15 * time.Second,
 		}
+
+		if features.SupportsCustomTimeouts() {
+			stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
+		} else {
+			stateConf.Timeout = 60 * time.Minute
+		}
+
 		if _, err := stateConf.WaitForState(); err != nil {
 			return fmt.Errorf("Error waiting for HDInsight Cluster %q (Resource Group %q) to be running: %s", name, resourceGroup, err)
 		}

--- a/azurerm/internal/services/netapp/resource_arm_netapp_pool.go
+++ b/azurerm/internal/services/netapp/resource_arm_netapp_pool.go
@@ -192,19 +192,21 @@ func resourceArmNetAppPoolDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error deleting NetApp Pool %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	return waitForNetAppPoolToBeDeleted(ctx, client, resourceGroup, accountName, name)
-}
-
-func waitForNetAppPoolToBeDeleted(ctx context.Context, client *netapp.PoolsClient, resourceGroup, accountName, name string) error {
-	log.Printf("[DEBUG] Waiting for NetApp Pool Provisioning Service %q (Resource Group %q) to be deleted", name, resourceGroup)
+	log.Printf("[DEBUG] Waiting for NetApp Pool %q (Resource Group %q) to be deleted", name, resourceGroup)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"200", "202"},
 		Target:  []string{"404"},
 		Refresh: netappPoolDeleteStateRefreshFunc(ctx, client, resourceGroup, accountName, name),
-		Timeout: 20 * time.Minute,
 	}
+
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		stateConf.Timeout = 20 * time.Minute
+	}
+
 	if _, err := stateConf.WaitForState(); err != nil {
-		return fmt.Errorf("Error waiting for NetApp Pool Provisioning Service %q (Resource Group %q) to be deleted: %+v", name, resourceGroup, err)
+		return fmt.Errorf("Error waiting for NetApp Pool %q (Resource Group %q) to be deleted: %+v", name, resourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/netapp/resource_arm_netapp_volume.go
+++ b/azurerm/internal/services/netapp/resource_arm_netapp_volume.go
@@ -266,23 +266,23 @@ func resourceArmNetAppVolumeDelete(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error deleting NetApp Volume %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	return waitForNetAppVolumeToBeDeleted(ctx, client, resourceGroup, accountName, poolName, name)
-}
-
-func waitForNetAppVolumeToBeDeleted(ctx context.Context, client *netapp.VolumesClient, resourceGroup, accountName, poolName, name string) error {
 	// The resource NetApp Volume depends on the resource NetApp Pool.
 	// Although the delete API returns 404 which means the NetApp Volume resource has been deleted.
 	// Then it tries to immediately delete NetApp Pool but it still throws error `Can not delete resource before nested resources are deleted.`
 	// In this case we're going to try triggering the Deletion again, in-case it didn't work prior to this attempt.
 	// For more details, see related Bug: https://github.com/Azure/azure-sdk-for-go/issues/6485
-
 	log.Printf("[DEBUG] Waiting for NetApp Volume Provisioning Service %q (Resource Group %q) to be deleted", name, resourceGroup)
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"200", "202"},
 		Target:  []string{"404"},
 		Refresh: netappVolumeDeleteStateRefreshFunc(ctx, client, resourceGroup, accountName, poolName, name),
-		Timeout: 20 * time.Minute,
 	}
+	if features.SupportsCustomTimeouts() {
+		stateConf.Timeout = d.Timeout(schema.TimeoutDelete)
+	} else {
+		stateConf.Timeout = 20 * time.Minute
+	}
+
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for NetApp Volume Provisioning Service %q (Resource Group %q) to be deleted: %+v", name, resourceGroup, err)
 	}

--- a/azurerm/internal/services/sql/resource_arm_sql_database.go
+++ b/azurerm/internal/services/sql/resource_arm_sql_database.go
@@ -473,10 +473,13 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 			return err2
 		}
 
-		// this is set in config.go, but something sets
-		// it back to 15 minutes, which isn't long enough
-		// for most imports
-		client.Client.PollingDuration = 60 * time.Minute
+		// TODO: remove me in 2.0
+		if !features.SupportsCustomTimeouts() {
+			// this is set in config.go, but something sets
+			// it back to 15 minutes, which isn't long enough
+			// for most imports
+			client.Client.PollingDuration = 60 * time.Minute
+		}
 
 		if err = importFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return err


### PR DESCRIPTION
Whilst putting together the documentation for the upcoming Beta I noticed that some of the custom polling methods didn't support using custom timeouts when that feature's enabled, as such this PR fixes that on the resources I found via grepping