### PR TITLE
compute: Preparation for the Virtual Machine Resources

### DIFF
--- a/azurerm/internal/clients/builder.go
+++ b/azurerm/internal/clients/builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/authentication"
 	"github.com/hashicorp/go-azure-helpers/sender"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
 type ClientBuilder struct {
@@ -17,6 +18,7 @@ type ClientBuilder struct {
 	PartnerId                   string
 	SkipProviderRegistration    bool
 	TerraformVersion            string
+	Features                    features.UserFeatures
 }
 
 func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
@@ -86,6 +88,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		DisableCorrelationRequestID: builder.DisableCorrelationRequestID,
 		DisableTerraformPartnerID:   builder.DisableTerraformPartnerID,
 		Environment:                 *env,
+		Features:                    builder.Features,
 	}
 
 	if err := client.Build(ctx, o); err != nil {

--- a/azurerm/internal/clients/client.go
+++ b/azurerm/internal/clients/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	analysisServices "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/analysisservices/client"
 	apiManagement "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/client"
 	appConfiguration "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/appconfiguration/client"
@@ -71,7 +72,8 @@ type Client struct {
 	// StopContext is used for propagating control from Terraform Core (e.g. Ctrl/Cmd+C)
 	StopContext context.Context
 
-	Account *ResourceManagerAccount
+	Account  *ResourceManagerAccount
+	Features features.UserFeatures
 
 	AnalysisServices *analysisServices.Client
 	ApiManagement    *apiManagement.Client
@@ -139,6 +141,7 @@ type Client struct {
 // NOTE: it should be possible for this method to become Private once the top level Client's removed
 
 func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error {
+	client.Features = o.Features
 	client.StopContext = ctx
 
 	client.AnalysisServices = analysisServices.NewClient(o)

--- a/azurerm/internal/common/client_options.go
+++ b/azurerm/internal/common/client_options.go
@@ -32,6 +32,7 @@ type ClientOptions struct {
 	DisableCorrelationRequestID bool
 	DisableTerraformPartnerID   bool
 	Environment                 azure.Environment
+	Features                    features.UserFeatures
 
 	// TODO: remove me in 2.0
 	PollingDuration time.Duration

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -1,0 +1,9 @@
+package features
+
+type UserFeatures struct {
+	VirtualMachine VirtualMachineFeatures
+}
+
+type VirtualMachineFeatures struct {
+	DeleteOSDiskOnDeletion bool
+}

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -1,0 +1,61 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+func schemaFeatures() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeList,
+		// TODO: make this Required in 2.0
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"virtual_machine": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"delete_os_disk_on_deletion": {
+								Type:     schema.TypeBool,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func expandFeatures(input []interface{}) features.UserFeatures {
+	// TODO: in 2.0 when Required this can become:
+	//val := input[0].(map[string]interface{})
+
+	var val map[string]interface{}
+	if len(input) > 0 {
+		val = input[0].(map[string]interface{})
+	}
+
+	features := features.UserFeatures{
+		// NOTE: ensure all nested objects are fully populated
+		VirtualMachine: features.VirtualMachineFeatures{
+			DeleteOSDiskOnDeletion: true,
+		},
+	}
+
+	if raw, ok := val["virtual_machine"]; ok {
+		items := raw.([]interface{})
+		if len(items) > 0 {
+			virtualMachinesRaw := items[0].(map[string]interface{})
+			if v, ok := virtualMachinesRaw["delete_os_disk_on_deletion"]; ok {
+				features.VirtualMachine.DeleteOSDiskOnDeletion = v.(bool)
+			}
+		}
+	}
+
+	return features
+}

--- a/azurerm/internal/provider/features_test.go
+++ b/azurerm/internal/provider/features_test.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+func TestExpandFeatures(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    []interface{}
+		EnvVars  map[string]interface{}
+		Expected features.UserFeatures
+	}{
+		{
+			// TODO: remove this test case in 2.0
+			Name:  "Empty Block",
+			Input: []interface{}{},
+			Expected: features.UserFeatures{
+				VirtualMachine: features.VirtualMachineFeatures{
+					DeleteOSDiskOnDeletion: true,
+				},
+			},
+		},
+		{
+			Name: "Virtual Machine - Empty Block",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine": []interface{}{},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachine: features.VirtualMachineFeatures{
+					DeleteOSDiskOnDeletion: true,
+				},
+			},
+		},
+		{
+			Name: "Virtual Machine - Delete OS Disk Enabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine": []interface{}{
+						map[string]interface{}{
+							"delete_os_disk_on_deletion": true,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachine: features.VirtualMachineFeatures{
+					DeleteOSDiskOnDeletion: true,
+				},
+			},
+		},
+		{
+			Name: "Virtual Machine - Delete OS Disk Disabled",
+			Input: []interface{}{
+				map[string]interface{}{
+					"virtual_machine": []interface{}{
+						map[string]interface{}{
+							"delete_os_disk_on_deletion": false,
+						},
+					},
+				},
+			},
+			Expected: features.UserFeatures{
+				VirtualMachine: features.VirtualMachineFeatures{
+					DeleteOSDiskOnDeletion: false,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test Case: %q", testCase.Name)
+		result := expandFeatures(testCase.Input)
+		if !reflect.DeepEqual(result, testCase.Expected) {
+			t.Fatalf("Expected %+v but got %+v", result, testCase.Expected)
+		}
+	}
+}

--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -159,6 +159,8 @@ func AzureProvider() terraform.ResourceProvider {
 				Description: "This will disable the Terraform Partner ID which is used if a custom `partner_id` isn't specified.",
 			},
 
+			"features": schemaFeatures(),
+
 			// Advanced feature flags
 			"skip_credentials_validation": {
 				Type:        schema.TypeBool,
@@ -241,6 +243,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			PartnerId:                   d.Get("partner_id").(string),
 			DisableCorrelationRequestID: d.Get("disable_correlation_request_id").(bool),
 			DisableTerraformPartnerID:   d.Get("disable_terraform_partner_id").(bool),
+			Features:                    expandFeatures(d.Get("features").([]interface{})),
 		}
 		client, err := clients.Build(p.StopContext(), clientBuilder)
 		if err != nil {

--- a/azurerm/internal/services/compute/diff_suppress.go
+++ b/azurerm/internal/services/compute/diff_suppress.go
@@ -2,6 +2,7 @@ package compute
 
 import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
+// nolint: deadcode unused
 func adminPasswordDiffSuppressFunc(_, old, new string, d *schema.ResourceData) bool {
 	// this is not the greatest hack in the world, this is just a tribute.
 	if old == "ignored-as-imported" || new == "ignored-as-imported" {

--- a/azurerm/internal/services/compute/diff_suppress.go
+++ b/azurerm/internal/services/compute/diff_suppress.go
@@ -1,0 +1,12 @@
+package compute
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+func adminPasswordDiffSuppressFunc(_, old, new string, d *schema.ResourceData) bool {
+	// this is not the greatest hack in the world, this is just a tribute.
+	if old == "ignored-as-imported" || new == "ignored-as-imported" {
+		return true
+	}
+
+	return false
+}

--- a/azurerm/internal/services/compute/network_interface.go
+++ b/azurerm/internal/services/compute/network_interface.go
@@ -24,6 +24,7 @@ type connectionInfo struct {
 }
 
 // retrieveConnectionInformation retrieves all of the Public and Private IP Addresses assigned to a Virtual Machine
+// nolint: deadcode unused
 func retrieveConnectionInformation(ctx context.Context, nicsClient *network.InterfacesClient, pipsClient *network.PublicIPAddressesClient, input *compute.VirtualMachineProperties) connectionInfo {
 	if input == nil || input.NetworkProfile == nil || input.NetworkProfile.NetworkInterfaces == nil {
 		return connectionInfo{}
@@ -94,7 +95,6 @@ func retrieveIPAddressesForNIC(ctx context.Context, nicClient *network.Interface
 	publicIPAddresses := make([]string, 0)
 	for _, config := range *nic.InterfacePropertiesFormat.IPConfigurations {
 		if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
-
 			if props.PrivateIPAddress != nil {
 				privateIPAddresses = append(privateIPAddresses, *props.PrivateIPAddress)
 			}
@@ -145,6 +145,7 @@ func retrievePublicIPAddress(ctx context.Context, client *network.PublicIPAddres
 // setConnectionInformation sets the connection information required for Provisioners
 // to connect to the Virtual Machine. A Public IP Address is used if one is available
 // but this falls back to a Private IP Address (which should always exist)
+// nolint: deadcode unused
 func setConnectionInformation(d *schema.ResourceData, input connectionInfo, isWindows bool) {
 	provisionerType := "ssh"
 	if isWindows {

--- a/azurerm/internal/services/compute/network_interface.go
+++ b/azurerm/internal/services/compute/network_interface.go
@@ -1,0 +1,163 @@
+package compute
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
+)
+
+type connectionInfo struct {
+	// primaryPrivateAddress is the Primary Private IP Address for this VM
+	primaryPrivateAddress string
+
+	// privateAddresses is a slice of the Private IP Addresses supported by this VM
+	privateAddresses []string
+
+	// primaryPublicAddress is the Primary Public IP Address for this VM
+	primaryPublicAddress string
+
+	// publicAddresses is a slice of the Public IP Addresses supported by this VM
+	publicAddresses []string
+}
+
+// retrieveConnectionInformation retrieves all of the Public and Private IP Addresses assigned to a Virtual Machine
+func retrieveConnectionInformation(ctx context.Context, nicsClient *network.InterfacesClient, pipsClient *network.PublicIPAddressesClient, input *compute.VirtualMachineProperties) connectionInfo {
+	if input == nil || input.NetworkProfile == nil || input.NetworkProfile.NetworkInterfaces == nil {
+		return connectionInfo{}
+	}
+
+	privateIPAddresses := make([]string, 0)
+	publicIPAddresses := make([]string, 0)
+
+	if input != nil && input.NetworkProfile != nil && input.NetworkProfile.NetworkInterfaces != nil {
+		for _, v := range *input.NetworkProfile.NetworkInterfaces {
+			if v.ID == nil {
+				continue
+			}
+
+			nic := retrieveIPAddressesForNIC(ctx, nicsClient, pipsClient, *v.ID)
+			if nic == nil {
+				continue
+			}
+
+			privateIPAddresses = append(privateIPAddresses, nic.privateIPAddresses...)
+			publicIPAddresses = append(publicIPAddresses, nic.publicIPAddresses...)
+		}
+	}
+
+	primaryPrivateAddress := ""
+	if len(privateIPAddresses) > 0 {
+		primaryPrivateAddress = privateIPAddresses[0]
+	}
+	primaryPublicAddress := ""
+	if len(publicIPAddresses) > 0 {
+		primaryPublicAddress = publicIPAddresses[0]
+	}
+
+	return connectionInfo{
+		primaryPrivateAddress: primaryPrivateAddress,
+		privateAddresses:      privateIPAddresses,
+		primaryPublicAddress:  primaryPublicAddress,
+		publicAddresses:       publicIPAddresses,
+	}
+}
+
+type interfaceDetails struct {
+	// privateIPAddresses is a slice of the Private IP Addresses supported by this VM
+	privateIPAddresses []string
+
+	// publicIPAddresses is a slice of the Public IP Addresses supported by this VM
+	publicIPAddresses []string
+}
+
+// retrieveIPAddressesForNIC returns the Public and Private IP Addresses associated
+// with the specified Network Interface
+func retrieveIPAddressesForNIC(ctx context.Context, nicClient *network.InterfacesClient, pipClient *network.PublicIPAddressesClient, nicID string) *interfaceDetails {
+	id, err := parse.NetworkInterfaceID(nicID)
+	if err != nil {
+		return nil
+	}
+
+	nic, err := nicClient.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		return nil
+	}
+
+	if nic.InterfacePropertiesFormat == nil || nic.InterfacePropertiesFormat.IPConfigurations == nil {
+		return nil
+	}
+
+	privateIPAddresses := make([]string, 0)
+	publicIPAddresses := make([]string, 0)
+	for _, config := range *nic.InterfacePropertiesFormat.IPConfigurations {
+		if props := config.InterfaceIPConfigurationPropertiesFormat; props != nil {
+
+			if props.PrivateIPAddress != nil {
+				privateIPAddresses = append(privateIPAddresses, *props.PrivateIPAddress)
+			}
+
+			if pip := props.PublicIPAddress; pip != nil {
+				if pip.ID != nil {
+					publicIPAddress, err := retrievePublicIPAddress(ctx, pipClient, *pip.ID)
+					if err != nil {
+						continue
+					}
+
+					if publicIPAddress != nil {
+						publicIPAddresses = append(publicIPAddresses, *publicIPAddress)
+					}
+				}
+			}
+		}
+	}
+
+	return &interfaceDetails{
+		privateIPAddresses: privateIPAddresses,
+		publicIPAddresses:  publicIPAddresses,
+	}
+}
+
+// retrievePublicIPAddress returns the Public IP Address associated with an Azure Public IP
+func retrievePublicIPAddress(ctx context.Context, client *network.PublicIPAddressesClient, publicIPAddressID string) (*string, error) {
+	id, err := parse.PublicIPAddressID(publicIPAddressID)
+	if err != nil {
+		return nil, err
+	}
+
+	pip, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if props := pip.PublicIPAddressPropertiesFormat; props != nil {
+		// if it's Static it'll always have an IP Address assigned
+		// however there's a bug here where Dynamic IP's can take some time until it's assigned after attachment
+		// TODO: fix the bug with Dynamic IP's here
+		return props.IPAddress, nil
+	}
+
+	return nil, nil
+}
+
+// setConnectionInformation sets the connection information required for Provisioners
+// to connect to the Virtual Machine. A Public IP Address is used if one is available
+// but this falls back to a Private IP Address (which should always exist)
+func setConnectionInformation(d *schema.ResourceData, input connectionInfo, isWindows bool) {
+	provisionerType := "ssh"
+	if isWindows {
+		provisionerType = "winrm"
+	}
+
+	ipAddress := input.primaryPublicAddress
+	if ipAddress == "" {
+		ipAddress = input.primaryPrivateAddress
+	}
+
+	d.SetConnInfo(map[string]string{
+		"type": provisionerType,
+		"host": ipAddress,
+	})
+}

--- a/azurerm/internal/services/compute/parse/availability_set.go
+++ b/azurerm/internal/services/compute/parse/availability_set.go
@@ -6,22 +6,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type DedicatedHostGroupId struct {
+type AvailabilitySetId struct {
 	ResourceGroup string
 	Name          string
 }
 
-func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
+func AvailabilitySetID(input string) (*AvailabilitySetId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host Group ID %q: %+v", input, err)
+		return nil, fmt.Errorf("[ERROR] Unable to parse Availability Set ID %q: %+v", input, err)
 	}
 
-	group := DedicatedHostGroupId{
+	set := AvailabilitySetId{
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	if group.Name, err = id.PopSegment("hostGroups"); err != nil {
+	if set.Name, err = id.PopSegment("availabilitySets"); err != nil {
 		return nil, err
 	}
 
@@ -29,5 +29,5 @@ func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 		return nil, err
 	}
 
-	return &group, nil
+	return &set, nil
 }

--- a/azurerm/internal/services/compute/parse/availability_set_test.go
+++ b/azurerm/internal/services/compute/parse/availability_set_test.go
@@ -1,0 +1,75 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestAvailabilitySetID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *AvailabilitySetId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Availability Set Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/availabilitySets/",
+			Error: true,
+		},
+		{
+			Name:  "Availability Set ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/availabilitySets/set1",
+			Error: false,
+			Expect: &AvailabilitySetId{
+				ResourceGroup: "resGroup1",
+				Name:          "set1",
+			},
+		},
+		{
+			Name:  "Wrong Casing",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/AvailabilitySets/set1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := AvailabilitySetID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/compute/parse/dedicated_host.go
+++ b/azurerm/internal/services/compute/parse/dedicated_host.go
@@ -18,15 +18,15 @@ func DedicatedHostID(input string) (*DedicatedHostId, error) {
 		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host ID %q: %+v", input, err)
 	}
 
-	server := DedicatedHostId{
+	host := DedicatedHostId{
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	if server.HostGroup, err = id.PopSegment("hostGroups"); err != nil {
+	if host.HostGroup, err = id.PopSegment("hostGroups"); err != nil {
 		return nil, err
 	}
 
-	if server.Name, err = id.PopSegment("hosts"); err != nil {
+	if host.Name, err = id.PopSegment("hosts"); err != nil {
 		return nil, err
 	}
 
@@ -34,5 +34,5 @@ func DedicatedHostID(input string) (*DedicatedHostId, error) {
 		return nil, err
 	}
 
-	return &server, nil
+	return &host, nil
 }

--- a/azurerm/internal/services/compute/parse/image.go
+++ b/azurerm/internal/services/compute/parse/image.go
@@ -6,22 +6,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type DedicatedHostGroupId struct {
+type ImageId struct {
 	ResourceGroup string
 	Name          string
 }
 
-func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
+func ImageID(input string) (*ImageId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host Group ID %q: %+v", input, err)
+		return nil, fmt.Errorf("[ERROR] Unable to parse Image ID %q: %+v", input, err)
 	}
 
-	group := DedicatedHostGroupId{
+	set := ImageId{
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	if group.Name, err = id.PopSegment("hostGroups"); err != nil {
+	if set.Name, err = id.PopSegment("images"); err != nil {
 		return nil, err
 	}
 
@@ -29,5 +29,5 @@ func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 		return nil, err
 	}
 
-	return &group, nil
+	return &set, nil
 }

--- a/azurerm/internal/services/compute/parse/image_test.go
+++ b/azurerm/internal/services/compute/parse/image_test.go
@@ -1,0 +1,75 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestImageID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *ImageId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Image Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/images/",
+			Error: true,
+		},
+		{
+			Name:  "Image ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/images/image1",
+			Error: false,
+			Expect: &ImageId{
+				ResourceGroup: "resGroup1",
+				Name:          "image1",
+			},
+		},
+		{
+			Name:  "Wrong Casing",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/Images/image1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ImageID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/compute/parse/managed_disk.go
+++ b/azurerm/internal/services/compute/parse/managed_disk.go
@@ -6,22 +6,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type DedicatedHostGroupId struct {
+type ManagedDiskId struct {
 	ResourceGroup string
 	Name          string
 }
 
-func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
+func ManagedDiskID(input string) (*ManagedDiskId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host Group ID %q: %+v", input, err)
+		return nil, fmt.Errorf("[ERROR] Unable to parse Managed Disk ID %q: %+v", input, err)
 	}
 
-	group := DedicatedHostGroupId{
+	disk := ManagedDiskId{
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	if group.Name, err = id.PopSegment("hostGroups"); err != nil {
+	if disk.Name, err = id.PopSegment("disks"); err != nil {
 		return nil, err
 	}
 
@@ -29,5 +29,5 @@ func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 		return nil, err
 	}
 
-	return &group, nil
+	return &disk, nil
 }

--- a/azurerm/internal/services/compute/parse/managed_disk_test.go
+++ b/azurerm/internal/services/compute/parse/managed_disk_test.go
@@ -1,0 +1,75 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestManagedDiskID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *ManagedDiskId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Disk Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/disks/",
+			Error: true,
+		},
+		{
+			Name:  "Managed Disk ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/disks/disk1",
+			Error: false,
+			Expect: &ManagedDiskId{
+				ResourceGroup: "resGroup1",
+				Name:          "disk1",
+			},
+		},
+		{
+			Name:  "Wrong Casing",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/Disks/disk1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ManagedDiskID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/compute/parse/proximity_placement_group.go
+++ b/azurerm/internal/services/compute/parse/proximity_placement_group.go
@@ -6,22 +6,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type DedicatedHostGroupId struct {
+type ProximityPlacementGroupId struct {
 	ResourceGroup string
 	Name          string
 }
 
-func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
+func ProximityPlacementGroupID(input string) (*ProximityPlacementGroupId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host Group ID %q: %+v", input, err)
+		return nil, fmt.Errorf("[ERROR] Unable to parse Proximity Placement Group ID %q: %+v", input, err)
 	}
 
-	group := DedicatedHostGroupId{
+	server := ProximityPlacementGroupId{
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	if group.Name, err = id.PopSegment("hostGroups"); err != nil {
+	if server.Name, err = id.PopSegment("proximityPlacementGroups"); err != nil {
 		return nil, err
 	}
 
@@ -29,5 +29,5 @@ func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 		return nil, err
 	}
 
-	return &group, nil
+	return &server, nil
 }

--- a/azurerm/internal/services/compute/parse/proximity_placement_group_test.go
+++ b/azurerm/internal/services/compute/parse/proximity_placement_group_test.go
@@ -1,0 +1,75 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestProximityPlacementGroupID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *ProximityPlacementGroupId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Proximity Placement Group Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/proximityPlacementGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Proximity Placement Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/proximityPlacementGroups/group1",
+			Error: false,
+			Expect: &ProximityPlacementGroupId{
+				ResourceGroup: "resGroup1",
+				Name:          "group1",
+			},
+		},
+		{
+			Name:  "Wrong Casing",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Compute/ProximityPlacementGroups/group1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ProximityPlacementGroupID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/compute/resource_arm_linux_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_linux_virtual_machine_scale_set.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/base64"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
@@ -88,9 +89,11 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 				Optional:  true,
 				ForceNew:  true,
 				Sensitive: true,
+				// TODO: does this want:
+				// DiffSuppressFunc: linuxAdminPasswordDiffSuppressFunc,
 			},
 
-			"admin_ssh_key": SSHKeysSchema(),
+			"admin_ssh_key": SSHKeysSchema(false),
 
 			"automatic_os_upgrade_policy": VirtualMachineScaleSetAutomatedOSUpgradePolicySchema(),
 
@@ -108,7 +111,7 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 				ValidateFunc: ValidateLinuxName,
 			},
 
-			"custom_data": base64.OptionalSchema(),
+			"custom_data": base64.OptionalSchema(false),
 
 			"data_disk": VirtualMachineScaleSetDataDiskSchema(),
 
@@ -180,7 +183,7 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				ValidateFunc: computeValidate.ProximityPlacementGroupID,
 				// the Compute API is broken and returns the Resource Group name in UPPERCASE :shrug:
 				DiffSuppressFunc: suppress.CaseDifference,
 			},
@@ -198,10 +201,10 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 			"source_image_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				ValidateFunc: computeValidate.ImageID,
 			},
 
-			"source_image_reference": sourceImageReferenceSchema(),
+			"source_image_reference": sourceImageReferenceSchema(false),
 
 			"tags": tags.Schema(),
 

--- a/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
@@ -136,7 +136,7 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 				ValidateFunc: ValidateWindowsName,
 			},
 
-			"custom_data": base64.OptionalSchema(),
+			"custom_data": base64.OptionalSchema(false),
 
 			"data_disk": VirtualMachineScaleSetDataDiskSchema(),
 
@@ -239,7 +239,7 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
-			"source_image_reference": sourceImageReferenceSchema(),
+			"source_image_reference": sourceImageReferenceSchema(false),
 
 			"tags": tags.Schema(),
 

--- a/azurerm/internal/services/compute/shared_schema.go
+++ b/azurerm/internal/services/compute/shared_schema.go
@@ -238,7 +238,7 @@ func flattenPlan(input *compute.Plan) []interface{} {
 	}
 }
 
-func sourceImageReferenceSchema() *schema.Schema {
+func sourceImageReferenceSchema(isVirtualMachine bool) *schema.Schema {
 	// whilst originally I was hoping we could use the 'id' from `azurerm_platform_image' unfortunately Azure doesn't
 	// like this as a value for the 'id' field:
 	// Id /...../Versions/16.04.201909091 is not a valid resource reference."
@@ -246,6 +246,7 @@ func sourceImageReferenceSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:          schema.TypeList,
 		Optional:      true,
+		ForceNew:      isVirtualMachine,
 		MaxItems:      1,
 		ConflictsWith: []string{"source_image_id"},
 		Elem: &schema.Resource{
@@ -253,18 +254,22 @@ func sourceImageReferenceSchema() *schema.Schema {
 				"publisher": {
 					Type:     schema.TypeString,
 					Required: true,
+					ForceNew: isVirtualMachine,
 				},
 				"offer": {
 					Type:     schema.TypeString,
 					Required: true,
+					ForceNew: isVirtualMachine,
 				},
 				"sku": {
 					Type:     schema.TypeString,
 					Required: true,
+					ForceNew: isVirtualMachine,
 				},
 				"version": {
 					Type:     schema.TypeString,
 					Required: true,
+					ForceNew: isVirtualMachine,
 				},
 			},
 		},

--- a/azurerm/internal/services/compute/ssh_keys.go
+++ b/azurerm/internal/services/compute/ssh_keys.go
@@ -10,21 +10,27 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func SSHKeysSchema() *schema.Schema {
+func SSHKeysSchema(isVirtualMachine bool) *schema.Schema {
+	// the SSH Keys for a Virtual Machine cannot be changed once provisioned:
+	// Code="PropertyChangeNotAllowed" Message="Changing property 'linuxConfiguration.ssh.publicKeys' is not allowed."
+
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Optional: true,
+		ForceNew: isVirtualMachine,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"public_key": {
 					Type:         schema.TypeString,
 					Required:     true,
+					ForceNew:     isVirtualMachine,
 					ValidateFunc: validate.NoEmptyStrings,
 				},
 
 				"username": {
 					Type:         schema.TypeString,
 					Required:     true,
+					ForceNew:     isVirtualMachine,
 					ValidateFunc: validate.NoEmptyStrings,
 				},
 			},

--- a/azurerm/internal/services/compute/validate/availability_set.go
+++ b/azurerm/internal/services/compute/validate/availability_set.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+)
+
+func AvailabilitySetID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := parse.AvailabilitySetID(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", k, err))
+		return
+	}
+
+	return warnings, errors
+}

--- a/azurerm/internal/services/compute/validate/image.go
+++ b/azurerm/internal/services/compute/validate/image.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+)
+
+func ImageID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := parse.ImageID(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", k, err))
+		return
+	}
+
+	return warnings, errors
+}

--- a/azurerm/internal/services/compute/validate/proximity_placement_group.go
+++ b/azurerm/internal/services/compute/validate/proximity_placement_group.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+)
+
+func ProximityPlacementGroupID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := parse.ProximityPlacementGroupID(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", k, err))
+		return
+	}
+
+	return warnings, errors
+}

--- a/azurerm/internal/services/compute/virtual_machine_instance.go
+++ b/azurerm/internal/services/compute/virtual_machine_instance.go
@@ -1,0 +1,36 @@
+package compute
+
+import (
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+)
+
+// shouldBootVirtualMachine determines if the Virtual Machine should be started after
+// the Virtual Machine has been shut down for maintainence. This means that Virtual Machines
+// which are already stopped can be updated but will not be started
+func shouldBootVirtualMachine(instanceView compute.VirtualMachineInstanceView) bool {
+	if instanceView.Statuses != nil {
+		for _, status := range *instanceView.Statuses {
+			if status.Code == nil {
+				continue
+			}
+
+			// could also be the provisioning state which we're not bothered with here
+			state := strings.ToLower(*status.Code)
+			if !strings.HasPrefix(state, "PowerState/") {
+				continue
+			}
+
+			state = strings.TrimPrefix(state, "powerstate/")
+			switch strings.ToLower(state) {
+			case "deallocating":
+			case "deallocated":
+			case "stopped":
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/azurerm/internal/services/compute/virtual_machine_instance.go
+++ b/azurerm/internal/services/compute/virtual_machine_instance.go
@@ -9,6 +9,7 @@ import (
 // shouldBootVirtualMachine determines if the Virtual Machine should be started after
 // the Virtual Machine has been shut down for maintainence. This means that Virtual Machines
 // which are already stopped can be updated but will not be started
+// nolint: deadcode unused
 func shouldBootVirtualMachine(instanceView compute.VirtualMachineInstanceView) bool {
 	if instanceView.Statuses != nil {
 		for _, status := range *instanceView.Statuses {

--- a/azurerm/internal/services/compute/virtual_machine_instance.go
+++ b/azurerm/internal/services/compute/virtual_machine_instance.go
@@ -7,7 +7,7 @@ import (
 )
 
 // shouldBootVirtualMachine determines if the Virtual Machine should be started after
-// the Virtual Machine has been shut down for maintainence. This means that Virtual Machines
+// the Virtual Machine has been shut down for maintenance. This means that Virtual Machines
 // which are already stopped can be updated but will not be started
 // nolint: deadcode unused
 func shouldBootVirtualMachine(instanceView compute.VirtualMachineInstanceView) bool {

--- a/azurerm/internal/services/network/parse/network_interface.go
+++ b/azurerm/internal/services/network/parse/network_interface.go
@@ -6,22 +6,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type DedicatedHostGroupId struct {
+type NetworkInterfaceId struct {
 	ResourceGroup string
 	Name          string
 }
 
-func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
+func NetworkInterfaceID(input string) (*NetworkInterfaceId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host Group ID %q: %+v", input, err)
+		return nil, fmt.Errorf("[ERROR] Unable to parse Network Interface ID %q: %+v", input, err)
 	}
 
-	group := DedicatedHostGroupId{
+	server := NetworkInterfaceId{
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	if group.Name, err = id.PopSegment("hostGroups"); err != nil {
+	if server.Name, err = id.PopSegment("networkInterfaces"); err != nil {
 		return nil, err
 	}
 
@@ -29,5 +29,5 @@ func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 		return nil, err
 	}
 
-	return &group, nil
+	return &server, nil
 }

--- a/azurerm/internal/services/network/parse/network_interface_test.go
+++ b/azurerm/internal/services/network/parse/network_interface_test.go
@@ -1,0 +1,75 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestNetworkInterfaceID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *NetworkInterfaceId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Network Interfaces Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Network/networkInterfaces/",
+			Error: true,
+		},
+		{
+			Name:  "Network Interface ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Network/networkInterfaces/interface1",
+			Error: false,
+			Expect: &NetworkInterfaceId{
+				ResourceGroup: "resGroup1",
+				Name:          "interface1",
+			},
+		},
+		{
+			Name:  "Wrong Casing",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Network/NetworkInterfaces/set1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := NetworkInterfaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/network/parse/public_ip_address.go
+++ b/azurerm/internal/services/network/parse/public_ip_address.go
@@ -6,22 +6,22 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type DedicatedHostGroupId struct {
+type PublicIPAddressId struct {
 	ResourceGroup string
 	Name          string
 }
 
-func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
+func PublicIPAddressID(input string) (*PublicIPAddressId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Unable to parse Dedicated Host Group ID %q: %+v", input, err)
+		return nil, fmt.Errorf("[ERROR] Unable to parse Public IP Address ID %q: %+v", input, err)
 	}
 
-	group := DedicatedHostGroupId{
+	ipAddress := PublicIPAddressId{
 		ResourceGroup: id.ResourceGroup,
 	}
 
-	if group.Name, err = id.PopSegment("hostGroups"); err != nil {
+	if ipAddress.Name, err = id.PopSegment("publicIPAddresses"); err != nil {
 		return nil, err
 	}
 
@@ -29,5 +29,5 @@ func DedicatedHostGroupID(input string) (*DedicatedHostGroupId, error) {
 		return nil, err
 	}
 
-	return &group, nil
+	return &ipAddress, nil
 }

--- a/azurerm/internal/services/network/parse/public_ip_address_test.go
+++ b/azurerm/internal/services/network/parse/public_ip_address_test.go
@@ -1,0 +1,75 @@
+package parse
+
+import (
+	"testing"
+)
+
+func TestPublicIPAddressID(t *testing.T) {
+	testData := []struct {
+		Name   string
+		Input  string
+		Error  bool
+		Expect *PublicIPAddressId
+	}{
+		{
+			Name:  "Empty",
+			Input: "",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Segment",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Error: true,
+		},
+		{
+			Name:  "No Resource Groups Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Error: true,
+		},
+		{
+			Name:  "Resource Group ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Error: true,
+		},
+		{
+			Name:  "Missing Public IP Address Value",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Network/publicIPAddresses/",
+			Error: true,
+		},
+		{
+			Name:  "Public IP Address ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Network/publicIPAddresses/address1",
+			Error: false,
+			Expect: &PublicIPAddressId{
+				ResourceGroup: "resGroup1",
+				Name:          "address1",
+			},
+		},
+		{
+			Name:  "Wrong Casing",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Network/PublicIPAddresses/set1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := PublicIPAddressID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expect.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expect.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expect.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expect.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/network/validate/network_interface.go
+++ b/azurerm/internal/services/network/validate/network_interface.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
+)
+
+func NetworkInterfaceID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := parse.NetworkInterfaceID(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", k, err))
+		return
+	}
+
+	return warnings, errors
+}

--- a/azurerm/internal/tf/base64/schema.go
+++ b/azurerm/internal/tf/base64/schema.go
@@ -5,10 +5,14 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 )
 
-func OptionalSchema() *schema.Schema {
+func OptionalSchema(isVirtualMachine bool) *schema.Schema {
+	// Virtual Machine's don't allow updating the Custom Data
+	// Code="PropertyChangeNotAllowed" Message="Changing property 'customData' is not allowed."
+
 	return &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,
+		ForceNew:     isVirtualMachine,
 		ValidateFunc: validate.Base64String(),
 	}
 }

--- a/azurerm/internal/tf/schema/import.go
+++ b/azurerm/internal/tf/schema/import.go
@@ -14,6 +14,13 @@ type ResourceIDValidator func(resourceId string) error
 // valid for this Resource prior to performing an import - allowing for incorrect
 // Resource ID's to be caught prior to Import and subsequent crashes
 func ValidateResourceIDPriorToImport(idParser ResourceIDValidator) *schema.ResourceImporter {
+	return ValidateResourceIDPriorToImportThen(idParser, schema.ImportStatePassthrough)
+}
+
+// ValidateResourceIDPriorToImportThen parses the Resource ID to confirm it's
+// valid for this Resource prior to calling the importer - allowing for incorrect
+// Resource ID's to be caught prior to Import and subsequent crashes
+func ValidateResourceIDPriorToImportThen(idParser ResourceIDValidator, importer schema.StateFunc) *schema.ResourceImporter {
 	return &schema.ResourceImporter{
 		State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 			log.Printf("[DEBUG] Importing Resource - parsing %q", d.Id())
@@ -22,7 +29,7 @@ func ValidateResourceIDPriorToImport(idParser ResourceIDValidator) *schema.Resou
 				return []*schema.ResourceData{d}, fmt.Errorf("Error parsing Resource ID %q: %+v", d.Id(), err)
 			}
 
-			return schema.ImportStatePassthrough(d, meta)
+			return importer(d, meta)
 		},
 	}
 }


### PR DESCRIPTION
This PR introduces a few things needed for the upcoming Linux/Windows Virtual Machine resources (as outlined in #2807).

Firstly this introduces the concept of the Features block which is Optional in 1.x but will become Required in 2.0. This will be used to define the behaviour of select resources (at this time only the new Virtual Machine resource [deleting the os disk on deletion], but in time the new Virtual Machine Scale Set [rolling instances] and Key Vault resources [soft delete]). What this looks like in practice:

```
provider "azurerm" {
    features {      
      virtual_machine {
        delete_os_disk_on_deletion = true
      }
    }
}
```

(since there's no Acceptance Tests covering the Provider block directly, I've added unit tests covering the expand in this instance)

Secondly this introduces a bunch of Parsers/Validators across both Compute and Networking for resources which are required by the Virtual Machine resource - but it /intentionally/ doesn't retrofit these into other resources since that's a larger/out-of-scope task.

Finally this introduces some helper functions which are required by the upcoming Virtual Machine resources - mostly to make that PR easier to review, since it's a large resource.