### PR TITLE
r/(linux|windows)_virtual_machine_scale_set: import validation

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_linux_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_linux_virtual_machine_scale_set.go
@@ -28,11 +28,10 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 		Update: resourceArmLinuxVirtualMachineScaleSetUpdate,
 		Delete: resourceArmLinuxVirtualMachineScaleSetDelete,
 
-		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+		Importer: azSchema.ValidateResourceIDPriorToImportThen(func(id string) error {
 			_, err := ParseVirtualMachineScaleSetID(id)
-			// TODO: (prior to Beta) look up the VM & confirm this is a Linux VMSS
 			return err
-		}),
+		}, importVirtualMachineScaleSet(compute.Linux, "azurerm_linux_virtual_machine_scale_set")),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(time.Minute * 30),
@@ -84,12 +83,11 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 			"additional_capabilities": VirtualMachineScaleSetAdditionalCapabilitiesSchema(),
 
 			"admin_password": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  true,
-				Sensitive: true,
-				// TODO: does this want:
-				// DiffSuppressFunc: linuxAdminPasswordDiffSuppressFunc,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
 			},
 
 			"admin_ssh_key": SSHKeysSchema(false),

--- a/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_windows_virtual_machine_scale_set.go
@@ -28,11 +28,10 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 		Update: resourceArmWindowsVirtualMachineScaleSetUpdate,
 		Delete: resourceArmWindowsVirtualMachineScaleSetDelete,
 
-		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+		Importer: azSchema.ValidateResourceIDPriorToImportThen(func(id string) error {
 			_, err := ParseVirtualMachineScaleSetID(id)
-			// TODO: (prior to Beta) look up the VM & confirm this is a Windows VMSS
 			return err
-		}),
+		}, importVirtualMachineScaleSet(compute.Windows, "azurerm_windows_virtual_machine_scale_set")),
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
@@ -65,11 +64,12 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 			},
 
 			"admin_password": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				Sensitive:    true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				Sensitive:        true,
+				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
+				ValidateFunc:     validation.StringIsNotEmpty,
 			},
 
 			"network_interface": VirtualMachineScaleSetNetworkInterfaceSchema(),

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
@@ -1,0 +1,66 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+)
+
+func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceType string) func(d *schema.ResourceData, meta interface{}) (data []*schema.ResourceData, err error) {
+	return func(d *schema.ResourceData, meta interface{}) (data []*schema.ResourceData, err error) {
+		id, err := ParseVirtualMachineScaleSetID(d.Id())
+		if err != nil {
+			return []*schema.ResourceData{}, err
+		}
+
+		client := meta.(*clients.Client).Compute.VMScaleSetClient
+		ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+		defer cancel()
+
+		vm, err := client.Get(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			return []*schema.ResourceData{}, fmt.Errorf("Error retrieving Virtual Machine Scale Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		if vm.VirtualMachineScaleSetProperties == nil {
+			return []*schema.ResourceData{}, fmt.Errorf("Error retrieving Virtual Machine Scale Set %q (Resource Group %q): `properties` was nil", id.Name, id.ResourceGroup)
+		}
+
+		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile == nil {
+			return []*schema.ResourceData{}, fmt.Errorf("Error retrieving Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile` was nil", id.Name, id.ResourceGroup)
+		}
+
+		if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.OsProfile == nil {
+			return []*schema.ResourceData{}, fmt.Errorf("Error retrieving Virtual Machine Scale Set %q (Resource Group %q): `properties.virtualMachineProfile.osProfile` was nil", id.Name, id.ResourceGroup)
+		}
+
+		isCorrectOS := false
+		hasSshKeys := false
+		if profile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.OsProfile; profile != nil {
+			if profile.LinuxConfiguration != nil && osType == compute.Linux {
+				isCorrectOS = true
+
+				if profile.LinuxConfiguration.SSH != nil && profile.LinuxConfiguration.SSH.PublicKeys != nil {
+					hasSshKeys = len(*profile.LinuxConfiguration.SSH.PublicKeys) > 0
+				}
+			}
+
+			if profile.WindowsConfiguration != nil && osType == compute.Windows {
+				isCorrectOS = true
+			}
+		}
+
+		if !isCorrectOS {
+			return []*schema.ResourceData{}, fmt.Errorf("The %q resource only supports %s Virtual Machine Scale Sets", resourceType, string(osType))
+		}
+
+		if !hasSshKeys {
+			d.Set("admin_password", "ignored-as-imported")
+		}
+
+		return []*schema.ResourceData{d}, nil
+	}
+}


### PR DESCRIPTION
This PR adds import-time validation to the `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources to ensure the correct OS is being imported.

In addition this correctly handles a perpetual diff when importing these resources where a password is present by matching the behaviour used by the new VM resources