### PR TITLE
`azurerm_cosmosdb_sql_container` - support for `default_ttl`

### DIFF
--- a/azurerm/internal/services/cosmos/resource_arm_cosmosdb_sql_container.go
+++ b/azurerm/internal/services/cosmos/resource_arm_cosmosdb_sql_container.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
@@ -72,6 +73,13 @@ func resourceArmCosmosDbSQLContainer() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validate.CosmosThroughput,
+			},
+
+			"default_ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntAtLeast(-1),
 			},
 
 			"unique_key": {
@@ -145,6 +153,10 @@ func resourceArmCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interfac
 		}
 	}
 
+	if defaultTTL, hasTTL := d.GetOk("default_ttl"); hasTTL {
+		db.SQLContainerCreateUpdateProperties.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
+	}
+
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
 		db.SQLContainerCreateUpdateProperties.Options = map[string]*string{
 			"throughput": utils.String(strconv.Itoa(throughput.(int))),
@@ -208,7 +220,11 @@ func resourceArmCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	future, err := client.CreateUpdateSQLContainer(ctx, id.Container, id.Account, id.Database, id.Container, db)
+	if defaultTTL, hasTTL := d.GetOk("default_ttl"); hasTTL {
+		db.SQLContainerCreateUpdateProperties.Resource.DefaultTTL = utils.Int32(int32(defaultTTL.(int)))
+	}
+
+	future, err := client.CreateUpdateSQLContainer(ctx, id.ResourceGroup, id.Account, id.Database, id.Container, db)
 	if err != nil {
 		return fmt.Errorf("Error issuing create/update request for Cosmos SQL Container %s (Account: %s, Database:%s): %+v", id.Container, id.Account, id.Database, err)
 	}
@@ -283,6 +299,10 @@ func resourceArmCosmosDbSQLContainerRead(d *schema.ResourceData, meta interface{
 			if err := d.Set("unique_key", flattenCosmosSQLContainerUniqueKeys(ukp.UniqueKeys)); err != nil {
 				return fmt.Errorf("Error setting `unique_key`: %+v", err)
 			}
+		}
+
+		if defaultTTL := props.DefaultTTL; defaultTTL != nil {
+			d.Set("default_ttl", defaultTTL)
 		}
 	}
 

--- a/azurerm/internal/services/cosmos/tests/resource_arm_cosmosdb_sql_container_test.go
+++ b/azurerm/internal/services/cosmos/tests/resource_arm_cosmosdb_sql_container_test.go
@@ -129,7 +129,7 @@ func testCheckAzureRMCosmosDbSqlContainerExists(resourceName string) resource.Te
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		database := rs.Primary.Attributes["database_name"]
 
-		resp, err := client.GetSQLContainer(ctx, resourceGroup, database, account, name)
+		resp, err := client.GetSQLContainer(ctx, resourceGroup, account, database, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on cosmosAccountsClient: %+v", err)
 		}

--- a/azurerm/internal/services/cosmos/tests/resource_arm_cosmosdb_sql_container_test.go
+++ b/azurerm/internal/services/cosmos/tests/resource_arm_cosmosdb_sql_container_test.go
@@ -65,6 +65,7 @@ func TestAccAzureRMCosmosDbSqlContainer_update(t *testing.T) {
 				Config: testAccAzureRMCosmosDbSqlContainer_complete(data),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "default_ttl", "500"),
 					resource.TestCheckResourceAttr(data.ResourceName, "throughput", "600"),
 				),
 			},
@@ -74,6 +75,7 @@ func TestAccAzureRMCosmosDbSqlContainer_update(t *testing.T) {
 				Config: testAccAzureRMCosmosDbSqlContainer_update(data),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "default_ttl", "1000"),
 					resource.TestCheckResourceAttr(data.ResourceName, "throughput", "400"),
 				),
 			},
@@ -168,7 +170,8 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   unique_key {
     paths = ["/definition/id1", "/definition/id2"]
   }
-  throughput = 600
+  default_ttl = 500
+  throughput  = 600
 }
 
 `, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger)
@@ -187,7 +190,8 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   unique_key {
     paths = ["/definition/id1", "/definition/id2"]
   }
-  throughput = 400
+  default_ttl = 1000
+  throughput  = 400
 }
 
 `, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger)

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -47,6 +47,8 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to "-1", it is equal to infinity, and items don’t expire by default. If present and the value is set to some number "n" – items will expire "n" seconds after their last modified time.
+
 ---
 A `unique_key` block supports the following:
 

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-* `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to "-1", it is equal to infinity, and items don’t expire by default. If present and the value is set to some number "n" – items will expire "n" seconds after their last modified time.
+* `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 
 ---
 A `unique_key` block supports the following:


### PR DESCRIPTION
Fixes #5451 

Adds the `default_ttl` argument for the `azurerm_cosmosdb_sql_container` resource.

Also, fixes a bug causing resource updates to fail since `id.Container` was being passed in instead of `id.ResourceGroup` for one of the function arguments.

```
--- PASS: TestAccAzureRMCosmosDbSqlContainer_complete (1108.43s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_basic (1109.64s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_update (1348.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cosmos/tests        1348.94
```