### PR TITLE
`network_security_rule`: suppress case diff on `resource_group_name`

### DIFF
--- a/azurerm/internal/services/network/resource_arm_network_security_rule.go
+++ b/azurerm/internal/services/network/resource_arm_network_security_rule.go
@@ -41,7 +41,7 @@ func resourceArmNetworkSecurityRule() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"network_security_group_name": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
This PR addresses an issue where a network security rule can be created with `resource_group_name` having different casing than the network security group to which it's being attached.

For example
```
resource "azurerm_network_security_group" "example" {
  resource_group_name = "acctestRG-123"
  ...
}

resource "azurerm_network_security_rule" "example" {
  resource_group_name = "acctestrg-123"
  ...
}
```
would successfully apply, but produces non-empty plan after apply. 