### PR TITLE
azurerm_databricks_workspace - allow underscores in name

### DIFF
--- a/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
+++ b/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
@@ -346,7 +346,7 @@ func ValidateDatabricksWorkspaceName(i interface{}, k string) (warnings []string
 
 	// First, second, and last characters must be a letter or number with a total length between 3 to 64 characters
 	// NOTE: Restricted name to 30 characters because that is the restriction in Azure Portal even though the API supports 64 characters
-	if !regexp.MustCompile("^[a-zA-Z0-9]{2}[_-a-zA-Z0-9]{0,27}[a-zA-Z0-9]{1}$").MatchString(v) {
+	if !regexp.MustCompile("^[a-zA-Z0-9]{2}[-_a-zA-Z0-9]{0,27}[a-zA-Z0-9]{1}$").MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q must be 3 - 30 characters in length", k))
 		errors = append(errors, fmt.Errorf("%q first, second, and last characters must be a letter or number", k))
 		errors = append(errors, fmt.Errorf("%q can only contain letters, numbers, underscores, and hyphens", k))

--- a/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
+++ b/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
@@ -346,10 +346,10 @@ func ValidateDatabricksWorkspaceName(i interface{}, k string) (warnings []string
 
 	// First, second, and last characters must be a letter or number with a total length between 3 to 64 characters
 	// NOTE: Restricted name to 30 characters because that is the restriction in Azure Portal even though the API supports 64 characters
-	if !regexp.MustCompile("^[a-zA-Z0-9]{2}[-a-zA-Z0-9]{0,27}[a-zA-Z0-9]{1}$").MatchString(v) {
+	if !regexp.MustCompile("^[a-zA-Z0-9]{2}[_-a-zA-Z0-9]{0,27}[a-zA-Z0-9]{1}$").MatchString(v) {
 		errors = append(errors, fmt.Errorf("%q must be 3 - 30 characters in length", k))
 		errors = append(errors, fmt.Errorf("%q first, second, and last characters must be a letter or number", k))
-		errors = append(errors, fmt.Errorf("%q can only contain letters, numbers, and hyphens", k))
+		errors = append(errors, fmt.Errorf("%q can only contain letters, numbers, underscores, and hyphens", k))
 	}
 
 	// No consecutive hyphens

--- a/azurerm/internal/services/databricks/tests/resource_arm_databricks_workspace_test.go
+++ b/azurerm/internal/services/databricks/tests/resource_arm_databricks_workspace_test.go
@@ -31,11 +31,23 @@ func TestAzureRMDatabrickWorkspaceName(t *testing.T) {
 			ShouldError: false,
 		},
 		{
+			Value:       "hello_1_2_3_there",
+			ShouldError: false,
+		},
+		{
 			Value:       "hello-1-2-3-",
 			ShouldError: true,
 		},
 		{
 			Value:       "-hello-1-2-3",
+			ShouldError: true,
+		},
+		{
+			Value:       "hello_1_2_3_",
+			ShouldError: true,
+		},
+		{
+			Value:       "_hello_1_2_3",
 			ShouldError: true,
 		},
 		{


### PR DESCRIPTION
Underscores are valid characters in an Azure Databricks workspace name.

I've updated the regex and added a couple of test cases to allow undescores to be used in workspace names.