### PR TITLE
Bug Fix: `azurerm_subnet` - added computed support `delegations.0.actions` 

### DIFF
--- a/azurerm/internal/services/network/resource_arm_subnet.go
+++ b/azurerm/internal/services/network/resource_arm_subnet.go
@@ -120,8 +120,10 @@ func resourceArmSubnet() *schema.Resource {
 										}, false),
 									},
 									"actions": {
-										Type:     schema.TypeList,
-										Optional: true,
+										Type:       schema.TypeList,
+										Optional:   true,
+										Computed:   true,
+										ConfigMode: schema.SchemaConfigModeAttr,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 											ValidateFunc: validation.StringInSlice([]string{

--- a/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
@@ -515,7 +515,7 @@ resource "azurerm_subnet" "test" {
     name = "acctestdelegation"
 
     service_delegation {
-      name    = "Microsoft.Sql/managedInstances"
+      name = "Microsoft.Sql/managedInstances"
     }
   }
 }

--- a/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
@@ -80,6 +80,25 @@ func TestAccAzureRMSubnet_delegation(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSubnet_delegationComputedActions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSubnet_delegationComputedActions(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "delegation.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 
@@ -466,6 +485,37 @@ resource "azurerm_subnet" "test" {
     service_delegation {
       name    = "Microsoft.ContainerInstance/containerGroups"
       actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMSubnet_delegationComputedActions(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+
+  delegation {
+    name = "acctestdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Sql/managedInstances"
     }
   }
 }

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -97,6 +97,8 @@ A `service_delegation` block supports the following:
 
 * `actions` - (Optional) A list of Actions which should be delegated. This list is specific to the service to delegate to. Possible values include `Microsoft.Network/networkinterfaces/*`, `Microsoft.Network/virtualNetworks/subnets/action`, `Microsoft.Network/virtualNetworks/subnets/join/action`, `Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action` and `Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action`.
 
+-> **NOTE:** Azure may add default actions depending on the service delegation name and they can't be changed.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This PR fixes #5476 where specifying certain subnet delegations returned default actions from azure that can't be modified. 

Before fix 
```
--- FAIL: TestAccAzureRMSubnet_delegationComputedActions (78.55s)
          delegation.0.service_delegation.0.actions.#:    "3" => "0"
```

After fix
```
--- PASS: TestAccAzureRMSubnet_delegationComputedActions (99.84s)
```