### PR TITLE
Adding links for Site Recovery resources to website

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -2056,6 +2056,30 @@
             </li>
 
             <li>
+              <a href="#">Site Recovery Resources</a>
+              <ul class="nav">
+                <li>
+                  <a href="/docs/providers/azurerm/r/site_recovery_fabric.html">azurerm_site_recovery_fabric</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azurerm/r/site_recovery_network_mapping.html">azurerm_site_recovery_network_mapping</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azurerm/r/site_recovery_protection_container_mapping.html">azurerm_site_recovery_protection_container_mapping</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azurerm/r/site_recovery_protection_container.html">azurerm_site_recovery_protection_container</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azurerm/r/site_recovery_replicated_vm.html">azurerm_site_recovery_replicated_vm</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azurerm/r/site_recovery_replication_policy.html">azurerm_site_recovery_replication_policy</a>
+                </li>
+              </ul>
+            </li>
+
+            <li>
               <a href="#">Stream Analytics Resources</a>
               <ul class="nav">
                 <li>


### PR DESCRIPTION
This is a follow up on the issue #5353 which was closed with a previous PR but that PR did not fix all of the additional missing resources on the website. This adds the links for the new `azurerm_site_recovery_*` resources. I've run `make website-test` and it succeeds.