### PR TITLE
Add name validation for azurerm_role_assignment

### DIFF
--- a/azurerm/internal/services/authorization/resource_arm_role_assignment.go
+++ b/azurerm/internal/services/authorization/resource_arm_role_assignment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -36,10 +37,11 @@ func resourceArmRoleAssignment() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.GUID,
 			},
 
 			"scope": {


### PR DESCRIPTION
This PR is the fix of the issue https://github.com/terraform-providers/terraform-provider-azurerm/issues/5543

After investigated, I found the root cause is the property "name" in azurerm_role_assignment the user provided includes character "/" and the client http request url would be appended "AtlasPeeringRoleAssignment/xxxx/xxxx/xxxx". So this request url cannot be found from server side.
After checked, the property "name" should be guid according by the doc(https://docs.microsoft.com/en-us/rest/api/authorization/roleassignments/create).

Fixes #5543