### PR TITLE
r/(linux|windows)_virtual_machine_scale_set: ultra ssd's now need to …

### DIFF
--- a/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_disk_data_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_disk_data_test.go
@@ -765,6 +765,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   instances           = 1
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
+  zones               = [1, 2, 3]
 
   disable_password_authentication = false
 

--- a/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_disk_data_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_disk_data_test.go
@@ -757,6 +757,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
   instances           = 1
   admin_username      = "adminuser"
   admin_password      = "P@ssword1234!"
+  zones               = [1, 2, 3]
 
   source_image_reference {
     publisher = "MicrosoftWindowsServer"


### PR DESCRIPTION
…be in an availability zone:

Looks like a behavioural change in the API since the resource was first built:

```
Code="InvalidParameter" Message="Feature 'UltraSSD' can be used only with Virtual Machine Scale Sets in an Availability Zone." Target="additionalCapabilities.ultraSSDEnabled"
```