### PR TITLE
azurerm_front_door - Add minimum_tls_version property

### DIFF
--- a/azurerm/internal/services/frontdoor/resource_arm_front_door.go
+++ b/azurerm/internal/services/frontdoor/resource_arm_front_door.go
@@ -408,6 +408,15 @@ func resourceArmFrontDoor() *schema.Resource {
 										}, false),
 										Default: string(frontdoor.CertificateSourceFrontDoor),
 									},
+									"minimum_tls_version": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(frontdoor.OneFullStopTwo),
+											string(frontdoor.OneFullStopZero),
+										}, false),
+										Default: string(frontdoor.OneFullStopTwo),
+									},
 									"provisioning_state": {
 										Type:     schema.TypeString,
 										Computed: true,
@@ -1265,6 +1274,8 @@ func flattenArmFrontDoorFrontendEndpoint(d *schema.ResourceData, input *[]frontd
 						chc["certificate_source"] = string(frontdoor.CertificateSourceFrontDoor)
 					}
 
+					chc["minimum_tls_version"] = string(customHTTPSConfiguration.MinimumTLSVersion)
+
 					if provisioningState := properties.CustomHTTPSProvisioningState; provisioningState != "" {
 						chc["provisioning_state"] = provisioningState
 						if provisioningState == frontdoor.CustomHTTPSProvisioningStateEnabled || provisioningState == frontdoor.CustomHTTPSProvisioningStateEnabling {
@@ -1502,8 +1513,11 @@ func makeCustomHttpsConfiguration(customHttpsConfiguration map[string]interface{
 	// https://github.com/Azure/azure-sdk-for-go/issues/6882
 	defaultProtocolType := "ServerNameIndication"
 
+	minTLSVersion := customHttpsConfiguration["minimum_tls_version"].(string)
+
 	customHTTPSConfigurationUpdate := frontdoor.CustomHTTPSConfiguration{
-		ProtocolType: &defaultProtocolType,
+		ProtocolType:      &defaultProtocolType,
+		MinimumTLSVersion: frontdoor.MinimumTLSVersion(minTLSVersion),
 	}
 
 	if customHttpsConfiguration["certificate_source"].(string) == "AzureKeyVault" {

--- a/azurerm/internal/services/frontdoor/resource_arm_front_door.go
+++ b/azurerm/internal/services/frontdoor/resource_arm_front_door.go
@@ -415,7 +415,7 @@ func resourceArmFrontDoor() *schema.Resource {
 											string(frontdoor.OneFullStopTwo),
 											string(frontdoor.OneFullStopZero),
 										}, false),
-										Default: string(frontdoor.OneFullStopTwo),
+										Default: string(frontdoor.OneFullStopZero), // TODO: Update default to TLS 1.2 in version 2.0
 									},
 									"provisioning_state": {
 										Type:     schema.TypeString,

--- a/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
+++ b/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
@@ -160,6 +160,40 @@ func TestAccAzureRMFrontDoor_EnableDisableCache(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMFrontDoor_CustomHttps(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_frontdoor", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMFrontDoorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMFrontDoor_CustomHttpsEnabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFrontDoorExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_provisioning_enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.certificate_source", "FrontDoor"),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.minimum_tls_version", "1.2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.provisioning_state", "Enabled"),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.provisioning_substate", "CertificateDeployed"),
+				),
+			},
+			{
+				Config: testAccAzureRMFrontDoor_CustomHttpsDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMFrontDoorExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_provisioning_enabled", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.certificate_source", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.minimum_tls_version", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.provisioning_state", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.provisioning_substate", ""),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMFrontDoorExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Frontdoor.FrontDoorsClient
@@ -570,6 +604,131 @@ resource "azurerm_frontdoor" "test" {
     host_name                         = "acctestfd-%d.azurefd.net"
     custom_https_provisioning_enabled = false
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMFrontDoor_CustomHttpsEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+locals {
+  backend_name        = "backend-bing"
+  endpoint_name       = "frontend-endpoint"
+  health_probe_name   = "health-probe"
+  load_balancing_name = "load-balancing-setting"
+}
+
+resource "azurerm_frontdoor" "test" {
+  name                                         = "acctestfd-%d"
+  location                                     = azurerm_resource_group.test.location
+  resource_group_name                          = azurerm_resource_group.test.name
+  enforce_backend_pools_certificate_name_check = false
+
+  routing_rule {
+    name               = "routing-rule"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = [local.endpoint_name]
+
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = local.backend_name
+    }
+  }
+
+  backend_pool_load_balancing {
+    name = local.load_balancing_name
+  }
+
+  backend_pool_health_probe {
+    name = local.health_probe_name
+  }
+
+  backend_pool {
+    name = local.backend_name
+    backend {
+      host_header = "www.bing.com"
+      address     = "www.bing.com"
+      http_port   = 80
+      https_port  = 443
+    }
+
+    load_balancing_name = local.load_balancing_name
+    health_probe_name   = local.health_probe_name
+  }
+
+  frontend_endpoint {
+    name                              = local.endpoint_name
+    host_name                         = "acctestfd-%d.azurefd.net"
+    custom_https_provisioning_enabled = true
+    certificate_source                = "FrontDoor"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMFrontDoor_CustomHttpsDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+locals {
+  backend_name        = "backend-bing"
+  endpoint_name       = "frontend-endpoint"
+  health_probe_name   = "health-probe"
+  load_balancing_name = "load-balancing-setting"
+}
+
+resource "azurerm_frontdoor" "test" {
+  name                                         = "acctestfd-%d"
+  location                                     = azurerm_resource_group.test.location
+  resource_group_name                          = azurerm_resource_group.test.name
+  enforce_backend_pools_certificate_name_check = false
+
+  routing_rule {
+    name               = "routing-rule"
+    accepted_protocols = ["Http", "Https"]
+    patterns_to_match  = ["/*"]
+    frontend_endpoints = [local.endpoint_name]
+
+    forwarding_configuration {
+      forwarding_protocol = "MatchRequest"
+      backend_pool_name   = local.backend_name
+    }
+  }
+
+  backend_pool_load_balancing {
+    name = local.load_balancing_name
+  }
+
+  backend_pool_health_probe {
+    name = local.health_probe_name
+  }
+
+  backend_pool {
+    name = local.backend_name
+    backend {
+      host_header = "www.bing.com"
+      address     = "www.bing.com"
+      http_port   = 80
+      https_port  = 443
+    }
+
+    load_balancing_name = local.load_balancing_name
+    health_probe_name   = local.health_probe_name
+  }
+
+  frontend_endpoint {
+    name                              = local.endpoint_name
+    host_name                         = "acctestfd-%d.azurefd.net"
+    custom_https_provisioning_enabled = false
+   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
+++ b/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
@@ -665,7 +665,9 @@ resource "azurerm_frontdoor" "test" {
     name                              = local.endpoint_name
     host_name                         = "acctestfd-%d.azurefd.net"
     custom_https_provisioning_enabled = true
-    certificate_source                = "FrontDoor"
+    custom_https_configuration {
+      certificate_source = "FrontDoor"
+    }
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
+++ b/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
@@ -726,7 +726,7 @@ resource "azurerm_frontdoor" "test" {
     name                              = local.endpoint_name
     host_name                         = "acctestfd-%d.azurefd.net"
     custom_https_provisioning_enabled = false
-   }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
+++ b/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_test.go
@@ -183,10 +183,6 @@ func TestAccAzureRMFrontDoor_CustomHttps(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMFrontDoorExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_provisioning_enabled", "false"),
-					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.certificate_source", ""),
-					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.minimum_tls_version", ""),
-					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.provisioning_state", ""),
-					resource.TestCheckResourceAttr(data.ResourceName, "frontend_endpoint.0.custom_https_configuration.0.provisioning_substate", ""),
 				),
 			},
 			data.ImportStep(),

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -299,6 +299,10 @@ The deprecated `location` field will be removed, since this is no longer used.
 
 The deprecated `internal_public_ip_address_id` field in the `ip_configuration` block will be removed. This field has been replaced by the `public_ip_address_id` field in the `ip_configuration` block.
 
+### Resource: `azurerm_frontdoor`
+
+The default value of the `minimum_tls_version` field in the `custom_https_configuration` block will be changed from `1.0` to `1.2` to align with [updates to the Azure platform defaults](https://docs.microsoft.com/en-us/azure/frontdoor/front-door-faq#what-tls-versions-are-supported-by-azure-front-door-service)
+
 ### Resource: `azurerm_iothub`
 
 The deprecated `sku.tier` property will be remove.

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -299,10 +299,6 @@ The deprecated `location` field will be removed, since this is no longer used.
 
 The deprecated `internal_public_ip_address_id` field in the `ip_configuration` block will be removed. This field has been replaced by the `public_ip_address_id` field in the `ip_configuration` block.
 
-### Resource: `azurerm_frontdoor`
-
-The default value of the `minimum_tls_version` field in the `custom_https_configuration` block will be changed from `1.0` to `1.2` to align with [updates to the Azure platform defaults](https://docs.microsoft.com/en-us/azure/frontdoor/front-door-faq#what-tls-versions-are-supported-by-azure-front-door-service)
-
 ### Resource: `azurerm_iothub`
 
 The deprecated `sku.tier` property will be remove.

--- a/website/docs/r/front_door.html.markdown
+++ b/website/docs/r/front_door.html.markdown
@@ -229,6 +229,8 @@ The `custom_https_configuration` block supports the following:
 
 * `certificate_source` - (Optional) Certificate source to encrypted `HTTPS` traffic with. Allowed values are `FrontDoor` or `AzureKeyVault`. Defaults to `FrontDoor`.
 
+* `minimum_tls_version` - (Optional) Minimum TLS version required for clients to connect. Allowed values are `1.0` or `1.2`. Defaults to `1.2`.
+
 The following attributes are only valid if `certificate_source` is set to `AzureKeyVault`:
 
 * `azure_key_vault_certificate_vault_id` - (Required) The ID of the Key Vault containing the SSL certificate.

--- a/website/docs/r/front_door.html.markdown
+++ b/website/docs/r/front_door.html.markdown
@@ -274,9 +274,13 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 * `id` - The Resource ID of the Azure Front Door Backend Load Balancer.
 
 
-`routing_rule`  exports the following:
+`routing_rule` exports the following:
 
 * `id` - The Resource ID of the Azure Front Door Backend Routing Rule.
+
+`custom_https_configuration` exports the following:
+
+* `minimum_tls_version` - Minimum client TLS version supported.
 
 
 The following attributes are exported:

--- a/website/docs/r/front_door.html.markdown
+++ b/website/docs/r/front_door.html.markdown
@@ -229,8 +229,6 @@ The `custom_https_configuration` block supports the following:
 
 * `certificate_source` - (Optional) Certificate source to encrypted `HTTPS` traffic with. Allowed values are `FrontDoor` or `AzureKeyVault`. Defaults to `FrontDoor`.
 
-* `minimum_tls_version` - (Optional) Minimum TLS version required for clients to connect. Allowed values are `1.0` or `1.2`. Defaults to `1.0`.
-
 The following attributes are only valid if `certificate_source` is set to `AzureKeyVault`:
 
 * `azure_key_vault_certificate_vault_id` - (Required) The ID of the Key Vault containing the SSL certificate.

--- a/website/docs/r/front_door.html.markdown
+++ b/website/docs/r/front_door.html.markdown
@@ -229,7 +229,7 @@ The `custom_https_configuration` block supports the following:
 
 * `certificate_source` - (Optional) Certificate source to encrypted `HTTPS` traffic with. Allowed values are `FrontDoor` or `AzureKeyVault`. Defaults to `FrontDoor`.
 
-* `minimum_tls_version` - (Optional) Minimum TLS version required for clients to connect. Allowed values are `1.0` or `1.2`. Defaults to `1.2`.
+* `minimum_tls_version` - (Optional) Minimum TLS version required for clients to connect. Allowed values are `1.0` or `1.2`. Defaults to `1.0`.
 
 The following attributes are only valid if `certificate_source` is set to `AzureKeyVault`:
 


### PR DESCRIPTION
Fixes #5538 

The latest version of the Front Door API requires a `minimumTlsVersion` property set in the request to enable custom domain HTTPS. This PR adds support for this property with a default of "1.0" to preserved backwards compatibility. Since September 2019, [Azure is making TLS 1.2 the default minimum.](https://docs.microsoft.com/en-us/azure/frontdoor/front-door-faq#what-tls-versions-are-supported-by-azure-front-door-service) Once version 2.0 is released, I think the default should be updated to 1.2 to align with Azure's defaults. I've included a TODO comment and note in the upgrade guide to mark this.