### PR TITLE
Update dns_caa_record.html.markdown

### DIFF
--- a/website/docs/r/dns_caa_record.html.markdown
+++ b/website/docs/r/dns_caa_record.html.markdown
@@ -62,7 +62,7 @@ resource "azurerm_dns_caa_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS CAA Record.
+* `name` - (Required) The name of the DNS CAA Record. If you are creating the record in the apex of the zone use `"@"` as the name.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Clarified use of the name parameter when the record is in the zone apex.
The Azure DNS doco doesnt make it clear and the correct syntax is buried in the Azure CLI documentation.