### PR TITLE
Fix issue #584 add option to set AI daily cap and hit daily cap stop notify

### DIFF
--- a/azurerm/internal/services/applicationinsights/client/client.go
+++ b/azurerm/internal/services/applicationinsights/client/client.go
@@ -10,6 +10,7 @@ type Client struct {
 	APIKeysClient        *insights.APIKeysClient
 	ComponentsClient     *insights.ComponentsClient
 	WebTestsClient       *insights.WebTestsClient
+	BillingFeatureClient *insights.ComponentCurrentBillingFeaturesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -25,10 +26,14 @@ func NewClient(o *common.ClientOptions) *Client {
 	webTestsClient := insights.NewWebTestsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&webTestsClient.Client, o.ResourceManagerAuthorizer)
 
+	billingFeatureClient := insights.NewComponentCurrentBillingFeaturesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&billingFeatureClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		AnalyticsItemsClient: &analyticsItemsClient,
 		APIKeysClient:        &apiKeysClient,
 		ComponentsClient:     &componentsClient,
 		WebTestsClient:       &webTestsClient,
+		BillingFeatureClient: &billingFeatureClient,
 	}
 }

--- a/azurerm/internal/services/applicationinsights/client/client.go
+++ b/azurerm/internal/services/applicationinsights/client/client.go
@@ -10,7 +10,7 @@ type Client struct {
 	APIKeysClient        *insights.APIKeysClient
 	ComponentsClient     *insights.ComponentsClient
 	WebTestsClient       *insights.WebTestsClient
-	BillingFeatureClient *insights.ComponentCurrentBillingFeaturesClient
+	BillingClient        *insights.ComponentCurrentBillingFeaturesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -26,14 +26,14 @@ func NewClient(o *common.ClientOptions) *Client {
 	webTestsClient := insights.NewWebTestsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&webTestsClient.Client, o.ResourceManagerAuthorizer)
 
-	billingFeatureClient := insights.NewComponentCurrentBillingFeaturesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&billingFeatureClient.Client, o.ResourceManagerAuthorizer)
+	billingClient := insights.NewComponentCurrentBillingFeaturesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&billingClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
 		AnalyticsItemsClient: &analyticsItemsClient,
 		APIKeysClient:        &apiKeysClient,
 		ComponentsClient:     &componentsClient,
 		WebTestsClient:       &webTestsClient,
-		BillingFeatureClient: &billingFeatureClient,
+		BillingClient:        &billingClient,
 	}
 }

--- a/azurerm/internal/services/applicationinsights/resource_arm_application_insights.go
+++ b/azurerm/internal/services/applicationinsights/resource_arm_application_insights.go
@@ -182,14 +182,14 @@ func resourceArmApplicationInsightsCreateUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Cannot read AzureRM Application Insights '%s' (Resource Group %s) ID", name, resGroup)
 	}
 
