### PR TITLE
Enhancement: `azurerm_private_endpoint` expose mapping between `group_id` and `subresource_names` 

### DIFF
--- a/azurerm/helpers/azure/string.go
+++ b/azurerm/helpers/azure/string.go
@@ -1,0 +1,10 @@
+package azure
+
+import (
+	"strings"
+)
+
+func StringContains(sourceStr, subStr string) bool {
+	sourceStr, subStr = strings.ToUpper(sourceStr), strings.ToUpper(subStr)
+	return strings.Contains(sourceStr, subStr)
+}

--- a/azurerm/internal/services/network/resource_arm_private_endpoint.go
+++ b/azurerm/internal/services/network/resource_arm_private_endpoint.go
@@ -143,7 +143,7 @@ func resourceArmPrivateEndpointCreateUpdate(d *schema.ResourceData, meta interfa
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters)
 	if err != nil {
 		if azure.StringContains(err.Error(), "is missing required parameter 'group Id'") {
-			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q) due to missing group ID, ensure that the `subresource_names` type is populated: %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q) due to missing 'group Id', ensure that the 'subresource_names' type is populated: %+v", name, resourceGroup, err)
 		} else {
 			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}

--- a/azurerm/internal/services/network/resource_arm_private_endpoint.go
+++ b/azurerm/internal/services/network/resource_arm_private_endpoint.go
@@ -142,7 +142,11 @@ func resourceArmPrivateEndpointCreateUpdate(d *schema.ResourceData, meta interfa
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters)
 	if err != nil {
-		return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q): %+v", name, resourceGroup, err)
+		if azure.StringContains(err.Error(), "is missing required parameter 'group Id'") {
+			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q): %+v Info=[terraform subresource_names attribute corresponds to the ARM group_id attribute]", name, resourceGroup, err)
+		} else {
+			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
 	}
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
 		return fmt.Errorf("Error waiting for creation of Private Endpoint %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/internal/services/network/resource_arm_private_endpoint.go
+++ b/azurerm/internal/services/network/resource_arm_private_endpoint.go
@@ -143,7 +143,7 @@ func resourceArmPrivateEndpointCreateUpdate(d *schema.ResourceData, meta interfa
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters)
 	if err != nil {
 		if azure.StringContains(err.Error(), "is missing required parameter 'group Id'") {
-			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q): %+v Info=[terraform subresource_names attribute corresponds to the ARM group_id attribute]", name, resourceGroup, err)
+			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q) due to missing grouop ID, ensure that the `subresource_names` type is populated: %+v", name, resourceGroup, err)
 		} else {
 			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}

--- a/azurerm/internal/services/network/resource_arm_private_endpoint.go
+++ b/azurerm/internal/services/network/resource_arm_private_endpoint.go
@@ -143,7 +143,7 @@ func resourceArmPrivateEndpointCreateUpdate(d *schema.ResourceData, meta interfa
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, name, parameters)
 	if err != nil {
 		if azure.StringContains(err.Error(), "is missing required parameter 'group Id'") {
-			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q) due to missing grouop ID, ensure that the `subresource_names` type is populated: %+v", name, resourceGroup, err)
+			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q) due to missing group ID, ensure that the `subresource_names` type is populated: %+v", name, resourceGroup, err)
 		} else {
 			return fmt.Errorf("Error creating Private Endpoint %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -117,7 +117,7 @@ A `private_service_connection` supports the following:
 
 * `private_connection_resource_id` - (Required) The ID of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. Changing this forces a new resource to be created.
 
-* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. subresource_names corresponds to group_id. Changing this forces a new resource to be created.
+* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Changing this forces a new resource to be created.
 
 -> Several possible values for this field are shown below, however this is not extensive:
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -117,7 +117,7 @@ A `private_service_connection` supports the following:
 
 * `private_connection_resource_id` - (Required) The ID of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. Changing this forces a new resource to be created.
 
-* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. Changing this forces a new resource to be created.
+* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. subresource_names corresponds to group_id. Changing this forces a new resource to be created.
 
 -> Several possible values for this field are shown below, however this is not extensive:
 


### PR DESCRIPTION
Some confusion about the naming between terraform and ARM was brought to our attention, adding this code to clarify the mapping.