### PR TITLE
[WIP] App service source control

### DIFF
--- a/azurerm/helpers/azure/web.go
+++ b/azurerm/helpers/azure/web.go
@@ -95,14 +95,13 @@ func ExpandWebCorsSettings(input interface{}) web.CorsSettings {
 	return corsSettings
 }
 
-func ExpandWebSourceControl(input []interface{}) web.SiteSourceControlProperties {
-	sourceControlProperties := web.SiteSourceControlProperties{}
-	
+func ExpandWebSourceControl(input []interface{}) *web.SiteSourceControlProperties {
 	if len(input) == 0 {
-		return sourceControlProperties
+		return nil
 	}
 
 	sourceControl := input[0].(map[string]interface{})
+	sourceControlProperties := web.SiteSourceControlProperties{}
 
 	if v, ok := sourceControl["repo_url"]; ok {
 		sourceControlProperties.RepoURL = utils.String(v.(string))
@@ -124,7 +123,7 @@ func ExpandWebSourceControl(input []interface{}) web.SiteSourceControlProperties
 		sourceControlProperties.IsMercurial = utils.Bool(v.(bool))
 	}
 
-	return sourceControlProperties
+	return &sourceControlProperties
 }
 
 func FlattenWebCorsSettings(input *web.CorsSettings) []interface{} {

--- a/azurerm/helpers/azure/web.go
+++ b/azurerm/helpers/azure/web.go
@@ -32,10 +32,11 @@ func SchemaWebCorsSettings() *schema.Schema {
 
 func SchemaWebSourceControl() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		Computed: true,
-		MaxItems: 1,
+		Type:       schema.TypeList,
+		Optional:   true,
+		Computed:   true,
+		MaxItems:   1,
+		ConfigMode: schema.SchemaConfigModeAttr,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"repo_url": {

--- a/azurerm/internal/services/web/app_service_source_control_token.go
+++ b/azurerm/internal/services/web/app_service_source_control_token.go
@@ -7,7 +7,7 @@ import (
 
 func ValidateAppServiceSourceControlTokenName() schema.SchemaValidateFunc {
 	return validation.StringInSlice([]string{
-		"BitBucket",
+		"Bitbucket",
 		"Dropbox",
 		"GitHub",
 		"OneDrive",

--- a/azurerm/internal/services/web/app_service_source_control_token_test.go
+++ b/azurerm/internal/services/web/app_service_source_control_token_test.go
@@ -8,7 +8,7 @@ func TestValidateAppServiceSourceControlToken(t *testing.T) {
 		Valid bool
 	}{
 		{Input: "", Valid: false},
-		{Input: "BitBucket", Valid: true},
+		{Input: "Bitbucket", Valid: true},
 		{Input: "Dropbox", Valid: true},
 		{Input: "GitLab", Valid: false},
 		{Input: "GitHub", Valid: true},

--- a/azurerm/internal/services/web/registration.go
+++ b/azurerm/internal/services/web/registration.go
@@ -30,6 +30,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_app_service_custom_hostname_binding":          resourceArmAppServiceCustomHostnameBinding(),
 		"azurerm_app_service_plan":                             resourceArmAppServicePlan(),
 		"azurerm_app_service_slot":                             resourceArmAppServiceSlot(),
+		"azurerm_app_service_source_control":                   resourceArmAppServiceSourceControl(),
 		"azurerm_app_service_source_control_token":             resourceArmAppServiceSourceControlToken(),
 		"azurerm_app_service_virtual_network_swift_connection": resourceArmAppServiceVirtualNetworkSwiftConnection(),
 		"azurerm_app_service":                                  resourceArmAppService(),

--- a/azurerm/internal/services/web/resource_arm_app_service_source_control.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_source_control.go
@@ -137,6 +137,14 @@ func resourceArmAppServiceSourceControlRead(d *schema.ResourceData, meta interfa
 	resourceGroup := id.ResourceGroup
 	name := id.Path["sites"]
 
+	appService, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(appService.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving existing App Service %q (Resource Group %q): %s", name, resourceGroup, err)
+	}
 	resp, err := client.GetSourceControl(ctx, resourceGroup, name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
@@ -154,6 +162,8 @@ func resourceArmAppServiceSourceControlRead(d *schema.ResourceData, meta interfa
 		d.Set("is_manual_integration", props.IsManualIntegration)
 		d.Set("is_mercurial", props.IsMercurial)
 	}
+
+	d.Set("app_service_id", appService.ID)
 
 	return nil
 }

--- a/azurerm/internal/services/web/resource_arm_app_service_source_control.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_source_control.go
@@ -101,8 +101,8 @@ func resourceArmAppServiceSourceControlCreate(d *schema.ResourceData, meta inter
 
 	siteSourceControl := web.SiteSourceControl{
 		SiteSourceControlProperties: &web.SiteSourceControlProperties{
-			RepoURL: utils.String(repoUrl),
-			Branch:  utils.String(branch),
+			RepoURL:                   utils.String(repoUrl),
+			Branch:                    utils.String(branch),
 			DeploymentRollbackEnabled: utils.Bool(deploymentRollbackEnabled),
 			IsManualIntegration:       utils.Bool(isManualIntegration),
 		},

--- a/azurerm/internal/services/web/resource_arm_app_service_source_control.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_source_control.go
@@ -1,0 +1,187 @@
+package web
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+var appServiceSourceControlResourceName = "azurerm_app_service_source_control"
+
+func resourceArmAppServiceSourceControl() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAppServiceSourceControlCreate,
+		Read:   resourceArmAppServiceSourceControlRead,
+		Delete: resourceArmAppServiceSourceControlDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"app_service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"repo_url": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"branch": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"deployment_rollback_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
+			"is_manual_integration": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
+			"is_mercurial": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArmAppServiceSourceControlCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for App Service Source Control creation.")
+
+	id, err := azure.ParseAzureResourceID(d.Get("app_service_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+	}
+
+	resourceGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	repoUrl := d.Get("repo_url").(string)
+	branch := d.Get("branch").(string)
+	deploymentRollbackEnabled := d.Get("deployment_rollback_enabled").(bool)
+	isManualIntegration := d.Get("is_manual_integration").(bool)
+
+	locks.ByName(name, appServiceSourceControlResourceName)
+	defer locks.UnlockByName(name, appServiceSourceControlResourceName)
+
+	siteSourceControl := web.SiteSourceControl{
+		SiteSourceControlProperties: &web.SiteSourceControlProperties{
+			RepoURL: utils.String(repoUrl),
+			Branch:  utils.String(branch),
+			DeploymentRollbackEnabled: utils.Bool(deploymentRollbackEnabled),
+			IsManualIntegration:       utils.Bool(isManualIntegration),
+		},
+	}
+
+	if _, err := client.CreateOrUpdateSourceControl(ctx, resourceGroup, name, siteSourceControl); err != nil {
+		return fmt.Errorf("Error updating App Service Source Control (App Service %q / Resource Group %q): %s", name, resourceGroup, err)
+	}
+
+	read, err := client.GetSourceControl(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving App Service Source Control (App Service %q / Resource Group %q): %s", name, resourceGroup, err)
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read App Service Source Control (App Service %q / Resource Group %q) ID", name, resourceGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmAppServiceSourceControlRead(d, meta)
+}
+
+func resourceArmAppServiceSourceControlRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+	}
+	resourceGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	resp, err := client.GetSourceControl(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] App Service Source Control (App Service %q / Resource Group %q) was not found - removing from state", name, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error making Read request on App Service Source Control (App Service %q / Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	if props := resp.SiteSourceControlProperties; props != nil {
+		d.Set("repo_url", props.RepoURL)
+		d.Set("branch", props.Branch)
+		d.Set("deployment_rollback_enabled", props.DeploymentRollbackEnabled)
+		d.Set("is_manual_integration", props.IsManualIntegration)
+		d.Set("is_mercurial", props.IsMercurial)
+	}
+
+	return nil
+}
+
+func resourceArmAppServiceSourceControlDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Get("app_service_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+	}
+
+	resourceGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	locks.ByName(name, appServiceSourceControlResourceName)
+	defer locks.UnlockByName(name, appServiceSourceControlResourceName)
+
+	log.Printf("[DEBUG] Deleting App Service Source Control (App Service %q / Resource Group %q)", name, resourceGroup)
+
+	resp, err := client.DeleteSourceControl(ctx, resourceGroup, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error deleting App Service Source Control (App Service %q / Resource Group %q): %s)", name, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/web/resource_arm_function_app.go
+++ b/azurerm/internal/services/web/resource_arm_function_app.go
@@ -245,6 +245,16 @@ func resourceArmFunctionApp() *schema.Resource {
 								string(web.FtpsOnly),
 							}, false),
 						},
+						"scm_type": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"source_control"},
+							Default:       string(web.ScmTypeNone),
+							ValidateFunc: validation.StringInSlice([]string{
+								string(web.ScmTypeLocalGit),
+								string(web.ScmTypeNone),
+							}, false),
+						},
 						"cors": azure.SchemaWebCorsSettings(),
 					},
 				},
@@ -798,6 +808,10 @@ func expandFunctionAppSiteConfig(d *schema.ResourceData) web.SiteConfig {
 		siteConfig.FtpsState = web.FtpsState(v.(string))
 	}
 
+	if v, ok := config["scm_type"]; ok {
+		siteConfig.ScmType = web.ScmType(v.(string))
+	}
+
 	return siteConfig
 }
 
@@ -836,6 +850,7 @@ func flattenFunctionAppSiteConfig(input *web.SiteConfig) []interface{} {
 
 	result["min_tls_version"] = string(input.MinTLSVersion)
 	result["ftps_state"] = string(input.FtpsState)
+	result["scm_type"] = string(input.ScmType)
 
 	result["cors"] = azure.FlattenWebCorsSettings(input.Cors)
 

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_source_control_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_source_control_test.go
@@ -9,64 +9,50 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMAppServiceSourceControl(t *testing.T) {
+func TestAccAzureRMAppServiceSourceControl_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control", "test")
-	repoUrl := "https://github.com/Azure-Samples/app-service-web-html-get-started"
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
 		CheckDestroy: testCheckAzureRMAppServiceSourceControlDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMAppServiceSourceControl(data, repoUrl),
+				Config: testAccAzureRMAppServiceSourceControl_basic(data),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "repo_url", repoUrl),
+					testCheckAzureRMAppServiceSourceControlExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "repo_url", "https://github.com/Azure-Samples/app-service-web-html-get-started"),
 				),
 			},
-			{
-				ResourceName:            data.ResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"app_service_id"},
-			},
+			data.ImportStep(),
 		},
 	})
 }
 
