### PR TITLE
Fix for Issue #5227

### DIFF
--- a/azurerm/helpers/validate/network.go
+++ b/azurerm/helpers/validate/network.go
@@ -94,7 +94,17 @@ func validateIPAddress(i interface{}, k string, allowEmpty bool) (warnings []str
 }
 
 // CIDR validations allow IPv4 and IPv6 CIDR notations as defined in RFC 4632 and RFC 4291
-func CIDR(i interface{}, k string, allowNoSuffix bool) (warnings []string, errors []error) {
+func CIDR(i interface{}, k string) (warnings []string, errors []error) {
+	return cIDR(i, k, false)
+}
+
+// CIDRAllowNoSuffix validations allow IPv4 and IPv6 CIDR notations as defined in RFC 4632 and RFC 4291
+// Additionally invalid CIDR notations without suffix are allowed.
+func CIDRAllowNoSuffix(i interface{}, k string) (warnings []string, errors []error) {
+	return cIDR(i, k, true)
+}
+
+func cIDR(i interface{}, k string, allowNoSuffix bool) (warnings []string, errors []error) {
 	cidr := i.(string)
 
 	// A CIDR without the suffix is invalid, but for compatibility reasons we need

--- a/azurerm/helpers/validate/network.go
+++ b/azurerm/helpers/validate/network.go
@@ -3,47 +3,15 @@ package validate
 import (
 	"fmt"
 	"net"
-	"regexp"
+	"strings"
 )
 
-func IPv6Address(i interface{}, k string) (warnings []string, errors []error) {
-	return validateIpv6Address(i, k, false)
-}
-
-func validateIpv6Address(i interface{}, k string, allowEmpty bool) (warnings []string, errors []error) { // nolint: unparam
-	v, ok := i.(string)
-	if !ok {
-		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
-		return
-	}
-
-	if v == "" && allowEmpty {
-		return
-	}
-
-	ip := net.ParseIP(v)
-	if six := ip.To16(); six == nil {
-		errors = append(errors, fmt.Errorf("%q is not a valid IPv6 address: %q", k, v))
-	}
-
-	return warnings, errors
-}
-
-func CIDR(i interface{}, k string) (warnings []string, errors []error) {
-	cidr := i.(string)
-
-	re := regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$`)
-	if re != nil && !re.MatchString(cidr) {
-		errors = append(errors, fmt.Errorf("%s must start with IPV4 address and/or slash, number of bits (0-32) as prefix. Example: 127.0.0.1/8. Got %q.", k, cidr))
-	}
-
-	return warnings, errors
-}
-
+// IPv4Address validation returns true if the given address is a valid IPv4 address
 func IPv4Address(i interface{}, k string) (warnings []string, errors []error) {
 	return validateIpv4Address(i, k, false)
 }
 
+// IPv4AddressOrEmpty validation returns true if the given address is a valid IPv4 address or empty
 func IPv4AddressOrEmpty(i interface{}, k string) (warnings []string, errors []error) {
 	return validateIpv4Address(i, k, true)
 }
@@ -67,6 +35,83 @@ func validateIpv4Address(i interface{}, k string, allowEmpty bool) (warnings []s
 	return warnings, errors
 }
 
+// IPv6Address validation returns true if the given address is a valid IPv6 address
+func IPv6Address(i interface{}, k string) (warnings []string, errors []error) {
+	return validateIpv6Address(i, k, false)
+}
+
+// IPv6AddressOrEmpty validation returns true if the given address is a valid IPv6 address or empty
+func IPv6AddressOrEmpty(i interface{}, k string) (warnings []string, errors []error) {
+	return validateIpv6Address(i, k, true)
+}
+
+func validateIpv6Address(i interface{}, k string, allowEmpty bool) (warnings []string, errors []error) { // nolint: unparam
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if v == "" && allowEmpty {
+		return
+	}
+
+	ip := net.ParseIP(v)
+	if six := ip.To16(); six == nil {
+		errors = append(errors, fmt.Errorf("%q is not a valid IPv6 address: %q", k, v))
+	}
+
+	return warnings, errors
+}
+
+// IPAddress validation returns true if the given address is a valid IPv4 or IPv6 address
+func IPAddress(i interface{}, k string) (warnings []string, errors []error) {
+	return validateIPAddress(i, k, false)
+}
+
+// IPAddressOrEmpty validation returns true if the given address is a valid IPv4 or IPv6 address, or empty
+func IPAddressOrEmpty(i interface{}, k string) (warnings []string, errors []error) {
+	return validateIPAddress(i, k, true)
+}
+
+func validateIPAddress(i interface{}, k string, allowEmpty bool) (warnings []string, errors []error) { // nolint: unparam
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if v == "" && allowEmpty {
+		return
+	}
+
+	ip := net.ParseIP(v)
+	if ip == nil {
+		errors = append(errors, fmt.Errorf("%q is not a valid IPv4 or IPv6 address: %q", k, v))
+	}
+
+	return warnings, errors
+}
+
+// CIDR validations allow IPv4 and IPv6 CIDR notations as defined in RFC 4632 and RFC 4291
+func CIDR(i interface{}, k string, allowNoSuffix bool) (warnings []string, errors []error) {
+	cidr := i.(string)
+
+	// A CIDR without the suffix is invalid, but for compatibility reasons we need
+	// to be able to validate those as valid, too.
+	if allowNoSuffix && !strings.Contains(cidr, "/") {
+		cidr = cidr + "/0"
+	}
+	_, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%s must be a valid IPv4 or IPv6 address and slash, number of bits (0-32) as prefix. Example: 127.0.0.1/8. Got %q", k, cidr))
+	}
+
+	return warnings, errors
+}
+
+// MACAddress validates the input to be a valid MAC address
+// Valid are addresses according to IEEE 802 MAC-48, EUI-48, EUI-64, or a 20-octet IP over InfiniBand link-layer address
 func MACAddress(i interface{}, k string) (warnings []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {

--- a/azurerm/helpers/validate/network_test.go
+++ b/azurerm/helpers/validate/network_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCIDR(t *testing.T) {
+func TestCIDRallowNoSuffix(t *testing.T) {
 	cases := []struct {
 		CIDR   string
 		Errors int
@@ -30,11 +30,69 @@ func TestCIDR(t *testing.T) {
 			CIDR:   "127.0.0.1/-1",
 			Errors: 1,
 		},
+		{
+			CIDR:   "2001:db8:a0b:12f0::1/32",
+			Errors: 0,
+		},
+		{
+			CIDR:   "2001:db8:a0b:12f0::1/222",
+			Errors: 1,
+		},
+		{
+			CIDR:   "2001:db8:a0b:12f0::1",
+			Errors: 0,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.CIDR, func(t *testing.T) {
-			_, errors := CIDR(tc.CIDR, "test")
+			_, errors := CIDR(tc.CIDR, "test", true)
+
+			if len(errors) != tc.Errors {
+				t.Fatalf("Expected CIDR to return %d error(s) not %d", tc.Errors, len(errors))
+			}
+		})
+	}
+}
+
+func TestCIDR(t *testing.T) {
+	cases := []struct {
+		CIDR   string
+		Errors int
+	}{
+		{
+			CIDR:   "",
+			Errors: 1,
+		},
+		{
+			CIDR:   "0.0.0.0",
+			Errors: 1,
+		},
+		{
+			CIDR:   "127.0.0.1/8",
+			Errors: 0,
+		},
+		{
+			CIDR:   "127.0.0.1/33",
+			Errors: 1,
+		},
+		{
+			CIDR:   "127.0.0.1/-1",
+			Errors: 1,
+		},
+		{
+			CIDR:   "2001:db8:a0b:12f0::1/32",
+			Errors: 0,
+		},
+		{
+			CIDR:   "2001:db8:a0b:12f0::1/222",
+			Errors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.CIDR, func(t *testing.T) {
+			_, errors := CIDR(tc.CIDR, "test", false)
 
 			if len(errors) != tc.Errors {
 				t.Fatalf("Expected CIDR to return %d error(s) not %d", tc.Errors, len(errors))
@@ -188,6 +246,122 @@ func TestIPv4AddressOrEmpty(t *testing.T) {
 
 			if len(errors) != tc.Errors {
 				t.Fatalf("Expected IPv4AddressOrEmpty to return %d error(s) not %d", len(errors), tc.Errors)
+			}
+		})
+	}
+}
+
+func TestIPAddress(t *testing.T) {
+	cases := []struct {
+		IP     string
+		Errors int
+	}{
+		{
+			IP:     "",
+			Errors: 1,
+		},
+		{
+			IP:     "0.0.0.0",
+			Errors: 0,
+		},
+		{
+			IP:     "1.2.3.no",
+			Errors: 1,
+		},
+		{
+			IP:     "text",
+			Errors: 1,
+		},
+		{
+			IP:     "1.2.3.4",
+			Errors: 0,
+		},
+		{
+			IP:     "12.34.43.21",
+			Errors: 0,
+		},
+		{
+			IP:     "100.123.199.0",
+			Errors: 0,
+		},
+		{
+			IP:     "255.255.255.255",
+			Errors: 0,
+		},
+		{
+			IP:     "2001:0db8:85a3:0:0:8a2e:0370:7334",
+			Errors: 0,
+		},
+		{
+			IP:     "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			Errors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.IP, func(t *testing.T) {
+			_, errors := IPAddress(tc.IP, "test")
+
+			if len(errors) != tc.Errors {
+				t.Fatalf("Expected IPAddress to return %d error(s) not %d", len(errors), tc.Errors)
+			}
+		})
+	}
+}
+
+func TestIPAddressOrEmpty(t *testing.T) {
+	cases := []struct {
+		IP     string
+		Errors int
+	}{
+		{
+			IP:     "",
+			Errors: 0,
+		},
+		{
+			IP:     "0.0.0.0",
+			Errors: 0,
+		},
+		{
+			IP:     "1.2.3.no",
+			Errors: 1,
+		},
+		{
+			IP:     "text",
+			Errors: 1,
+		},
+		{
+			IP:     "1.2.3.4",
+			Errors: 0,
+		},
+		{
+			IP:     "12.34.43.21",
+			Errors: 0,
+		},
+		{
+			IP:     "100.123.199.0",
+			Errors: 0,
+		},
+		{
+			IP:     "255.255.255.255",
+			Errors: 0,
+		},
+		{
+			IP:     "2001:0db8:85a3:0:0:8a2e:0370:7334",
+			Errors: 0,
+		},
+		{
+			IP:     "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+			Errors: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.IP, func(t *testing.T) {
+			_, errors := IPAddressOrEmpty(tc.IP, "test")
+
+			if len(errors) != tc.Errors {
+				t.Fatalf("Expected IPAddressOrEmpty to return %d error(s) not %d", len(errors), tc.Errors)
 			}
 		})
 	}

--- a/azurerm/helpers/validate/network_test.go
+++ b/azurerm/helpers/validate/network_test.go
@@ -46,10 +46,10 @@ func TestCIDRallowNoSuffix(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.CIDR, func(t *testing.T) {
-			_, errors := CIDR(tc.CIDR, "test", true)
+			_, errors := CIDRAllowNoSuffix(tc.CIDR, "test")
 
 			if len(errors) != tc.Errors {
-				t.Fatalf("Expected CIDR to return %d error(s) not %d", tc.Errors, len(errors))
+				t.Fatalf("Expected CIDRAllowNoSuffix to return %d error(s) not %d", tc.Errors, len(errors))
 			}
 		})
 	}
@@ -92,7 +92,7 @@ func TestCIDR(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.CIDR, func(t *testing.T) {
-			_, errors := CIDR(tc.CIDR, "test", false)
+			_, errors := CIDR(tc.CIDR, "test")
 
 			if len(errors) != tc.Errors {
 				t.Fatalf("Expected CIDR to return %d error(s) not %d", tc.Errors, len(errors))


### PR DESCRIPTION
This resolves issue  #5227.

CIDR notations are now checked using the respective go function instead of a regex.
This leads to old notations without the network suffix to be invalid and could possible break some deployments. 
Additionally a validation func is added for these invalid notations (CIDRAllowNoSuffix).

Also, as more and more services now allow IPv4 and IPv6 a func has been added to validate both versions (IPAddress)