-	billingFeatureRead, err := billingClient.Get(ctx, resGroup, name)
+	billingRead, err := billingClient.Get(ctx, resGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error read Application Insights Billing Features %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	applicationInsightsComponentBillingFeatures := insights.ApplicationInsightsComponentBillingFeatures{
-		CurrentBillingFeatures: billingFeatureRead.CurrentBillingFeatures,
-		DataVolumeCap:          billingFeatureRead.DataVolumeCap,
+		CurrentBillingFeatures: billingRead.CurrentBillingFeatures,
+		DataVolumeCap:          billingRead.DataVolumeCap,
 	}
 
 	if v, ok := d.GetOk("daily_data_cap_in_gb"); ok {
@@ -234,7 +234,7 @@ func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error making Read request on AzureRM Application Insights '%s': %+v", name, err)
 	}
 
-	billingFeatureResp, err := billingClient.Get(ctx, resGroup, name)
+	billingResp, err := billingClient.Get(ctx, resGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error making Read request on AzureRM Application Insights Billing Feature '%s': %+v", name, err)
 	}
@@ -255,9 +255,9 @@ func resourceArmApplicationInsightsRead(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if billingFeatureProps := billingFeatureResp.DataVolumeCap; billingFeatureProps != nil {
-		d.Set("daily_data_cap_in_gb", billingFeatureProps.Cap)
-		d.Set("daily_data_cap_notifications_disabled", billingFeatureProps.StopSendNotificationWhenHitCap)
+	if billingProps := billingResp.DataVolumeCap; billingProps != nil {
+		d.Set("daily_data_cap_in_gb", billingProps.Cap)
+		d.Set("daily_data_cap_notifications_disabled", billingProps.StopSendNotificationWhenHitCap)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/applicationinsights/resource_arm_application_insights.go
+++ b/azurerm/internal/services/applicationinsights/resource_arm_application_insights.go
@@ -177,7 +177,7 @@ func resourceArmApplicationInsightsCreateUpdate(d *schema.ResourceData, meta int
 		},
 	}
 
-	_ , err = billingFeatureClient.Update(ctx, resGroup, name, applicationInsightsComponentBillingFeatures)
+	_, err = billingFeatureClient.Update(ctx, resGroup, name, applicationInsightsComponentBillingFeatures)
 	if err != nil {
 		return fmt.Errorf("Error update Application Insights Billing Feature %q (Resource Group %q): %+v", name, resGroup, err)
 	}

--- a/azurerm/internal/services/applicationinsights/tests/resource_arm_application_insights_test.go
+++ b/azurerm/internal/services/applicationinsights/tests/resource_arm_application_insights_test.go
@@ -249,6 +249,8 @@ func TestAccAzureRMApplicationInsights_complete(t *testing.T) {
 					testCheckAzureRMApplicationInsightsExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "application_type", "web"),
 					resource.TestCheckResourceAttr(data.ResourceName, "sampling_percentage", "50"),
+					resource.TestCheckResourceAttr(data.ResourceName, "daily_cap", "50"),
+					resource.TestCheckResourceAttr(data.ResourceName, "stop_send_notification_when_hit_cap", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Hello", "World"),
 				),
@@ -296,11 +298,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_application_insights" "test" {
-  name                = "acctestappinsights-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  application_type    = "%s"
-  sampling_percentage = 50
+  name                                = "acctestappinsights-%d"
+  location                            = "${azurerm_resource_group.test.location}"
+  resource_group_name                 = "${azurerm_resource_group.test.name}"
+  application_type                    = "%s"
+  sampling_percentage                 = 50
+  daily_cap                           = 50
+  stop_send_notification_when_hit_cap = true
 
   tags = {
     Hello = "World"

--- a/azurerm/internal/services/applicationinsights/tests/resource_arm_application_insights_test.go
+++ b/azurerm/internal/services/applicationinsights/tests/resource_arm_application_insights_test.go
@@ -250,8 +250,8 @@ func TestAccAzureRMApplicationInsights_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "application_type", "web"),
 					resource.TestCheckResourceAttr(data.ResourceName, "retention_in_days", "120"),
 					resource.TestCheckResourceAttr(data.ResourceName, "sampling_percentage", "50"),
-					resource.TestCheckResourceAttr(data.ResourceName, "daily_cap", "50"),
-					resource.TestCheckResourceAttr(data.ResourceName, "stop_send_notification_when_hit_cap", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "daily_data_cap_in_gb", "50"),
+					resource.TestCheckResourceAttr(data.ResourceName, "daily_data_cap_notifications_disabled", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.Hello", "World"),
 				),
@@ -299,14 +299,14 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_application_insights" "test" {
-  name                                = "acctestappinsights-%d"
-  location                            = "${azurerm_resource_group.test.location}"
-  resource_group_name                 = "${azurerm_resource_group.test.name}"
-  application_type                    = "%s"
-  retention_in_days                   = 120
-  sampling_percentage                 = 50
-  daily_cap                           = 50
-  stop_send_notification_when_hit_cap = true
+  name                                  = "acctestappinsights-%d"
+  location                              = "${azurerm_resource_group.test.location}"
+  resource_group_name                   = "${azurerm_resource_group.test.name}"
+  application_type                      = "%s"
+  retention_in_days                     = 120
+  sampling_percentage                   = 50
+  daily_data_cap_in_gb                  = 50
+  daily_data_cap_notifications_disabled = true
 
   tags = {
     Hello = "World"

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -48,9 +48,9 @@ The following arguments are supported:
 
 * `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `ios` for _iOS_, `java` for _Java web_, `MobileCenter` for _App Center_, `Node.JS` for _Node.js_, `other` for _General_, `phone` for _Windows Phone_, `store` for _Windows Store_ and `web` for _ASP.NET_. Please note these values are case sensitive; unmatched values are treated as _ASP.NET_ by Azure. Changing this forces a new resource to be created.
 
-* `daily_cap` - (Optional) Specifies the Application Insights component daily data volume cap in GB. Default is `100`.
+* `daily_data_cap_in_gb` - (Optional) Specifies the Application Insights component daily data volume cap in GB.
 
-* `stop_send_notification_when_hit_cap` - (Optional) Specifies if a notification email will be send when the daily data volume cap is met. Default to `false`.
+* `daily_data_cap_notifications_disabled` - (Optional) Specifies if a notification email will be send when the daily data volume cap is met.
 
 * `retention_in_days` - (Optional) Specifies the retention period in days. Possible values are `30`, `60`, `90`, `120`, `180`, `270`, `365`, `550` or `730`.
 

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -48,6 +48,10 @@ The following arguments are supported:
 
 * `application_type` - (Required) Specifies the type of Application Insights to create. Valid values are `ios` for _iOS_, `java` for _Java web_, `MobileCenter` for _App Center_, `Node.JS` for _Node.js_, `other` for _General_, `phone` for _Windows Phone_, `store` for _Windows Store_ and `web` for _ASP.NET_. Please note these values are case sensitive; unmatched values are treated as _ASP.NET_ by Azure. Changing this forces a new resource to be created.
 
+* `daily_cap` - (Optional) Specifies the Application Insights component daily data volume cap in GB. Default is `100`.
+
+* `stop_send_notification_when_hit_cap` - (Optional) Specifies if a notification email will be send when the daily data volume cap is met. Default to `false`.
+
 * `sampling_percentage` - (Optional) Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
This PR should fix #584, so we can set now a daily cap for Applications Insight in GB. Beside setting a daily cap for Applications Insight it's also possible now to disable notifications if daily cap is hit. 

Compared to other resources this configuration is separated to it's own billing feature api. Which requires to update billing feature api once Application Insight was created.