-func testAccAzureRMAppServiceSourceControl(data acceptance.TestData, repoUrl string) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appservice-%d"
-  location = "%s"
-}
-resource "azurerm_app_service_plan" "test" {
-  name                = "acctest-ASP-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  sku {
-    tier = "Standard"
-    size = "S1"
-  }
-}
-resource "azurerm_app_service" "test" {
-  name                = "acctest-AS-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
-  lifecycle {
-    ignore_changes = [site_config.0.scm_type]
-  }
-}
-resource "azurerm_app_service_source_control" "test" {
-  app_service_id             = "${azurerm_app_service.test.id}"
-  repo_url                   = "%s"
-  branch                     = "master"
-  is_manual_integration      = true
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, repoUrl)
+func TestAccAzureRMAppServiceSourceControl_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSourceControlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceSourceControl_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceSourceControlExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMAppServiceSourceControl_requiresImport),
+		},
+	})
 }
 
 func testCheckAzureRMAppServiceSourceControlDestroy(s *terraform.State) error {
@@ -97,4 +83,80 @@ func testCheckAzureRMAppServiceSourceControlDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testCheckAzureRMAppServiceSourceControlExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := rs.Primary.Attributes["id"]
+		parsedID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+		}
+		name := parsedID.Path["sites"]
+		resourceGroup := parsedID.ResourceGroup
+
+		resp, err := client.GetSourceControl(ctx, resourceGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMAppServiceSourceControl_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appservice-%d"
+  location = "%s"
+}
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctest-ASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctest-AS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  lifecycle {
+    ignore_changes = [site_config.0.scm_type]
+  }
+}
+resource "azurerm_app_service_source_control" "test" {
+  app_service_id             = "${azurerm_app_service.test.id}"
+  repo_url                   = "https://github.com/Azure-Samples/app-service-web-html-get-started"
+  branch                     = "master"
+  is_manual_integration      = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppServiceSourceControl_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMAppServiceSourceControl_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_source_control" "import" {
+  app_service_id             = "${azurerm_app_service.test.id}"
+  repo_url                   = "https://github.com/Azure-Samples/app-service-web-html-get-started"
+  branch                     = "master"
+  is_manual_integration      = true
+}
+`, template)
 }

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_source_control_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_source_control_test.go
@@ -1,0 +1,100 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMAppServiceSourceControl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control", "test")
+	repoUrl := "https://github.com/Azure-Samples/app-service-web-html-get-started"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceSourceControlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceSourceControl(data, repoUrl),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "repo_url", repoUrl),
+				),
+			},
+			{
+				ResourceName:            data.ResourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_service_id"},
+			},
+		},
+	})
+}
+
+func testAccAzureRMAppServiceSourceControl(data acceptance.TestData, repoUrl string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appservice-%d"
+  location = "%s"
+}
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctest-ASP-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+resource "azurerm_app_service" "test" {
+  name                = "acctest-AS-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.test.id}"
+  lifecycle {
+    ignore_changes = [site_config.0.scm_type]
+  }
+}
+resource "azurerm_app_service_source_control" "test" {
+  app_service_id             = "${azurerm_app_service.test.id}"
+  repo_url                   = "%s"
+  branch                     = "master"
+  is_manual_integration      = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, repoUrl)
+}
+
+func testCheckAzureRMAppServiceSourceControlDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_app_service_source_control" {
+			continue
+		}
+
+		id := rs.Primary.Attributes["id"]
+		parsedID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+		}
+		name := parsedID.Path["sites"]
+		resourceGroup := parsedID.ResourceGroup
+
+		resp, err := client.GetSourceControl(ctx, resourceGroup, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_source_control_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_source_control_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -28,29 +27,6 @@ func TestAccAzureRMAppServiceSourceControl_basic(t *testing.T) {
 				),
 			},
 			data.ImportStep(),
-		},
-	})
-}
-
-func TestAccAzureRMAppServiceSourceControl_requiresImport(t *testing.T) {
-	if !features.ShouldResourcesBeImported() {
-		t.Skip("Skipping since resources aren't required to be imported")
-		return
-	}
-	data := acceptance.BuildTestData(t, "azurerm_app_service_source_control", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMAppServiceSourceControlDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMAppServiceSourceControl_basic(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceSourceControlExists(data.ResourceName),
-				),
-			},
-			data.RequiresImportErrorStep(testAccAzureRMAppServiceSourceControl_requiresImport),
 		},
 	})
 }
@@ -145,18 +121,4 @@ resource "azurerm_app_service_source_control" "test" {
   is_manual_integration      = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
-}
-
-func testAccAzureRMAppServiceSourceControl_requiresImport(data acceptance.TestData) string {
-	template := testAccAzureRMAppServiceSourceControl_basic(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_app_service_source_control" "import" {
-  app_service_id             = "${azurerm_app_service.test.id}"
-  repo_url                   = "https://github.com/Azure-Samples/app-service-web-html-get-started"
-  branch                     = "master"
-  is_manual_integration      = true
-}
-`, template)
 }

