### PR TITLE
Fix parallel acctest race on `Provider`

### DIFF
--- a/azurerm/internal/acceptance/data.go
+++ b/azurerm/internal/acceptance/data.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -16,6 +17,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
 )
+
+var once sync.Once
 
 type TestData struct {
 	// Locations is a set of Azure Regions which should be used for this Test
@@ -48,13 +51,15 @@ type TestData struct {
 
 // BuildTestData generates some test data for the given resource
 func BuildTestData(t *testing.T, resourceType string, resourceLabel string) TestData {
-	azureProvider := provider.AzureProvider().(*schema.Provider)
+	once.Do(func() {
+		azureProvider := provider.AzureProvider().(*schema.Provider)
 
-	AzureProvider = azureProvider
-	SupportedProviders = map[string]terraform.ResourceProvider{
-		"azurerm": azureProvider,
-		"azuread": azuread.Provider().(*schema.Provider),
-	}
+		AzureProvider = azureProvider
+		SupportedProviders = map[string]terraform.ResourceProvider{
+			"azurerm": azureProvider,
+			"azuread": azuread.Provider().(*schema.Provider),
+		}
+	})
 
 	env, err := Environment()
 	if err != nil {


### PR DESCRIPTION
Reopening/rebasing #5405

---

We should not initialize providers for every test, in which case it
might cause the global provider not same as the actual used provider in
each test. And might results into panic when user trying to retrive meta
from global provider when testing resource exist/destroy.