### PR TITLE
azurerm_storage_account - fix hanging destroy caused by multiple network rules 

### DIFF
--- a/azurerm/helpers/common/arrays.go
+++ b/azurerm/helpers/common/arrays.go
@@ -1,0 +1,16 @@
+package common
+
+// Remove duplicates from the input array and return unify array (without duplicated elements)
+func RemoveDuplicatesFromStringArray(elements []string) []string {
+	visited := map[string]bool{}
+	result := []string{}
+
+	for v := range elements {
+		if visited[elements[v]] != true {
+			visited[elements[v]] = true          // Mark the element as visited.
+			result = append(result, elements[v]) // Add it to the result.
+		}
+	}
+
+	return result
+}

--- a/azurerm/helpers/common/arrays.go
+++ b/azurerm/helpers/common/arrays.go
@@ -6,7 +6,7 @@ func RemoveDuplicatesFromStringArray(elements []string) []string {
 	result := []string{}
 
 	for v := range elements {
-		if visited[elements[v]] != true {
+		if !visited[elements[v]] {
 			visited[elements[v]] = true          // Mark the element as visited.
 			result = append(result, elements[v]) // Add it to the result.
 		}

--- a/azurerm/helpers/common/arrays_test.go
+++ b/azurerm/helpers/common/arrays_test.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveDuplicatesInStringArray(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Input  []string
+		Result []string
+	}{
+		{
+			Name:   "contain duplicates",
+			Input:  []string{"string1", "string2", "string1", "string3", ""},
+			Result: []string{"string1", "string2", "string3", ""},
+		},
+		{
+			Name:   "does not contain duplicates",
+			Input:  []string{"string1", "string2", "string3", ""},
+			Result: []string{"string1", "string2", "string3", ""},
+		},
+		{
+			Name:   "empty array",
+			Input:  []string{},
+			Result: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			if !reflect.DeepEqual(RemoveDuplicatesFromStringArray(tc.Input), tc.Result) {
+				t.Fatalf("Expected TestRemoveDuplicatesInStringArray to return %v", tc.Result)
+			}
+		})
+	}
+}

--- a/azurerm/internal/locks/lock.go
+++ b/azurerm/internal/locks/lock.go
@@ -1,9 +1,8 @@
 package locks
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/common"
 )
 
 // armMutexKV is the instance of MutexKV for ARM resources
@@ -20,11 +19,10 @@ func ByName(name string, resourceType string) {
 }
 
 func MultipleByName(names *[]string, resourceType string) {
-	for i, name := range *names {
-		// at the end of every array item add its index. This way we guarantee that this item will be unique (no duplicates are possible)
-		uniqueValue := fmt.Sprintf("%s-arrIdx-%d", name, i)
+	newSlice := common.RemoveDuplicatesFromStringArray(*names)
 
-		ByName(uniqueValue, resourceType)
+	for _, name := range newSlice {
+		ByName(name, resourceType)
 	}
 }
 
@@ -38,10 +36,9 @@ func UnlockByName(name string, resourceType string) {
 }
 
 func UnlockMultipleByName(names *[]string, resourceType string) {
-	for i, name := range *names {
-		// at the end of every array item add its index. We need to add this sufix because it was added during the lock process
-		uniqueValue := fmt.Sprintf("%s-arrIdx-%d", name, i)
+	newSlice := common.RemoveDuplicatesFromStringArray(*names)
 
-		UnlockByName(uniqueValue, resourceType)
+	for _, name := range newSlice {
+		UnlockByName(name, resourceType)
 	}
 }

--- a/azurerm/internal/locks/lock.go
+++ b/azurerm/internal/locks/lock.go
@@ -1,6 +1,10 @@
 package locks
 
-import "github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
+)
 
 // armMutexKV is the instance of MutexKV for ARM resources
 var armMutexKV = mutexkv.NewMutexKV()
@@ -16,8 +20,11 @@ func ByName(name string, resourceType string) {
 }
 
 func MultipleByName(names *[]string, resourceType string) {
-	for _, name := range *names {
-		ByName(name, resourceType)
+	for i, name := range *names {
+		// at the end of every array item add its index. This way we guarantee that this item will be unique (no duplicates are possible)
+		uniqueValue := fmt.Sprintf("%s-arrIdx-%d", name, i)
+
+		ByName(uniqueValue, resourceType)
 	}
 }
 
@@ -31,7 +38,10 @@ func UnlockByName(name string, resourceType string) {
 }
 
 func UnlockMultipleByName(names *[]string, resourceType string) {
-	for _, name := range *names {
-		UnlockByName(name, resourceType)
+	for i, name := range *names {
+		// at the end of every array item add its index. We need to add this sufix because it was added during the lock process
+		uniqueValue := fmt.Sprintf("%s-arrIdx-%d", name, i)
+
+		UnlockByName(uniqueValue, resourceType)
 	}
 }

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1305,12 +1305,6 @@ func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) e
 					}
 
 					networkName := id.Path["virtualNetworks"]
-
-					subnetName := id.Path["subnets"]
-					if subnetName != "" {
-						networkName = fmt.Sprintf("%s-%s", networkName, subnetName)
-					}
-
 					for _, virtualNetworkName := range virtualNetworkNames {
 						if networkName == virtualNetworkName {
 							continue

--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -1305,6 +1305,12 @@ func resourceArmStorageAccountDelete(d *schema.ResourceData, meta interface{}) e
 					}
 
 					networkName := id.Path["virtualNetworks"]
+
+					subnetName := id.Path["subnets"]
+					if subnetName != "" {
+						networkName = fmt.Sprintf("%s-%s", networkName, subnetName)
+					}
+
 					for _, virtualNetworkName := range virtualNetworkNames {
 						if networkName == virtualNetworkName {
 							continue


### PR DESCRIPTION
Fix for issue #5434 (and related issues: #5530 , #3156 )

* **Problem:** If you have a storage account with more than one network rule set - the destroy action hangs forever and the real destroy/deletion of the resource never happens. If you have a storage account with zero or one network rule attached then this problem is irrelevant - the destroy action completes successfully.

* **Reason:** In the `resourceArmStorageAccountDelete` method located in _azurerm/internal/services/storage/resource_arm_storage_account.go_ there is a string array which is passed to the mutex lock method `locks.MultipleByName`. The reason for the problem is that the creation of this array does not cover all possible cases. The logic of the method assumes that you have different virtual networks and inserts them into the array used for locking but does not work correctly in the corner case where you have one virtual network with few sub-networks and you are assigning these sub-networks as a network rules to your storage account. Hence the array passed to the lock method contains n-times strings with the same name (same strings). When this array goes to the mutex the first string is used to lock, the second string is used to lock etc. but at the end all the strings are the same and when the first unlock comes - everything is OK but when a second, third or what so ever unlock hits... dead lock there is nothing to unlock because the first unlock already used the string and it was removed and all other unlocks are trying to use something that simply does not exists.

* **Resolution:** Check if there are subnets and attach them to the network name hence all the strings used to populate the array are unique and the lock-unlock problem is resolved.