### PR TITLE
ssh key simple validation and error messaging

### DIFF
--- a/azurerm/internal/services/compute/ssh_keys.go
+++ b/azurerm/internal/services/compute/ssh_keys.go
@@ -138,9 +138,14 @@ func ValidateSSHKey(i interface{}, k string) (warnings []string, errors []error)
 
 	switch validSig {
 	case "ssh-rsa":
-		strLen := len(strings.TrimSpace(v))
-		if strLen < 379 {
-			return nil, []error{fmt.Errorf("expected %q to have a key size of at least 2048 bits", k)}
+		keyParts := strings.Fields(v)
+		if len(keyParts) > 1 {
+			strLen := len(keyParts[1])
+			if strLen < 371 {
+				return nil, []error{fmt.Errorf("expected %q to have a key size of at least 2048 bits", k)}
+			}
+		} else {
+			return nil, []error{fmt.Errorf("expected %q to be valid of at least 2 parts, signature and key", k)}
 		}
 	case "":
 		return nil, []error{fmt.Errorf("Bad: Azure currently supports SSH protocol 2 (SSH-2) RSA public-private key pairs with a minimum length of 2048 bits")}

--- a/azurerm/internal/services/compute/ssh_keys.go
+++ b/azurerm/internal/services/compute/ssh_keys.go
@@ -141,13 +141,13 @@ func ValidateSSHKey(i interface{}, k string) (warnings []string, errors []error)
 		}
 
 		if pubKey.Type() != ssh.KeyAlgoRSA {
-			return nil, []error{fmt.Errorf("Error - Only RSA SSH2 keys are supported by Azure")}
+			return nil, []error{fmt.Errorf("Error - only ssh-rsa keys with 2048 bits or higher are supported by Azure")}
 		} else {
 			//check length - held at bytes 20 and 21 for ssh-rsa
 			sizeRaw := []byte{byteStr[20], byteStr[21]}
 			sizeDec := binary.BigEndian.Uint16(sizeRaw)
 			if sizeDec < 257 {
-				return nil, []error{fmt.Errorf("Error - Only key lengths of 2048 bits or longer are supported by Azure")}
+				return nil, []error{fmt.Errorf("Error - only ssh-rsa keys with 2048 bits or higher are supported by azure")}
 			}
 		}
 	} else {

--- a/azurerm/internal/services/compute/validation_test.go
+++ b/azurerm/internal/services/compute/validation_test.go
@@ -215,3 +215,56 @@ func TestValidateDiskEncryptionSetName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSSHKey(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			input:    "",
+			expected: false,
+		},
+		{
+			input:    "ssh-dss AAAAB3NzaC1kc3MAAACBAJTdkgVSk8cgM6h0MrnH9yoihsQVZ9c6OQcFqS1FZ/5DD4Z/8qfJlKFhICwhSCTX0dHqbZumG5KkFyrn2XznDf15idCHxxK4Vd51tyq5XaRyk89lFZCogIYPzocD+RdYVBwX7Y9ju+t7FqEhshd0q4tO6MzENIE//Wx+QWeiZrWlAAAAFQCsaVnyLr+Q+akj4M/K7pYR+GwpJQAAAIBtcypWCzJrPUgxy33rRMbrnWlQDY3H81iS4n7U5SDlUE7V0VaH8IxoQdSiGe6FJCUbu9XEvSQ+v6raBHPM6ca3t9NyPgBDdIRlCcgxrIQzbhTzgi85HdfDyED3wqDgMMdIYZ1AOeRQ3u3tLlGlOXrKCEIPH5x/tvysTn0+2mYKmwAAAIAtOGBS6M+IrrH+kMIOyLFGiL9b1s4rv5Vv6izULYb2DU0zoBnlRkmq/cLkFSgHeE5MqzOosybhwt5PRzMfoFtyUBpMgChdfuPnFwZbeTjitWRVS7tB/FDknbBXsk8mmnUEmodbTYVYtVSxbBgfKtc6pgomY1gxsYpByxyIA3A9gQ==",
+			expected: false,
+		},
+		{
+			input:    "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA95ywHY2HQsFe59iIhJCNmPjQdGbAJ7/5ZcxfOdHs98gG6UhCj5KwjpSICNGTZ+ZE+W4ExRPWzAGfFzjibUzsE=",
+			expected: false,
+		},
+		{
+			input:    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOwlR9xtbM69hWLJbB5nHi0a65TuRvtaldgTJQ4ClL1W",
+			expected: false,
+		},
+		{
+			input:    "ssh-rsa",
+			expected: false,
+		},
+		{
+			// 1024
+			input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDbzSM5KBFKmNilWjlw2YenzARxww1H+BMDMBVyzKYsNwEQc6Tj3ZB1Jun0l6Xkaw5BxKdwKFdhPlQh3nqpbm7xmSY7MuRZLPU+LRM3wI9RwcreDb3BXWacy41YIRGhUzpAzXmWdVyub/k70AJAngpVLLBmLcjuavjplR/fkTjslw==",
+			expected: false,
+		},
+		{
+			// 2048
+			input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTVRznAD63AGg2tJJ2MZhbN2DTEeeBjb+C+ivxQf5yJpKFhZP1NxMBgPZ/sDqW3odngi2IOQ5PMJ1C/m6VNBxblJqE+wLClU+rkYAbnREoRM7jeHFE9SbGyCdqotUExLF4aNQ4TibNVeA+dH3IfwCpLf76iCORVA6VGMNfwvj1oYSFoqKQUVaakn0NpyaCjsHf6kJa7f85JTmRlnd8MetOKeMkVDzbyNTRRwojWtIbYOocIRDd4M9NBf9LERcK3vRQq7cpOahco7uaf5jDfS/ajRFjFLfh8m0VRkSZfTi8D7VuYvWB6HstXDgTyepavLcO6Hy3eCwJVM8p+WLPSz5",
+			expected: true,
+		},
+		{
+			// 4096
+			input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFP6r3wb/79MqRYI4dpgMwmjlrDDrk3A/pehysk1wzQn3lSEUtrNeQsHI6o/8au8Un1ndaZXZl/yWQQDDW4kqGw5ty8xPUZ+DB1ZVWkFOVNAgARl0bMNCgm2kB85l66g0zHWDCKLt+xi8xQiL7tGvdq3SWpogY3pWF2AABXoNDloHEN0mzzjJ09hdAHbygaDDr/9k3uyGKH3x0qo7fx5g8GqTtM3YWRxqUqdtkjsNomq94c/PMybCGR6qRoGI0Cdr/OP6/kszDHwf87B9hpTDMNa6x6FVJSDHc9v0CWePJZpjEOAFN3GCyPFFQTA9jvy026jt43wzyeH0kPe/T0ZZdr9YzQETN1b/oAKWKoayIoiLyJtFqUKcFFJSPcMz9ISgCD5Q/jRxQwMuMHpQ8TslxZ38l+41/0V1LWwKj0IkyJVFVWzu4zhgAZXr5y9Qbsis9sStRc+LU9/FQJ/VzNQfL83l86rH/u3NiPFfqisXILSybtMCD0OoRRHfQvWFsSwgt9JCIqLpmrJXRYs679aHzTHDgitlovJyprwqrbjg5N3XNSB5FohAUJUnVMF8z+qzvb4pPhly6mj6tiSJGYbXPngN6Iv8t3mRko3PbYLrWuxMb345BxcD+j9XteUgm1j/10qrSvqq+1R+/FAFPYwLXCflZgKst2g8/rEiVQz+a3w==",
+			expected: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q...", v.input)
+
+		_, errors := ValidateSSHKey(v.input, "public_key")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/azurerm/internal/services/compute/validation_test.go
+++ b/azurerm/internal/services/compute/validation_test.go
@@ -242,13 +242,17 @@ func TestValidateSSHKey(t *testing.T) {
 			expected: false,
 		},
 		{
+			input:    "ssh-rsa ThisIsNot a REAL key",
+			expected: false,
+		},
+		{
 			// 1024
 			input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDbzSM5KBFKmNilWjlw2YenzARxww1H+BMDMBVyzKYsNwEQc6Tj3ZB1Jun0l6Xkaw5BxKdwKFdhPlQh3nqpbm7xmSY7MuRZLPU+LRM3wI9RwcreDb3BXWacy41YIRGhUzpAzXmWdVyub/k70AJAngpVLLBmLcjuavjplR/fkTjslw==",
 			expected: false,
 		},
 		{
 			// 2048
-			input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDTVRznAD63AGg2tJJ2MZhbN2DTEeeBjb+C+ivxQf5yJpKFhZP1NxMBgPZ/sDqW3odngi2IOQ5PMJ1C/m6VNBxblJqE+wLClU+rkYAbnREoRM7jeHFE9SbGyCdqotUExLF4aNQ4TibNVeA+dH3IfwCpLf76iCORVA6VGMNfwvj1oYSFoqKQUVaakn0NpyaCjsHf6kJa7f85JTmRlnd8MetOKeMkVDzbyNTRRwojWtIbYOocIRDd4M9NBf9LERcK3vRQq7cpOahco7uaf5jDfS/ajRFjFLfh8m0VRkSZfTi8D7VuYvWB6HstXDgTyepavLcO6Hy3eCwJVM8p+WLPSz5",
+			input:    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0pA4vzGH+cmR+blZnoxO5HorOP1ubD4SxuOiW2DSNTSptlj+mPmFIL6sZeYMvSqAjXK368qL3DKHLpp2+1ws1XnYn/Zx/O4WBQAY7VbtzwFc7w7uirQaK6lVqXn8q4CnO0+5IYHgKLrNMEipwLKo+R3E3e1KrH5Xbyhj5yJzrMe3lWOAPzS27DJvjpN5SGWo65X6qFJRh3q95xOQhSOaEqZ/A2ZtfOuagq3FmASzoo/pbq7ianvnxzAYsb2Hg/9uAvypj4Beli6BP7419aP14XS0yyiW4XTKY/9XZiR/3VIKBN/stGN5NFLw82/j12E1GznbDG9PL7PQhijP7QgJh",
 			expected: true,
 		},
 		{

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -266,7 +266,7 @@ A `plan` block supports the following:
 
 A `ssh_keys` block supports the following:
 
-* `key_data` - (Required) The Public SSH Key which should be written to the `path` defined above.
+* `key_data` - (Required) The Public SSH Key which should be written to the `path` defined above. Azure only supports RSA SSH2 key signatures of at least 2048 bits in length
 
 -> **NOTE:** Rather than defining this in-line you can source this from a local file using [the `file` function](https://www.terraform.io/docs/configuration/functions/file.html) - for example `key_data = file("~/.ssh/id_rsa.pub")`.
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -266,7 +266,9 @@ A `plan` block supports the following:
 
 A `ssh_keys` block supports the following:
 
-* `key_data` - (Required) The Public SSH Key which should be written to the `path` defined above. Azure only supports RSA SSH2 key signatures of at least 2048 bits in length
+* `key_data` - (Required) The Public SSH Key which should be written to the `path` defined above.
+
+~> **Note:** Azure only supports RSA SSH2 key signatures of at least 2048 bits in length
 
 -> **NOTE:** Rather than defining this in-line you can source this from a local file using [the `file` function](https://www.terraform.io/docs/configuration/functions/file.html) - for example `key_data = file("~/.ssh/id_rsa.pub")`.
 


### PR DESCRIPTION
Fixes #5605 

Added simple validation function to check supplied string carries valid key signature type and is of minimum length or greater.