--- a/examples/app-service-source-control/continuous-deployment/README.md
+++ b/examples/app-service-source-control/continuous-deployment/README.md
@@ -1,0 +1,3 @@
+# Example: App Service with Source Control to enable continuous deployment
+
+This example creates an App Service with Source Control to enable continuous deployment (which configures webhooks into online repos like GitHub).

--- a/examples/app-service-source-control/continuous-deployment/main.tf
+++ b/examples/app-service-source-control/continuous-deployment/main.tf
@@ -1,0 +1,39 @@
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+# NOTE: Source Control Tokens are configured at the subscription level, 
+# not on each App Service - as such this can only be configured Subscription-wide.
+resource "azurerm_app_service_source_control_token" "example" {
+  type  = "GitHub"
+  token = "${var.github_token}"
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "${var.prefix}-asp"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "example" {
+  name                = "${var.prefix}-appservice"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.example.id}"
+
+  lifecycle {
+    ignore_changes = [site_config.0.scm_type]
+  }
+}
+
+resource "azurerm_app_service_source_control" "example" {
+  app_service_id = "${azurerm_app_service.example.id}"
+  repo_url       = "${var.repo_url}"
+  branch         = "master"
+}

--- a/examples/app-service-source-control/continuous-deployment/variables.tf
+++ b/examples/app-service-source-control/continuous-deployment/variables.tf
@@ -1,0 +1,15 @@
+variable "prefix" {
+  description = "The prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure location where all resources in this example should be created"
+}
+
+variable "github_token" {
+  description = "A personal access token with the `admin:repo hook` scope."
+}
+
+variable "repo_url" {
+  description = "The repository URL. For example: https://github.com/example-user/example-repo"
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -663,6 +663,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/app_service_source_control.html">azurerm_app_service_source_control</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service_source_control_token.html">azurerm_app_service_source_control_token</a>
                 </li>
 

--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -45,7 +45,7 @@ resource "azurerm_app_service_source_control" "example" {
   app_service_id             = "${azurerm_app_service.example.id}"
   repo_url                   = "https://github.com/Azure-Samples/app-service-web-html-get-started"
   branch                     = "master"
-  manual_integration_enabled = true
+  is_manual_integration      = true
 }
 ```
 

--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -42,10 +42,10 @@ resource "azurerm_app_service" "example" {
 }
 
 resource "azurerm_app_service_source_control" "example" {
-  app_service_id             = "${azurerm_app_service.example.id}"
-  repo_url                   = "https://github.com/Azure-Samples/app-service-web-html-get-started"
-  branch                     = "master"
-  is_manual_integration      = true
+  app_service_id        = "${azurerm_app_service.example.id}"
+  repo_url              = "https://github.com/Azure-Samples/app-service-web-html-get-started"
+  branch                = "master"
+  is_manual_integration = true
 }
 ```
 

--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "App Service (Web Apps)"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_source_control"
+description: |-
+  Manages source control for an App Service.
+
+---
+
+# azurerm_app_service_source_control
+
+Manages source control for an App Service.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "example-app-service-plan"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "example" {
+  name                = "example-app-service"
+  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = "${azurerm_resource_group.example.name}"
+  app_service_plan_id = "${azurerm_app_service_plan.example.id}"
+
+  lifecycle {
+    ignore_changes = [site_config.0.scm_type]
+  }
+}
+
+resource "azurerm_app_service_source_control" "example" {
+  app_service_id             = "${azurerm_app_service.example.id}"
+  repo_url                   = "https://github.com/Azure-Samples/app-service-web-html-get-started"
+  branch                     = "master"
+  manual_integration_enabled = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repo_url` - (Required) The repository or source control URL. Changing this forces a new resource to be created.
+
+* `branch` - (Optional) The name of branch to use for deployment. Changing this forces a new resource to be created.
+
+* `deployment_rollback_enabled` - (Optional) Should deployment rollback be enabled? Defaults to `false`. Changing this forces a new resource to be created.
+
+* `is_manual_integration` - (Optional) Should manual integration be enabled, rather than continuous integration (which configures webhooks into online repos like GitHub)? Defaults to `false`. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the App Service Source Control.
+
+## Import
+
+App Service source control can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_app_service_source_control.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-group/providers/Microsoft.Web/sites/test-app/sourcecontrols/web
+```

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -26,7 +26,7 @@ resource "azurerm_app_service_source_control_token" "example" {
 
 The following arguments are supported:
 
-* `type` - (Required) The source control type. Possible values are `BitBucket`, `Dropbox`, `GitHub` and `OneDrive`.
+* `type` - (Required) The source control type. Possible values are `Bitbucket`, `Dropbox`, `GitHub` and `OneDrive`.
 
 * `token` - (Required) The OAuth access token.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -119,6 +119,8 @@ The following arguments are supported:
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 
+* `source_control` - (Optional) A Source Control block as defined below.
+
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -167,6 +169,18 @@ A `cors` block supports the following:
 `identity` supports the following:
 
 * `type` - (Required) Specifies the identity type of the App Service. At this time the only allowed value is `SystemAssigned`.
+
+---
+
+A `source_control` block supports the following:
+
+* `repo_url` - (Required) The repository or source control URL.
+
+* `branch` - (Required) The name of branch to use for deployment. Defaults to `master`.
+
+* `deployment_rollback_enabled` - (Optional) Should deployment rollback be enabled? Defaults to `false`.
+
+* `is_manual_integration` - (Optional) Whether manual integration be enabled, rather than continuous integration (which configures webhooks into online repos like GitHub). Defaults to `false`.
 
 ---
 


### PR DESCRIPTION
- [x] New resource: `azurerm_app_service_source_control`
- [ ] `azurerm_app_service`: support for setting fields within the `source_control` block
  - Implementing this is a bit of a hack, see https://github.com/terraform-providers/terraform-provider-azurerm/issues/3696#issuecomment-529224458
- [ ] `azurerm_function_app`: support for setting fields within the `source_control` block
- [ ] Additional tests
- [ ] Additional documentation and examples (describing manual integration and which providers support continuous deployment)

Fixes #5366
Fixes #4952
Fixes #3696

Not sure if to add tests for the different source control providers, since it requires a source control token to be configured.

Wanted start discussion on how to add support for managing source control for an app service before `v2.0.0` release, in case a breaking change is preferred.

References:
- https://github.com/projectkudu/kudu/wiki/Continuous-deployment
- https://godoc.org/github.com/Azure/azure-sdk-for-go/services/web/mgmt/2018-02-01/web#AppsClient.CreateOrUpdateSourceControl
- https://docs.microsoft.com/bs-latn-ba/cli/azure/webapp/deployment/source?view=azure-cli-latest#az-webapp-deployment-source-config
