### PR TITLE
New Resources: `azurerm_linux_virtual_machine` & `azurerm_windows_virtual_machine`

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -1,0 +1,979 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
+	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/base64"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+// TODO: confirm locking as appropriate
+
+func resourceLinuxVirtualMachine() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLinuxVirtualMachineCreate,
+		Read:   resourceLinuxVirtualMachineRead,
+		Update: resourceLinuxVirtualMachineUpdate,
+		Delete: resourceLinuxVirtualMachineDelete,
+		Importer: azSchema.ValidateResourceIDPriorToImportThen(func(id string) error {
+			_, err := ParseVirtualMachineID(id)
+			return err
+		}, importVirtualMachine(compute.Linux, "azurerm_linux_virtual_machine")),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(45 * time.Minute),
+			Delete: schema.DefaultTimeout(45 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidateLinuxName,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"location": azure.SchemaLocation(),
+
+			// Required
+			"admin_username": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"network_interface_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: networkValidate.NetworkInterfaceID,
+				},
+			},
+
+			"os_disk": virtualMachineOSDiskSchema(),
+
+			"size": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			// Optional
+			"additional_capabilities": virtualMachineAdditionalCapabilitiesSchema(),
+
+			"admin_password": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
+			},
+
+			"admin_ssh_key": SSHKeysSchema(true),
+
+			"allow_extension_operations": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+
+			"availability_set_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: computeValidate.AvailabilitySetID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				DiffSuppressFunc: suppress.CaseDifference,
+				// TODO: raise a GH issue for the broken API
+				// availability_set_id:                 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG-200122113424880096/providers/Microsoft.Compute/availabilitySets/ACCTESTAVSET-200122113424880096" => "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG-200122113424880096/providers/Microsoft.Compute/availabilitySets/acctestavset-200122113424880096" (forces new resource)
+				ConflictsWith: []string{
+					// TODO: "virtual_machine_scale_set_id"
+					"zone",
+				},
+			},
+
+			"boot_diagnostics": bootDiagnosticsSchema(),
+
+			"computer_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+
+				// Computed since we reuse the VM name if one's not specified
+				Computed: true,
+				ForceNew: true,
+				// note: whilst the portal says 1-15 characters it seems to mirror the rules for the vm name
+				// (e.g. 1-15 for Windows, 1-63 for Linux)
+				ValidateFunc: ValidateLinuxName,
+			},
+
+			"custom_data": base64.OptionalSchema(true),
+
+			"dedicated_host_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true, // TODO: investigate, looks like the Portal allows migration
+				ValidateFunc: computeValidate.DedicatedHostID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				DiffSuppressFunc: suppress.CaseDifference,
+				// TODO: raise a GH issue for the broken API
+				// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TOM-MANUAL/providers/Microsoft.Compute/hostGroups/tom-hostgroup/hosts/tom-manual-host
+			},
+
+			"disable_password_authentication": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+
+			"eviction_policy": {
+				// only applicable when `priority` is set to `Spot`
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					// NOTE: whilst Delete is an option here, it's only applicable for VMSS
+					string(compute.Deallocate),
+				}, false),
+			},
+
+			"identity": virtualMachineIdentitySchema(),
+
+			"max_bid_price": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				Default:  -1,
+			},
+
+			"plan": planSchema(),
+
+			"priority": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(compute.Regular),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.Regular),
+					string(compute.Spot),
+				}, false),
+			},
+
+			"provision_vm_agent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+
+			"proximity_placement_group_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: computeValidate.ProximityPlacementGroupID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+
+			"secret": linuxSecretSchema(),
+
+			"source_image_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: computeValidate.ImageID,
+			},
+
+			"source_image_reference": sourceImageReferenceSchema(true),
+
+			"tags": tags.Schema(),
+
+			"zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"availability_set_id",
+					// TODO: "virtual_machine_scale_set_id"
+				},
+			},
+
+			// Computed
+			"private_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"public_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_ip_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"virtual_machine_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLinuxVirtualMachineCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	locks.ByName(name, virtualMachineResourceName)
+	defer locks.UnlockByName(name, virtualMachineResourceName)
+
+	if features.ShouldResourcesBeImported() {
+		resp, err := client.Get(ctx, resourceGroup, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Error checking for existing Linux Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return tf.ImportAsExistsError("azurerm_linux_virtual_machine", *resp.ID)
+		}
+	}
+
+	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
+	additionalCapabilities := expandVirtualMachineAdditionalCapabilities(additionalCapabilitiesRaw)
+
+	adminUsername := d.Get("admin_username").(string)
+	allowExtensionOperations := d.Get("allow_extension_operations").(bool)
+	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
+	var computerName string
+	if v, ok := d.GetOk("computer_name"); ok && len(v.(string)) > 0 {
+		computerName = v.(string)
+	} else {
+		computerName = name
+	}
+	disablePasswordAuthentication := d.Get("disable_password_authentication").(bool)
+	location := azure.NormalizeLocation(d.Get("location").(string))
+	identityRaw := d.Get("identity").([]interface{})
+	identity, err := expandVirtualMachineIdentity(identityRaw)
+	if err != nil {
+		return fmt.Errorf("Error expanding `identity`: %+v", err)
+	}
+	planRaw := d.Get("plan").([]interface{})
+	plan := expandPlan(planRaw)
+	priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
+	provisionVMAgent := d.Get("provision_vm_agent").(bool)
+	size := d.Get("size").(string)
+	t := d.Get("tags").(map[string]interface{})
+
+	networkInterfaceIdsRaw := d.Get("network_interface_ids").([]interface{})
+	networkInterfaceIds := expandVirtualMachineNetworkInterfaceIDs(networkInterfaceIdsRaw)
+
+	osDiskRaw := d.Get("os_disk").([]interface{})
+	osDisk := expandVirtualMachineOSDisk(osDiskRaw, compute.Linux)
+
+	secretsRaw := d.Get("secret").([]interface{})
+	secrets := expandLinuxSecrets(secretsRaw)
+
+	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
+	sourceImageId := d.Get("source_image_id").(string)
+	sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	if err != nil {
+		return err
+	}
+
+	sshKeysRaw := d.Get("admin_ssh_key").(*schema.Set).List()
+	sshKeys := ExpandSSHKeys(sshKeysRaw)
+
+	params := compute.VirtualMachine{
+		Name:     utils.String(name),
+		Location: utils.String(location),
+		Identity: identity,
+		Plan:     plan,
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			HardwareProfile: &compute.HardwareProfile{
+				VMSize: compute.VirtualMachineSizeTypes(size),
+			},
+			OsProfile: &compute.OSProfile{
+				AdminUsername:            utils.String(adminUsername),
+				ComputerName:             utils.String(computerName),
+				AllowExtensionOperations: utils.Bool(allowExtensionOperations),
+				LinuxConfiguration: &compute.LinuxConfiguration{
+					DisablePasswordAuthentication: utils.Bool(disablePasswordAuthentication),
+					ProvisionVMAgent:              utils.Bool(provisionVMAgent),
+					SSH: &compute.SSHConfiguration{
+						PublicKeys: &sshKeys,
+					},
+				},
+				Secrets: secrets,
+			},
+			NetworkProfile: &compute.NetworkProfile{
+				NetworkInterfaces: &networkInterfaceIds,
+			},
+			Priority: priority,
+			StorageProfile: &compute.StorageProfile{
+				ImageReference: sourceImageReference,
+				OsDisk:         osDisk,
+
+				// Data Disks are instead handled via the Association resource - as such we can send an empty value here
+				// but for Updates this'll need to be nil, else any associations will be overwritten
+				DataDisks: &[]compute.DataDisk{},
+			},
+
+			// Optional
+			AdditionalCapabilities: additionalCapabilities,
+			DiagnosticsProfile:     bootDiagnostics,
+
+			// @tombuildsstuff: passing in a VMSS ID returns:
+			// > Code="InvalidParameter" Message="The value of parameter virtualMachineScaleSet is invalid." Target="virtualMachineScaleSet"
+			// presuming this isn't finished yet; note: this'll conflict with availability set id
+			VirtualMachineScaleSet: nil,
+		},
+		Tags: tags.Expand(t),
+	}
+
+	if !provisionVMAgent && allowExtensionOperations {
+		return fmt.Errorf("`allow_extension_operations` cannot be set to `true` when `provision_vm_agent` is set to `false`")
+	}
+
+	if v, ok := d.GetOk("availability_set_id"); ok {
+		params.AvailabilitySet = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
+	if v, ok := d.GetOk("custom_data"); ok {
+		params.OsProfile.CustomData = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("dedicated_host_id"); ok {
+		params.Host = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
+	if evictionPolicyRaw, ok := d.GetOk("eviction_policy"); ok {
+		if params.Priority != compute.Spot {
+			return fmt.Errorf("An `eviction_policy` can only be specified when `priority` is set to `Spot`")
+		}
+
+		params.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string))
+	} else if priority == compute.Spot {
+		return fmt.Errorf("An `eviction_policy` must be specified when `priority` is set to `Spot`")
+	}
+
+	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
+		if priority != compute.Spot {
+			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
+		}
+
+		params.BillingProfile = &compute.BillingProfile{
+			MaxPrice: utils.Float(v),
+		}
+	}
+
+	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
+		params.ProximityPlacementGroup = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
+	if v, ok := d.GetOk("zone"); ok {
+		params.Zones = &[]string{
+			v.(string),
+		}
+	}
+
+	// "Authentication using either SSH or by user name and password must be enabled in Linux profile." Target="linuxConfiguration"
+	adminPassword := d.Get("admin_password").(string)
+	if disablePasswordAuthentication && len(sshKeys) == 0 {
+		return fmt.Errorf("At least one `admin_ssh_key` must be specified when `disable_password_authentication` is set to `true`")
+	} else if !disablePasswordAuthentication {
+		if adminPassword == "" {
+			return fmt.Errorf("An `admin_password` must be specified if `disable_password_authentication` is set to `false`")
+		}
+
+		params.OsProfile.AdminPassword = utils.String(adminPassword)
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, params)
+	if err != nil {
+		return fmt.Errorf("Error creating Linux Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for creation of Linux Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, resourceGroup, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Linux Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	if read.ID == nil {
+		return fmt.Errorf("Error retrieving Linux Virtual Machine %q (Resource Group %q): `id` was nil", name, resourceGroup)
+	}
+
+	d.SetId(*read.ID)
+	return resourceLinuxVirtualMachineRead(d, meta)
+}
+
+func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	disksClient := meta.(*clients.Client).Compute.DisksClient
+	networkInterfacesClient := meta.(*clients.Client).Network.InterfacesClient
+	publicIPAddressesClient := meta.(*clients.Client).Network.PublicIPsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := ParseVirtualMachineID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Linux Virtual Machine %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*resp.Location))
+	}
+
+	if err := d.Set("identity", flattenVirtualMachineIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("Error setting `identity`: %+v", err)
+	}
+
+	if err := d.Set("plan", flattenPlan(resp.Plan)); err != nil {
+		return fmt.Errorf("Error setting `plan`: %+v", err)
+	}
+
+	if resp.VirtualMachineProperties == nil {
+		return fmt.Errorf("Error retrieving Linux Virtual Machine %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+	}
+
+	props := *resp.VirtualMachineProperties
+	if err := d.Set("additional_capabilities", flattenVirtualMachineAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
+		return fmt.Errorf("Error setting `additional_capabilities`: %+v", err)
+	}
+
+	availabilitySetId := ""
+	if props.AvailabilitySet != nil && props.AvailabilitySet.ID != nil {
+		availabilitySetId = *props.AvailabilitySet.ID
+	}
+	d.Set("availability_set_id", availabilitySetId)
+
+	if err := d.Set("boot_diagnostics", flattenBootDiagnostics(props.DiagnosticsProfile)); err != nil {
+		return fmt.Errorf("Error setting `boot_diagnostics`: %+v", err)
+	}
+
+	d.Set("eviction_policy", string(props.EvictionPolicy))
+	if profile := props.HardwareProfile; profile != nil {
+		d.Set("size", string(profile.VMSize))
+	}
+
+	// defaulted since BillingProfile isn't returned if it's unset
+	maxBidPrice := float64(-1.0)
+	if props.BillingProfile != nil && props.BillingProfile.MaxPrice != nil {
+		maxBidPrice = *props.BillingProfile.MaxPrice
+	}
+	d.Set("max_bid_price", maxBidPrice)
+
+	if profile := props.NetworkProfile; profile != nil {
+		if err := d.Set("network_interface_ids", flattenVirtualMachineNetworkInterfaceIDs(props.NetworkProfile.NetworkInterfaces)); err != nil {
+			return fmt.Errorf("Error setting `network_interface_ids`: %+v", err)
+		}
+	}
+
+	dedicatedHostId := ""
+	if props.Host != nil && props.Host.ID != nil {
+		dedicatedHostId = *props.Host.ID
+	}
+	d.Set("dedicated_host_id", dedicatedHostId)
+
+	if profile := props.OsProfile; profile != nil {
+		d.Set("admin_username", profile.AdminUsername)
+		d.Set("allow_extension_operations", profile.AllowExtensionOperations)
+		d.Set("computer_name", profile.ComputerName)
+
+		if config := profile.LinuxConfiguration; config != nil {
+			d.Set("disable_password_authentication", config.DisablePasswordAuthentication)
+			d.Set("provision_vm_agent", config.ProvisionVMAgent)
+
+			flattenedSSHKeys, err := FlattenSSHKeys(config.SSH)
+			if err != nil {
+				return fmt.Errorf("Error flattening `admin_ssh_key`: %+v", err)
+			}
+			if err := d.Set("admin_ssh_key", flattenedSSHKeys); err != nil {
+				return fmt.Errorf("Error setting `admin_ssh_key`: %+v", err)
+			}
+		}
+
+		if err := d.Set("secret", flattenLinuxSecrets(profile.Secrets)); err != nil {
+			return fmt.Errorf("Error setting `secret`: %+v", err)
+		}
+	}
+
+	d.Set("priority", string(props.Priority))
+	proximityPlacementGroupId := ""
+	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
+		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID
+	}
+	d.Set("proximity_placement_group_id", proximityPlacementGroupId)
+
+	if profile := props.StorageProfile; profile != nil {
+		// the storage_account_type isn't returned so we need to look it up
+		flattenedOSDisk, err := flattenVirtualMachineOSDisk(ctx, disksClient, profile.OsDisk)
+		if err != nil {
+			return fmt.Errorf("Error flattening `os_disk`: %+v", err)
+		}
+		if err := d.Set("os_disk", flattenedOSDisk); err != nil {
+			return fmt.Errorf("Error settings `os_disk`: %+v", err)
+		}
+
+		var storageImageId string
+		if profile.ImageReference != nil && profile.ImageReference.ID != nil {
+			storageImageId = *profile.ImageReference.ID
+		}
+		d.Set("source_image_id", storageImageId)
+
+		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference)); err != nil {
+			return fmt.Errorf("Error setting `source_image_reference`: %+v", err)
+		}
+	}
+
+	d.Set("virtual_machine_id", props.VMID)
+
+	zone := ""
+	if resp.Zones != nil {
+		if zones := *resp.Zones; len(zones) > 0 {
+			zone = zones[0]
+		}
+	}
+	d.Set("zone", zone)
+
+	connectionInfo := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, resp.VirtualMachineProperties)
+	d.Set("private_ip_address", connectionInfo.primaryPrivateAddress)
+	d.Set("private_ip_addresses", connectionInfo.privateAddresses)
+	d.Set("public_ip_address", connectionInfo.primaryPublicAddress)
+	d.Set("public_ip_addresses", connectionInfo.publicAddresses)
+	isWindows := false
+	setConnectionInformation(d, connectionInfo, isWindows)
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := ParseVirtualMachineID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, virtualMachineResourceName)
+	defer locks.UnlockByName(id.Name, virtualMachineResourceName)
+
+	log.Printf("[DEBUG] Retrieving Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Retrieving InstanceView for Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	instanceView, err := client.InstanceView(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving InstanceView for Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	shouldTurnBackOn := shouldBootVirtualMachine(instanceView)
+	hasEphemeralOSDisk := false
+	if props := existing.VirtualMachineProperties; props != nil {
+		if storage := props.StorageProfile; storage != nil {
+			if disk := storage.OsDisk; disk != nil {
+				if settings := disk.DiffDiskSettings; settings != nil {
+					hasEphemeralOSDisk = settings.Option == compute.Local
+				}
+			}
+		}
+	}
+
+	shouldUpdate := false
+	shouldShutDown := false
+	shouldDeallocate := false
+
+	update := compute.VirtualMachineUpdate{
+		VirtualMachineProperties: &compute.VirtualMachineProperties{},
+	}
+
+	if d.HasChange("boot_diagnostics") {
+		shouldUpdate = true
+
+		bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+		update.VirtualMachineProperties.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
+	}
+
+	if d.HasChange("custom_data") || d.HasChange("secret") {
+		shouldUpdate = true
+
+		profile := compute.OSProfile{}
+
+		if d.HasChange("custom_data") {
+			profile.CustomData = utils.String(d.Get("custom_data").(string))
+		}
+
+		if d.HasChange("secret") {
+			secretsRaw := d.Get("secret").([]interface{})
+			profile.Secrets = expandLinuxSecrets(secretsRaw)
+		}
+
+		update.VirtualMachineProperties.OsProfile = &profile
+	}
+
+	if d.HasChange("identity") {
+		shouldUpdate = true
+
+		identityRaw := d.Get("identity").([]interface{})
+		identity, err := expandVirtualMachineIdentity(identityRaw)
+		if err != nil {
+			return fmt.Errorf("Error expanding `identity`: %+v", err)
+		}
+		update.Identity = identity
+	}
+
+	if d.HasChange("max_bid_price") {
+		shouldUpdate = true
+
+		// Code="OperationNotAllowed" Message="Max price change is not allowed. For more information, see http://aka.ms/AzureSpot/errormessages"
+		shouldShutDown = true
+
+		// "code":"OperationNotAllowed"
+		// "message": "Max price change is not allowed when the VM [name] is currently allocated.
+		//			   Please deallocate and try again. For more information, see http://aka.ms/AzureSpot/errormessages"
+		shouldDeallocate = true
+
+		maxBidPrice := d.Get("max_bid_price").(float64)
+		update.VirtualMachineProperties.BillingProfile = &compute.BillingProfile{
+			MaxPrice: utils.Float(maxBidPrice),
+		}
+	}
+
+	if d.HasChange("network_interface_ids") {
+		shouldUpdate = true
+
+		// Code="CannotAddOrRemoveNetworkInterfacesFromARunningVirtualMachine"
+		// Message="Secondary network interfaces cannot be added or removed from a running virtual machine.
+		shouldShutDown = true
+
+		// @tombuildsstuff: after testing shutting it down isn't sufficient - we need a full deallocation
+		shouldDeallocate = true
+
+		networkInterfaceIdsRaw := d.Get("network_interface_ids").([]interface{})
+		networkInterfaceIds := expandVirtualMachineNetworkInterfaceIDs(networkInterfaceIdsRaw)
+
+		update.VirtualMachineProperties.NetworkProfile = &compute.NetworkProfile{
+			NetworkInterfaces: &networkInterfaceIds,
+		}
+	}
+
+	if d.HasChange("os_disk") {
+		shouldUpdate = true
+
+		// Code="Conflict" Message="Disk resizing is allowed only when creating a VM or when the VM is deallocated." Target="disk.diskSizeGB"
+		shouldShutDown = true
+		shouldDeallocate = true
+
+		osDiskRaw := d.Get("os_disk").([]interface{})
+		osDisk := expandVirtualMachineOSDisk(osDiskRaw, compute.Linux)
+		update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{
+			OsDisk: osDisk,
+		}
+	}
+
+	if d.HasChange("size") {
+		shouldUpdate = true
+
+		// this is kind of superflurious since Azure can do this for us, but if we do this we can subsequently
+		// deallocate the VM to switch hosts if required
+		shouldShutDown = true
+		vmSize := d.Get("size").(string)
+
+		// Azure will auto-reboot this for us, providing this machine will fit on this host
+		// otherwise we need to shut down the VM to move it to another host to be able to use this size
+		availableOnThisHost := false
+		sizes, err := client.ListAvailableSizes(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			return fmt.Errorf("Error retrieving available sizes for Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if sizes.Value != nil {
+			for _, size := range *sizes.Value {
+				if size.Name == nil {
+					continue
+				}
+
+				if strings.EqualFold(*size.Name, vmSize) {
+					availableOnThisHost = true
+					break
+				}
+			}
+		}
+
+		if !availableOnThisHost {
+			log.Printf("[DEBUG] Requested VM Size isn't available on the Host - must switch host to resize..")
+			// Code="OperationNotAllowed"
+			// Message="Unable to resize the VM [name] because the requested size Standard_F4s_v2 is not available in the current hardware cluster.
+			//         The available sizes in this cluster are: [list]. The requested size might be available in other clusters of this region.
+			//         Read more on VM resizing strategy at https://aka.ms/azure-resizevm."
+			shouldDeallocate = true
+		}
+
+		update.VirtualMachineProperties.HardwareProfile = &compute.HardwareProfile{
+			VMSize: compute.VirtualMachineSizeTypes(vmSize),
+		}
+	}
+
+	if d.HasChange("tags") {
+		shouldUpdate = true
+
+		tagsRaw := d.Get("tags").(map[string]interface{})
+		update.Tags = tags.Expand(tagsRaw)
+	}
+
+	if shouldShutDown {
+		log.Printf("[DEBUG] Shutting Down Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		forceShutdown := false
+		future, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(forceShutdown))
+		if err != nil {
+			return fmt.Errorf("Error sending Power Off to Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for Power Off of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Shut Down Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	}
+
+	if shouldDeallocate {
+		if !hasEphemeralOSDisk {
+			log.Printf("[DEBUG] Deallocating Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+			future, err := client.Deallocate(ctx, id.ResourceGroup, id.Name)
+			if err != nil {
+				return fmt.Errorf("Error Deallocating Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("Error waiting for Deallocation of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+
+			log.Printf("[DEBUG] Deallocated Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		} else {
+			// Code="OperationNotAllowed" Message="Operation 'deallocate' is not supported for VMs or VM Scale Set instances using an ephemeral OS disk."
+			log.Printf("[DEBUG] Skipping deallocation for Linux Virtual Machine %q (Resource Group %q) since cannot deallocate a Virtual Machine with an Ephemeral OS Disk", id.Name, id.ResourceGroup)
+		}
+	}
+
+	// now the VM's shutdown/deallocated we can update the disk which can't be done via the VM API:
+	// Code="ResizeDiskError" Message="Managed disk resize via Virtual Machine [name] is not allowed. Please resize disk resource at [id]."
+	// Portal: "Disks can be resized or account type changed only when they are unattached or the owner VM is deallocated."
+	if d.HasChange("os_disk.0.disk_size_gb") {
+		diskName := d.Get("os_disk.0.name").(string)
+		newSize := d.Get("os_disk.0.disk_size_gb").(int)
+		log.Printf("[DEBUG] Resizing OS Disk %q for Linux Virtual Machine %q (Resource Group %q) to %dGB..", diskName, id.Name, id.ResourceGroup, newSize)
+
+		disksClient := meta.(*clients.Client).Compute.DisksClient
+
+		update := compute.DiskUpdate{
+			DiskUpdateProperties: &compute.DiskUpdateProperties{
+				DiskSizeGB: utils.Int32(int32(newSize)),
+			},
+		}
+
+		future, err := disksClient.Update(ctx, id.ResourceGroup, diskName, update)
+		if err != nil {
+			return fmt.Errorf("Error resizing OS Disk %q for Linux Virtual Machine %q (Resource Group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for resize of OS Disk %q for Linux Virtual Machine %q (Resource Group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Resized OS Disk %q for Linux Virtual Machine %q (Resource Group %q) to %dGB.", diskName, id.Name, id.ResourceGroup, newSize)
+	}
+
+	if shouldUpdate {
+		log.Printf("[DEBUG] Updating Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
+		if err != nil {
+			return fmt.Errorf("Error updating Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for update of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Updated Linux Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
+	}
+
+	// if we've shut it down and it was turned off, let's boot it back up
+	if shouldTurnBackOn && shouldShutDown {
+		log.Printf("[DEBUG] Starting Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		future, err := client.Start(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			return fmt.Errorf("Error starting Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for start of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Started Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	}
+
+	return resourceLinuxVirtualMachineRead(d, meta)
+}
+
+func resourceLinuxVirtualMachineDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := ParseVirtualMachineID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, virtualMachineResourceName)
+	defer locks.UnlockByName(id.Name, virtualMachineResourceName)
+
+	log.Printf("[DEBUG] Retrieving Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	// ISSUE: XXX
+	// shutting down the Virtual Machine prior to removing it means users are no longer charged for the compute
+	// thus this can be a large cost-saving when deleting larger instances
+	// in addition - since we're shutting down the machine to remove it, forcing a power-off is fine (as opposed
+	// to waiting for a graceful shut down)
+	log.Printf("[DEBUG] Powering Off Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	skipShutdown := true
+	powerOffFuture, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(skipShutdown))
+	if err != nil {
+		return fmt.Errorf("Error powering off Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	if err := powerOffFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for power off of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Powered Off Linux Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
+
+	log.Printf("[DEBUG] Deleting Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	deleteFuture, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("Error deleting Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	if err := deleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for deletion of Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Deleted Linux Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
+
+	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
+	if deleteOSDisk {
+		log.Printf("[DEBUG] Deleting OS Disk from Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		disksClient := meta.(*clients.Client).Compute.DisksClient
+		managedDiskId := ""
+		if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {
+			if disk := props.StorageProfile.OsDisk.ManagedDisk; disk != nil && disk.ID != nil {
+				managedDiskId = *disk.ID
+			}
+		}
+
+		if managedDiskId != "" {
+			diskId, err := parse.ManagedDiskID(managedDiskId)
+			if err != nil {
+				return err
+			}
+
+			diskDeleteFuture, err := disksClient.Delete(ctx, diskId.ResourceGroup, diskId.Name)
+			if err != nil {
+				if !response.WasNotFound(diskDeleteFuture.Response()) {
+					return fmt.Errorf("Error deleting OS Disk %q (Resource Group %q) for Linux Virtual Machine %q (Resource Group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+				}
+			}
+			if !response.WasNotFound(diskDeleteFuture.Response()) {
+				if err := diskDeleteFuture.WaitForCompletionRef(ctx, disksClient.Client); err != nil {
+					return fmt.Errorf("Error OS Disk %q (Resource Group %q) for Linux Virtual Machine %q (Resource Group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+				}
+			}
+
+			log.Printf("[DEBUG] Deleted OS Disk from Linux Virtual Machine %q (Resource Group %q).", diskId.Name, diskId.ResourceGroup)
+		} else {
+			log.Printf("[DEBUG] Skipping Deleting OS Disk from Linux Virtual Machine %q (Resource Group %q) - cannot determine OS Disk ID.", id.Name, id.ResourceGroup)
+		}
+	} else {
+		log.Printf("[DEBUG] Skipping Deleting OS Disk from Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -642,7 +642,7 @@ func resourceLinuxVirtualMachineUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error retrieving InstanceView for Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	shouldTurnBackOn := shouldBootVirtualMachine(instanceView)
+	shouldTurnBackOn := virtualMachineShouldBeStarted(instanceView)
 	hasEphemeralOSDisk := false
 	if props := existing.VirtualMachineProperties; props != nil {
 		if storage := props.StorageProfile; storage != nil {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -487,7 +487,7 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(location))
+		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
 	if err := d.Set("identity", flattenVirtualMachineIdentity(resp.Identity)); err != nil {

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -171,7 +171,7 @@ func resourceLinuxVirtualMachine() *schema.Resource {
 				Type:         schema.TypeFloat,
 				Optional:     true,
 				Default:      -1,
-				ValidateFunc: validation.IntAtLeast(-1),
+				ValidateFunc: validation.FloatAtLeast(-1.0),
 			},
 
 			"plan": planSchema(),

--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -54,6 +54,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 
 	// 2.0 resources
 	if features.SupportsTwoPointZeroResources() {
+		resources["azurerm_linux_virtual_machine"] = resourceLinuxVirtualMachine()
 		resources["azurerm_linux_virtual_machine_scale_set"] = resourceArmLinuxVirtualMachineScaleSet()
 		resources["azurerm_virtual_machine_scale_set_extension"] = resourceArmVirtualMachineScaleSetExtension()
 		resources["azurerm_windows_virtual_machine_scale_set"] = resourceArmWindowsVirtualMachineScaleSet()

--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -57,6 +57,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		resources["azurerm_linux_virtual_machine"] = resourceLinuxVirtualMachine()
 		resources["azurerm_linux_virtual_machine_scale_set"] = resourceArmLinuxVirtualMachineScaleSet()
 		resources["azurerm_virtual_machine_scale_set_extension"] = resourceArmVirtualMachineScaleSetExtension()
+		resources["azurerm_windows_virtual_machine"] = resourceWindowsVirtualMachine()
 		resources["azurerm_windows_virtual_machine_scale_set"] = resourceArmWindowsVirtualMachineScaleSet()
 	}
 

--- a/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
@@ -150,6 +150,7 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
+					"None",
 					"Windows_Client",
 					"Windows_Server",
 				}, false),

--- a/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
@@ -91,34 +91,7 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 			// Optional
 			"additional_capabilities": VirtualMachineScaleSetAdditionalCapabilitiesSchema(),
 
-			"additional_unattend_config": {
-				Type:     schema.TypeList,
-				Optional: true,
-				// whilst the SDK supports updating, the API doesn't:
-				//   Code="PropertyChangeNotAllowed"
-				//   Message="Changing property 'windowsConfiguration.additionalUnattendContent' is not allowed."
-				//   Target="windowsConfiguration.additionalUnattendContent
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"content": {
-							Type:      schema.TypeString,
-							Required:  true,
-							ForceNew:  true,
-							Sensitive: true,
-						},
-						"setting": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(compute.AutoLogon),
-								string(compute.FirstLogonCommands),
-							}, false),
-						},
-					},
-				},
-			},
+			"additional_unattend_content": additionalUnattendContentSchema(),
 
 			"automatic_os_upgrade_policy": VirtualMachineScaleSetAutomatedOSUpgradePolicySchema(),
 
@@ -261,35 +234,7 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 				}, false),
 			},
 
-			"winrm_listener": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				// Whilst the SDK allows you to modify this, the API does not:
-				//   Code="PropertyChangeNotAllowed"
-				//   Message="Changing property 'windowsConfiguration.winRM.listeners' is not allowed."
-				//   Target="windowsConfiguration.winRM.listeners"
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"protocol": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(compute.HTTP),
-								string(compute.HTTPS),
-							}, false),
-						},
-
-						"certificate_url": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							ValidateFunc: azure.ValidateKeyVaultChildId,
-						},
-					},
-				},
-			},
+			"winrm_listener": winRmListenerSchema(),
 
 			"zone_balance": {
 				Type:     schema.TypeBool,
@@ -336,8 +281,8 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
 	additionalCapabilities := ExpandVirtualMachineScaleSetAdditionalCapabilities(additionalCapabilitiesRaw)
 
-	additionalUnattendConfigRaw := d.Get("additional_unattend_config").([]interface{})
-	additionalUnattendConfig := expandWindowsVirtualMachineScaleSetAdditionalUnattendConfig(additionalUnattendConfigRaw)
+	additionalUnattendContentRaw := d.Get("additional_unattend_content").([]interface{})
+	additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
 
 	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
 	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
@@ -397,7 +342,7 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 	}
 
 	winRmListenersRaw := d.Get("winrm_listener").(*schema.Set).List()
-	winRmListeners := expandWindowsVirtualMachineScaleSetWinRMListeners(winRmListenersRaw)
+	winRmListeners := expandWinRMListener(winRmListenersRaw)
 
 	secretsRaw := d.Get("secret").([]interface{})
 	secrets := expandWindowsSecrets(secretsRaw)
@@ -479,8 +424,8 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 		return fmt.Errorf("An `eviction_policy` must be specified when `priority` is set to `Spot`")
 	}
 
-	if len(additionalUnattendConfigRaw) > 0 {
-		virtualMachineProfile.OsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendConfig
+	if len(additionalUnattendContentRaw) > 0 {
+		virtualMachineProfile.OsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent
 	}
 
 	if v, ok := d.GetOk("license_type"); ok {
@@ -965,8 +910,8 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 			}
 
 			if windows := osProfile.WindowsConfiguration; windows != nil {
-				if err := d.Set("additional_unattend_config", flattenWindowsVirtualMachineScaleSetAdditionalUnattendConfig(windows.AdditionalUnattendContent, d)); err != nil {
-					return fmt.Errorf("Error setting `additional_unattend_config`: %+v", err)
+				if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(windows.AdditionalUnattendContent, d)); err != nil {
+					return fmt.Errorf("Error setting `additional_unattend_content`: %+v", err)
 				}
 
 				enableAutomaticUpdates := false
@@ -984,7 +929,7 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 				d.Set("provision_vm_agent", windows.ProvisionVMAgent)
 				d.Set("timezone", windows.TimeZone)
 
-				if err := d.Set("winrm_listener", flattenWindowsVirtualMachineScaleSetWinRMListener(windows.WinRM)); err != nil {
+				if err := d.Set("winrm_listener", flattenWinRMListener(windows.WinRM)); err != nil {
 					return fmt.Errorf("Error setting `winrm_listener`: %+v", err)
 				}
 			}
@@ -1071,102 +1016,4 @@ func resourceArmWindowsVirtualMachineScaleSetDelete(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] Deleted Windows Virtual Machine Scale Set %q (Resource Group %q).", id.Name, id.ResourceGroup)
 
 	return nil
-}
-
-func expandWindowsVirtualMachineScaleSetAdditionalUnattendConfig(input []interface{}) *[]compute.AdditionalUnattendContent {
-	output := make([]compute.AdditionalUnattendContent, 0)
-
-	for _, v := range input {
-		raw := v.(map[string]interface{})
-
-		output = append(output, compute.AdditionalUnattendContent{
-			SettingName: compute.SettingNames(raw["setting"].(string)),
-			Content:     utils.String(raw["content"].(string)),
-
-			// no other possible values
-			PassName:      compute.OobeSystem,
-			ComponentName: compute.MicrosoftWindowsShellSetup,
-		})
-	}
-
-	return &output
-}
-
-func flattenWindowsVirtualMachineScaleSetAdditionalUnattendConfig(input *[]compute.AdditionalUnattendContent, d *schema.ResourceData) []interface{} {
-	if input == nil {
-		return []interface{}{}
-	}
-
-	existing := make([]interface{}, 0)
-	if v, ok := d.GetOk("additional_unattend_config"); ok {
-		existing = v.([]interface{})
-	}
-
-	output := make([]interface{}, 0)
-	for i, v := range *input {
-		// content isn't returned from the API as it's sensitive so we need to look it up
-		content := ""
-		if len(existing) > i {
-			existingVal := existing[i]
-			existingRaw, ok := existingVal.(map[string]interface{})
-			if ok {
-				contentRaw, ok := existingRaw["content"]
-				if ok {
-					content = contentRaw.(string)
-				}
-			}
-		}
-
-		output = append(output, map[string]interface{}{
-			"content": content,
-			"setting": string(v.SettingName),
-		})
-	}
-
-	return output
-}
-
-func expandWindowsVirtualMachineScaleSetWinRMListeners(input []interface{}) *compute.WinRMConfiguration {
-	listeners := make([]compute.WinRMListener, 0)
-
-	for _, v := range input {
-		raw := v.(map[string]interface{})
-
-		listener := compute.WinRMListener{
-			Protocol: compute.ProtocolTypes(raw["protocol"].(string)),
-		}
-
-		certificateUrl := raw["certificate_url"].(string)
-		if certificateUrl != "" {
-			listener.CertificateURL = utils.String(certificateUrl)
-		}
-
-		listeners = append(listeners, listener)
-	}
-
-	return &compute.WinRMConfiguration{
-		Listeners: &listeners,
-	}
-}
-
-func flattenWindowsVirtualMachineScaleSetWinRMListener(input *compute.WinRMConfiguration) []interface{} {
-	if input == nil || input.Listeners == nil {
-		return []interface{}{}
-	}
-
-	output := make([]interface{}, 0)
-
-	for _, v := range *input.Listeners {
-		certificateUrl := ""
-		if v.CertificateURL != nil {
-			certificateUrl = *v.CertificateURL
-		}
-
-		output = append(output, map[string]interface{}{
-			"certificate_url": certificateUrl,
-			"protocol":        string(v.Protocol),
-		})
-	}
-
-	return output
 }

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_auth_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_auth_test.go
@@ -1,0 +1,232 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccLinuxVirtualMachine_authPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_authPassword(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_authPasswordAndSSH(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_authPasswordAndSSH(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_authSSH(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_authSSH(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_authSSHMultipleKeys(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_authSSHMultiple(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testLinuxVirtualMachine_authPassword(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  disable_password_authentication = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_authPasswordAndSSH(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_authSSH(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_authSSHMultiple(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.second_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_auth_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_auth_test.go
@@ -126,12 +126,12 @@ func testLinuxVirtualMachine_authPasswordAndSSH(data acceptance.TestData) string
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -162,11 +162,11 @@ func testLinuxVirtualMachine_authSSH(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -197,11 +197,11 @@ func testLinuxVirtualMachine_authSSHMultiple(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
@@ -1,0 +1,731 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccLinuxVirtualMachine_diskOSBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSBasic(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSCachingType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSCachingType(data, "None"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_diskOSCachingType(data, "ReadOnly"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_diskOSCachingType(data, "ReadWrite"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSCustomName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSCustomName(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSCustomSize(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSCustomSize(data, 30),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSCustomSizeExpanded(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSCustomSize(data, 30),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_diskOSCustomSize(data, 60),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSDiskEncryptionSet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
+				Config: testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data),
+				Check: resource.ComposeTestCheckFunc(
+					enableSoftDeleteAndPurgeProtectionForKeyVault("azurerm_key_vault.test"),
+				),
+			},
+			{
+				Config: testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetResource(data),
+			},
+			{
+				Config: testLinuxVirtualMachine_diskOSDiskDiskEncryptionSet(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSEphemeral(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSEphemeral(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSStorageTypeStandardLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSStorageAccountType(data, "Standard_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSStorageTypeStandardSSDLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSStorageAccountType(data, "StandardSSD_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSStorageTypePremiumLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSStorageAccountType(data, "Premium_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSStorageTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_diskOSStorageAccountType(data, "Standard_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_diskOSStorageAccountType(data, "Premium_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_diskOSStorageAccountType(data, "StandardSSD_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_diskOSStorageAccountType(data, "Standard_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSWriteAcceleratorEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// Enabled
+				Config: testLinuxVirtualMachine_diskOSWriteAcceleratorEnabled(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				// Disabled
+				Config: testLinuxVirtualMachine_diskOSWriteAcceleratorEnabled(data, false),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				// Enabled
+				Config: testLinuxVirtualMachine_diskOSWriteAcceleratorEnabled(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testLinuxVirtualMachine_diskOSBasic(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_diskOSCachingType(data acceptance.TestData, cachingType string) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "%s"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, cachingType)
+}
+
+func testLinuxVirtualMachine_diskOSCustomName(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    name                 = "osdisk1"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_diskOSCustomSize(data acceptance.TestData, size int) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    name                 = "osdisk1"
+    caching              = "ReadWrite"
+    disk_size_gb         = %d
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, size)
+}
+
+func testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data acceptance.TestData) string {
+	// whilst this is in Preview it's only supported in: West Central US, Canada Central, North Europe
+	// TODO: switch back to default location
+	// once that's done this can also use the same template as everything else too
+	location := "westus2"
+
+	return fmt.Sprintf(`
+# note: whilst these aren't used in all tests, it saves us redefining these everywhere
+locals {
+  first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestkv%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  sku_name                    = "premium"
+  enabled_for_disk_encryption = true
+}
+
+resource "azurerm_key_vault_access_policy" "service-principal" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_client_config.current.service_principal_object_id
+
+  key_permissions = [
+    "create",
+    "delete",
+    "get",
+    "update",
+  ]
+
+  secret_permissions = [
+    "get",
+    "delete",
+    "set",
+  ]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "examplekey"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+
+  depends_on = ["azurerm_key_vault_access_policy.service-principal"]
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+ name                = "acctestnic-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, data.RandomInteger, location, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetResource(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_disk_encryption_set" "test" {
+  name                = "acctestdes-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  key_vault_key_id    = azurerm_key_vault_key.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "disk-encryption" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  key_permissions = [
+    "get",
+    "wrapkey",
+    "unwrapkey",
+  ]
+
+  tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id
+  object_id = azurerm_disk_encryption_set.test.identity.0.principal_id
+}
+
+resource "azurerm_role_assignment" "disk-encryption-read-keyvault" {
+  scope                = azurerm_key_vault.test.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_disk_encryption_set.test.identity.0.principal_id
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_diskOSDiskDiskEncryptionSet(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetResource(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching                 = "ReadWrite"
+    disk_encryption_set_id  = azurerm_disk_encryption_set.test.id
+    storage_account_type    = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  depends_on = [
+    "azurerm_role_assignment.disk-encryption-read-keyvault",
+    "azurerm_key_vault_access_policy.disk-encryption",
+  ]
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_diskOSEphemeral(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2s_v2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadOnly"
+    storage_account_type = "Standard_LRS"
+
+    diff_disk_settings {
+      option = "Local"
+    }
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_diskOSStorageAccountType(data acceptance.TestData, accountType string) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2s_v2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "%s"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, accountType)
+}
+
+func testLinuxVirtualMachine_diskOSWriteAcceleratorEnabled(data acceptance.TestData, enabled bool) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_M8ms"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    storage_account_type      = "Premium_LRS"
+    caching                   = "None"
+    write_accelerator_enabled = %t
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, enabled)
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
@@ -311,11 +311,11 @@ func testLinuxVirtualMachine_diskOSBasic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -346,11 +346,11 @@ func testLinuxVirtualMachine_diskOSCachingType(data acceptance.TestData, caching
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -381,11 +381,11 @@ func testLinuxVirtualMachine_diskOSCustomName(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -417,11 +417,11 @@ func testLinuxVirtualMachine_diskOSCustomSize(data acceptance.TestData, size int
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -479,8 +479,8 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
-  tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azurerm_client_config.current.service_principal_object_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.service_principal_object_id
 
   key_permissions = [
     "create",
@@ -529,15 +529,15 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_network_interface" "test" {
- name                = "acctestnic-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, data.RandomInteger, location, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
@@ -585,11 +585,11 @@ func testLinuxVirtualMachine_diskOSDiskDiskEncryptionSet(data acceptance.TestDat
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -600,9 +600,9 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   os_disk {
-    caching                 = "ReadWrite"
-    disk_encryption_set_id  = azurerm_disk_encryption_set.test.id
-    storage_account_type    = "Standard_LRS"
+    caching                = "ReadWrite"
+    disk_encryption_set_id = azurerm_disk_encryption_set.test.id
+    storage_account_type   = "Standard_LRS"
   }
 
   source_image_reference {
@@ -626,11 +626,11 @@ func testLinuxVirtualMachine_diskOSEphemeral(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2s_v2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2s_v2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -665,11 +665,11 @@ func testLinuxVirtualMachine_diskOSStorageAccountType(data acceptance.TestData, 
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2s_v2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2s_v2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -700,11 +700,11 @@ func testLinuxVirtualMachine_diskOSWriteAcceleratorEnabled(data acceptance.TestD
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_M8ms"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_M8ms"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_identity_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_identity_test.go
@@ -1,0 +1,366 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccLinuxVirtualMachine_identityNone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_identityNone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.%", "0"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_identitySystemAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_identitySystemAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_identitySystemAssignedUserAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_identitySystemAssignedUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_identityUserAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_identityUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_identityUserAssignedUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_identityUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_identityNone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.%", "0"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_identitySystemAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_identityUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_identitySystemAssignedUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_identityNone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testLinuxVirtualMachine_identityNone(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_identitySystemAssigned(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_identitySystemAssignedUserAssigned(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_identityUserAssigned(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_identityUserAssignedUpdated(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_user_assigned_identity" "other" {
+  name                = "acctestuai2-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+      azurerm_user_assigned_identity.other.id,
+    ]
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_identity_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_identity_test.go
@@ -146,11 +146,11 @@ func testLinuxVirtualMachine_identityNone(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -181,11 +181,11 @@ func testLinuxVirtualMachine_identitySystemAssigned(data acceptance.TestData) st
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -226,11 +226,11 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -274,11 +274,11 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -328,11 +328,11 @@ resource "azurerm_user_assigned_identity" "other" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_images_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_images_test.go
@@ -1,0 +1,418 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccLinuxVirtualMachine_imageFromImage(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// create the original VM
+				Config: testLinuxVirtualMachine_imageFromExistingMachinePrep(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists("azurerm_linux_virtual_machine.source"),
+					generalizeLinuxVirtualMachine("azurerm_linux_virtual_machine.source"),
+				),
+			},
+			{
+				// then create an image from that VM, and then create a VM from that image
+				Config: testLinuxVirtualMachine_imageFromImage(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_imageFromPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_imageFromPlan(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_imageFromSharedImageGallery(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// create the original VM
+				Config: testLinuxVirtualMachine_imageFromExistingMachinePrep(data),
+				Check: resource.ComposeTestCheckFunc(
+
+					checkLinuxVirtualMachineExists("azurerm_linux_virtual_machine.source"),
+					generalizeLinuxVirtualMachine("azurerm_linux_virtual_machine.source"),
+				),
+			},
+			{
+				// then create an image from that VM, and then create a VM from that image
+				Config: testLinuxVirtualMachine_imageFromSharedImageGallery(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_imageFromSourceImageReference(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_imageFromSourceImageReference(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testLinuxVirtualMachine_imageFromExistingMachineDependencies(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+# note: whilst these aren't used in all tests, it saves us redefining these everywhere
+locals {
+  first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
+  vm_name           = "acctestvm-%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctpip-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  allocation_method   = "Static"
+  domain_name_label   = local.vm_name
+}
+
+resource "azurerm_network_interface" "public" {
+  name                = "acctnicsource-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+	name                          = "testconfigurationsource"
+	subnet_id                     = "${azurerm_subnet.test.id}"
+	private_ip_address_allocation = "Dynamic"
+	public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+}
+`, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_imageFromExistingMachinePrep(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_imageFromExistingMachineDependencies(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "source" {
+  name                            = "acctestsourceVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.public.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_imageFromImage(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_imageFromExistingMachinePrep(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_linux_virtual_machine.source.id
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  source_image_id                 = azurerm_image.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_imageFromPlan(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_marketplace_agreement" "test" {
+  publisher = "cloudbees"
+  offer     = "jenkins-operations-center"
+  plan      = "jenkins-operations-center-solo"
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  plan {
+    name      = "jenkins-operations-center-solo"
+    product   = "jenkins-operations-center"
+    publisher = "cloudbees"
+  }
+
+  source_image_reference {
+    publisher = "cloudbees"
+    offer     = "jenkins-operations-center"
+    sku       = "jenkins-operations-center-solo"
+    version   = "latest"
+  }
+
+  depends_on = ["azurerm_marketplace_agreement.test"]
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_imageFromSharedImageGallery(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_imageFromExistingMachinePrep(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_linux_virtual_machine.source.id
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctest-gallery-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctest-gallery-image"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+
+  identifier {
+    publisher = "AcceptanceTest-Publisher"
+    offer     = "AcceptanceTest-Offer"
+    sku       = "AcceptanceTest-Sku"
+  }
+}
+
+resource "azurerm_shared_image_version" "test" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+  location            = azurerm_shared_image.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_shared_image.test.location
+    regional_replica_count = "5"
+    storage_account_type   = "Standard_LRS"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  source_image_id                 = azurerm_shared_image_version.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_imageFromSourceImageReference(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func generalizeLinuxVirtualMachine(resourceName string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		name := rs.Primary.Attributes["name"]
+		username := rs.Primary.Attributes["admin_username"]
+		password := rs.Primary.Attributes["admin_password"]
+		port := "22"
+		location := rs.Primary.Attributes["location"]
+
+		return testGeneralizeVMImage(resourceGroup, name, username, password, name, port, location)(s)
+	}
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_images_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_images_test.go
@@ -146,10 +146,10 @@ resource "azurerm_network_interface" "public" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   ip_configuration {
-	name                          = "testconfigurationsource"
-	subnet_id                     = "${azurerm_subnet.test.id}"
-	private_ip_address_allocation = "Dynamic"
-	public_ip_address_id          = "${azurerm_public_ip.test.id}"
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
   }
 }
 
@@ -179,11 +179,11 @@ func testLinuxVirtualMachine_imageFromExistingMachinePrep(data acceptance.TestDa
 %s
 
 resource "azurerm_linux_virtual_machine" "source" {
-  name                            = "acctestsourceVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestsourceVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.public.id,
   ]
@@ -221,12 +221,12 @@ resource "azurerm_image" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  source_image_id                 = azurerm_image.test.id
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  source_image_id     = azurerm_image.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -256,11 +256,11 @@ resource "azurerm_marketplace_agreement" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -341,12 +341,12 @@ resource "azurerm_shared_image_version" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  source_image_id                 = azurerm_shared_image_version.test.id
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  source_image_id     = azurerm_shared_image_version.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -370,11 +370,11 @@ func testLinuxVirtualMachine_imageFromSourceImageReference(data acceptance.TestD
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_network_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_network_test.go
@@ -1,0 +1,1010 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+/*
+Load Balancer + updating the backend pool
+App Gateway + updating the backend pool
+FrontDoor?
+*/
+
+func TestAccLinuxVirtualMachine_networkIPv6(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkIPv6(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkMultiple(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "0"),
+				),
+			},
+			data.ImportStep(),
+			{
+				// update the Primary IP
+				Config: testLinuxVirtualMachine_networkMultipleUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "0"),
+				),
+			},
+			data.ImportStep(),
+			{
+				// remove the secondary IP
+				Config: testLinuxVirtualMachine_networkMultipleRemoved(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "0"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkMultiplePublic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkMultiplePublic(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "2"),
+				),
+			},
+			data.ImportStep(),
+			{
+				// update the Primary IP
+				Config: testLinuxVirtualMachine_networkMultiplePublicUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "2"),
+				),
+			},
+			data.ImportStep(),
+			{
+				// remove the secondary IP
+				Config: testLinuxVirtualMachine_networkMultiplePublicRemoved(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "1"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPrivateDynamicIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPrivateStaticIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPrivateUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_networkPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPublicDynamicPrivateDynamicIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPublicDynamicPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPublicDynamicPrivateStaticIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPublicDynamicPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPublicDynamicUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPublicDynamicPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_networkPublicDynamicPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPublicStaticPrivateDynamicIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPublicStaticPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPublicStaticPrivateStaticIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPublicStaticPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_networkPublicStaticPrivateUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_networkPublicStaticPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_networkPublicStaticPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testLinuxVirtualMachine_networkIPv6(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "dynamic"
+    primary                       = true
+  }
+
+  ip_configuration {
+    name                          = "secondary"
+    private_ip_address_version    = "IPv6"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultipleTemplate(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "first" {
+ name                = "acctestnic1-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+
+resource "azurerm_network_interface" "second" {
+ name                = "acctestnic2-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultiple(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_networkMultipleTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.first.id,
+    azurerm_network_interface.second.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultipleUpdated(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_networkMultipleTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+    azurerm_network_interface.first.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultipleRemoved(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_networkMultipleTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultiplePublicTemplate(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "first" {
+  name                = "acctpip1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_interface" "first" {
+  name                = "acctestnic1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.first.id
+  }
+}
+
+resource "azurerm_public_ip" "second" {
+  name                = "acctpip2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_interface" "second" {
+  name                = "acctestnic2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.second.id
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultiplePublic(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_networkMultiplePublicTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.first.id,
+    azurerm_network_interface.second.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultiplePublicUpdated(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_networkMultiplePublicTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+    azurerm_network_interface.first.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkMultiplePublicRemoved(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_networkMultiplePublicTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkPrivateDynamicIP(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkPrivateStaticIP(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkPublicDynamicPrivateDynamicIP(data acceptance.TestData) string {
+	privateIPIsStatic := false
+	template := testLinuxVirtualMachine_templatePrivateIP(data, privateIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkPublicDynamicPrivateStaticIP(data acceptance.TestData) string {
+	privateIPIsStatic := true
+	template := testLinuxVirtualMachine_templatePrivateIP(data, privateIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkPublicStaticPrivateDynamicIP(data acceptance.TestData) string {
+	privateIPIsStatic := false
+	publicIPIsStatic := true
+	template := testLinuxVirtualMachine_templatePublicIP(data, privateIPIsStatic, publicIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_networkPublicStaticPrivateStaticIP(data acceptance.TestData) string {
+	privateIPIsStatic := true
+	publicIPIsStatic := true
+	template := testLinuxVirtualMachine_templatePublicIP(data, privateIPIsStatic, publicIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_templatePrivateIP(data acceptance.TestData, static bool) string {
+	template := testLinuxVirtualMachine_templateBase(data)
+	if static {
+		return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Static" 
+    private_ip_address            = "10.0.2.30"
+ }
+}
+`, template, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+ name                = "acctestnic-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_templatePublicIP(data acceptance.TestData, privateStatic, publicStatic bool) string {
+	template := testLinuxVirtualMachine_templateBase(data)
+	publicAllocationType := allocationType(publicStatic)
+
+	if privateStatic {
+		return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = %q
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Static"
+    private_ip_address            = "10.0.2.30"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+`, template, data.RandomInteger, publicAllocationType, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = %q
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+`, template, data.RandomInteger, publicAllocationType, data.RandomInteger)
+}
+
+func allocationType(static bool) string {
+	if static {
+		return "Static"
+	}
+
+	return "Dynamic"
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_network_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_network_test.go
@@ -370,11 +370,11 @@ resource "azurerm_network_interface" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -405,27 +405,27 @@ func testLinuxVirtualMachine_networkMultipleTemplate(data acceptance.TestData) s
 %s
 
 resource "azurerm_network_interface" "first" {
- name                = "acctestnic1-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 
 resource "azurerm_network_interface" "second" {
- name                = "acctestnic2-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, template, data.RandomInteger, data.RandomInteger)
 }
@@ -436,11 +436,11 @@ func testLinuxVirtualMachine_networkMultiple(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.first.id,
     azurerm_network_interface.second.id,
@@ -472,11 +472,11 @@ func testLinuxVirtualMachine_networkMultipleUpdated(data acceptance.TestData) st
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.second.id,
     azurerm_network_interface.first.id,
@@ -508,11 +508,11 @@ func testLinuxVirtualMachine_networkMultipleRemoved(data acceptance.TestData) st
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.second.id,
   ]
@@ -590,11 +590,11 @@ func testLinuxVirtualMachine_networkMultiplePublic(data acceptance.TestData) str
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.first.id,
     azurerm_network_interface.second.id,
@@ -626,11 +626,11 @@ func testLinuxVirtualMachine_networkMultiplePublicUpdated(data acceptance.TestDa
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.second.id,
     azurerm_network_interface.first.id,
@@ -662,11 +662,11 @@ func testLinuxVirtualMachine_networkMultiplePublicRemoved(data acceptance.TestDa
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.second.id,
   ]
@@ -697,11 +697,11 @@ func testLinuxVirtualMachine_networkPrivateDynamicIP(data acceptance.TestData) s
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -732,11 +732,11 @@ func testLinuxVirtualMachine_networkPrivateStaticIP(data acceptance.TestData) st
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -768,11 +768,11 @@ func testLinuxVirtualMachine_networkPublicDynamicPrivateDynamicIP(data acceptanc
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -804,11 +804,11 @@ func testLinuxVirtualMachine_networkPublicDynamicPrivateStaticIP(data acceptance
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -841,11 +841,11 @@ func testLinuxVirtualMachine_networkPublicStaticPrivateDynamicIP(data acceptance
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -878,11 +878,11 @@ func testLinuxVirtualMachine_networkPublicStaticPrivateStaticIP(data acceptance.
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -921,9 +921,9 @@ resource "azurerm_network_interface" "test" {
   ip_configuration {
     name                          = "internal"
     subnet_id                     = azurerm_subnet.test.id
-    private_ip_address_allocation = "Static" 
+    private_ip_address_allocation = "Static"
     private_ip_address            = "10.0.2.30"
- }
+  }
 }
 `, template, data.RandomInteger)
 	}
@@ -932,15 +932,15 @@ resource "azurerm_network_interface" "test" {
 %s
 
 resource "azurerm_network_interface" "test" {
- name                = "acctestnic-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_other_test.go
@@ -1,0 +1,1103 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+func TestAccLinuxVirtualMachine_otherAllowExtensionOperationsDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherAllowExtensionOperationsDefault(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "allow_extension_operations", "true"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherAllowExtensionOperationsDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherAllowExtensionOperationsDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "allow_extension_operations", "false"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherBootDiagnostics(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// Enabled
+				Config: testLinuxVirtualMachine_otherBootDiagnostics(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				// Disabled
+				Config: testLinuxVirtualMachine_otherBootDiagnosticsDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				// Enabled
+				Config: testLinuxVirtualMachine_otherBootDiagnostics(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherComputerNameDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherComputerNameDefault(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "computer_name"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherComputerNameCustom(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherComputerNameCustom(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "computer_name", "custom123"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherCustomData(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherCustomData(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("custom_data"),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherPrioritySpot(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherPrioritySpot(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherPrioritySpotMaxBidPrice(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// expensive, but guarantees this test will pass
+				Config: testLinuxVirtualMachine_otherPrioritySpotMaxBidPrice(data, "0.5000"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				// no limit
+				Config: testLinuxVirtualMachine_otherPrioritySpotMaxBidPrice(data, "-1"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherProvisionVMAgentDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherProvisionVMAgentDefault(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "provision_vm_agent", "true"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherProvisionVMAgentDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherProvisionVMAgentDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "provision_vm_agent", "false"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherRequiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_authSSH(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testLinuxVirtualMachine_requiresImport),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherSecret(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherSecret(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_otherSecretUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_otherSecretRemoved(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "secret.#", "0"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_otherTags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_otherTags(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_otherTagsUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testLinuxVirtualMachine_otherAllowExtensionOperationsDefault(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherAllowExtensionOperationsDisabled(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  allow_extension_operations      = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherBootDiagnostics(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_otherBootDiagnosticsTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.test.primary_blob_endpoint
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherBootDiagnosticsDisabled(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_otherBootDiagnosticsTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherBootDiagnosticsTemplate(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+`, template, data.RandomString)
+}
+
+func testLinuxVirtualMachine_otherComputerNameDefault(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherComputerNameCustom(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  computer_name                   = "custom123"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherCustomData(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  custom_data                     = base64encode("/bin/bash")
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherPrioritySpot(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                 = "acctestVM-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_F2"
+  admin_username       = "adminuser"
+  eviction_policy      = "Deallocate"
+  priority             = "Spot"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherPrioritySpotMaxBidPrice(data acceptance.TestData, maxBidPrice string) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                 = "acctestVM-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_F2"
+  admin_username       = "adminuser"
+  eviction_policy      = "Deallocate"
+  priority             = "Spot"
+  max_bid_price        = %q
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, maxBidPrice)
+}
+
+func testLinuxVirtualMachine_otherProvisionVMAgentDefault(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherProvisionVMAgentDisabled(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  provision_vm_agent              = false
+  allow_extension_operations      = false
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_requiresImport(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_authSSH(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "import" {
+  name                  = azurerm_linux_virtual_machine.test.name
+  resource_group_name   = azurerm_linux_virtual_machine.test.resource_group_name
+  location              = azurerm_linux_virtual_machine.test.location
+  size                  = azurerm_linux_virtual_machine.test.size
+  admin_username        = azurerm_linux_virtual_machine.test.admin_username
+  network_interface_ids = azurerm_linux_virtual_machine.test.network_interface_ids
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testLinuxVirtualMachine_otherSecretTemplate(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkeyvault%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name                        = "standard"
+  enabled_for_template_deployment = true
+  enabled_for_deployment          = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.service_principal_object_id
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "get",
+      "update",
+    ]
+
+    key_permissions = [
+      "create",
+    ]
+
+    secret_permissions = [
+      "set",
+    ]
+
+    storage_permissions = [
+      "set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_certificate" "first" {
+  name         = "first"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=hello-world-first"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_key_vault_certificate" "second" {
+  name         = "second"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=hello-world-second"
+      validity_in_months = 12
+    }
+  }
+}
+`, template, data.RandomString)
+}
+
+func testLinuxVirtualMachine_otherSecret(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_otherSecretTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  secret {
+    key_vault_id = azurerm_key_vault.test.id
+
+    certificate {
+      url = azurerm_key_vault_certificate.first.secret_id
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherSecretRemoved(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_otherSecretTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherSecretUpdated(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_otherSecretTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  secret {
+    key_vault_id = azurerm_key_vault.test.id
+
+    certificate {
+      url = azurerm_key_vault_certificate.first.secret_id
+    }
+
+    certificate {
+      url = azurerm_key_vault_certificate.second.secret_id
+    }
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherTags(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  tags = {
+    Hello = "World"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_otherTagsUpdated(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  tags = {
+    Hello     = "World"
+    Dimension = "C-137"
+  }
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_other_test.go
@@ -321,11 +321,11 @@ func testLinuxVirtualMachine_otherAllowExtensionOperationsDefault(data acceptanc
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -356,12 +356,12 @@ func testLinuxVirtualMachine_otherAllowExtensionOperationsDisabled(data acceptan
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  allow_extension_operations      = false
+  name                       = "acctestVM-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  size                       = "Standard_F2"
+  admin_username             = "adminuser"
+  allow_extension_operations = false
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -392,11 +392,11 @@ func testLinuxVirtualMachine_otherBootDiagnostics(data acceptance.TestData) stri
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -431,11 +431,11 @@ func testLinuxVirtualMachine_otherBootDiagnosticsDisabled(data acceptance.TestDa
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -481,11 +481,11 @@ func testLinuxVirtualMachine_otherComputerNameDefault(data acceptance.TestData) 
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -516,12 +516,12 @@ func testLinuxVirtualMachine_otherComputerNameCustom(data acceptance.TestData) s
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  computer_name                   = "custom123"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  computer_name       = "custom123"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -552,12 +552,12 @@ func testLinuxVirtualMachine_otherCustomData(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  custom_data                     = base64encode("/bin/bash")
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  custom_data         = base64encode("/bin/bash")
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -588,13 +588,13 @@ func testLinuxVirtualMachine_otherPrioritySpot(data acceptance.TestData) string 
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                 = "acctestVM-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  size                 = "Standard_F2"
-  admin_username       = "adminuser"
-  eviction_policy      = "Deallocate"
-  priority             = "Spot"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  eviction_policy     = "Deallocate"
+  priority            = "Spot"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -625,14 +625,14 @@ func testLinuxVirtualMachine_otherPrioritySpotMaxBidPrice(data acceptance.TestDa
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                 = "acctestVM-%d"
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  size                 = "Standard_F2"
-  admin_username       = "adminuser"
-  eviction_policy      = "Deallocate"
-  priority             = "Spot"
-  max_bid_price        = %q
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  eviction_policy     = "Deallocate"
+  priority            = "Spot"
+  max_bid_price       = %q
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -663,11 +663,11 @@ func testLinuxVirtualMachine_otherProvisionVMAgentDefault(data acceptance.TestDa
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -698,13 +698,13 @@ func testLinuxVirtualMachine_otherProvisionVMAgentDisabled(data acceptance.TestD
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  provision_vm_agent              = false
-  allow_extension_operations      = false
-  admin_username                  = "adminuser"
+  name                       = "acctestVM-%d"
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  size                       = "Standard_F2"
+  provision_vm_agent         = false
+  allow_extension_operations = false
+  admin_username             = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -904,11 +904,11 @@ func testLinuxVirtualMachine_otherSecret(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -947,11 +947,11 @@ func testLinuxVirtualMachine_otherSecretRemoved(data acceptance.TestData) string
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -982,11 +982,11 @@ func testLinuxVirtualMachine_otherSecretUpdated(data acceptance.TestData) string
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1029,11 +1029,11 @@ func testLinuxVirtualMachine_otherTags(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1068,11 +1068,11 @@ func testLinuxVirtualMachine_otherTagsUpdated(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_scaling_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_scaling_test.go
@@ -1,0 +1,385 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// NOTE: this requires a large-ish machine to provision
+				Config: testLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_scalingAvailabilitySet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_scalingAvailabilitySet(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_scalingDedicatedHost(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_scalingDedicatedHost(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_scalingProximityPlacementGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_scalingProximityPlacementGroup(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_scalingMachineSizeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_scalingMachineSize(data, "Standard_F2"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_scalingMachineSize(data, "Standard_F4"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testLinuxVirtualMachine_scalingMachineSize(data, "Standard_F4s_v2"),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccLinuxVirtualMachine_scalingZones(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkLinuxVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testLinuxVirtualMachine_scalingZone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkLinuxVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                  = "acctestVM-%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_D2S_V3"
+  admin_username        = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+  zone = 1
+
+  additional_capabilities {
+    ultra_ssd_enabled = true
+  }
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_scalingAvailabilitySet(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_availability_set" "test" {
+  name                = "acctestavset-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  managed             = true
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                  = "acctestVM-%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_F2"
+  admin_username        = "adminuser"
+  availability_set_id   = azurerm_availability_set.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_scalingDedicatedHost(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+}
+
+resource "azurerm_dedicated_host" "test" {
+  name                    = "acctestDH-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                  = "acctestVM-%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username        = "adminuser"
+  dedicated_host_id     = azurerm_dedicated_host.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_scalingProximityPlacementGroup(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_proximity_placement_group" "test" {
+  name                = "acctestPPG-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                         = "acctestVM-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  size                         = "Standard_F2"
+  admin_username               = "adminuser"
+  proximity_placement_group_id = azurerm_proximity_placement_group.test.id
+  network_interface_ids        = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_scalingMachineSize(data acceptance.TestData, size string) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = %q
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, size)
+}
+
+func testLinuxVirtualMachine_scalingZone(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                  = "acctestVM-%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_F2"
+  admin_username        = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+  zone                  = 1
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_scaling_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_scaling_test.go
@@ -143,11 +143,11 @@ func testLinuxVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(data acceptan
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                  = "acctestVM-%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_D2S_V3"
-  admin_username        = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2S_V3"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -190,12 +190,12 @@ resource "azurerm_availability_set" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                  = "acctestVM-%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_F2"
-  admin_username        = "adminuser"
-  availability_set_id   = azurerm_availability_set.test.id
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  availability_set_id = azurerm_availability_set.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -241,12 +241,12 @@ resource "azurerm_dedicated_host" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                  = "acctestVM-%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
-  admin_username        = "adminuser"
-  dedicated_host_id     = azurerm_dedicated_host.test.id
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  dedicated_host_id   = azurerm_dedicated_host.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -289,7 +289,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   size                         = "Standard_F2"
   admin_username               = "adminuser"
   proximity_placement_group_id = azurerm_proximity_placement_group.test.id
-  network_interface_ids        = [
+  network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
 
@@ -319,11 +319,11 @@ func testLinuxVirtualMachine_scalingMachineSize(data acceptance.TestData, size s
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = %q
-  admin_username                  = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = %q
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -354,15 +354,15 @@ func testLinuxVirtualMachine_scalingZone(data acceptance.TestData) string {
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                  = "acctestVM-%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_F2"
-  admin_username        = "adminuser"
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
-  zone                  = 1
+  zone = 1
 
   admin_ssh_key {
     username   = "adminuser"

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_test.go
@@ -1,0 +1,108 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func checkLinuxVirtualMachineIsDestroyed(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_linux_virtual_machine" {
+			continue
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		name := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		resp, err := client.Get(ctx, resourceGroup, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func checkLinuxVirtualMachineExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		name := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		resp, err := client.Get(ctx, resourceGroup, name, "")
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Linux Virtual Machine %q (Resource Group: %q) does not exist", name, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on VMClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testLinuxVirtualMachine_templateBase(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+# note: whilst these aren't used in all tests, it saves us redefining these everywhere
+locals {
+  first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+wWK73dCr+jgQOAxNsHAnNNNMEMWOHYEccp6wJm2gotpr9katuF/ZAdou5AaW1C61slRkHRkpRRX9FA9CYBiitZgvCCz+3nWNN7l/Up54Zps/pHWGZLHNJZRYyAB6j5yVLMVHIHriY49d/GZTZVNB8GoJv9Gakwc/fuEZYYl4YDFiGMBP///TzlI4jhiJzjKnEvqPFki5p2ZRJqcbCiF4pJrxUQR/RXqVFQdbRLZgYfJ8xGB878RENq3yQ39d8dVOkq4edbkzwcUmwwwkYVPIoDGsYLaRHnG+To7FvMeyO7xDVQkMKzopTQV8AuKpyvpqu0a9pWOMaiCyDytO7GGN you@me.com"
+  second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testLinuxVirtualMachine_template(data acceptance.TestData) string {
+	template := testLinuxVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+ name                = "acctestnic-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_test.go
@@ -94,15 +94,15 @@ func testLinuxVirtualMachine_template(data acceptance.TestData) string {
 %s
 
 resource "azurerm_network_interface" "test" {
- name                = "acctestnic-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_other_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_other_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
-func TestAccAzureRMWindowsVirtualMachineScaleSet_otherAdditionalUnattendConfig(t *testing.T) {
+func TestAccAzureRMWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -18,13 +18,13 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherAdditionalUnattendConfig(t
 		CheckDestroy: testCheckAzureRMWindowsVirtualMachineScaleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherAdditionalUnattendConfig(data),
+				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(
-				"additional_unattend_config.0.content",
+				"additional_unattend_content.0.content",
 				"admin_password",
 			),
 		},
@@ -530,7 +530,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_updateHealthProbe(t *testing.T)
 	})
 }
 
-func testAccAzureRMWindowsVirtualMachineScaleSet_otherAdditionalUnattendConfig(data acceptance.TestData) string {
+func testAccAzureRMWindowsVirtualMachineScaleSet_otherAdditionalUnattendContent(data acceptance.TestData) string {
 	template := testAccAzureRMWindowsVirtualMachineScaleSet_template(data)
 	return fmt.Sprintf(`
 %s
@@ -567,7 +567,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 
-  additional_unattend_config {
+  additional_unattend_content {
     setting = "AutoLogon"
     content = "<AutoLogon><Username>myadmin</Username><Password><Value>P@ssword1234!</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount></AutoLogon>"
   }

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_auth_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_auth_test.go
@@ -35,22 +35,22 @@ func testWindowsVirtualMachine_authPassword(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
- name                            = local.vm_name
- resource_group_name             = azurerm_resource_group.test.name
- location                        = azurerm_resource_group.test.location
- size                            = "Standard_F2"
- admin_username                  = "adminuser"
- admin_password                  = "P@$$w0rd1234!"
- network_interface_ids = [
-   azurerm_network_interface.test.id,
- ]
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
 
- os_disk {
-   caching              = "ReadWrite"
-   storage_account_type = "Standard_LRS"
- }
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
 
- source_image_reference {
+  source_image_reference {
     publisher = "MicrosoftWindowsServer"
     offer     = "WindowsServer"
     sku       = "2016-Datacenter"

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_auth_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_auth_test.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccWindowsVirtualMachine_authPassword(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_authPassword(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_authPassword(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+ name                            = local.vm_name
+ resource_group_name             = azurerm_resource_group.test.name
+ location                        = azurerm_resource_group.test.location
+ size                            = "Standard_F2"
+ admin_username                  = "adminuser"
+ admin_password                  = "P@$$w0rd1234!"
+ network_interface_ids = [
+   azurerm_network_interface.test.id,
+ ]
+
+ os_disk {
+   caching              = "ReadWrite"
+   storage_account_type = "Standard_LRS"
+ }
+
+ source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
@@ -351,12 +351,12 @@ func testWindowsVirtualMachine_diskOSBasic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -382,12 +382,12 @@ func testWindowsVirtualMachine_diskOSCachingType(data acceptance.TestData, cachi
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -413,12 +413,12 @@ func testWindowsVirtualMachine_diskOSCustomName(data acceptance.TestData) string
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -445,12 +445,12 @@ func testWindowsVirtualMachine_diskOSCustomSize(data acceptance.TestData, size i
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -502,8 +502,8 @@ resource "azurerm_key_vault" "test" {
 
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
-  tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azurerm_client_config.current.service_principal_object_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.service_principal_object_id
 
   key_permissions = [
     "create",
@@ -552,15 +552,15 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_network_interface" "test" {
- name                = "acctestnic-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, data.RandomString, data.RandomInteger, location, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
@@ -608,20 +608,20 @@ func testWindowsVirtualMachine_diskOSDiskDiskEncryptionSet(data acceptance.TestD
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
 
   os_disk {
-    caching                 = "ReadWrite"
-    disk_encryption_set_id  = azurerm_disk_encryption_set.test.id
-    storage_account_type    = "Standard_LRS"
+    caching                = "ReadWrite"
+    disk_encryption_set_id = azurerm_disk_encryption_set.test.id
+    storage_account_type   = "Standard_LRS"
   }
 
   source_image_reference {
@@ -645,13 +645,13 @@ func testWindowsVirtualMachine_diskOSEphemeral(data acceptance.TestData) string 
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
   # Message="OS disk of Ephemeral VM with size greater than 32 GB is not allowed for VM size Standard_F2s_v2"
-  size                            = "Standard_DS3_v2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  size           = "Standard_DS3_v2"
+  admin_username = "adminuser"
+  admin_password = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -681,12 +681,12 @@ func testWindowsVirtualMachine_diskOSStorageAccountType(data acceptance.TestData
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2s_v2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2s_v2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -712,12 +712,12 @@ func testWindowsVirtualMachine_diskOSWriteAcceleratorEnabled(data acceptance.Tes
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_M8ms"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_M8ms"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
@@ -1,0 +1,739 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccWindowsVirtualMachine_diskOSBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSBasic(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSCachingType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSCachingType(data, "None"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_diskOSCachingType(data, "ReadOnly"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_diskOSCachingType(data, "ReadWrite"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSCustomName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSCustomName(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSCustomSize(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSCustomSize(data, 130),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSCustomSizeExpanded(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSCustomSize(data, 130),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_diskOSCustomSize(data, 140),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSDiskEncryptionSet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
+				Config: testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data),
+				Check: resource.ComposeTestCheckFunc(
+					enableSoftDeleteAndPurgeProtectionForKeyVault("azurerm_key_vault.test"),
+				),
+			},
+			{
+				Config: testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetResource(data),
+			},
+			{
+				Config: testWindowsVirtualMachine_diskOSDiskDiskEncryptionSet(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSEphemeral(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSEphemeral(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSStorageTypeStandardLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSStorageAccountType(data, "Standard_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSStorageTypeStandardSSDLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSStorageAccountType(data, "StandardSSD_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSStorageTypePremiumLRS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSStorageAccountType(data, "Premium_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSStorageTypeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_diskOSStorageAccountType(data, "Standard_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_diskOSStorageAccountType(data, "Premium_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_diskOSStorageAccountType(data, "StandardSSD_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_diskOSStorageAccountType(data, "Standard_LRS"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_diskOSWriteAcceleratorEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// Enabled
+				Config: testWindowsVirtualMachine_diskOSWriteAcceleratorEnabled(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// Disabled
+				Config: testWindowsVirtualMachine_diskOSWriteAcceleratorEnabled(data, false),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// Enabled
+				Config: testWindowsVirtualMachine_diskOSWriteAcceleratorEnabled(data, true),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_diskOSBasic(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_diskOSCachingType(data acceptance.TestData, cachingType string) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "%s"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, cachingType)
+}
+
+func testWindowsVirtualMachine_diskOSCustomName(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    name                 = "osdisk1"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_diskOSCustomSize(data acceptance.TestData, size int) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    name                 = "osdisk1"
+    caching              = "ReadWrite"
+    disk_size_gb         = %d
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, size)
+}
+
+func testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data acceptance.TestData) string {
+	// whilst this is in Preview it's only supported in: West Central US, Canada Central, North Europe
+	// TODO: switch back to default location
+	// once that's done this can also use the same template as everything else too
+	location := "westus2"
+
+	return fmt.Sprintf(`
+# note: whilst these aren't used in all tests, it saves us redefining these everywhere
+locals {
+  vm_name = "acctestvm%s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctestkv%s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  sku_name                    = "premium"
+  enabled_for_disk_encryption = true
+}
+
+resource "azurerm_key_vault_access_policy" "service-principal" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_client_config.current.service_principal_object_id
+
+  key_permissions = [
+    "create",
+    "delete",
+    "get",
+    "update",
+  ]
+
+  secret_permissions = [
+    "get",
+    "delete",
+    "set",
+  ]
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "examplekey"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+
+  depends_on = ["azurerm_key_vault_access_policy.service-principal"]
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+ name                = "acctestnic-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, data.RandomString, data.RandomInteger, location, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetResource(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_disk_encryption_set" "test" {
+  name                = "acctestdes-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  key_vault_key_id    = azurerm_key_vault_key.test.id
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "disk-encryption" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  key_permissions = [
+    "get",
+    "wrapkey",
+    "unwrapkey",
+  ]
+
+  tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id
+  object_id = azurerm_disk_encryption_set.test.identity.0.principal_id
+}
+
+resource "azurerm_role_assignment" "disk-encryption-read-keyvault" {
+  scope                = azurerm_key_vault.test.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_disk_encryption_set.test.identity.0.principal_id
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_diskOSDiskDiskEncryptionSet(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetResource(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching                 = "ReadWrite"
+    disk_encryption_set_id  = azurerm_disk_encryption_set.test.id
+    storage_account_type    = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  depends_on = [
+    "azurerm_role_assignment.disk-encryption-read-keyvault",
+    "azurerm_key_vault_access_policy.disk-encryption",
+  ]
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_diskOSEphemeral(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  # Message="OS disk of Ephemeral VM with size greater than 32 GB is not allowed for VM size Standard_F2s_v2"
+  size                            = "Standard_DS3_v2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadOnly"
+    storage_account_type = "Standard_LRS"
+
+    diff_disk_settings {
+      option = "Local"
+    }
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_diskOSStorageAccountType(data acceptance.TestData, accountType string) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2s_v2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "%s"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, accountType)
+}
+
+func testWindowsVirtualMachine_diskOSWriteAcceleratorEnabled(data acceptance.TestData, enabled bool) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_M8ms"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    storage_account_type      = "Premium_LRS"
+    caching                   = "None"
+    write_accelerator_enabled = %t
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, enabled)
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_identity_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_identity_test.go
@@ -164,12 +164,12 @@ func testWindowsVirtualMachine_identityNone(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -195,12 +195,12 @@ func testWindowsVirtualMachine_identitySystemAssigned(data acceptance.TestData) 
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -236,12 +236,12 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -280,12 +280,12 @@ resource "azurerm_user_assigned_identity" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -330,12 +330,12 @@ resource "azurerm_user_assigned_identity" "other" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_identity_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_identity_test.go
@@ -1,0 +1,364 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccWindowsVirtualMachine_identityNone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_identityNone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.%", "0"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_identitySystemAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_identitySystemAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_identitySystemAssignedUserAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_identitySystemAssignedUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_identityUserAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_identityUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_identityUserAssignedUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_identityUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_identityNone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.%", "0"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_identitySystemAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_identityUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_identitySystemAssignedUserAssigned(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_identityNone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.%", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testWindowsVirtualMachine_identityNone(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_identitySystemAssigned(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_identitySystemAssignedUserAssigned(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_identityUserAssigned(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+    ]
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_identityUserAssignedUpdated(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_user_assigned_identity" "other" {
+  name                = "acctestuai2-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id,
+      azurerm_user_assigned_identity.other.id,
+    ]
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_images_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_images_test.go
@@ -1,0 +1,404 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccWindowsVirtualMachine_imageFromImage(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// create the original VM
+				Config: testWindowsVirtualMachine_imageFromExistingMachinePrep(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists("azurerm_windows_virtual_machine.source"),
+					generalizeWindowsVirtualMachine("azurerm_windows_virtual_machine.source"),
+				),
+			},
+			{
+				// then create an image from that VM, and then create a VM from that image
+				Config: testWindowsVirtualMachine_imageFromImage(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_imageFromPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_imageFromPlan(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_imageFromSharedImageGallery(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// create the original VM
+				Config: testWindowsVirtualMachine_imageFromExistingMachinePrep(data),
+				Check: resource.ComposeTestCheckFunc(
+
+					checkWindowsVirtualMachineExists("azurerm_windows_virtual_machine.source"),
+					generalizeWindowsVirtualMachine("azurerm_windows_virtual_machine.source"),
+				),
+			},
+			{
+				// then create an image from that VM, and then create a VM from that image
+				Config: testWindowsVirtualMachine_imageFromSharedImageGallery(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_imageFromSourceImageReference(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_imageFromSourceImageReference(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_imageFromExistingMachineDependencies(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+locals {
+  vm_name = "acctvm-%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctpip-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  allocation_method   = "Static"
+  domain_name_label   = local.vm_name
+}
+
+resource "azurerm_network_interface" "public" {
+  name                = "acctnicsource-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+	name                          = "testconfigurationsource"
+	subnet_id                     = "${azurerm_subnet.test.id}"
+	private_ip_address_allocation = "Dynamic"
+	public_ip_address_id          = "${azurerm_public_ip.test.id}"
+  }
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+}
+`, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_imageFromExistingMachinePrep(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_imageFromExistingMachineDependencies(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "source" {
+  name                            = "${local.vm_name}1"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.public.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_imageFromImage(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_imageFromExistingMachinePrep(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_windows_virtual_machine.source.id
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = "${local.vm_name}2"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  source_image_id                 = azurerm_image.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_imageFromPlan(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_marketplace_agreement" "test" {
+  publisher = "plesk"
+  offer     = "plesk-onyx-windows"
+  plan      = "plsk-win-hst-azr-m"
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  plan {
+    name      = "plsk-win-hst-azr-m"
+    product   = "plesk-onyx-windows"
+    publisher = "plesk"
+  }
+
+  source_image_reference {
+    publisher = "plesk"
+    offer     = "plesk-onyx-windows"
+    sku       = "plsk-win-hst-azr-m"
+    version   = "latest"
+  }
+
+  depends_on = ["azurerm_marketplace_agreement.test"]
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_imageFromSharedImageGallery(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_imageFromExistingMachinePrep(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_windows_virtual_machine.source.id
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctest-gallery-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctest-gallery-image"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Windows"
+
+  identifier {
+    publisher = "AcceptanceTest-Publisher"
+    offer     = "AcceptanceTest-Offer"
+    sku       = "AcceptanceTest-Sku"
+  }
+}
+
+resource "azurerm_shared_image_version" "test" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+  location            = azurerm_shared_image.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_shared_image.test.location
+    regional_replica_count = "5"
+    storage_account_type   = "Standard_LRS"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  source_image_id                 = azurerm_shared_image_version.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_imageFromSourceImageReference(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func generalizeWindowsVirtualMachine(resourceName string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		// TODO: make this for Windows..
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		name := rs.Primary.Attributes["name"]
+		username := rs.Primary.Attributes["admin_username"]
+		password := rs.Primary.Attributes["admin_password"]
+		port := "22"
+		location := rs.Primary.Attributes["location"]
+
+		return testGeneralizeVMImage(resourceGroup, name, username, password, name, port, location)(s)
+	}
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_images_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_images_test.go
@@ -151,10 +151,10 @@ resource "azurerm_network_interface" "public" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   ip_configuration {
-	name                          = "testconfigurationsource"
-	subnet_id                     = "${azurerm_subnet.test.id}"
-	private_ip_address_allocation = "Dynamic"
-	public_ip_address_id          = "${azurerm_public_ip.test.id}"
+    name                          = "testconfigurationsource"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = "${azurerm_public_ip.test.id}"
   }
 }
 
@@ -184,12 +184,12 @@ func testWindowsVirtualMachine_imageFromExistingMachinePrep(data acceptance.Test
 %s
 
 resource "azurerm_windows_virtual_machine" "source" {
-  name                            = "${local.vm_name}1"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = "${local.vm_name}1"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.public.id,
   ]
@@ -222,13 +222,13 @@ resource "azurerm_image" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = "${local.vm_name}2"
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  source_image_id                 = azurerm_image.test.id
+  name                = "${local.vm_name}2"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  source_image_id     = azurerm_image.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -253,12 +253,12 @@ resource "azurerm_marketplace_agreement" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -334,13 +334,13 @@ resource "azurerm_shared_image_version" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  source_image_id                 = azurerm_shared_image_version.test.id
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  source_image_id     = azurerm_shared_image_version.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -359,12 +359,12 @@ func testWindowsVirtualMachine_imageFromSourceImageReference(data acceptance.Tes
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_network_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_network_test.go
@@ -1,0 +1,988 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+/*
+Load Balancer + updating the backend pool
+App Gateway + updating the backend pool
+FrontDoor?
+*/
+
+func TestAccWindowsVirtualMachine_networkIPv6(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkIPv6(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkMultiple(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "0"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// update the Primary IP
+				Config: testWindowsVirtualMachine_networkMultipleUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "0"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// remove the secondary IP
+				Config: testWindowsVirtualMachine_networkMultipleRemoved(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "0"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkMultiplePublic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkMultiplePublic(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "2"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// update the Primary IP
+				Config: testWindowsVirtualMachine_networkMultiplePublicUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "2"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "2"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// remove the secondary IP
+				Config: testWindowsVirtualMachine_networkMultiplePublicRemoved(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_ip_addresses.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_addresses.#", "1"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPrivateDynamicIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPrivateStaticIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPrivateUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_networkPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttr(data.ResourceName, "public_ip_address", ""),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPublicDynamicPrivateDynamicIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPublicDynamicPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPublicDynamicPrivateStaticIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPublicDynamicPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPublicDynamicUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPublicDynamicPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_networkPublicDynamicPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPublicStaticPrivateDynamicIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPublicStaticPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPublicStaticPrivateStaticIP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPublicStaticPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_networkPublicStaticPrivateUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_networkPublicStaticPrivateDynamicIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_networkPublicStaticPrivateStaticIP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_ip_address"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_address"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_networkIPv6(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "dynamic"
+    primary                       = true
+  }
+
+  ip_configuration {
+    name                          = "secondary"
+    private_ip_address_version    = "IPv6"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_networkMultipleTemplate(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "first" {
+ name                = "acctestnic1-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+
+resource "azurerm_network_interface" "second" {
+ name                = "acctestnic2-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_networkMultiple(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_networkMultipleTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.first.id,
+    azurerm_network_interface.second.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkMultipleUpdated(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_networkMultipleTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+    azurerm_network_interface.first.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkMultipleRemoved(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_networkMultipleTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkMultiplePublicTemplate(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "first" {
+  name                = "acctpip1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_interface" "first" {
+  name                = "acctestnic1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.first.id
+  }
+}
+
+resource "azurerm_public_ip" "second" {
+  name                = "acctpip2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_interface" "second" {
+  name                = "acctestnic2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.second.id
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_networkMultiplePublic(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_networkMultiplePublicTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.first.id,
+    azurerm_network_interface.second.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkMultiplePublicUpdated(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_networkMultiplePublicTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+    azurerm_network_interface.first.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkMultiplePublicRemoved(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_networkMultiplePublicTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.second.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkPrivateDynamicIP(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkPrivateStaticIP(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkPublicDynamicPrivateDynamicIP(data acceptance.TestData) string {
+	privateIPIsStatic := false
+	template := testWindowsVirtualMachine_templatePrivateIP(data, privateIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkPublicDynamicPrivateStaticIP(data acceptance.TestData) string {
+	privateIPIsStatic := true
+	template := testWindowsVirtualMachine_templatePrivateIP(data, privateIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkPublicStaticPrivateDynamicIP(data acceptance.TestData) string {
+	privateIPIsStatic := false
+	publicIPIsStatic := true
+	template := testWindowsVirtualMachine_templatePublicIP(data, privateIPIsStatic, publicIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_networkPublicStaticPrivateStaticIP(data acceptance.TestData) string {
+	privateIPIsStatic := true
+	publicIPIsStatic := true
+	template := testWindowsVirtualMachine_templatePublicIP(data, privateIPIsStatic, publicIPIsStatic)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_templatePrivateIP(data acceptance.TestData, static bool) string {
+	template := testWindowsVirtualMachine_templateBase(data)
+	if static {
+		return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Static" 
+    private_ip_address            = "10.0.2.30"
+ }
+}
+`, template, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+ name                = "acctestnic-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_templatePublicIP(data acceptance.TestData, privateStatic, publicStatic bool) string {
+	template := testWindowsVirtualMachine_templateBase(data)
+	publicAllocationType := allocationType(publicStatic)
+
+	if privateStatic {
+		return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = %q
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Static"
+    private_ip_address            = "10.0.2.30"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+`, template, data.RandomInteger, publicAllocationType, data.RandomInteger)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctpip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = %q
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+`, template, data.RandomInteger, publicAllocationType, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_network_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_network_test.go
@@ -408,12 +408,12 @@ resource "azurerm_network_interface" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -439,27 +439,27 @@ func testWindowsVirtualMachine_networkMultipleTemplate(data acceptance.TestData)
 %s
 
 resource "azurerm_network_interface" "first" {
- name                = "acctestnic1-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic1-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 
 resource "azurerm_network_interface" "second" {
- name                = "acctestnic2-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic2-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, template, data.RandomInteger, data.RandomInteger)
 }
@@ -470,12 +470,12 @@ func testWindowsVirtualMachine_networkMultiple(data acceptance.TestData) string 
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.first.id,
     azurerm_network_interface.second.id,
@@ -502,12 +502,12 @@ func testWindowsVirtualMachine_networkMultipleUpdated(data acceptance.TestData) 
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.second.id,
     azurerm_network_interface.first.id,
@@ -534,12 +534,12 @@ func testWindowsVirtualMachine_networkMultipleRemoved(data acceptance.TestData) 
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.second.id,
   ]
@@ -612,12 +612,12 @@ func testWindowsVirtualMachine_networkMultiplePublic(data acceptance.TestData) s
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.first.id,
     azurerm_network_interface.second.id,
@@ -644,12 +644,12 @@ func testWindowsVirtualMachine_networkMultiplePublicUpdated(data acceptance.Test
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.second.id,
     azurerm_network_interface.first.id,
@@ -676,12 +676,12 @@ func testWindowsVirtualMachine_networkMultiplePublicRemoved(data acceptance.Test
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.second.id,
   ]
@@ -707,12 +707,12 @@ func testWindowsVirtualMachine_networkPrivateDynamicIP(data acceptance.TestData)
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -738,12 +738,12 @@ func testWindowsVirtualMachine_networkPrivateStaticIP(data acceptance.TestData) 
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -770,12 +770,12 @@ func testWindowsVirtualMachine_networkPublicDynamicPrivateDynamicIP(data accepta
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -802,12 +802,12 @@ func testWindowsVirtualMachine_networkPublicDynamicPrivateStaticIP(data acceptan
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -835,12 +835,12 @@ func testWindowsVirtualMachine_networkPublicStaticPrivateDynamicIP(data acceptan
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -868,12 +868,12 @@ func testWindowsVirtualMachine_networkPublicStaticPrivateStaticIP(data acceptanc
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -907,9 +907,9 @@ resource "azurerm_network_interface" "test" {
   ip_configuration {
     name                          = "internal"
     subnet_id                     = azurerm_subnet.test.id
-    private_ip_address_allocation = "Static" 
+    private_ip_address_allocation = "Static"
     private_ip_address            = "10.0.2.30"
- }
+  }
 }
 `, template, data.RandomInteger)
 	}
@@ -918,15 +918,15 @@ resource "azurerm_network_interface" "test" {
 %s
 
 resource "azurerm_network_interface" "test" {
- name                = "acctestnic-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
@@ -547,12 +547,12 @@ func testWindowsVirtualMachine_otherAdditionalUnattendContent(data acceptance.Te
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -583,12 +583,12 @@ func testWindowsVirtualMachine_otherAllowExtensionOperationsDefault(data accepta
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -614,13 +614,13 @@ func testWindowsVirtualMachine_otherAllowExtensionOperationsDisabled(data accept
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  allow_extension_operations      = false
+  name                       = local.vm_name
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  size                       = "Standard_F2"
+  admin_username             = "adminuser"
+  admin_password             = "P@$$w0rd1234!"
+  allow_extension_operations = false
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -646,12 +646,12 @@ func testWindowsVirtualMachine_otherBootDiagnostics(data acceptance.TestData) st
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -681,12 +681,12 @@ func testWindowsVirtualMachine_otherBootDiagnosticsDisabled(data acceptance.Test
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -727,12 +727,12 @@ func testWindowsVirtualMachine_otherComputerNameDefault(data acceptance.TestData
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -758,13 +758,13 @@ func testWindowsVirtualMachine_otherComputerNameCustom(data acceptance.TestData)
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  computer_name                   = "custom123"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  computer_name       = "custom123"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -790,13 +790,13 @@ func testWindowsVirtualMachine_otherCustomData(data acceptance.TestData) string 
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  custom_data                     = base64encode("/bin/bash")
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  custom_data         = base64encode("/bin/bash")
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -822,13 +822,13 @@ func testWindowsVirtualMachine_otherEnableAutomaticUpdatesDefault(data acceptanc
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                     = local.vm_name
-  resource_group_name      = azurerm_resource_group.test.name
-  location                 = azurerm_resource_group.test.location
-  size                     = "Standard_F2"
-  admin_username           = "adminuser"
-  admin_password           = "P@$$w0rd1234!"
-  network_interface_ids    = [
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
 
@@ -885,13 +885,13 @@ func testWindowsVirtualMachine_otherLicenseType(data acceptance.TestData, licens
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  license_type                    = %q
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  license_type        = %q
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -917,13 +917,13 @@ func testWindowsVirtualMachine_otherLicenseTypeWindowsClient(data acceptance.Tes
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  license_type                    = "Windows_Client"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  license_type        = "Windows_Client"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -949,14 +949,14 @@ func testWindowsVirtualMachine_otherPrioritySpot(data acceptance.TestData) strin
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                 = local.vm_name
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  size                 = "Standard_F2"
-  admin_username       = "adminuser"
-  admin_password       = "P@$$w0rd1234!"
-  eviction_policy      = "Deallocate"
-  priority             = "Spot"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  eviction_policy     = "Deallocate"
+  priority            = "Spot"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -982,15 +982,15 @@ func testWindowsVirtualMachine_otherPrioritySpotMaxBidPrice(data acceptance.Test
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                 = local.vm_name
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  size                 = "Standard_F2"
-  admin_username       = "adminuser"
-  admin_password       = "P@$$w0rd1234!"
-  eviction_policy      = "Deallocate"
-  priority             = "Spot"
-  max_bid_price        = %q
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  eviction_policy     = "Deallocate"
+  priority            = "Spot"
+  max_bid_price       = %q
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1016,12 +1016,12 @@ func testWindowsVirtualMachine_otherProvisionVMAgentDefault(data acceptance.Test
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1047,14 +1047,14 @@ func testWindowsVirtualMachine_otherProvisionVMAgentDisabled(data acceptance.Tes
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  provision_vm_agent              = false
-  allow_extension_operations      = false
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                       = local.vm_name
+  resource_group_name        = azurerm_resource_group.test.name
+  location                   = azurerm_resource_group.test.location
+  size                       = "Standard_F2"
+  provision_vm_agent         = false
+  allow_extension_operations = false
+  admin_username             = "adminuser"
+  admin_password             = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1245,12 +1245,12 @@ func testWindowsVirtualMachine_otherSecret(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1285,12 +1285,12 @@ func testWindowsVirtualMachine_otherSecretRemoved(data acceptance.TestData) stri
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1316,12 +1316,12 @@ func testWindowsVirtualMachine_otherSecretUpdated(data acceptance.TestData) stri
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1361,12 +1361,12 @@ func testWindowsVirtualMachine_otherTags(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1396,12 +1396,12 @@ func testWindowsVirtualMachine_otherTagsUpdated(data acceptance.TestData) string
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1432,13 +1432,13 @@ func testWindowsVirtualMachine_otherTimeZone(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
-  timezone                        = "Hawaiian Standard Time"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  timezone            = "Hawaiian Standard Time"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1464,12 +1464,12 @@ func testWindowsVirtualMachine_otherWinRMHTTP(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -1608,12 +1608,12 @@ resource "azurerm_key_vault_certificate" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                            = local.vm_name
-  resource_group_name             = azurerm_resource_group.test.name
-  location                        = azurerm_resource_group.test.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
-  admin_password                  = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
@@ -1,0 +1,1652 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+func TestAccWindowsVirtualMachine_otherAdditionalUnattendContent(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherAdditionalUnattendContent(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"additional_unattend_content.0.content",
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherAllowExtensionOperationsDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherAllowExtensionOperationsDefault(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "allow_extension_operations", "true"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherAllowExtensionOperationsDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherAllowExtensionOperationsDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "allow_extension_operations", "false"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherBootDiagnostics(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// Enabled
+				Config: testWindowsVirtualMachine_otherBootDiagnostics(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// Disabled
+				Config: testWindowsVirtualMachine_otherBootDiagnosticsDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// Enabled
+				Config: testWindowsVirtualMachine_otherBootDiagnostics(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherComputerNameDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherComputerNameDefault(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "computer_name"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherComputerNameCustom(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherComputerNameCustom(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "computer_name", "custom123"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherCustomData(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherCustomData(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("admin_password", "custom_data"),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherEnableAutomaticUpdatesDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherEnableAutomaticUpdatesDefault(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_automatic_updates", "true"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherEnableAutomaticUpdatesDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherEnableAutomaticUpdatesDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_automatic_updates", "false"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherLicenseTypeNone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherLicenseType(data, "None"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherLicenseTypeWindowsClient(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherLicenseTypeWindowsClient(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherLicenseTypeWindowsServer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherLicenseType(data, "Windows_Server"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherPrioritySpot(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherPrioritySpot(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherPrioritySpotMaxBidPrice(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// expensive, but guarantees this test will pass
+				Config: testWindowsVirtualMachine_otherPrioritySpotMaxBidPrice(data, "0.5000"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				// no limit
+				Config: testWindowsVirtualMachine_otherPrioritySpotMaxBidPrice(data, "-1"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherProvisionVMAgentDefault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherProvisionVMAgentDefault(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "provision_vm_agent", "true"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherProvisionVMAgentDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherProvisionVMAgentDisabled(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "provision_vm_agent", "false"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherRequiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_authPassword(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testWindowsVirtualMachine_requiresImport),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherSecret(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherSecret(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_otherSecretUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_otherSecretRemoved(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "secret.#", "0"),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherTags(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherTags(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_otherTagsUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherTimeZone(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherTimeZone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherWinRMHTTP(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherWinRMHTTP(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_otherWinRMHTTPS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_otherWinRMHTTPS(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_otherAdditionalUnattendContent(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  additional_unattend_content {
+    setting = "AutoLogon"
+    content = "<AutoLogon><Username>myadmin</Username><Password><Value>P@ssword1234!</Value></Password><Enabled>true</Enabled><LogonCount>1</LogonCount></AutoLogon>"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherAllowExtensionOperationsDefault(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherAllowExtensionOperationsDisabled(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  allow_extension_operations      = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherBootDiagnostics(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_otherBootDiagnosticsTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.test.primary_blob_endpoint
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherBootDiagnosticsDisabled(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_otherBootDiagnosticsTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherBootDiagnosticsTemplate(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+`, template, data.RandomString)
+}
+
+func testWindowsVirtualMachine_otherComputerNameDefault(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherComputerNameCustom(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  computer_name                   = "custom123"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherCustomData(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  custom_data                     = base64encode("/bin/bash")
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherEnableAutomaticUpdatesDefault(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                     = local.vm_name
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  size                     = "Standard_F2"
+  admin_username           = "adminuser"
+  admin_password           = "P@$$w0rd1234!"
+  network_interface_ids    = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherEnableAutomaticUpdatesDisabled(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                     = local.vm_name
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  size                     = "Standard_F2"
+  admin_username           = "adminuser"
+  admin_password           = "P@$$w0rd1234!"
+  enable_automatic_updates = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherLicenseType(data acceptance.TestData, licenseType string) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  license_type                    = %q
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, licenseType)
+}
+
+func testWindowsVirtualMachine_otherLicenseTypeWindowsClient(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  license_type                    = "Windows_Client"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsDesktop"
+    offer     = "Windows-10"
+    sku       = "rs5-pro"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherPrioritySpot(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                 = local.vm_name
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_F2"
+  admin_username       = "adminuser"
+  admin_password       = "P@$$w0rd1234!"
+  eviction_policy      = "Deallocate"
+  priority             = "Spot"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherPrioritySpotMaxBidPrice(data acceptance.TestData, maxBidPrice string) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                 = local.vm_name
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_F2"
+  admin_username       = "adminuser"
+  admin_password       = "P@$$w0rd1234!"
+  eviction_policy      = "Deallocate"
+  priority             = "Spot"
+  max_bid_price        = %q
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, maxBidPrice)
+}
+
+func testWindowsVirtualMachine_otherProvisionVMAgentDefault(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherProvisionVMAgentDisabled(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  provision_vm_agent              = false
+  allow_extension_operations      = false
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_requiresImport(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_authPassword(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "import" {
+  name                  = azurerm_windows_virtual_machine.test.name
+  resource_group_name   = azurerm_windows_virtual_machine.test.resource_group_name
+  location              = azurerm_windows_virtual_machine.test.location
+  size                  = azurerm_windows_virtual_machine.test.size
+  admin_username        = "adminuser"
+  admin_password        = "P@$$w0rd1234!"
+  network_interface_ids = azurerm_windows_virtual_machine.test.network_interface_ids
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherSecretTemplate(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkeyvault%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name                        = "standard"
+  enabled_for_template_deployment = true
+  enabled_for_deployment          = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.service_principal_object_id
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "get",
+      "update",
+    ]
+
+    key_permissions = [
+      "create",
+    ]
+
+    secret_permissions = [
+      "set",
+    ]
+
+    storage_permissions = [
+      "set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_certificate" "first" {
+  name         = "first"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=hello-world-first"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_key_vault_certificate" "second" {
+  name         = "second"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=hello-world-second"
+      validity_in_months = 12
+    }
+  }
+}
+`, template, data.RandomString)
+}
+
+func testWindowsVirtualMachine_otherSecret(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_otherSecretTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  secret {
+    key_vault_id = azurerm_key_vault.test.id
+
+    certificate {
+      store = "My"
+      url   = azurerm_key_vault_certificate.first.secret_id
+    }
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherSecretRemoved(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_otherSecretTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherSecretUpdated(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_otherSecretTemplate(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  secret {
+    key_vault_id = azurerm_key_vault.test.id
+
+    certificate {
+      store = "My"
+      url   = azurerm_key_vault_certificate.first.secret_id
+    }
+
+    certificate {
+      store = "My"
+      url   = azurerm_key_vault_certificate.second.secret_id
+    }
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherTags(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  tags = {
+    Hello = "World"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherTagsUpdated(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  tags = {
+    Hello     = "World"
+    Dimension = "C-137"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherTimeZone(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  timezone                        = "Hawaiian Standard Time"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherWinRMHTTP(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  winrm_listener {
+    protocol = "Http"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_otherWinRMHTTPS(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv%s"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  sku_name            = "standard"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.service_principal_object_id
+
+    key_permissions = [
+      "backup",
+      "create",
+      "decrypt",
+      "delete",
+      "encrypt",
+      "get",
+      "import",
+      "list",
+      "purge",
+      "recover",
+      "restore",
+      "sign",
+      "unwrapKey",
+      "update",
+      "verify",
+      "wrapKey",
+    ]
+
+    secret_permissions = [
+      "backup",
+      "delete",
+      "get",
+      "list",
+      "purge",
+      "recover",
+      "restore",
+      "set",
+    ]
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "deleteissuers",
+      "get",
+      "getissuers",
+      "import",
+      "list",
+      "listissuers",
+      "managecontacts",
+      "manageissuers",
+      "setissuers",
+      "update",
+    ]
+  }
+
+  enabled_for_deployment          = true
+  enabled_for_template_deployment = true
+}
+
+resource "azurerm_key_vault_certificate" "test" {
+  name      = "example"
+  vault_uri = azurerm_key_vault.test.vault_uri
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=${local.vm_name}"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                            = local.vm_name
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  admin_password                  = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  secret {
+    key_vault_id = azurerm_key_vault.test.id
+
+    certificate {
+      store = "My"
+      url   = azurerm_key_vault_certificate.test.secret_id
+    }
+  }
+
+  winrm_listener {
+    protocol = "Http"
+  }
+
+  winrm_listener {
+    certificate_url = azurerm_key_vault_certificate.test.secret_id
+    protocol        = "Https"
+  }
+}
+`, template, data.RandomString)
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_scaling_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_scaling_test.go
@@ -1,0 +1,377 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				// NOTE: this requires a large-ish machine to provision
+				Config: testWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_scalingAvailabilitySet(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_scalingAvailabilitySet(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_scalingDedicatedHost(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_scalingDedicatedHost(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_scalingProximityPlacementGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_scalingProximityPlacementGroup(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_scalingMachineSizeUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_scalingMachineSize(data, "Standard_F2"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_scalingMachineSize(data, "Standard_F4"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+			{
+				Config: testWindowsVirtualMachine_scalingMachineSize(data, "Standard_F4s_v2"),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func TestAccWindowsVirtualMachine_scalingZones(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: checkWindowsVirtualMachineIsDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: testWindowsVirtualMachine_scalingZone(data),
+				Check: resource.ComposeTestCheckFunc(
+					checkWindowsVirtualMachineExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"admin_password",
+			),
+		},
+	})
+}
+
+func testWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                  = local.vm_name
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_D2S_V3"
+  admin_username        = "adminuser"
+  admin_password        = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+  zone = 1
+
+  additional_capabilities {
+    ultra_ssd_enabled = true
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}
+
+func testWindowsVirtualMachine_scalingAvailabilitySet(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_availability_set" "test" {
+  name                = "acctestavset-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  managed             = true
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                  = local.vm_name
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_F2"
+  admin_username        = "adminuser"
+  admin_password        = "P@$$w0rd1234!"
+  availability_set_id   = azurerm_availability_set.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_scalingDedicatedHost(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dedicated_host_group" "test" {
+  name                        = "acctestDHG-%d"
+  resource_group_name         = azurerm_resource_group.test.name
+  location                    = azurerm_resource_group.test.location
+  platform_fault_domain_count = 2
+}
+
+resource "azurerm_dedicated_host" "test" {
+  name                    = "acctestDH-%d"
+  dedicated_host_group_id = azurerm_dedicated_host_group.test.id
+  location                = azurerm_resource_group.test.location
+  sku_name                = "DSv3-Type1"
+  platform_fault_domain   = 1
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                  = local.vm_name
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username        = "adminuser"
+  admin_password        = "P@$$w0rd1234!"
+  dedicated_host_id     = azurerm_dedicated_host.test.id
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_scalingProximityPlacementGroup(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_proximity_placement_group" "test" {
+  name                = "acctestPPG-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                         = local.vm_name
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  size                         = "Standard_F2"
+  admin_username               = "adminuser"
+  admin_password               = "P@$$w0rd1234!"
+  proximity_placement_group_id = azurerm_proximity_placement_group.test.id
+  network_interface_ids        = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_scalingMachineSize(data acceptance.TestData, size string) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                  = local.vm_name
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = %q
+  admin_username        = "adminuser"
+  admin_password        = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template, size)
+}
+
+func testWindowsVirtualMachine_scalingZone(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                  = local.vm_name
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  size                  = "Standard_F2"
+  admin_username        = "adminuser"
+  admin_password        = "P@$$w0rd1234!"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+  zone                  = 1
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+}
+`, template)
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_scaling_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_scaling_test.go
@@ -159,12 +159,12 @@ func testWindowsVirtualMachine_scalingAdditionalCapabilitiesUltraSSD(data accept
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                  = local.vm_name
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_D2S_V3"
-  admin_username        = "adminuser"
-  admin_password        = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2S_V3"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -202,13 +202,13 @@ resource "azurerm_availability_set" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                  = local.vm_name
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_F2"
-  admin_username        = "adminuser"
-  admin_password        = "P@$$w0rd1234!"
-  availability_set_id   = azurerm_availability_set.test.id
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  availability_set_id = azurerm_availability_set.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -249,13 +249,13 @@ resource "azurerm_dedicated_host" "test" {
 }
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                  = local.vm_name
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
-  admin_username        = "adminuser"
-  admin_password        = "P@$$w0rd1234!"
-  dedicated_host_id     = azurerm_dedicated_host.test.id
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_D2s_v3" # NOTE: SKU's are limited by the Dedicated Host
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  dedicated_host_id   = azurerm_dedicated_host.test.id
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -294,7 +294,7 @@ resource "azurerm_windows_virtual_machine" "test" {
   admin_username               = "adminuser"
   admin_password               = "P@$$w0rd1234!"
   proximity_placement_group_id = azurerm_proximity_placement_group.test.id
-  network_interface_ids        = [
+  network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
 
@@ -319,12 +319,12 @@ func testWindowsVirtualMachine_scalingMachineSize(data acceptance.TestData, size
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                  = local.vm_name
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = %q
-  admin_username        = "adminuser"
-  admin_password        = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = %q
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
@@ -350,16 +350,16 @@ func testWindowsVirtualMachine_scalingZone(data acceptance.TestData) string {
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                  = local.vm_name
-  resource_group_name   = azurerm_resource_group.test.name
-  location              = azurerm_resource_group.test.location
-  size                  = "Standard_F2"
-  admin_username        = "adminuser"
-  admin_password        = "P@$$w0rd1234!"
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]
-  zone                  = 1
+  zone = 1
 
   os_disk {
     caching              = "ReadWrite"

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_test.go
@@ -1,0 +1,106 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func checkWindowsVirtualMachineIsDestroyed(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_windows_virtual_machine" {
+			continue
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		name := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		resp, err := client.Get(ctx, resourceGroup, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func checkWindowsVirtualMachineExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		name := rs.Primary.Attributes["name"]
+
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+		resp, err := client.Get(ctx, resourceGroup, name, "")
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Windows Virtual Machine %q (Resource Group: %q) does not exist", name, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on VMClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testWindowsVirtualMachine_templateBase(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+locals {
+  vm_name = "acctestvm%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+}
+`, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testWindowsVirtualMachine_template(data acceptance.TestData) string {
+	template := testWindowsVirtualMachine_templateBase(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+ name                = "acctestnic-%d"
+ location            = azurerm_resource_group.test.location
+ resource_group_name = azurerm_resource_group.test.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.test.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+`, template, data.RandomInteger)
+}

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_test.go
@@ -92,15 +92,15 @@ func testWindowsVirtualMachine_template(data acceptance.TestData) string {
 %s
 
 resource "azurerm_network_interface" "test" {
- name                = "acctestnic-%d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestnic-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.test.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 `, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -53,7 +53,7 @@ func validateName(maxLength int) func(i interface{}, k string) (warnings []strin
 
 		// The value must be between 1 and 64 (Linux) or 16 (Windows) characters long.
 		if len(v) >= maxLength {
-			errors = append(errors, fmt.Errorf("%q can be at most %d characters, got %d", k, maxLength, len(v)))
+			errors = append(errors, fmt.Errorf("%q can be at most %d characters, got %d", k, maxLength-1, len(v)))
 		}
 
 		if strings.HasPrefix(v, "_") {

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -1,9 +1,15 @@
 package compute
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 type VirtualMachineID struct {
@@ -25,6 +31,10 @@ func ParseVirtualMachineID(input string) (*VirtualMachineID, error) {
 		return nil, err
 	}
 
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
 	return &virtualMachine, nil
 }
 
@@ -41,4 +51,384 @@ func ValidateVirtualMachineID(i interface{}, k string) (warnings []string, error
 	}
 
 	return warnings, errors
+}
+
+func virtualMachineAdditionalCapabilitiesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				// TODO: confirm this command
+
+				// NOTE: requires registration to use:
+				// $ az feature show --namespace Microsoft.Compute --name UltraSSDWithVMSS
+				// $ az provider register -n Microsoft.Compute
+				"ultra_ssd_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+					ForceNew: true,
+				},
+			},
+		},
+	}
+}
+
+func expandVirtualMachineAdditionalCapabilities(input []interface{}) *compute.AdditionalCapabilities {
+	capabilities := compute.AdditionalCapabilities{}
+
+	if len(input) > 0 {
+		raw := input[0].(map[string]interface{})
+
+		capabilities.UltraSSDEnabled = utils.Bool(raw["ultra_ssd_enabled"].(bool))
+	}
+
+	return &capabilities
+}
+
+func flattenVirtualMachineAdditionalCapabilities(input *compute.AdditionalCapabilities) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	ultraSsdEnabled := false
+
+	if input.UltraSSDEnabled != nil {
+		ultraSsdEnabled = *input.UltraSSDEnabled
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"ultra_ssd_enabled": ultraSsdEnabled,
+		},
+	}
+}
+
+func virtualMachineIdentitySchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.ResourceIdentityTypeSystemAssigned),
+						string(compute.ResourceIdentityTypeUserAssigned),
+						string(compute.ResourceIdentityTypeSystemAssignedUserAssigned),
+					}, false),
+				},
+
+				"identity_ids": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+
+				"principal_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func expandVirtualMachineIdentity(input []interface{}) (*compute.VirtualMachineIdentity, error) {
+	if len(input) == 0 {
+		// TODO: Does this want to be this, or nil?
+		return &compute.VirtualMachineIdentity{
+			Type: compute.ResourceIdentityTypeNone,
+		}, nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	identity := compute.VirtualMachineIdentity{
+		Type: compute.ResourceIdentityType(raw["type"].(string)),
+	}
+
+	identityIdsRaw := raw["identity_ids"].(*schema.Set).List()
+	identityIds := make(map[string]*compute.VirtualMachineIdentityUserAssignedIdentitiesValue)
+	for _, v := range identityIdsRaw {
+		identityIds[v.(string)] = &compute.VirtualMachineIdentityUserAssignedIdentitiesValue{}
+	}
+
+	if len(identityIds) > 0 {
+		if identity.Type != compute.ResourceIdentityTypeUserAssigned && identity.Type != compute.ResourceIdentityTypeSystemAssignedUserAssigned {
+			return nil, fmt.Errorf("`identity_ids` can only be specified when `type` includes `UserAssigned`")
+		}
+
+		identity.UserAssignedIdentities = identityIds
+	}
+
+	return &identity, nil
+}
+
+func flattenVirtualMachineIdentity(input *compute.VirtualMachineIdentity) []interface{} {
+	if input == nil || input.Type == compute.ResourceIdentityTypeNone {
+		return []interface{}{}
+	}
+
+	identityIds := make([]string, 0)
+	if input.UserAssignedIdentities != nil {
+		for k := range input.UserAssignedIdentities {
+			identityIds = append(identityIds, k)
+		}
+	}
+
+	principalId := ""
+	if input.PrincipalID != nil {
+		principalId = *input.PrincipalID
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"type":         string(input.Type),
+			"identity_ids": identityIds,
+			"principal_id": principalId,
+		},
+	}
+}
+
+func expandVirtualMachineNetworkInterfaceIDs(input []interface{}) []compute.NetworkInterfaceReference {
+	output := make([]compute.NetworkInterfaceReference, 0)
+
+	for i, v := range input {
+		output = append(output, compute.NetworkInterfaceReference{
+			ID: utils.String(v.(string)),
+			NetworkInterfaceReferenceProperties: &compute.NetworkInterfaceReferenceProperties{
+				Primary: utils.Bool(i == 0),
+			},
+		})
+	}
+
+	return output
+}
+
+func flattenVirtualMachineNetworkInterfaceIDs(input *[]compute.NetworkInterfaceReference) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	output := make([]interface{}, 0)
+
+	for _, v := range *input {
+		if v.ID == nil {
+			continue
+		}
+
+		output = append(output, *v.ID)
+	}
+
+	return output
+}
+
+func virtualMachineOSDiskSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"caching": {
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.CachingTypesNone),
+						string(compute.CachingTypesReadOnly),
+						string(compute.CachingTypesReadWrite),
+					}, false),
+				},
+				"storage_account_type": {
+					Type:     schema.TypeString,
+					Required: true,
+					// whilst this appears in the Update block the API returns this when changing:
+					// Changing property 'osDisk.managedDisk.storageAccountType' is not allowed
+					ForceNew: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						// note: OS Disks don't support Ultra SSDs
+						string(compute.StorageAccountTypesPremiumLRS),
+						string(compute.StorageAccountTypesStandardLRS),
+						string(compute.StorageAccountTypesStandardSSDLRS),
+					}, false),
+				},
+
+				// Optional
+				"diff_disk_settings": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"option": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(compute.Local),
+								}, false),
+							},
+						},
+					},
+				},
+
+				"disk_encryption_set_id": {
+					Type:     schema.TypeString,
+					Optional: true,
+					// TODO: make this more specific
+					ValidateFunc: azure.ValidateResourceID,
+				},
+
+				"disk_size_gb": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.IntBetween(0, 1023),
+				},
+
+				"name": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+					Computed: true,
+				},
+
+				"write_accelerator_enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}
+
+func expandVirtualMachineOSDisk(input []interface{}, osType compute.OperatingSystemTypes) *compute.OSDisk {
+	raw := input[0].(map[string]interface{})
+	disk := compute.OSDisk{
+		Caching: compute.CachingTypes(raw["caching"].(string)),
+		ManagedDisk: &compute.ManagedDiskParameters{
+			StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
+		},
+		WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
+
+		// these have to be hard-coded so there's no point exposing them
+		// for CreateOption, whilst it's possible for this to be "Attach" for an OS Disk
+		// from what we can tell this approach has been superseded by provisioning from
+		// an image of the machine (e.g. an Image/Shared Image Gallery)
+		CreateOption: compute.DiskCreateOptionTypesFromImage,
+		OsType:       osType,
+	}
+
+	if osDiskSize := raw["disk_size_gb"].(int); osDiskSize > 0 {
+		disk.DiskSizeGB = utils.Int32(int32(osDiskSize))
+	}
+
+	if diffDiskSettingsRaw := raw["diff_disk_settings"].([]interface{}); len(diffDiskSettingsRaw) > 0 {
+		diffDiskRaw := diffDiskSettingsRaw[0].(map[string]interface{})
+		disk.DiffDiskSettings = &compute.DiffDiskSettings{
+			Option: compute.DiffDiskOptions(diffDiskRaw["option"].(string)),
+		}
+	}
+
+	if id := raw["disk_encryption_set_id"].(string); id != "" {
+		disk.ManagedDisk.DiskEncryptionSet = &compute.DiskEncryptionSetParameters{
+			ID: utils.String(id),
+		}
+	}
+
+	if name := raw["name"].(string); name != "" {
+		disk.Name = utils.String(name)
+	}
+
+	return &disk
+}
+
+func flattenVirtualMachineOSDisk(ctx context.Context, disksClient *compute.DisksClient, input *compute.OSDisk) ([]interface{}, error) {
+	if input == nil {
+		return []interface{}{}, nil
+	}
+
+	diffDiskSettings := make([]interface{}, 0)
+	if input.DiffDiskSettings != nil {
+		diffDiskSettings = append(diffDiskSettings, map[string]interface{}{
+			"option": string(input.DiffDiskSettings.Option),
+		})
+	}
+
+	diskSizeGb := 0
+	if input.DiskSizeGB != nil && *input.DiskSizeGB != 0 {
+		diskSizeGb = int(*input.DiskSizeGB)
+	}
+
+	var name string
+	if input.Name != nil {
+		name = *input.Name
+	}
+
+	diskEncryptionSetId := ""
+	storageAccountType := ""
+
+	if input.ManagedDisk != nil {
+		storageAccountType = string(input.ManagedDisk.StorageAccountType)
+
+		if input.ManagedDisk.ID != nil {
+			id, err := parse.ManagedDiskID(*input.ManagedDisk.ID)
+			if err != nil {
+				return nil, err
+			}
+
+			disk, err := disksClient.Get(ctx, id.ResourceGroup, id.Name)
+			if err != nil {
+				// turns out ephemeral disks aren't returned/available here
+				if !utils.ResponseWasNotFound(disk.Response) {
+					return nil, err
+				}
+			}
+
+			// Ephemeral Disks get an ARM ID but aren't available via the regular API
+			// ergo fingers crossed we've got it from the resource because ¯\_(ツ)_/¯
+			// where else we'd be able to pull it from
+			if !utils.ResponseWasNotFound(disk.Response) {
+				// whilst this is available as `input.ManagedDisk.StorageAccountType` it's not returned there
+				// however it's only available there for ephemeral os disks
+				if disk.Sku != nil && storageAccountType == "" {
+					storageAccountType = string(disk.Sku.Name)
+				}
+
+				// same goes for Disk Size GB apparently
+				if diskSizeGb == 0 && disk.DiskProperties != nil && disk.DiskProperties.DiskSizeGB != nil {
+					diskSizeGb = int(*disk.DiskProperties.DiskSizeGB)
+				}
+			}
+		}
+
+		if input.ManagedDisk.DiskEncryptionSet != nil && input.ManagedDisk.DiskEncryptionSet.ID != nil {
+			diskEncryptionSetId = *input.ManagedDisk.DiskEncryptionSet.ID
+		}
+	}
+
+	writeAcceleratorEnabled := false
+	if input.WriteAcceleratorEnabled != nil {
+		writeAcceleratorEnabled = *input.WriteAcceleratorEnabled
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"caching":                   string(input.Caching),
+			"disk_size_gb":              diskSizeGb,
+			"diff_disk_settings":        diffDiskSettings,
+			"disk_encryption_set_id":    diskEncryptionSetId,
+			"name":                      name,
+			"storage_account_type":      storageAccountType,
+			"write_accelerator_enabled": writeAcceleratorEnabled,
+		},
+	}, nil
 }

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -128,6 +128,7 @@ func virtualMachineIdentitySchema() *schema.Schema {
 					Optional: true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
+						// TODO: validation for a UAI which requires an ID Parser/Validator
 					},
 				},
 

--- a/azurerm/internal/services/compute/virtual_machine.go
+++ b/azurerm/internal/services/compute/virtual_machine.go
@@ -292,7 +292,7 @@ func virtualMachineOSDiskSchema() *schema.Schema {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 1023),
+					ValidateFunc: validation.IntBetween(0, 2048),
 				},
 
 				"name": {

--- a/azurerm/internal/services/compute/virtual_machine_import.go
+++ b/azurerm/internal/services/compute/virtual_machine_import.go
@@ -1,0 +1,67 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+)
+
+func importVirtualMachine(osType compute.OperatingSystemTypes, resourceType string) func(d *schema.ResourceData, meta interface{}) (data []*schema.ResourceData, err error) {
+	return func(d *schema.ResourceData, meta interface{}) (data []*schema.ResourceData, err error) {
+		id, err := ParseVirtualMachineID(d.Id())
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
+
+		client := meta.(*clients.Client).Compute.VMClient
+		ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+		defer cancel()
+
+		vm, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+		if err != nil {
+			return []*schema.ResourceData{}, fmt.Errorf("Error retrieving Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if vm.VirtualMachineProperties == nil {
+			return []*schema.ResourceData{}, fmt.Errorf("Error retrieving Virtual Machine %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+		}
+
+		isCorrectOS := false
+		if profile := vm.VirtualMachineProperties.StorageProfile; profile != nil {
+			if profile.OsDisk != nil && profile.OsDisk.OsType == osType {
+				isCorrectOS = true
+			}
+
+			if profile.OsDisk.Vhd != nil {
+				return []*schema.ResourceData{}, fmt.Errorf("The %q resource only supports Managed Disks - please use the `azurerm_virtual_machine` resource for Unmanaged Disks", resourceType)
+			}
+		}
+
+		if !isCorrectOS {
+			return []*schema.ResourceData{}, fmt.Errorf("The %q resource only supports %s Virtual Machines", resourceType, string(osType))
+		}
+
+		// we don't support VM's without an OS Profile / attach
+		if vm.VirtualMachineProperties.OsProfile == nil {
+			return []*schema.ResourceData{}, fmt.Errorf("The %q resource doesn't support attaching OS Disks - please use the `azurerm_virtual_machine` resource instead", resourceType)
+		}
+
+		hasSshKeys := false
+		if osType == compute.Linux {
+			if linux := vm.VirtualMachineProperties.OsProfile.LinuxConfiguration; linux != nil {
+				if linux.SSH != nil && linux.SSH.PublicKeys != nil {
+					hasSshKeys = len(*linux.SSH.PublicKeys) > 0
+				}
+			}
+		}
+
+		if !hasSshKeys {
+			d.Set("admin_password", "ignored-as-imported")
+		}
+
+		return []*schema.ResourceData{d}, nil
+	}
+}

--- a/azurerm/internal/services/compute/virtual_machine_instance.go
+++ b/azurerm/internal/services/compute/virtual_machine_instance.go
@@ -28,6 +28,7 @@ func shouldBootVirtualMachine(instanceView compute.VirtualMachineInstanceView) b
 			case "deallocating":
 			case "deallocated":
 			case "stopped":
+			case "stopping":
 				return true
 			}
 		}

--- a/azurerm/internal/services/compute/virtual_machine_instance.go
+++ b/azurerm/internal/services/compute/virtual_machine_instance.go
@@ -6,11 +6,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 )
 
-// shouldBootVirtualMachine determines if the Virtual Machine should be started after
+// virtualMachineShouldBeStarted determines if the Virtual Machine should be started after
 // the Virtual Machine has been shut down for maintenance. This means that Virtual Machines
 // which are already stopped can be updated but will not be started
 // nolint: deadcode unused
-func shouldBootVirtualMachine(instanceView compute.VirtualMachineInstanceView) bool {
+func virtualMachineShouldBeStarted(instanceView compute.VirtualMachineInstanceView) bool {
 	if instanceView.Statuses != nil {
 		for _, status := range *instanceView.Statuses {
 			if status.Code == nil {
@@ -19,16 +19,12 @@ func shouldBootVirtualMachine(instanceView compute.VirtualMachineInstanceView) b
 
 			// could also be the provisioning state which we're not bothered with here
 			state := strings.ToLower(*status.Code)
-			if !strings.HasPrefix(state, "PowerState/") {
+			if !strings.HasPrefix(state, "powerstate/") {
 				continue
 			}
 
 			state = strings.TrimPrefix(state, "powerstate/")
-			switch strings.ToLower(state) {
-			case "deallocating":
-			case "deallocated":
-			case "stopped":
-			case "stopping":
+			if strings.EqualFold(state, "running") {
 				return true
 			}
 		}

--- a/azurerm/internal/services/compute/virtual_machine_instance_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_instance_test.go
@@ -78,5 +78,4 @@ func TestVirtualMachineShouldBeStarted(t *testing.T) {
 			t.Fatalf("Expected %t but got %t", testCase.Expected, result)
 		}
 	}
-
 }

--- a/azurerm/internal/services/compute/virtual_machine_instance_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_instance_test.go
@@ -1,0 +1,82 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestVirtualMachineShouldBeStarted(t *testing.T) {
+	var buildInstanceViewStatus = func(statuses ...string) *[]compute.InstanceViewStatus {
+		results := make([]compute.InstanceViewStatus, 0)
+
+		for _, v := range statuses {
+			results = append(results, compute.InstanceViewStatus{
+				Code: utils.String(v),
+			})
+		}
+
+		return &results
+	}
+
+	testCases := []struct {
+		Name     string
+		Input    *[]compute.InstanceViewStatus
+		Expected bool
+	}{
+		{
+			Name:     "None",
+			Expected: false,
+			Input:    nil,
+		},
+		{
+			Name:     "No Power State",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/Creating"),
+			Expected: false,
+		},
+		{
+			Name:     "Running",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/succeeded", "PowerState/running"),
+			Expected: true,
+		},
+		{
+			Name:     "Deallocated",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/succeeded", "PowerState/deallocated"),
+			Expected: false,
+		},
+		{
+			Name:     "Deallocating",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/updating", "PowerState/deallocating"),
+			Expected: false,
+		},
+		{
+			Name:     "Stopped",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/updating", "PowerState/stopped"),
+			Expected: false,
+		},
+		{
+			Name:     "Stopping",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/updating", "PowerState/stopping"),
+			Expected: false,
+		},
+		{
+			Name:     "Failed",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/failed", "PowerState/failed"),
+			Expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Logf("Running %q..", testCase.Name)
+
+		instanceView := compute.VirtualMachineInstanceView{
+			Statuses: testCase.Input,
+		}
+		result := virtualMachineShouldBeStarted(instanceView)
+		if result != testCase.Expected {
+			t.Fatalf("Expected %t but got %t", testCase.Expected, result)
+		}
+	}
+
+}

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -937,7 +937,7 @@ func VirtualMachineScaleSetOSDiskSchema() *schema.Schema {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 1023),
+					ValidateFunc: validation.IntBetween(0, 2048),
 				},
 
 				"write_accelerator_enabled": {

--- a/azurerm/internal/services/compute/virtual_machine_test.go
+++ b/azurerm/internal/services/compute/virtual_machine_test.go
@@ -37,6 +37,7 @@ func TestParseVirtualMachineID(t *testing.T) {
 			},
 		},
 	}
+
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q", v.Name)
 

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -1,0 +1,1004 @@
+package compute
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
+	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
+	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/base64"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+// TODO: confirm locking as appropriate
+
+func resourceWindowsVirtualMachine() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWindowsVirtualMachineCreate,
+		Read:   resourceWindowsVirtualMachineRead,
+		Update: resourceWindowsVirtualMachineUpdate,
+		Delete: resourceWindowsVirtualMachineDelete,
+		Importer: azSchema.ValidateResourceIDPriorToImportThen(func(id string) error {
+			_, err := ParseVirtualMachineID(id)
+			return err
+		}, importVirtualMachine(compute.Windows, "azurerm_windows_virtual_machine")),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(45 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(45 * time.Minute),
+			Delete: schema.DefaultTimeout(45 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidateWindowsName,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"location": azure.SchemaLocation(),
+
+			// Required
+			"admin_password": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
+			},
+
+			"admin_username": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			"network_interface_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: networkValidate.NetworkInterfaceID,
+				},
+			},
+
+			"os_disk": virtualMachineOSDiskSchema(),
+
+			"size": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.NoEmptyStrings,
+			},
+
+			// Optional
+			"additional_capabilities": virtualMachineAdditionalCapabilitiesSchema(),
+
+			"additional_unattend_content": additionalUnattendContentSchema(),
+
+			"allow_extension_operations": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+
+			"availability_set_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: computeValidate.AvailabilitySetID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				DiffSuppressFunc: suppress.CaseDifference,
+				// TODO: raise a GH issue for the broken API
+				// availability_set_id:                 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG-200122113424880096/providers/Microsoft.Compute/availabilitySets/ACCTESTAVSET-200122113424880096" => "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG-200122113424880096/providers/Microsoft.Compute/availabilitySets/acctestavset-200122113424880096" (forces new resource)
+				ConflictsWith: []string{
+					// TODO: "virtual_machine_scale_set_id"
+					"zone",
+				},
+			},
+
+			"boot_diagnostics": bootDiagnosticsSchema(),
+
+			"computer_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+
+				// Computed since we reuse the VM name if one's not specified
+				Computed: true,
+				ForceNew: true,
+				// note: whilst the portal says 1-15 characters it seems to mirror the rules for the vm name
+				// (e.g. 1-15 for Windows, 1-63 for Windows)
+				ValidateFunc: ValidateWindowsName,
+			},
+
+			"custom_data": base64.OptionalSchema(true),
+
+			"dedicated_host_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true, // TODO: investigate, looks like the Portal allows migration
+				ValidateFunc: computeValidate.DedicatedHostID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				DiffSuppressFunc: suppress.CaseDifference,
+				// TODO: raise a GH issue for the broken API
+				// /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/TOM-MANUAL/providers/Microsoft.Compute/hostGroups/tom-hostgroup/hosts/tom-manual-host
+			},
+
+			"enable_automatic_updates": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true, // TODO: confirm
+				Default:  true,
+			},
+
+			"eviction_policy": {
+				// only applicable when `priority` is set to `Spot`
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					// NOTE: whilst Delete is an option here, it's only applicable for VMSS
+					string(compute.Deallocate),
+				}, false),
+			},
+
+			"identity": virtualMachineIdentitySchema(),
+
+			"license_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"None",
+					"Windows_Client",
+					"Windows_Server",
+				}, false),
+			},
+
+			"max_bid_price": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				Default:  -1,
+			},
+
+			"plan": planSchema(),
+
+			"priority": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(compute.Regular),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(compute.Regular),
+					string(compute.Spot),
+				}, false),
+			},
+
+			"provision_vm_agent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+
+			"proximity_placement_group_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: computeValidate.ProximityPlacementGroupID,
+				// the Compute/VM API is broken and returns the Resource Group name in UPPERCASE :shrug:
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+
+			"secret": windowsSecretSchema(),
+
+			"source_image_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: computeValidate.ImageID,
+			},
+
+			"source_image_reference": sourceImageReferenceSchema(true),
+
+			"tags": tags.Schema(),
+
+			"timezone": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.VirtualMachineTimeZone(),
+			},
+
+			"winrm_listener": winRmListenerSchema(),
+
+			"zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"availability_set_id",
+					// TODO: "virtual_machine_scale_set_id"
+				},
+			},
+
+			// Computed
+			"private_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"public_ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_ip_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"virtual_machine_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWindowsVirtualMachineCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	locks.ByName(name, virtualMachineResourceName)
+	defer locks.UnlockByName(name, virtualMachineResourceName)
+
+	if features.ShouldResourcesBeImported() {
+		resp, err := client.Get(ctx, resourceGroup, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Error checking for existing Windows Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return tf.ImportAsExistsError("azurerm_windows_virtual_machine", *resp.ID)
+		}
+	}
+
+	additionalCapabilitiesRaw := d.Get("additional_capabilities").([]interface{})
+	additionalCapabilities := expandVirtualMachineAdditionalCapabilities(additionalCapabilitiesRaw)
+
+	additionalUnattendContentRaw := d.Get("additional_unattend_content").([]interface{})
+	additionalUnattendContent := expandAdditionalUnattendContent(additionalUnattendContentRaw)
+
+	adminPassword := d.Get("admin_password").(string)
+	adminUsername := d.Get("admin_username").(string)
+	allowExtensionOperations := d.Get("allow_extension_operations").(bool)
+	bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+	bootDiagnostics := expandBootDiagnostics(bootDiagnosticsRaw)
+	var computerName string
+	if v, ok := d.GetOk("computer_name"); ok && len(v.(string)) > 0 {
+		computerName = v.(string)
+	} else {
+		computerName = name
+	}
+	enableAutomaticUpdates := d.Get("enable_automatic_updates").(bool)
+	location := azure.NormalizeLocation(d.Get("location").(string))
+	identityRaw := d.Get("identity").([]interface{})
+	identity, err := expandVirtualMachineIdentity(identityRaw)
+	if err != nil {
+		return fmt.Errorf("Error expanding `identity`: %+v", err)
+	}
+	planRaw := d.Get("plan").([]interface{})
+	plan := expandPlan(planRaw)
+	priority := compute.VirtualMachinePriorityTypes(d.Get("priority").(string))
+	provisionVMAgent := d.Get("provision_vm_agent").(bool)
+	size := d.Get("size").(string)
+	t := d.Get("tags").(map[string]interface{})
+
+	networkInterfaceIdsRaw := d.Get("network_interface_ids").([]interface{})
+	networkInterfaceIds := expandVirtualMachineNetworkInterfaceIDs(networkInterfaceIdsRaw)
+
+	osDiskRaw := d.Get("os_disk").([]interface{})
+	osDisk := expandVirtualMachineOSDisk(osDiskRaw, compute.Windows)
+
+	secretsRaw := d.Get("secret").([]interface{})
+	secrets := expandWindowsSecrets(secretsRaw)
+
+	sourceImageReferenceRaw := d.Get("source_image_reference").([]interface{})
+	sourceImageId := d.Get("source_image_id").(string)
+	sourceImageReference, err := expandSourceImageReference(sourceImageReferenceRaw, sourceImageId)
+	if err != nil {
+		return err
+	}
+
+	winRmListenersRaw := d.Get("winrm_listener").(*schema.Set).List()
+	winRmListeners := expandWinRMListener(winRmListenersRaw)
+
+	params := compute.VirtualMachine{
+		Name:     utils.String(name),
+		Location: utils.String(location),
+		Identity: identity,
+		Plan:     plan,
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			HardwareProfile: &compute.HardwareProfile{
+				VMSize: compute.VirtualMachineSizeTypes(size),
+			},
+			OsProfile: &compute.OSProfile{
+				AdminPassword:            utils.String(adminPassword),
+				AdminUsername:            utils.String(adminUsername),
+				ComputerName:             utils.String(computerName),
+				AllowExtensionOperations: utils.Bool(allowExtensionOperations),
+				WindowsConfiguration: &compute.WindowsConfiguration{
+					ProvisionVMAgent:       utils.Bool(provisionVMAgent),
+					EnableAutomaticUpdates: utils.Bool(enableAutomaticUpdates),
+					WinRM:                  winRmListeners,
+				},
+				Secrets: secrets,
+			},
+			NetworkProfile: &compute.NetworkProfile{
+				NetworkInterfaces: &networkInterfaceIds,
+			},
+			Priority: priority,
+			StorageProfile: &compute.StorageProfile{
+				ImageReference: sourceImageReference,
+				OsDisk:         osDisk,
+
+				// Data Disks are instead handled via the Association resource - as such we can send an empty value here
+				// but for Updates this'll need to be nil, else any associations will be overwritten
+				DataDisks: &[]compute.DataDisk{},
+			},
+
+			// Optional
+			AdditionalCapabilities: additionalCapabilities,
+			DiagnosticsProfile:     bootDiagnostics,
+
+			// @tombuildsstuff: passing in a VMSS ID returns:
+			// > Code="InvalidParameter" Message="The value of parameter virtualMachineScaleSet is invalid." Target="virtualMachineScaleSet"
+			// presuming this isn't finished yet; note: this'll conflict with availability set id
+			VirtualMachineScaleSet: nil,
+		},
+		Tags: tags.Expand(t),
+	}
+
+	if !provisionVMAgent && allowExtensionOperations {
+		return fmt.Errorf("`allow_extension_operations` cannot be set to `true` when `provision_vm_agent` is set to `false`")
+	}
+
+	if len(additionalUnattendContentRaw) > 0 {
+		params.OsProfile.WindowsConfiguration.AdditionalUnattendContent = additionalUnattendContent
+	}
+
+	if v, ok := d.GetOk("availability_set_id"); ok {
+		params.AvailabilitySet = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
+	if v, ok := d.GetOk("custom_data"); ok {
+		params.OsProfile.CustomData = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("dedicated_host_id"); ok {
+		params.Host = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
+	if evictionPolicyRaw, ok := d.GetOk("eviction_policy"); ok {
+		if params.Priority != compute.Spot {
+			return fmt.Errorf("An `eviction_policy` can only be specified when `priority` is set to `Spot`")
+		}
+
+		params.EvictionPolicy = compute.VirtualMachineEvictionPolicyTypes(evictionPolicyRaw.(string))
+	} else if priority == compute.Spot {
+		return fmt.Errorf("An `eviction_policy` must be specified when `priority` is set to `Spot`")
+	}
+
+	if v, ok := d.GetOk("license_type"); ok {
+		params.LicenseType = utils.String(v.(string))
+	}
+
+	if v, ok := d.Get("max_bid_price").(float64); ok && v > 0 {
+		if priority != compute.Spot {
+			return fmt.Errorf("`max_bid_price` can only be configured when `priority` is set to `Spot`")
+		}
+
+		params.BillingProfile = &compute.BillingProfile{
+			MaxPrice: utils.Float(v),
+		}
+	}
+
+	if v, ok := d.GetOk("proximity_placement_group_id"); ok {
+		params.ProximityPlacementGroup = &compute.SubResource{
+			ID: utils.String(v.(string)),
+		}
+	}
+
+	if v, ok := d.GetOk("timezone"); ok {
+		params.VirtualMachineProperties.OsProfile.WindowsConfiguration.TimeZone = utils.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("zone"); ok {
+		params.Zones = &[]string{
+			v.(string),
+		}
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, params)
+	if err != nil {
+		return fmt.Errorf("Error creating Windows Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for creation of Windows Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, resourceGroup, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Windows Virtual Machine %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	if read.ID == nil {
+		return fmt.Errorf("Error retrieving Windows Virtual Machine %q (Resource Group %q): `id` was nil", name, resourceGroup)
+	}
+
+	d.SetId(*read.ID)
+	return resourceWindowsVirtualMachineRead(d, meta)
+}
+
+func resourceWindowsVirtualMachineRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	disksClient := meta.(*clients.Client).Compute.DisksClient
+	networkInterfacesClient := meta.(*clients.Client).Network.InterfacesClient
+	publicIPAddressesClient := meta.(*clients.Client).Network.PublicIPsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := ParseVirtualMachineID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Windows Virtual Machine %q was not found in Resource Group %q - removing from state!", id.Name, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	d.Set("name", id.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	if location := resp.Location; location != nil {
+		d.Set("location", azure.NormalizeLocation(*resp.Location))
+	}
+
+	if err := d.Set("identity", flattenVirtualMachineIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("Error setting `identity`: %+v", err)
+	}
+
+	if err := d.Set("plan", flattenPlan(resp.Plan)); err != nil {
+		return fmt.Errorf("Error setting `plan`: %+v", err)
+	}
+
+	if resp.VirtualMachineProperties == nil {
+		return fmt.Errorf("Error retrieving Windows Virtual Machine %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+	}
+
+	props := *resp.VirtualMachineProperties
+	if err := d.Set("additional_capabilities", flattenVirtualMachineAdditionalCapabilities(props.AdditionalCapabilities)); err != nil {
+		return fmt.Errorf("Error setting `additional_capabilities`: %+v", err)
+	}
+
+	availabilitySetId := ""
+	if props.AvailabilitySet != nil && props.AvailabilitySet.ID != nil {
+		availabilitySetId = *props.AvailabilitySet.ID
+	}
+	d.Set("availability_set_id", availabilitySetId)
+
+	if err := d.Set("boot_diagnostics", flattenBootDiagnostics(props.DiagnosticsProfile)); err != nil {
+		return fmt.Errorf("Error setting `boot_diagnostics`: %+v", err)
+	}
+
+	d.Set("eviction_policy", string(props.EvictionPolicy))
+	if profile := props.HardwareProfile; profile != nil {
+		d.Set("size", string(profile.VMSize))
+	}
+	d.Set("license_type", props.LicenseType)
+
+	// defaulted since BillingProfile isn't returned if it's unset
+	maxBidPrice := float64(-1.0)
+	if props.BillingProfile != nil && props.BillingProfile.MaxPrice != nil {
+		maxBidPrice = *props.BillingProfile.MaxPrice
+	}
+	d.Set("max_bid_price", maxBidPrice)
+
+	if profile := props.NetworkProfile; profile != nil {
+		if err := d.Set("network_interface_ids", flattenVirtualMachineNetworkInterfaceIDs(props.NetworkProfile.NetworkInterfaces)); err != nil {
+			return fmt.Errorf("Error setting `network_interface_ids`: %+v", err)
+		}
+	}
+
+	dedicatedHostId := ""
+	if props.Host != nil && props.Host.ID != nil {
+		dedicatedHostId = *props.Host.ID
+	}
+	d.Set("dedicated_host_id", dedicatedHostId)
+
+	if profile := props.OsProfile; profile != nil {
+		d.Set("admin_username", profile.AdminUsername)
+		d.Set("allow_extension_operations", profile.AllowExtensionOperations)
+		d.Set("computer_name", profile.ComputerName)
+
+		if config := profile.WindowsConfiguration; config != nil {
+			if err := d.Set("additional_unattend_content", flattenAdditionalUnattendContent(config.AdditionalUnattendContent, d)); err != nil {
+				return fmt.Errorf("Error setting `additional_unattend_content`: %+v", err)
+			}
+
+			d.Set("enable_automatic_updates", config.EnableAutomaticUpdates)
+
+			d.Set("provision_vm_agent", config.ProvisionVMAgent)
+			d.Set("timezone", config.TimeZone)
+
+			if err := d.Set("winrm_listener", flattenWinRMListener(config.WinRM)); err != nil {
+				return fmt.Errorf("Error setting `winrm_listener`: %+v", err)
+			}
+		}
+
+		if err := d.Set("secret", flattenWindowsSecrets(profile.Secrets)); err != nil {
+			return fmt.Errorf("Error setting `secret`: %+v", err)
+		}
+	}
+
+	d.Set("priority", string(props.Priority))
+	proximityPlacementGroupId := ""
+	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
+		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID
+	}
+	d.Set("proximity_placement_group_id", proximityPlacementGroupId)
+
+	if profile := props.StorageProfile; profile != nil {
+		// the storage_account_type isn't returned so we need to look it up
+		flattenedOSDisk, err := flattenVirtualMachineOSDisk(ctx, disksClient, profile.OsDisk)
+		if err != nil {
+			return fmt.Errorf("Error flattening `os_disk`: %+v", err)
+		}
+		if err := d.Set("os_disk", flattenedOSDisk); err != nil {
+			return fmt.Errorf("Error settings `os_disk`: %+v", err)
+		}
+
+		var storageImageId string
+		if profile.ImageReference != nil && profile.ImageReference.ID != nil {
+			storageImageId = *profile.ImageReference.ID
+		}
+		d.Set("source_image_id", storageImageId)
+
+		if err := d.Set("source_image_reference", flattenSourceImageReference(profile.ImageReference)); err != nil {
+			return fmt.Errorf("Error setting `source_image_reference`: %+v", err)
+		}
+	}
+
+	d.Set("virtual_machine_id", props.VMID)
+
+	zone := ""
+	if resp.Zones != nil {
+		if zones := *resp.Zones; len(zones) > 0 {
+			zone = zones[0]
+		}
+	}
+	d.Set("zone", zone)
+
+	connectionInfo := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, resp.VirtualMachineProperties)
+	d.Set("private_ip_address", connectionInfo.primaryPrivateAddress)
+	d.Set("private_ip_addresses", connectionInfo.privateAddresses)
+	d.Set("public_ip_address", connectionInfo.primaryPublicAddress)
+	d.Set("public_ip_addresses", connectionInfo.publicAddresses)
+	isWindows := false
+	setConnectionInformation(d, connectionInfo, isWindows)
+
+	return tags.FlattenAndSet(d, resp.Tags)
+}
+
+func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := ParseVirtualMachineID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, virtualMachineResourceName)
+	defer locks.UnlockByName(id.Name, virtualMachineResourceName)
+
+	log.Printf("[DEBUG] Retrieving Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Retrieving InstanceView for Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	instanceView, err := client.InstanceView(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving InstanceView for Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	shouldTurnBackOn := shouldBootVirtualMachine(instanceView)
+	hasEphemeralOSDisk := false
+	if props := existing.VirtualMachineProperties; props != nil {
+		if storage := props.StorageProfile; storage != nil {
+			if disk := storage.OsDisk; disk != nil {
+				if settings := disk.DiffDiskSettings; settings != nil {
+					hasEphemeralOSDisk = settings.Option == compute.Local
+				}
+			}
+		}
+	}
+
+	shouldUpdate := false
+	shouldShutDown := false
+	shouldDeallocate := false
+
+	update := compute.VirtualMachineUpdate{
+		VirtualMachineProperties: &compute.VirtualMachineProperties{},
+	}
+
+	if d.HasChange("boot_diagnostics") {
+		shouldUpdate = true
+
+		bootDiagnosticsRaw := d.Get("boot_diagnostics").([]interface{})
+		update.VirtualMachineProperties.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
+	}
+
+	if d.HasChange("custom_data") || d.HasChange("enable_automatic_updates") || d.HasChange("secret") {
+		shouldUpdate = true
+
+		profile := compute.OSProfile{}
+
+		if d.HasChange("custom_data") {
+			profile.CustomData = utils.String(d.Get("custom_data").(string))
+		}
+
+		if d.HasChange("secret") {
+			secretsRaw := d.Get("secret").([]interface{})
+			profile.Secrets = expandWindowsSecrets(secretsRaw)
+		}
+
+		update.VirtualMachineProperties.OsProfile = &profile
+	}
+
+	if d.HasChange("identity") {
+		shouldUpdate = true
+
+		identityRaw := d.Get("identity").([]interface{})
+		identity, err := expandVirtualMachineIdentity(identityRaw)
+		if err != nil {
+			return fmt.Errorf("Error expanding `identity`: %+v", err)
+		}
+		update.Identity = identity
+	}
+
+	if d.HasChange("max_bid_price") {
+		shouldUpdate = true
+
+		// Code="OperationNotAllowed" Message="Max price change is not allowed. For more information, see http://aka.ms/AzureSpot/errormessages"
+		shouldShutDown = true
+
+		// "code":"OperationNotAllowed"
+		// "message": "Max price change is not allowed when the VM [name] is currently allocated.
+		//			   Please deallocate and try again. For more information, see http://aka.ms/AzureSpot/errormessages"
+		shouldDeallocate = true
+
+		maxBidPrice := d.Get("max_bid_price").(float64)
+		update.VirtualMachineProperties.BillingProfile = &compute.BillingProfile{
+			MaxPrice: utils.Float(maxBidPrice),
+		}
+	}
+
+	if d.HasChange("network_interface_ids") {
+		shouldUpdate = true
+
+		// Code="CannotAddOrRemoveNetworkInterfacesFromARunningVirtualMachine"
+		// Message="Secondary network interfaces cannot be added or removed from a running virtual machine.
+		shouldShutDown = true
+
+		// @tombuildsstuff: after testing shutting it down isn't sufficient - we need a full deallocation
+		shouldDeallocate = true
+
+		networkInterfaceIdsRaw := d.Get("network_interface_ids").([]interface{})
+		networkInterfaceIds := expandVirtualMachineNetworkInterfaceIDs(networkInterfaceIdsRaw)
+
+		update.VirtualMachineProperties.NetworkProfile = &compute.NetworkProfile{
+			NetworkInterfaces: &networkInterfaceIds,
+		}
+	}
+
+	if d.HasChange("os_disk") {
+		shouldUpdate = true
+
+		// Code="Conflict" Message="Disk resizing is allowed only when creating a VM or when the VM is deallocated." Target="disk.diskSizeGB"
+		shouldShutDown = true
+		shouldDeallocate = true
+
+		osDiskRaw := d.Get("os_disk").([]interface{})
+		osDisk := expandVirtualMachineOSDisk(osDiskRaw, compute.Windows)
+		update.VirtualMachineProperties.StorageProfile = &compute.StorageProfile{
+			OsDisk: osDisk,
+		}
+	}
+
+	if d.HasChange("size") {
+		shouldUpdate = true
+
+		// this is kind of superflurious since Azure can do this for us, but if we do this we can subsequently
+		// deallocate the VM to switch hosts if required
+		shouldShutDown = true
+		vmSize := d.Get("size").(string)
+
+		// Azure will auto-reboot this for us, providing this machine will fit on this host
+		// otherwise we need to shut down the VM to move it to another host to be able to use this size
+		availableOnThisHost := false
+		sizes, err := client.ListAvailableSizes(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			return fmt.Errorf("Error retrieving available sizes for Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if sizes.Value != nil {
+			for _, size := range *sizes.Value {
+				if size.Name == nil {
+					continue
+				}
+
+				if strings.EqualFold(*size.Name, vmSize) {
+					availableOnThisHost = true
+					break
+				}
+			}
+		}
+
+		if !availableOnThisHost {
+			log.Printf("[DEBUG] Requested VM Size isn't available on the Host - must switch host to resize..")
+			// Code="OperationNotAllowed"
+			// Message="Unable to resize the VM [name] because the requested size Standard_F4s_v2 is not available in the current hardware cluster.
+			//         The available sizes in this cluster are: [list]. The requested size might be available in other clusters of this region.
+			//         Read more on VM resizing strategy at https://aka.ms/azure-resizevm."
+			shouldDeallocate = true
+		}
+
+		update.VirtualMachineProperties.HardwareProfile = &compute.HardwareProfile{
+			VMSize: compute.VirtualMachineSizeTypes(vmSize),
+		}
+	}
+
+	if d.HasChange("tags") {
+		shouldUpdate = true
+
+		tagsRaw := d.Get("tags").(map[string]interface{})
+		update.Tags = tags.Expand(tagsRaw)
+	}
+
+	if shouldShutDown {
+		log.Printf("[DEBUG] Shutting Down Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		forceShutdown := false
+		future, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(forceShutdown))
+		if err != nil {
+			return fmt.Errorf("Error sending Power Off to Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for Power Off of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Shut Down Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	}
+
+	if shouldDeallocate {
+		if !hasEphemeralOSDisk {
+			log.Printf("[DEBUG] Deallocating Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+			future, err := client.Deallocate(ctx, id.ResourceGroup, id.Name)
+			if err != nil {
+				return fmt.Errorf("Error Deallocating Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("Error waiting for Deallocation of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+			}
+
+			log.Printf("[DEBUG] Deallocated Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		} else {
+			// Code="OperationNotAllowed" Message="Operation 'deallocate' is not supported for VMs or VM Scale Set instances using an ephemeral OS disk."
+			log.Printf("[DEBUG] Skipping deallocation for Windows Virtual Machine %q (Resource Group %q) since cannot deallocate a Virtual Machine with an Ephemeral OS Disk", id.Name, id.ResourceGroup)
+		}
+	}
+
+	// now the VM's shutdown/deallocated we can update the disk which can't be done via the VM API:
+	// Code="ResizeDiskError" Message="Managed disk resize via Virtual Machine [name] is not allowed. Please resize disk resource at [id]."
+	// Portal: "Disks can be resized or account type changed only when they are unattached or the owner VM is deallocated."
+	if d.HasChange("os_disk.0.disk_size_gb") {
+		diskName := d.Get("os_disk.0.name").(string)
+		newSize := d.Get("os_disk.0.disk_size_gb").(int)
+		log.Printf("[DEBUG] Resizing OS Disk %q for Windows Virtual Machine %q (Resource Group %q) to %dGB..", diskName, id.Name, id.ResourceGroup, newSize)
+
+		disksClient := meta.(*clients.Client).Compute.DisksClient
+
+		update := compute.DiskUpdate{
+			DiskUpdateProperties: &compute.DiskUpdateProperties{
+				DiskSizeGB: utils.Int32(int32(newSize)),
+			},
+		}
+
+		future, err := disksClient.Update(ctx, id.ResourceGroup, diskName, update)
+		if err != nil {
+			return fmt.Errorf("Error resizing OS Disk %q for Windows Virtual Machine %q (Resource Group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for resize of OS Disk %q for Windows Virtual Machine %q (Resource Group %q): %+v", diskName, id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Resized OS Disk %q for Windows Virtual Machine %q (Resource Group %q) to %dGB.", diskName, id.Name, id.ResourceGroup, newSize)
+	}
+
+	if shouldUpdate {
+		log.Printf("[DEBUG] Updating Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		future, err := client.Update(ctx, id.ResourceGroup, id.Name, update)
+		if err != nil {
+			return fmt.Errorf("Error updating Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for update of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Updated Windows Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
+	}
+
+	// if we've shut it down and it was turned off, let's boot it back up
+	if shouldTurnBackOn && shouldShutDown {
+		log.Printf("[DEBUG] Starting Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		future, err := client.Start(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			return fmt.Errorf("Error starting Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for start of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		log.Printf("[DEBUG] Started Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	}
+
+	return resourceWindowsVirtualMachineRead(d, meta)
+}
+
+func resourceWindowsVirtualMachineDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := ParseVirtualMachineID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.Name, virtualMachineResourceName)
+	defer locks.UnlockByName(id.Name, virtualMachineResourceName)
+
+	log.Printf("[DEBUG] Retrieving Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+
+	// ISSUE: XXX
+	// shutting down the Virtual Machine prior to removing it means users are no longer charged for the compute
+	// thus this can be a large cost-saving when deleting larger instances
+	// in addition - since we're shutting down the machine to remove it, forcing a power-off is fine (as opposed
+	// to waiting for a graceful shut down)
+	log.Printf("[DEBUG] Powering Off Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	skipShutdown := true
+	powerOffFuture, err := client.PowerOff(ctx, id.ResourceGroup, id.Name, utils.Bool(skipShutdown))
+	if err != nil {
+		return fmt.Errorf("Error powering off Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	if err := powerOffFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for power off of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Powered Off Windows Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
+
+	log.Printf("[DEBUG] Deleting Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	deleteFuture, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+	if err != nil {
+		return fmt.Errorf("Error deleting Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	if err := deleteFuture.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for deletion of Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+	}
+	log.Printf("[DEBUG] Deleted Windows Virtual Machine %q (Resource Group %q).", id.Name, id.ResourceGroup)
+
+	deleteOSDisk := meta.(*clients.Client).Features.VirtualMachine.DeleteOSDiskOnDeletion
+	if deleteOSDisk {
+		log.Printf("[DEBUG] Deleting OS Disk from Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+		disksClient := meta.(*clients.Client).Compute.DisksClient
+		managedDiskId := ""
+		if props := existing.VirtualMachineProperties; props != nil && props.StorageProfile != nil && props.StorageProfile.OsDisk != nil {
+			if disk := props.StorageProfile.OsDisk.ManagedDisk; disk != nil && disk.ID != nil {
+				managedDiskId = *disk.ID
+			}
+		}
+
+		if managedDiskId != "" {
+			diskId, err := parse.ManagedDiskID(managedDiskId)
+			if err != nil {
+				return err
+			}
+
+			diskDeleteFuture, err := disksClient.Delete(ctx, diskId.ResourceGroup, diskId.Name)
+			if err != nil {
+				if !response.WasNotFound(diskDeleteFuture.Response()) {
+					return fmt.Errorf("Error deleting OS Disk %q (Resource Group %q) for Windows Virtual Machine %q (Resource Group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+				}
+			}
+			if !response.WasNotFound(diskDeleteFuture.Response()) {
+				if err := diskDeleteFuture.WaitForCompletionRef(ctx, disksClient.Client); err != nil {
+					return fmt.Errorf("Error OS Disk %q (Resource Group %q) for Windows Virtual Machine %q (Resource Group %q): %+v", diskId.Name, diskId.ResourceGroup, id.Name, id.ResourceGroup, err)
+				}
+			}
+
+			log.Printf("[DEBUG] Deleted OS Disk from Windows Virtual Machine %q (Resource Group %q).", diskId.Name, diskId.ResourceGroup)
+		} else {
+			log.Printf("[DEBUG] Skipping Deleting OS Disk from Windows Virtual Machine %q (Resource Group %q) - cannot determine OS Disk ID.", id.Name, id.ResourceGroup)
+		}
+	} else {
+		log.Printf("[DEBUG] Skipping Deleting OS Disk from Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -182,7 +182,7 @@ func resourceWindowsVirtualMachine() *schema.Resource {
 				Type:         schema.TypeFloat,
 				Optional:     true,
 				Default:      -1,
-				ValidateFunc: validation.IntAtLeast(-1),
+				ValidateFunc: validation.FloatAtLeast(-1.0),
 			},
 
 			"plan": planSchema(),

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -667,7 +667,7 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error retrieving InstanceView for Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
-	shouldTurnBackOn := shouldBootVirtualMachine(instanceView)
+	shouldTurnBackOn := virtualMachineShouldBeStarted(instanceView)
 	hasEphemeralOSDisk := false
 	if props := existing.VirtualMachineProperties; props != nil {
 		if storage := props.StorageProfile; storage != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -508,7 +508,7 @@ func resourceWindowsVirtualMachineRead(d *schema.ResourceData, meta interface{})
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*resp.Location))
+		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
 	if err := d.Set("identity", flattenVirtualMachineIdentity(resp.Identity)); err != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -179,9 +179,10 @@ func resourceWindowsVirtualMachine() *schema.Resource {
 			},
 
 			"max_bid_price": {
-				Type:     schema.TypeFloat,
-				Optional: true,
-				Default:  -1,
+				Type:         schema.TypeFloat,
+				Optional:     true,
+				Default:      -1,
+				ValidateFunc: validation.IntAtLeast(-1),
 			},
 
 			"plan": planSchema(),
@@ -693,14 +694,10 @@ func resourceWindowsVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 		update.VirtualMachineProperties.DiagnosticsProfile = expandBootDiagnostics(bootDiagnosticsRaw)
 	}
 
-	if d.HasChange("custom_data") || d.HasChange("enable_automatic_updates") || d.HasChange("secret") {
+	if d.HasChange("secret") {
 		shouldUpdate = true
 
 		profile := compute.OSProfile{}
-
-		if d.HasChange("custom_data") {
-			profile.CustomData = utils.String(d.Get("custom_data").(string))
-		}
 
 		if d.HasChange("secret") {
 			secretsRaw := d.Get("secret").([]interface{})

--- a/azurerm/internal/tags/schema.go
+++ b/azurerm/internal/tags/schema.go
@@ -19,8 +19,9 @@ func SchemaDataSource() *schema.Schema {
 // require recreation of the resource
 func ForceNewSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:         schema.TypeMap,
-		Optional:     true,
+		Type:     schema.TypeMap,
+		Optional: true,
+		// TODO: remove "Computed" in 2.0
 		Computed:     true,
 		ForceNew:     true,
 		ValidateFunc: Validate,
@@ -33,8 +34,9 @@ func ForceNewSchema() *schema.Schema {
 // Schema returns the Schema used for Tags
 func Schema() *schema.Schema {
 	return &schema.Schema{
-		Type:         schema.TypeMap,
-		Optional:     true,
+		Type:     schema.TypeMap,
+		Optional: true,
+		// TODO: remove "Computed" in 2.0
 		Computed:     true,
 		ValidateFunc: Validate,
 		Elem: &schema.Schema{

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -22,6 +22,8 @@ Manages a Linux Virtual Machine.
 
 ~> **Note** This resource does not support attaching existing OS Disks. You can instead [capture an image of the OS Disk](image.html) or continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
 
+~> In this Beta release there's a known issue where the `public_ip_address` and `public_ip_addresses` fields may not be fully populated for Dynamic Public IP's. 
+
 ## Example Usage
 
 This example provisions a basic Linux Virtual Machine on an internal network. Additional examples of how to use the `azurerm_linux_virtual_machine` resource can be found [in the ./examples/virtual-machine/linux` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machine/linux).

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -1,0 +1,297 @@
+---
+subcategory: "Beta"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_linux_virtual_machine"
+description: |-
+  Manages a Linux Virtual Machine.
+---
+
+# azurerm_linux_virtual_machine
+
+Manages a Linux Virtual Machine.
+
+## Disclaimers
+
+~> **NOTE:** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
+
+-> **NOTE:** Terraform will automatically remove the OS Disk by default - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#argument-reference).
+
+~> **NOTE**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+-> This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
+
+## Example Usage
+
+This example provisions a basic Linux Virtual Machine on an internal network. Additional examples of how to use the `azurerm_linux_virtual_machine` resource can be found [in the ./examples/virtual-machine/linux` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machine/linux).
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "example-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "example" {
+ name                = "example-nic"
+ location            = azurerm_resource_group.example.location
+ resource_group_name = azurerm_resource_group.example.name
+
+ ip_configuration {
+   name                          = "internal"
+   subnet_id                     = azurerm_subnet.example.id
+   private_ip_address_allocation = "Dynamic"
+ }
+}
+
+resource "azurerm_linux_virtual_machine" "example" {
+  name                            = "example-machine"
+  resource_group_name             = azurerm_resource_group.example.name
+  location                        = azurerm_resource_group.example.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.example.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `admin_username` - (Required) The username of the local administrator used for the Virtual Machine. Changing this forces a new resource to be created.
+
+* `location` - (Required) The Azure location where the Linux Virtual Machine should exist. Changing this forces a new resource to be created.
+
+* `name` - (Required) The name of the Linux Virtual Machine. Changing this forces a new resource to be created.
+
+* `network_interface_ids` - (Required). A list of Network Interface ID's which should be attached to this Virtual Machine. The first Network Interface ID in this list will be the Primary Network Interface on the Virtual Machine.
+
+* `os_disk` - (Required) A `os_disk` block as defined below.
+
+* `resource_group_name` - (Required) The name of the Resource Group in which the Linux Virtual Machine should be exist. Changing this forces a new resource to be created.
+
+* `size` - (Required) The Virtual Machine SKU for the Scale Set, such as `Standard_F2`.
+
+---
+
+* `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
+
+* `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
+
+-> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
+~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
+
+* `admin_ssh_key` - (Optional) One or more `admin_ssh_key` blocks as defined below.
+
+~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
+
+* `allow_extension_operations` - (Optional) Should Extension Operations be allowed on this Virtual Machine? Changing this forces a new resource to be created.
+
+* `availability_set_id` - (Optional) Specifies the ID of the Availability Set in which the Virtual Machine should exist. Changing this forces a new resource to be created.
+
+* `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
+
+* `computer_name` - (Optional) Specifies the Hostname which should be used for this Virtual Machine. If unspecified this defaults to the value for the `name` field. Changing this forces a new resource to be created.
+
+* `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine. Changing this forces a new resource to be created.
+
+* `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Changing this forces a new resource to be created.
+
+* `disable_password_authentication` - (Optional) Should Password Authentication be disabled on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
+
+-> In general we'd recommend using SSH Keys for authentication rather than Passwords - but there's tradeoff's to each - please [see this thread for more information](https://security.stackexchange.com/questions/69407/why-is-using-an-ssh-key-more-secure-than-using-passwords).
+
+-> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
+
+* `eviction_policy` - (Optional) Specifies what should happen when the Virtual Machine is evicted for price reasons when using a Spot instance. At this time the only supported value is `Deallocate`. Changing this forces a new resource to be created.
+
+-> **NOTE:** This can only be configured when `priority` is set to `Spot`.
+
+* `identity` - (Optional) An `identity` block as defined below.
+
+* `max_bid_price` - (Optional) The maximum price you're willing to pay for this Virtual Machine, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machine will be evicted using the `eviction_policy`. Defaults to `-1`, which means that the Virtual Machine should not be evicted for price reasons.
+
+-> **NOTE:** This can only be configured when `priority` is set to `Spot`.
+
+* `plan` - (Optional) A `plan` block as defined below. Changing this forces a new resource to be created.
+
+* `priority`- (Optional) Specifies the priority of this Virtual Machine. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this forces a new resource to be created.
+
+* `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
+
+* `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group which the Virtual Machine should be assigned to. Changing this forces a new resource to be created.
+
+* `secret` - (Optional) One or more `secret` blocks as defined below.
+
+* `source_image_id` - (Optional) The ID of the Image which this Virtual Machine should be created from. Changing this forces a new resource to be created.
+
+-> **NOTE:** One of either `source_image_id` or `source_image_reference` must be set.
+
+* `source_image_reference` - (Optional) A `source_image_reference` block as defined below. Changing this forces a new resource to be created.
+
+-> **NOTE:** One of either `source_image_id` or `source_image_reference` must be set.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to this Virtual Machine.
+
+* `zone` - (Optional) The Zone in which this Virtual Machine should be created. Changing this forces a new resource to be created.
+
+---
+
+A `additional_capabilities` block supports the following:
+
+* `ultra_ssd_enabled` - (Optional) Should the capacity to enable Data Disks of the `UltraSSD_LRS` storage account type be supported on this Virtual Machine? Defaults to `false`. Changing this forces a new resource to be created.
+
+---
+
+A `admin_ssh_key` block supports the following:
+
+* `public_key` - (Required) The Public Key which should be used for authentication, which needs to be at least 2048-bit and in `ssh-rsa` format. Changing this forces a new resource to be created.
+
+* `username` - (Required) The Username for which this Public SSH Key should be configured. Changing this forces a new resource to be created.
+
+-> **NOTE:** The Azure VM Agent only allows creating SSH Keys at the path `/home/{username}/.ssh/authorized_keys` - as such this public key will be written to the authorized keys file.
+
+---
+
+A `boot_diagnostics` block supports the following:
+
+* `storage_account_uri` - (Required) The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor.
+
+---
+
+A `certificate` block supports the following:
+
+* `url` - (Required) The Secret URL of a Key Vault Certificate.
+
+-> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
+
+---
+
+A `diff_disk_settings` block supports the following:
+
+* `option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
+
+---
+
+A `identity` block supports the following:
+
+* `type` - (Required) The type of Managed Identity which should be assigned to the Linux Virtual Machine. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+
+* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Linux Virtual Machine.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned`.
+
+---
+
+A `os_disk` block supports the following:
+
+* `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS` and `Premium_LRS`. Changing this forces a new resource to be created.
+
+* `diff_disk_settings` (Optional) A `diff_disk_settings` block as defined above.
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to Encrypt this OS Disk.
+
+-> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
+
+~> **NOTE:** Disk Encryption Sets are in Public Preview in a limited set of regions
+
+* `disk_size_gb` - (Optional) The Size of the Internal OS Disk in GB, if you wish to vary from the size used in the image this Virtual Machine is sourced from.
+
+-> **NOTE:** If specified this must be equal to or larger than the size of the Image the Virtual Machine is based on. When creating a larger disk than exists in the image you'll need to repartition the disk to use the remaining space.
+
+* `name` - (Optional) The name which should be used for the Internal OS Disk. Changing this forces a new resource to be created.
+
+* `write_accelerator_enabled` - (Optional) Should Write Accelerator be Enabled for this OS Disk? Defaults to `false`.
+
+-> **NOTE:** This requires that the `storage_account_type` is set to `Premium_LRS` and that `caching` is set to `None`.
+
+---
+
+A `plan` block supports the following:
+
+* `name` - (Required) Specifies the Name of the Marketplace Image this Virtual Machine should be created from. Changing this forces a new resource to be created.
+
+* `product` - (Required) Specifies the Product of the Marketplace Image this Virtual Machine should be created from. Changing this forces a new resource to be created.
+
+* `publisher` - (Required) Specifies the Publisher of the Marketplace Image this Virtual Machine should be created from. Changing this forces a new resource to be created.
+
+---
+
+A `secret` block supports the following:
+
+* `certificate` - (Required) One or more `certificate` blocks as defined above.
+
+* `key_vault_id` - (Required) The ID of the Key Vault from which all Secrets should be sourced.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Linux Virtual Machine.
+
+* `identity` - An `identity` block as documented below.
+
+* `private_ip_address` - The Primary Private IP Address assigned to this Virtual Machine.
+
+* `private_ip_addresses` - A list of Private IP Addresses assigned to this Virtual Machine.
+
+* `public_ip_address` - The Primary Public IP Address assigned to this Virtual Machine.
+
+* `public_ip_addresses` - A list of the Public IP Addresses assigned to this Virtual Machine.
+
+* `virtual_machine_id` - A 128-bit identifier which uniquely identifies this Virtual Machine.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The ID of the System Managed Service Principal.
+
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 45 minutes) Used when creating the Linux Virtual Machine.
+* `update` - (Defaults to 45 minutes) Used when updating the Linux Virtual Machine.
+* `delete` - (Defaults to 45 minutes) Used when deleting the Linux Virtual Machine.
+
+## Import
+
+Linux Virtual Machines can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_linux_virtual_machine.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/Microsoft.Compute/virtualMachines/machine1
+```

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -49,23 +49,23 @@ resource "azurerm_subnet" "example" {
 }
 
 resource "azurerm_network_interface" "example" {
- name                = "example-nic"
- location            = azurerm_resource_group.example.location
- resource_group_name = azurerm_resource_group.example.name
+  name                = "example-nic"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.example.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 
 resource "azurerm_linux_virtual_machine" "example" {
-  name                            = "example-machine"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+  name                = "example-machine"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.example.id,
   ]

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -12,13 +12,15 @@ Manages a Linux Virtual Machine.
 
 ## Disclaimers
 
-~> **NOTE:** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
+~> **Note** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
 
--> **NOTE:** Terraform will automatically remove the OS Disk by default - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#argument-reference).
+-> **Note** Terraform will automatically remove the OS Disk by default - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#argument-reference).
 
-~> **NOTE**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+~> **Note** All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
--> This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
+-> **Note** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
+
+~> **Note** This resource does not support attaching existing OS Disks. You can instead [capture an image of the OS Disk](image.html) or continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
 
 ## Example Usage
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -22,7 +22,7 @@ Manages a Linux Virtual Machine.
 
 ~> **Note** This resource does not support attaching existing OS Disks. You can instead [capture an image of the OS Disk](image.html) or continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
 
-~> In this Beta release there's a known issue where the `public_ip_address` and `public_ip_addresses` fields may not be fully populated for Dynamic Public IP's. 
+~> In this Beta release there's a known issue where the `public_ip_address` and `public_ip_addresses` fields may not be fully populated for Dynamic Public IP's.
 
 ## Example Usage
 
@@ -285,6 +285,8 @@ An `identity` block exports the following:
 * `principal_id` - The ID of the System Managed Service Principal.
 
 ### Timeouts
+
+~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 
 * `identity` - (Optional) A `identity` block as defined below.
 
-* `max_bid_price` - (Optional) The maximum price you're willing to pay for each Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current low-priority price. If this bid price falls below the current low-priority price the Virtual Machines in the Scale Set will be evicted using the `eviction_policy`. Defaults to `-1`, which means that each Virtual Machine in this Scale Set should not be evicted for price reasons.
+* `max_bid_price` - (Optional) The maximum price you're willing to pay for each Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machines in the Scale Set will be evicted using the `eviction_policy`. Defaults to `-1`, which means that each Virtual Machine in this Scale Set should not be evicted for price reasons.
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -8,15 +8,19 @@ description: |-
 
 # azurerm_linux_virtual_machine_scale_set
 
-~> **NOTE:** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
-
-~> **NOTE**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
-
 Manages a Linux Virtual Machine Scale Set.
 
-~> **NOTE:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
+## Disclaimers
+
+~> **Note** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
+
+~> **Note:** Terraform will automatically update & reimage the nodes in the Scale Set if Required during an Update (for example, when changing Sku) - you can opt out of this by setting the `terraform_should_roll_instances_when_required` field to `false`.
+
+~> **Note**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 -> **Note** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#features).
+
+~> **Note:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
 
 ## Example Usage
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -14,8 +14,6 @@ Manages a Linux Virtual Machine Scale Set.
 
 ~> **Note** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
 
-~> **Note:** Terraform will automatically update & reimage the nodes in the Scale Set if Required during an Update (for example, when changing Sku) - you can opt out of this by setting the `terraform_should_roll_instances_when_required` field to `false`.
-
 ~> **Note**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 -> **Note** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#features).

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -20,6 +20,8 @@ Manages a Linux Virtual Machine Scale Set.
 
 ~> **Note:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
 
+~> In this Beta release there's a known issue where the `health_probe_id` is not passed to the Azure API during an update for machines using an Automatic or Rolling Upgrade Policy.
+
 ## Example Usage
 
 This example provisions a basic Linux Virtual Machine Scale Set on an internal network. Additional examples of how to use the `azurerm_linux_virtual_machine_scale_set` resource can be found [in the ./examples/vm-scale-set/linux` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/vm-scale-set/linux).

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -398,6 +398,8 @@ An `identity` block exports the following:
 
 ### Timeouts
 
+~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
+
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Linux Virtual Machine Scale Set.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -22,6 +22,8 @@ Manages a Windows Virtual Machine.
 
 ~> **Note** This resource does not support attaching existing OS Disks. You can instead [capture an image of the OS Disk](image.html) or continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
 
+~> In this Beta release there's a known issue where the `public_ip_address` and `public_ip_addresses` fields may not be fully populated for Dynamic Public IP's.
+
 ## Example Usage
 
 This example provisions a basic Windows Virtual Machine on an internal network. Additional examples of how to use the `azurerm_windows_virtual_machine` resource can be found [in the ./examples/virtual-machine/windows` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machine/windows).

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -12,13 +12,15 @@ Manages a Windows Virtual Machine.
 
 ## Disclaimers
 
-~> **NOTE:** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
+~> **Note** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
 
--> **NOTE:** Terraform will automatically remove the OS Disk by default - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#argument-reference).
+-> **Note** Terraform will automatically remove the OS Disk by default - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#argument-reference).
 
-~> **NOTE**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+~> **Note** All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
--> This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
+~> **Note** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
+
+~> **Note** This resource does not support attaching existing OS Disks. You can instead [capture an image of the OS Disk](image.html) or continue to use [the `azurerm_virtual_machine` resource](virtual_machine.html) instead.
 
 ## Example Usage
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -1,14 +1,14 @@
 ---
 subcategory: "Beta"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_linux_virtual_machine"
+page_title: "Azure Resource Manager: azurerm_windows_virtual_machine"
 description: |-
-  Manages a Linux Virtual Machine.
+  Manages a Windows Virtual Machine.
 ---
 
-# azurerm_linux_virtual_machine
+# azurerm_windows_virtual_machine
 
-Manages a Linux Virtual Machine.
+Manages a Windows Virtual Machine.
 
 ## Disclaimers
 
@@ -22,7 +22,7 @@ Manages a Linux Virtual Machine.
 
 ## Example Usage
 
-This example provisions a basic Linux Virtual Machine on an internal network. Additional examples of how to use the `azurerm_linux_virtual_machine` resource can be found [in the ./examples/virtual-machine/linux` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machine/linux).
+This example provisions a basic Windows Virtual Machine on an internal network. Additional examples of how to use the `azurerm_windows_virtual_machine` resource can be found [in the ./examples/virtual-machine/windows` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/virtual-machine/windows).
 
 ```hcl
 resource "azurerm_resource_group" "example" {
@@ -56,20 +56,16 @@ resource "azurerm_network_interface" "example" {
  }
 }
 
-resource "azurerm_linux_virtual_machine" "example" {
-  name                            = "example-machine"
-  resource_group_name             = azurerm_resource_group.example.name
-  location                        = azurerm_resource_group.example.location
-  size                            = "Standard_F2"
-  admin_username                  = "adminuser"
+resource "azurerm_windows_virtual_machine" "example" {
+  name                  = "example-machine"
+  resource_group_name   = azurerm_resource_group.example.name
+  location              = azurerm_resource_group.example.location
+  size                  = "Standard_F2"
+  admin_username        = "adminuser"
+  admin_password        = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.example.id,
   ]
-
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = file("~/.ssh/id_rsa.pub")
-  }
 
   os_disk {
     caching              = "ReadWrite"
@@ -77,9 +73,9 @@ resource "azurerm_linux_virtual_machine" "example" {
   }
 
   source_image_reference {
-    publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
     version   = "latest"
   }
 }
@@ -89,17 +85,19 @@ resource "azurerm_linux_virtual_machine" "example" {
 
 The following arguments are supported:
 
+* `admin_password` - (Required) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
+
 * `admin_username` - (Required) The username of the local administrator used for the Virtual Machine. Changing this forces a new resource to be created.
 
-* `location` - (Required) The Azure location where the Linux Virtual Machine should exist. Changing this forces a new resource to be created.
+* `location` - (Required) The Azure location where the Windows Virtual Machine should exist. Changing this forces a new resource to be created.
 
-* `name` - (Required) The name of the Linux Virtual Machine. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Windows Virtual Machine. Changing this forces a new resource to be created.
 
 * `network_interface_ids` - (Required). A list of Network Interface ID's which should be attached to this Virtual Machine. The first Network Interface ID in this list will be the Primary Network Interface on the Virtual Machine.
 
 * `os_disk` - (Required) A `os_disk` block as defined below.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Linux Virtual Machine should be exist. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the Resource Group in which the Windows Virtual Machine should be exist. Changing this forces a new resource to be created.
 
 * `size` - (Required) The SKU which should be used for this Virtual Machine, such as `Standard_F2`.
 
@@ -107,14 +105,7 @@ The following arguments are supported:
 
 * `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
 
-* `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
-
--> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
-~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
-
-* `admin_ssh_key` - (Optional) One or more `admin_ssh_key` blocks as defined below.
-
-~> **NOTE:** One of either `admin_password` or `admin_ssh_key` must be specified.
+* `additional_unattend_content` - (Optional) One or more `additional_unattend_content` blocks as defined below. Changing this forces a new resource to be created.
 
 * `allow_extension_operations` - (Optional) Should Extension Operations be allowed on this Virtual Machine? Changing this forces a new resource to be created.
 
@@ -128,17 +119,15 @@ The following arguments are supported:
 
 * `dedicated_host_id` - (Optional) The ID of a Dedicated Host where this machine should be run on. Changing this forces a new resource to be created.
 
-* `disable_password_authentication` - (Optional) Should Password Authentication be disabled on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
-
--> In general we'd recommend using SSH Keys for authentication rather than Passwords - but there's tradeoff's to each - please [see this thread for more information](https://security.stackexchange.com/questions/69407/why-is-using-an-ssh-key-more-secure-than-using-passwords).
-
--> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
+* `enable_automatic_updates` - (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created.
 
 * `eviction_policy` - (Optional) Specifies what should happen when the Virtual Machine is evicted for price reasons when using a Spot instance. At this time the only supported value is `Deallocate`. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
 
 * `identity` - (Optional) An `identity` block as defined below.
+
+* `license_type` - (Optional) Specifies the type of on-premise license (also known as [Azure Hybrid Use Benefit](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing)) which should be used for this Virtual Machine. Possible values are `None`, `Windows_Client` and `Windows_Server`. Changing this forces a new resource to be created.
 
 * `max_bid_price` - (Optional) The maximum price you're willing to pay for this Virtual Machine, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machine will be evicted using the `eviction_policy`. Defaults to `-1`, which means that the Virtual Machine should not be evicted for price reasons.
 
@@ -164,6 +153,10 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags which should be assigned to this Virtual Machine.
 
+* `timezone` - (Optional) Specifies the Time Zone which should be used by the Virtual Machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).
+
+* `winrm_listener` - (Optional) One or more `winrm_listener` blocks as defined below.
+
 * `zone` - (Optional) The Zone in which this Virtual Machine should be created. Changing this forces a new resource to be created.
 
 ---
@@ -174,13 +167,11 @@ A `additional_capabilities` block supports the following:
 
 ---
 
-A `admin_ssh_key` block supports the following:
+A `additional_unattend_content` block supports the following:
 
-* `public_key` - (Required) The Public Key which should be used for authentication, which needs to be at least 2048-bit and in `ssh-rsa` format. Changing this forces a new resource to be created.
+* `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component. Changing this forces a new resource to be created.
 
-* `username` - (Required) The Username for which this Public SSH Key should be configured. Changing this forces a new resource to be created.
-
--> **NOTE:** The Azure VM Agent only allows creating SSH Keys at the path `/home/{username}/.ssh/authorized_keys` - as such this public key will be written to the authorized keys file.
+* `setting` - (Required) The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`. Changing this forces a new resource to be created.
 
 ---
 
@@ -191,6 +182,8 @@ A `boot_diagnostics` block supports the following:
 ---
 
 A `certificate` block supports the following:
+
+* `store` - (Required) The certificate store on the Virtual Machine where the certificate should be added.
 
 * `url` - (Required) The Secret URL of a Key Vault Certificate.
 
@@ -206,9 +199,9 @@ A `diff_disk_settings` block supports the following:
 
 A `identity` block supports the following:
 
-* `type` - (Required) The type of Managed Identity which should be assigned to the Linux Virtual Machine. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+* `type` - (Required) The type of Managed Identity which should be assigned to the Windows Virtual Machine. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
 
-* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Linux Virtual Machine.
+* `identity_ids` - (Optional) A list of User Managed Identity ID's which should be assigned to the Windows Virtual Machine.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned`.
 
@@ -256,11 +249,17 @@ A `secret` block supports the following:
 
 * `key_vault_id` - (Required) The ID of the Key Vault from which all Secrets should be sourced.
 
+---
+
+A `winrm_listener` block supports the following:
+
+* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The ID of the Linux Virtual Machine.
+* `id` - The ID of the Windows Virtual Machine.
 
 * `identity` - An `identity` block as documented below.
 
@@ -284,14 +283,14 @@ An `identity` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 45 minutes) Used when creating the Linux Virtual Machine.
-* `update` - (Defaults to 45 minutes) Used when updating the Linux Virtual Machine.
-* `delete` - (Defaults to 45 minutes) Used when deleting the Linux Virtual Machine.
+* `create` - (Defaults to 45 minutes) Used when creating the Windows Virtual Machine.
+* `update` - (Defaults to 45 minutes) Used when updating the Windows Virtual Machine.
+* `delete` - (Defaults to 45 minutes) Used when deleting the Windows Virtual Machine.
 
 ## Import
 
-Linux Virtual Machines can be imported using the `resource id`, e.g.
+Windows Virtual Machines can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_linux_virtual_machine.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/Microsoft.Compute/virtualMachines/machine1
+terraform import azurerm_windows_virtual_machine.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/Microsoft.Compute/virtualMachines/machine1
 ```

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -49,24 +49,24 @@ resource "azurerm_subnet" "example" {
 }
 
 resource "azurerm_network_interface" "example" {
- name                = "example-nic"
- location            = azurerm_resource_group.example.location
- resource_group_name = azurerm_resource_group.example.name
+  name                = "example-nic"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
- ip_configuration {
-   name                          = "internal"
-   subnet_id                     = azurerm_subnet.example.id
-   private_ip_address_allocation = "Dynamic"
- }
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
+  }
 }
 
 resource "azurerm_windows_virtual_machine" "example" {
-  name                  = "example-machine"
-  resource_group_name   = azurerm_resource_group.example.name
-  location              = azurerm_resource_group.example.location
-  size                  = "Standard_F2"
-  admin_username        = "adminuser"
-  admin_password        = "P@$$w0rd1234!"
+  name                = "example-machine"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
   network_interface_ids = [
     azurerm_network_interface.example.id,
   ]

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -285,6 +285,8 @@ An `identity` block exports the following:
 
 ### Timeouts
 
+~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
+
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 45 minutes) Used when creating the Windows Virtual Machine.

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -8,15 +8,19 @@ description: |-
 
 # azurerm_windows_virtual_machine_scale_set
 
-~> **NOTE:** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
-
-~> **NOTE**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
-
 Manages a Windows Virtual Machine Scale Set.
 
-~> **NOTE:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
+## Disclaimers
+
+~> **Note** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
+
+~> **Note:** Terraform will automatically update & reimage the nodes in the Scale Set if Required during an Update (for example, when changing Sku) - you can opt out of this by setting the `terraform_should_roll_instances_when_required` field to `false`.
+
+~> **Note**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 -> **Note** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#features).
+
+~> **Note:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
 
 ## Example Usage
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -400,6 +400,8 @@ An `identity` block exports the following:
 
 ### Timeouts
 
+~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
+
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Windows Virtual Machine Scale Set.

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -20,6 +20,8 @@ Manages a Windows Virtual Machine Scale Set.
 
 ~> **Note:** This resource does not support Unmanaged Disks. If you need to use Unmanaged Disks you can continue to use [the `azurerm_virtual_machine_scale_set` resource](virtual_machine_scale_set.html) instead
 
+~> In this Beta release there's a known issue where the `health_probe_id` is not passed to the Azure API during an update for machines using an Automatic or Rolling Upgrade Policy.
+
 ## Example Usage
 
 This example provisions a basic Windows Virtual Machine Scale Set on an internal network. Additional examples of how to use the `azurerm_windows_virtual_machine_scale_set` resource can be found [in the ./examples/vm-scale-set/windows` directory within the Github Repository](https://github.com/terraform-providers/terraform-provider-azurerm/tree/master/examples/vm-scale-set/windows).

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -14,8 +14,6 @@ Manages a Windows Virtual Machine Scale Set.
 
 ~> **Note** **This resource is in Beta** and as such the Schema can change in Minor versions of the Provider.
 
-~> **Note:** Terraform will automatically update & reimage the nodes in the Scale Set if Required during an Update (for example, when changing Sku) - you can opt out of this by setting the `terraform_should_roll_instances_when_required` field to `false`.
-
 ~> **Note**: All arguments including the administrator login and password will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
 -> **Note** Terraform will automatically update & reimage the nodes in the Scale Set (if Required) during an Update - this behaviour can be configured [using the `features` setting within the Provider block](https://www.terraform.io/docs/providers/azurerm/index.html#features).

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -130,7 +130,7 @@ The following arguments are supported:
 
 * `identity` - (Optional) A `identity` block as defined below.
 
-* `license_type` - (Optional) Specifies the type of on-premise license (also known as [Azure Hybrid Use Benefit](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing)) which should be used for this Virtual Machine Scale Set. Possible values are `Windows_Client` and `Windows_Server`. Changing this forces a new resource to be created.
+* `license_type` - (Optional) Specifies the type of on-premise license (also known as [Azure Hybrid Use Benefit](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing)) which should be used for this Virtual Machine Scale Set. Possible values are `None`, `Windows_Client` and `Windows_Server`. Changing this forces a new resource to be created.
 
 * `max_bid_price` - (Optional) The maximum price you're willing to pay for each Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machines in the Scale Set will be evicted using the `eviction_policy`. Defaults to `-1`, which means that each Virtual Machine in the Scale Set should not be evicted for price reasons.
 
@@ -184,9 +184,9 @@ A `additional_capabilities` block supports the following:
 
 A `additional_unattend_content` block supports the following:
 
-* `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component.
+* `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component. Changing this forces a new resource to be created.
 
-* `setting` - (Required) The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`.
+* `setting` - (Required) The name of the setting to which the content applies. Possible values are `AutoLogon` and `FirstLogonCommands`. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -104,7 +104,7 @@ The following arguments are supported:
 
 * `additional_capabilities` - (Optional) A `additional_capabilities` block as defined below.
 
-* `additional_unattend_config` - (Optional) One or more `additional_unattend_config` blocks as defined below.
+* `additional_unattend_content` - (Optional) One or more `additional_unattend_content` blocks as defined below.
 
 * `automatic_os_upgrade_policy` - (Optional) A `automatic_os_upgrade_policy` block as defined below. This is Required and can only be specified when `upgrade_mode` is set to `Automatic`.
 
@@ -132,7 +132,7 @@ The following arguments are supported:
 
 * `license_type` - (Optional) Specifies the type of on-premise license (also known as [Azure Hybrid Use Benefit](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing)) which should be used for this Virtual Machine Scale Set. Possible values are `Windows_Client` and `Windows_Server`. Changing this forces a new resource to be created.
 
-* `max_bid_price` - (Optional) The maximum price you're willing to pay for each Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current low-priority price. If this bid price falls below the current low-priority price the Virtual Machines in the Scale Set will be evicted using the `eviction_policy`. Defaults to `-1`, which means that each Virtual Machine in the Scale Set should not be evicted for price reasons.
+* `max_bid_price` - (Optional) The maximum price you're willing to pay for each Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machines in the Scale Set will be evicted using the `eviction_policy`. Defaults to `-1`, which means that each Virtual Machine in the Scale Set should not be evicted for price reasons.
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
 
@@ -182,7 +182,7 @@ A `additional_capabilities` block supports the following:
 
 ---
 
-A `additional_unattend_config` block supports the following:
+A `additional_unattend_content` block supports the following:
 
 * `content` - (Required) The XML formatted content that is added to the unattend.xml file for the specified path and component.
 


### PR DESCRIPTION
This Pull Request introduces two new resources previously outlined in #2807:

* `azurerm_linux_virtual_machine`
* `azurerm_windows_virtual_machine`

As detailed in #2807 - the `azurerm_virtual_machine` resource was first added to Terraform in 2006 when Azure Resource Manager was in Beta. Over time both the behaviour and capabilities of the Virtual Machine API have diverged sufficiently that whilst the existing resource captures most of the use-cases - it's fallen out of sync.

Whilst it's potentially possible to fix some of these issues with the `azurerm_virtual_machine` resource - in practice some of these are larger design issues where the Azure API is now sufficiently generic it's hard to provide useful validation.

As such this PR introduces two resources (one for Linux/Windows) for managing Virtual Machines allowing us to provide more granular validation and the new features.

At this time there's a couple of known issues/failing tests which we'll fix prior to GA:

1. The `public_ip_address` and `public_ip_addresses` fields aren't correctly populated when using a Dynamic Public IP
2. The "image" acceptance tests need updating - on Linux the Public IP needs fixing; on Windows we need to switch to using WinRM

There's Acceptance Tests covering both of these issues, but these are acceptable limitations for the Beta.

Examples for both the new Virtual Machine & VM Scale Set resources will be added in a subsequent PR since this won't go live until the Beta / is out of scope for this PR.

---

Acceptance Tests for the VM resources:

<img width="717" alt="Screenshot 2020-01-29 at 12 51 15" src="https://user-images.githubusercontent.com/666005/73354452-0be05400-4296-11ea-9e35-e513b5b2919b.png">

Acceptance Tests for the VM Scale set resources:

<img width="744" alt="Screenshot 2020-01-29 at 12 51 34" src="https://user-images.githubusercontent.com/666005/73354468-169ae900-4296-11ea-8f8d-23a9a36a3824.png">


(these are also expected/will be fixed by other open PR's)

---

Depends on #5542

Fixes #148
Fixes #184
Fixes #486
Fixes #603
Fixes #956
Fixes #1013
Fixes #1170
Fixes #1279
Fixes #1433
Fixes #1670
Fixes #2298
Fixes #3592
Fixes #4750
Fixes #4749
Fixes #5068
Fixes #5447
Fixes #5482