### PR TITLE
Improvement: Data Source Documentation Cleanup

### DIFF
--- a/website/docs/d/api_management.html.markdown
+++ b/website/docs/d/api_management.html.markdown
@@ -25,9 +25,9 @@ output "api_management_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the API Management service.
+* `name` - The name of the API Management service.
 
-* `resource_group_name` - (Required) The Name of the Resource Group in which the API Management Service exists.
+* `resource_group_name` - The Name of the Resource Group in which the API Management Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/api_management_api.html.markdown
+++ b/website/docs/d/api_management_api.html.markdown
@@ -27,13 +27,13 @@ output "api_management_api_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the API Management API.
+* `name` - The name of the API Management API.
 
-* `api_management_name` - (Required) The name of the API Management Service in which the API Management API exists.
+* `api_management_name` - The name of the API Management Service in which the API Management API exists.
 
-* `resource_group_name` - (Required) The Name of the Resource Group in which the API Management Service exists.
+* `resource_group_name` - The Name of the Resource Group in which the API Management Service exists.
 
-* `revision` - (Required) The Revision of the API Management API.
+* `revision` - The Revision of the API Management API.
 
 ## Attributes Reference
 

--- a/website/docs/d/api_management_api_version_set.html.markdown
+++ b/website/docs/d/api_management_api_version_set.html.markdown
@@ -26,11 +26,11 @@ output "api_management_api_version_set_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the API Version Set.
+* `name` - The name of the API Version Set.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the parent API Management Service exists.
+* `resource_group_name` - The name of the Resource Group in which the parent API Management Service exists.
 
-* `api_management_name` - (Required) The name of the [API Management Service](api_management.html) where the API Version Set exists.
+* `api_management_name` - The name of the [API Management Service](api_management.html) where the API Version Set exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/api_management_group.html.markdown
+++ b/website/docs/d/api_management_group.html.markdown
@@ -26,11 +26,11 @@ output "group_type" {
 
 ## Argument Reference
 
-* `api_management_name` - (Required) The Name of the API Management Service in which this Group exists.
+* `api_management_name` - The Name of the API Management Service in which this Group exists.
 
-* `name` - (Required) The Name of the API Management Group.
+* `name` - The Name of the API Management Group.
 
-* `resource_group_name` - (Required) The Name of the Resource Group in which the API Management Service exists.
+* `resource_group_name` - The Name of the Resource Group in which the API Management Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/api_management_product.html.markdown
+++ b/website/docs/d/api_management_product.html.markdown
@@ -26,11 +26,11 @@ output "product_terms" {
 
 ## Argument Reference
 
-* `api_management_name` - (Required) The Name of the API Management Service in which this Product exists.
+* `api_management_name` - The Name of the API Management Service in which this Product exists.
 
-* `product_id` - (Required) The Identifier for the API Management Product.
+* `product_id` - The Identifier for the API Management Product.
 
-* `resource_group_name` - (Required) The Name of the Resource Group in which the API Management Service exists.
+* `resource_group_name` - The Name of the Resource Group in which the API Management Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/api_management_user.html.markdown
+++ b/website/docs/d/api_management_user.html.markdown
@@ -26,11 +26,11 @@ output "notes" {
 
 ## Argument Reference
 
-* `api_management_name` - (Required) The Name of the API Management Service in which this User exists.
+* `api_management_name` - The Name of the API Management Service in which this User exists.
 
-* `resource_group_name` - (Required) The Name of the Resource Group in which the API Management Service exists.
+* `resource_group_name` - The Name of the Resource Group in which the API Management Service exists.
 
-* `user_id` - (Required) The Identifier for the User.
+* `user_id` - The Identifier for the User.
 
 ## Attributes Reference
 

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -25,9 +25,9 @@ output "app_service_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the App Service.
+* `name` - The name of the App Service.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the App Service exists.
+* `resource_group_name` - The Name of the Resource Group where the App Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/app_service_certificate.html.markdown
+++ b/website/docs/d/app_service_certificate.html.markdown
@@ -28,9 +28,9 @@ output "app_service_certificate_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the certificate.
+* `name` - Specifies the name of the certificate.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the certificate.
+* `resource_group_name` - The name of the resource group in which to create the certificate.
 
 ## Attributes Reference
 

--- a/website/docs/d/app_service_certificate_order.html.markdown
+++ b/website/docs/d/app_service_certificate_order.html.markdown
@@ -25,9 +25,9 @@ output "certificate_order_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the App Service.
+* `name` - The name of the App Service.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the App Service exists.
+* `resource_group_name` - The Name of the Resource Group where the App Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -25,8 +25,8 @@ output "app_service_plan_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the App Service Plan.
-* `resource_group_name` - (Required) The Name of the Resource Group where the App Service Plan exists.
+* `name` - The name of the App Service Plan.
+* `resource_group_name` - The Name of the Resource Group where the App Service Plan exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/application_insights.html.markdown
+++ b/website/docs/d/application_insights.html.markdown
@@ -25,8 +25,8 @@ output "application_insights_instrumentation_key" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Application Insights component.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Application Insights component is located in.
+* `name` - Specifies the name of the Application Insights component.
+* `resource_group_name` - Specifies the name of the resource group the Application Insights component is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -24,9 +24,9 @@ output "automation_account_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Automation Account.
+* `name` - The name of the Automation Account.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Automation Account exists.
+* `resource_group_name` - Specifies the name of the Resource Group where the Automation Account exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/automation_variable_bool.html.markdown
+++ b/website/docs/d/automation_variable_bool.html.markdown
@@ -30,11 +30,11 @@ output "variable_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Automation Variable.
+* `name` - The name of the Automation Variable.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the automation account exists.
+* `resource_group_name` - The Name of the Resource Group where the automation account exists.
 
-* `automation_account_name` - (Required) The name of the automation account in which the Automation Variable exists.
+* `automation_account_name` - The name of the automation account in which the Automation Variable exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/automation_variable_datetime.html.markdown
+++ b/website/docs/d/automation_variable_datetime.html.markdown
@@ -30,11 +30,11 @@ output "variable_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Automation Variable.
+* `name` - The name of the Automation Variable.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the automation account exists.
+* `resource_group_name` - The Name of the Resource Group where the automation account exists.
 
-* `automation_account_name` - (Required) The name of the automation account in which the Automation Variable exists.
+* `automation_account_name` - The name of the automation account in which the Automation Variable exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/automation_variable_int.html.markdown
+++ b/website/docs/d/automation_variable_int.html.markdown
@@ -30,11 +30,11 @@ output "variable_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Automation Variable.
+* `name` - The name of the Automation Variable.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the automation account exists.
+* `resource_group_name` - The Name of the Resource Group where the automation account exists.
 
-* `automation_account_name` - (Required) The name of the automation account in which the Automation Variable exists.
+* `automation_account_name` - The name of the automation account in which the Automation Variable exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/automation_variable_string.html.markdown
+++ b/website/docs/d/automation_variable_string.html.markdown
@@ -30,11 +30,11 @@ output "variable_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Automation Variable.
+* `name` - The name of the Automation Variable.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the automation account exists.
+* `resource_group_name` - The Name of the Resource Group where the automation account exists.
 
-* `automation_account_name` - (Required) The name of the automation account in which the Automation Variable exists.
+* `automation_account_name` - The name of the automation account in which the Automation Variable exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -26,9 +26,9 @@ output "pool_allocation_mode" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Batch account.
+* `name` - The name of the Batch account.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where this Batch account exists.
+* `resource_group_name` - The Name of the Resource Group where this Batch account exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/batch_certificate.html.markdown
+++ b/website/docs/d/batch_certificate.html.markdown
@@ -27,11 +27,11 @@ output "thumbprint" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Batch certificate.
+* `name` - The name of the Batch certificate.
 
-* `account_name` - (Required) The name of the Batch account.
+* `account_name` - The name of the Batch account.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where this Batch account exists.
+* `resource_group_name` - The Name of the Resource Group where this Batch account exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -81,7 +81,7 @@ A `start_task` block exports the following:
 
 * `user_identity` - A `user_identity` block that describes the user identity under which the start task runs.
 
-* `resource_file` - (Optional) One or more `resource_file` blocks that describe the files to be downloaded to a compute node.
+* `resource_file` - One or more `resource_file` blocks that describe the files to be downloaded to a compute node.
 
 ---
 
@@ -153,9 +153,9 @@ A `container_registries` block exports the following:
 
 A `network_configuration` block exports the following:
 
-* `subnet_id` - (Optional) The ARM resource identifier of the virtual network subnet which the compute nodes of the pool are joined too.
+* `subnet_id` - The ARM resource identifier of the virtual network subnet which the compute nodes of the pool are joined too.
 
-* `endpoint_configuration` - (Optional) The inbound NAT pools that are used to address specific ports on the individual compute node externally.
+* `endpoint_configuration` - The inbound NAT pools that are used to address specific ports on the individual compute node externally.
 
 ---
 
@@ -169,7 +169,7 @@ A `endpoint_configuration` block exports the following:
 
 * `frontend_port_range` - The range of external ports that are used to provide inbound access to the backendPort on the individual compute nodes in the format of `1000-1100`.
 
-* `network_security_group_rules` - (Optional) The list of network security group rules that are applied to the endpoint.
+* `network_security_group_rules` - The list of network security group rules that are applied to the endpoint.
 
 ---
 

--- a/website/docs/d/builtin_role_definition.markdown
+++ b/website/docs/d/builtin_role_definition.markdown
@@ -26,7 +26,7 @@ output "contributor_role_definition_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the built-in Role Definition. Possible values are: `Contributor`, `Owner`, `Reader` and `VirtualMachineContributor`.
+* `name` - Specifies the name of the built-in Role Definition. Possible values are: `Contributor`, `Owner`, `Reader` and `VirtualMachineContributor`.
 
 
 ## Attributes Reference

--- a/website/docs/d/cdn_profile.html.markdown
+++ b/website/docs/d/cdn_profile.html.markdown
@@ -25,9 +25,9 @@ output "cdn_profile_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the CDN Profile.
+* `name` - The name of the CDN Profile.
 
-* `resource_group_name` - (Required) The name of the resource group in which the CDN Profile exists.
+* `resource_group_name` - The name of the resource group in which the CDN Profile exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/container_registry.markdown
+++ b/website/docs/d/container_registry.markdown
@@ -26,8 +26,8 @@ output "login_server" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Container Registry.
-* `resource_group_name` - (Required) The Name of the Resource Group where this Container Registry exists.
+* `name` - The name of the Container Registry.
+* `resource_group_name` - The Name of the Resource Group where this Container Registry exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -27,9 +27,9 @@ output "cosmosdb_account_endpoint" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the CosmosDB Account.
+* `name` - Specifies the name of the CosmosDB Account.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group in which the CosmosDB Account resides.
+* `resource_group_name` - Specifies the name of the resource group in which the CosmosDB Account resides.
 
 ## Attributes Reference
 

--- a/website/docs/d/data_factory.html.markdown
+++ b/website/docs/d/data_factory.html.markdown
@@ -29,9 +29,9 @@ output "data_factory_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Data Factory to retrieve information about. 
+* `name` - Specifies the name of the Data Factory to retrieve information about. 
 
-* `resource_group_name` - (Required) The name of the resource group where the Data Factory exists.
+* `resource_group_name` - The name of the resource group where the Data Factory exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/data_lake_store.html.markdown
+++ b/website/docs/d/data_lake_store.html.markdown
@@ -26,9 +26,9 @@ output "data_lake_store_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Data Lake Store.
+* `name` - The name of the Data Lake Store.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the Data Lake Store exists.
+* `resource_group_name` - The Name of the Resource Group where the Data Lake Store exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/dedicated_host.html.markdown
+++ b/website/docs/d/dedicated_host.html.markdown
@@ -28,11 +28,11 @@ output "dedicated_host_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Dedicated Host.
+* `name` - Specifies the name of the Dedicated Host.
 
-* `dedicated_host_group_name` - (Required) Specifies the name of the Dedicated Host Group the Dedicated Host is located in.
+* `dedicated_host_group_name` - Specifies the name of the Dedicated Host Group the Dedicated Host is located in.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group the Dedicated Host is located in.
+* `resource_group_name` - Specifies the name of the resource group the Dedicated Host is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/dedicated_host_group.html.markdown
+++ b/website/docs/d/dedicated_host_group.html.markdown
@@ -27,9 +27,9 @@ output "id" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Dedicated Host Group.
+* `name` - Specifies the name of the Dedicated Host Group.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group the Dedicated Host Group is located in.
+* `resource_group_name` - Specifies the name of the resource group the Dedicated Host Group is located in.
 
 
 ## Attributes Reference

--- a/website/docs/d/dev_test_lab.html.markdown
+++ b/website/docs/d/dev_test_lab.html.markdown
@@ -25,9 +25,9 @@ output "unique_identifier" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Dev Test Lab.
+* `name` - The name of the Dev Test Lab.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the Dev Test Lab exists.
+* `resource_group_name` - The Name of the Resource Group where the Dev Test Lab exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/dev_test_virtual_network.html.markdown
+++ b/website/docs/d/dev_test_virtual_network.html.markdown
@@ -26,9 +26,9 @@ output "lab_subnet_name" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Virtual Network.
-* `lab_name` - (Required) Specifies the name of the Dev Test Lab.
-* `resource_group_name` - (Required) Specifies the name of the resource group that contains the Virtual Network.
+* `name` - Specifies the name of the Virtual Network.
+* `lab_name` - Specifies the name of the Dev Test Lab.
+* `resource_group_name` - Specifies the name of the resource group that contains the Virtual Network.
 
 ## Attributes Reference
 

--- a/website/docs/d/disk_encryption_set.html.markdown
+++ b/website/docs/d/disk_encryption_set.html.markdown
@@ -14,9 +14,9 @@ Use this data source to access information about an existing Disk Encryption Set
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Disk Encryption Set exists.
+* `name` - The name of the Disk Encryption Set exists.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Disk Encryption Set exists.
+* `resource_group_name` - The name of the Resource Group where the Disk Encryption Set exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/dns_zone.html.markdown
+++ b/website/docs/d/dns_zone.html.markdown
@@ -26,7 +26,7 @@ output "dns_zone_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the DNS Zone.
+* `name` - The name of the DNS Zone.
 * `resource_group_name` - (Optional) The Name of the Resource Group where the DNS Zone exists.
 If the Name of the Resource Group is not provided, the first DNS Zone from the list of DNS Zones
 in your subscription that matches `name` will be returned.

--- a/website/docs/d/eventgrid_topic.html.markdown
+++ b/website/docs/d/eventgrid_topic.html.markdown
@@ -24,9 +24,9 @@ data "azurerm_eventgrid_topic" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the EventGrid Topic resource.
+* `name` - The name of the EventGrid Topic resource.
 
-* `resource_group_name` - (Required) The name of the resource group in which the EventGrid Topic exists.
+* `resource_group_name` - The name of the resource group in which the EventGrid Topic exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/eventhub_namespace.html.markdown
+++ b/website/docs/d/eventhub_namespace.html.markdown
@@ -25,8 +25,8 @@ output "eventhub_namespace_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the EventHub Namespace.
-* `resource_group_name` - (Required) The Name of the Resource Group where the EventHub Namespace exists.
+* `name` - The name of the EventHub Namespace.
+* `resource_group_name` - The Name of the Resource Group where the EventHub Namespace exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/eventhub_namespace_authorization_rule.html.markdown
+++ b/website/docs/d/eventhub_namespace_authorization_rule.html.markdown
@@ -27,9 +27,9 @@ output "eventhub_authorization_rule_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the EventHub Authorization Rule resource. 
+* `name` - The name of the EventHub Authorization Rule resource. 
 
-* `resource_group_name` - (Required) The name of the resource group in which the EventHub Namespace exists.
+* `resource_group_name` - The name of the resource group in which the EventHub Namespace exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/express_route_circuit.html.markdown
+++ b/website/docs/d/express_route_circuit.html.markdown
@@ -29,8 +29,8 @@ output "service_key" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the ExpressRoute circuit.
-* `resource_group_name` - (Required) The Name of the Resource Group where the ExpressRoute circuit exists.
+* `name` - The name of the ExpressRoute circuit.
+* `resource_group_name` - The Name of the Resource Group where the ExpressRoute circuit exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -26,9 +26,9 @@ output "firewall_private_ip" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Azure Firewall.
+* `name` - The name of the Azure Firewall.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Azure Firewall exists.
+* `resource_group_name` - The name of the Resource Group in which the Azure Firewall exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/hdinsight_cluster.html.markdown
+++ b/website/docs/d/hdinsight_cluster.html.markdown
@@ -26,9 +26,9 @@ output "https_endpoint" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of this HDInsight Cluster.
+* `name` - Specifies the name of this HDInsight Cluster.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group in which this HDInsight Cluster exists.
+* `resource_group_name` - Specifies the name of the Resource Group in which this HDInsight Cluster exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/healthcare_service.html.markdown
+++ b/website/docs/d/healthcare_service.html.markdown
@@ -26,9 +26,9 @@ output "healthcare_service_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Healthcare Service.
+* `name` - Specifies the name of the Healthcare Service.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Healthcare Service exists.
+* `resource_group_name` - The name of the Resource Group in which the Healthcare Service exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -29,7 +29,7 @@ output "image_id" {
 * `name` - (Optional) The name of the Image.
 * `name_regex` - (Optional) Regex pattern of the image to match.
 * `sort_descending` - (Optional) By default when matching by regex, images are sorted by name in ascending order and the first match is chosen, to sort descending, set this flag.
-* `resource_group_name` - (Required) The Name of the Resource Group where this Image exists.
+* `resource_group_name` - The Name of the Resource Group where this Image exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/iothub_dps.html.markdown
+++ b/website/docs/d/iothub_dps.html.markdown
@@ -23,9 +23,9 @@ data "azurerm_iothub_dps" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Iot Device Provisioning Service resource.
+* `name` - Specifies the name of the Iot Device Provisioning Service resource.
 
-* `resource_group_name` - (Required) The name of the resource group under which the Iot Device Provisioning Service is located in.
+* `resource_group_name` - The name of the resource group under which the Iot Device Provisioning Service is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/iothub_shared_access_policy.html.markdown
+++ b/website/docs/d/iothub_shared_access_policy.html.markdown
@@ -24,11 +24,11 @@ data "azurerm_iothub_shared_access_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the IotHub Shared Access Policy resource.
+* `name` - Specifies the name of the IotHub Shared Access Policy resource.
 
-* `resource_group_name` - (Required) The name of the resource group under which the IotHub Shared Access Policy resource has to be created.
+* `resource_group_name` - The name of the resource group under which the IotHub Shared Access Policy resource has to be created.
 
-* `iothub_name` - (Required) The name of the IoTHub to which this Shared Access Policy belongs.
+* `iothub_name` - The name of the IoTHub to which this Shared Access Policy belongs.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_vault.html.markdown
+++ b/website/docs/d/key_vault.html.markdown
@@ -27,9 +27,9 @@ output "vault_uri" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Key Vault.
+* `name` - Specifies the name of the Key Vault.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Key Vault exists.
+* `resource_group_name` - The name of the Resource Group in which the Key Vault exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/key_vault_access_policy.html.markdown
+++ b/website/docs/d/key_vault_access_policy.html.markdown
@@ -24,7 +24,7 @@ output "access_policy_key_permissions" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Management Template. Possible values are: `Key Management`,
+* `name` - Specifies the name of the Management Template. Possible values are: `Key Management`,
 `Secret Management`, `Certificate Management`, `Key & Secret Management`, `Key & Certificate Management`,
 `Secret & Certificate Management`,  `Key, Secret, & Certificate Management`
 

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -31,9 +31,9 @@ output "key_type" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Key Vault Key.
+* `name` - Specifies the name of the Key Vault Key.
 
-* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. 
+* `key_vault_id` - Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. 
 
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -30,9 +30,9 @@ output "secret_value" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Key Vault Secret.
+* `name` - Specifies the name of the Key Vault Secret.
 
-* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. 
+* `key_vault_id` - Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource. 
 
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -26,9 +26,9 @@ data "azurerm_kubernetes_cluster" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the managed Kubernetes Cluster.
+* `name` - The name of the managed Kubernetes Cluster.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the managed Kubernetes Cluster exists.
+* `resource_group_name` - The name of the Resource Group in which the managed Kubernetes Cluster exists.
 
 ## Attributes Reference
 
@@ -213,13 +213,13 @@ A `oms_agent` block exports the following:
 
 A `kube_dashboard` block supports the following:
 
-* `enabled` - (Required) Is the Kubernetes Dashboard enabled?
+* `enabled` - Is the Kubernetes Dashboard enabled?
 
 ---
 
 A `azure_policy` block supports the following:
 
-* `enabled` - (Required) Is Azure Policy for Kubernetes enabled?
+* `enabled` - Is Azure Policy for Kubernetes enabled?
 
 ---
 

--- a/website/docs/d/kubernetes_service_versions.html.markdown
+++ b/website/docs/d/kubernetes_service_versions.html.markdown
@@ -28,7 +28,7 @@ output "latest_version" {
 
 ## Argument Reference
 
-* `location` - (Required) Specifies the location in which to query for versions.
+* `location` - Specifies the location in which to query for versions.
 
 * `version_prefix` - (Optional) A prefix filter for the versions of Kubernetes which should be returned; for example `1.` will return `1.9` to `1.14`, whereas `1.12` will return `1.12.2`.
 

--- a/website/docs/d/loadbalancer.html.markdown
+++ b/website/docs/d/loadbalancer.html.markdown
@@ -26,9 +26,9 @@ output "loadbalancer_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Load Balancer.
+* `name` - Specifies the name of the Load Balancer.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Load Balancer exists.
+* `resource_group_name` - The name of the Resource Group in which the Load Balancer exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/loadbalancer_backend_address_pool.html.markdown
+++ b/website/docs/d/loadbalancer_backend_address_pool.html.markdown
@@ -35,9 +35,9 @@ output "backend_ip_configuration_ids" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Backend Address Pool.
+* `name` - Specifies the name of the Backend Address Pool.
 
-* `loadbalancer_id` - (Required) The ID of the Load Balancer in which the Backend Address Pool exists.
+* `loadbalancer_id` - The ID of the Load Balancer in which the Backend Address Pool exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -27,8 +27,8 @@ output "log_analytics_workspace_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Log Analytics Workspace.
-* `resource_group_name` - (Required) The name of the resource group in which the Log Analytics workspace is located in.
+* `name` - Specifies the name of the Log Analytics Workspace.
+* `resource_group_name` - The name of the resource group in which the Log Analytics workspace is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/logic_app_workflow.html.markdown
+++ b/website/docs/d/logic_app_workflow.html.markdown
@@ -27,9 +27,9 @@ output "access_endpoint" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Logic App Workflow.
+* `name` - The name of the Logic App Workflow.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Logic App Workflow exists.
+* `resource_group_name` - The name of the Resource Group in which the Logic App Workflow exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -25,9 +25,9 @@ output "id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Managed Disk.
+* `name` - Specifies the name of the Managed Disk.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where this Managed Disk exists.
+* `resource_group_name` - Specifies the name of the Resource Group where this Managed Disk exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -26,7 +26,7 @@ output "display_name" {
 
 The following arguments are supported:
 
-* `group_id` - (Required) Specifies the UUID of this Management Group.
+* `group_id` - Specifies the UUID of this Management Group.
 
 ## Attributes Reference
 

--- a/website/docs/d/maps_account.html.markdown
+++ b/website/docs/d/maps_account.html.markdown
@@ -25,9 +25,9 @@ output "maps_account_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Maps Account.
+* `name` - Specifies the name of the Maps Account.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group in which the Maps Account is located.
+* `resource_group_name` - Specifies the name of the Resource Group in which the Maps Account is located.
 
 ## Attributes Reference
 

--- a/website/docs/d/mariadb_server.html.markdown
+++ b/website/docs/d/mariadb_server.html.markdown
@@ -26,9 +26,9 @@ output "mariadb_server_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the MariaDB Server to retrieve information about.
+* `name` - The name of the MariaDB Server to retrieve information about.
 
-* `resource_group_name` - (Required) The name of the resource group where the MariaDB Server exists.
+* `resource_group_name` - The name of the resource group where the MariaDB Server exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/monitor_action_group.html.markdown
+++ b/website/docs/d/monitor_action_group.html.markdown
@@ -25,8 +25,8 @@ output "action_group_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Action Group.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Action Group is located in.
+* `name` - Specifies the name of the Action Group.
+* `resource_group_name` - Specifies the name of the resource group the Action Group is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/monitor_diagnostic_categories.html.markdown
+++ b/website/docs/d/monitor_diagnostic_categories.html.markdown
@@ -26,7 +26,7 @@ data "azurerm_monitor_diagnostic_categories" "example" {
 
 ## Argument Reference
 
-* `resource_id` - (Required) The ID of an existing Resource which Monitor Diagnostics Categories should be retrieved for.
+* `resource_id` - The ID of an existing Resource which Monitor Diagnostics Categories should be retrieved for.
 
 ## Attributes Reference
 

--- a/website/docs/d/monitor_log_profile.html.markdown
+++ b/website/docs/d/monitor_log_profile.html.markdown
@@ -24,7 +24,7 @@ output "log_profile_storage_account_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the Name of the Log Profile.
+* `name` - Specifies the Name of the Log Profile.
 
 
 ## Attributes Reference

--- a/website/docs/d/mssql_elasticpool.html.markdown
+++ b/website/docs/d/mssql_elasticpool.html.markdown
@@ -26,11 +26,11 @@ output "elasticpool_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the elastic pool.
+* `name` - The name of the elastic pool.
 
-* `resource_group_name` - (Required) The name of the resource group which contains the elastic pool.
+* `resource_group_name` - The name of the resource group which contains the elastic pool.
 
-* `server_name` - (Required) The name of the SQL Server which contains the elastic pool.
+* `server_name` - The name of the SQL Server which contains the elastic pool.
 
 ## Attributes Reference
 

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -16,9 +16,9 @@ Use this data source to access information about an existing NAT Gateway.
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the Name of the NAT Gateway.
+* `name` - Specifies the Name of the NAT Gateway.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the NAT Gateway exists.
+* `resource_group_name` - Specifies the name of the Resource Group where the NAT Gateway exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/netapp_account.html.markdown
+++ b/website/docs/d/netapp_account.html.markdown
@@ -28,9 +28,9 @@ output "netapp_account_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the NetApp Account.
+* `name` - The name of the NetApp Account.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the NetApp Account exists.
+* `resource_group_name` - The Name of the Resource Group where the NetApp Account exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -30,11 +30,11 @@ output "netapp_pool_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the NetApp Pool.
+* `name` - The name of the NetApp Pool.
 
-* `account_name` - (Required) The name of the NetApp account where the NetApp pool exists.
+* `account_name` - The name of the NetApp account where the NetApp pool exists.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the NetApp Pool exists.
+* `resource_group_name` - The Name of the Resource Group where the NetApp Pool exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/netapp_snapshot.html.markdown
+++ b/website/docs/d/netapp_snapshot.html.markdown
@@ -30,15 +30,15 @@ output "netapp_snapshot_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the NetApp Snapshot.
+* `name` - The name of the NetApp Snapshot.
 
-* `account_name` - (Required) The name of the NetApp Account where the NetApp Pool exists.
+* `account_name` - The name of the NetApp Account where the NetApp Pool exists.
 
-* `pool_name` - (Required) The name of the NetApp Pool where the NetApp Volume exists.
+* `pool_name` - The name of the NetApp Pool where the NetApp Volume exists.
 
-* `volume_name` - (Required) The name of the NetApp Volume where the NetApp Snapshot exists.
+* `volume_name` - The name of the NetApp Volume where the NetApp Snapshot exists.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the NetApp Snapshot exists.
+* `resource_group_name` - The Name of the Resource Group where the NetApp Snapshot exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/netapp_volume.html.markdown
+++ b/website/docs/d/netapp_volume.html.markdown
@@ -29,13 +29,13 @@ output "netapp_volume_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the NetApp Volume.
+* `name` - The name of the NetApp Volume.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the NetApp Volume exists.
+* `resource_group_name` - The Name of the Resource Group where the NetApp Volume exists.
 
-* `account_name` - (Required) The name of the NetApp account where the NetApp pool exists.
+* `account_name` - The name of the NetApp account where the NetApp pool exists.
 
-* `pool_name` - (Required) The name of the NetApp pool where the NetApp volume exists.
+* `pool_name` - The name of the NetApp pool where the NetApp volume exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/network_ddos_protection_plan.html.markdown
+++ b/website/docs/d/network_ddos_protection_plan.html.markdown
@@ -28,9 +28,9 @@ output "ddos_protection_plan_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Network DDoS Protection Plan.
+* `name` - The name of the Network DDoS Protection Plan.
 
-* `resource_group_name` - (Required) The name of the resource group where the Network DDoS Protection Plan exists.
+* `resource_group_name` - The name of the resource group where the Network DDoS Protection Plan exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -26,8 +26,8 @@ output "network_interface_id" {
 ## Argument Reference
 
 
-* `name` - (Required) Specifies the name of the Network Interface.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Network Interface is located in.
+* `name` - Specifies the name of the Network Interface.
+* `resource_group_name` - Specifies the name of the resource group the Network Interface is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -25,8 +25,8 @@ output "location" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the Name of the Network Security Group.
-* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the Network Security Group exists
+* `name` - Specifies the Name of the Network Security Group.
+* `resource_group_name` - Specifies the Name of the Resource Group within which the Network Security Group exists
 
 
 ## Attributes Reference

--- a/website/docs/d/network_watcher.html.markdown
+++ b/website/docs/d/network_watcher.html.markdown
@@ -25,8 +25,8 @@ output "network_watcher_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the Name of the Network Watcher.
-* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the Network Watcher exists.
+* `name` - Specifies the Name of the Network Watcher.
+* `resource_group_name` - Specifies the Name of the Resource Group within which the Network Watcher exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/notification_hub.html.markdown
+++ b/website/docs/d/notification_hub.html.markdown
@@ -26,11 +26,11 @@ output "id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the Name of the Notification Hub.
+* `name` - Specifies the Name of the Notification Hub.
 
-* `namespace_name` - (Required)  Specifies the Name of the Notification Hub Namespace which contains the Notification Hub.
+* `namespace_name` -  Specifies the Name of the Notification Hub Namespace which contains the Notification Hub.
 
-* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the Notification Hub exists.
+* `resource_group_name` - Specifies the Name of the Resource Group within which the Notification Hub exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/notification_hub_namespace.html.markdown
+++ b/website/docs/d/notification_hub_namespace.html.markdown
@@ -25,9 +25,9 @@ output "servicebus_endpoint" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the Name of the Notification Hub Namespace.
+* `name` - Specifies the Name of the Notification Hub Namespace.
 
-* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the Notification Hub exists.
+* `resource_group_name` - Specifies the Name of the Resource Group within which the Notification Hub exists.
 
 ## Attributes Reference
 
@@ -45,7 +45,7 @@ output "servicebus_endpoint" {
 
 A `sku` block exports the following:
 
-* `name` - (Required) The name of the SKU to use for this Notification Hub Namespace. Possible values are `Free`, `Basic` or `Standard.`
+* `name` - The name of the SKU to use for this Notification Hub Namespace. Possible values are `Free`, `Basic` or `Standard.`
 
 ### Timeouts
 

--- a/website/docs/d/platform_image.html.markdown
+++ b/website/docs/d/platform_image.html.markdown
@@ -27,10 +27,10 @@ output "version" {
 
 ## Argument Reference
 
-* `location` - (Required) Specifies the Location to pull information about this Platform Image from.
-* `publisher` - (Required) Specifies the Publisher associated with the Platform Image.
-* `offer` - (Required) Specifies the Offer associated with the Platform Image.
-* `sku` - (Required) Specifies the SKU of the Platform Image.
+* `location` - Specifies the Location to pull information about this Platform Image from.
+* `publisher` - Specifies the Publisher associated with the Platform Image.
+* `offer` - Specifies the Offer associated with the Platform Image.
+* `sku` - Specifies the SKU of the Platform Image.
 
 
 ## Attributes Reference

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -24,7 +24,7 @@ output "id" {
 
 ## Argument Reference
 
-* `display_name` - (Required) Specifies the name of the Policy Definition.
+* `display_name` - Specifies the name of the Policy Definition.
 * `management_group_id` - (Optional) Only retrieve Policy Definitions from this Management Group.
 
 

--- a/website/docs/d/postgresql_server.html.markdown
+++ b/website/docs/d/postgresql_server.html.markdown
@@ -25,9 +25,9 @@ output "postgresql_server_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the PostgreSQL Server.
+* `name` - The name of the PostgreSQL Server.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the PostgreSQL Server exists.
+* `resource_group_name` - Specifies the name of the Resource Group where the PostgreSQL Server exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/private_endpoint_connection.html.markdown
+++ b/website/docs/d/private_endpoint_connection.html.markdown
@@ -29,8 +29,8 @@ output "private_endpoint_status" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the Name of the private endpoint.
-* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the private endpoint exists.
+* `name` - Specifies the Name of the private endpoint.
+* `resource_group_name` - Specifies the Name of the Resource Group within which the private endpoint exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/private_link_endpoint_connection.html.markdown
+++ b/website/docs/d/private_link_endpoint_connection.html.markdown
@@ -32,8 +32,8 @@ output "private_link_endpoint_status" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the Name of the private link endpoint.
-* `resource_group_name` - (Required) Specifies the Name of the Resource Group within which the private link endpoint exists.
+* `name` - Specifies the Name of the private link endpoint.
+* `resource_group_name` - Specifies the Name of the Resource Group within which the private link endpoint exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/private_link_service.html.markdown
+++ b/website/docs/d/private_link_service.html.markdown
@@ -29,9 +29,9 @@ output "private_link_service_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the private link service.
+* `name` - The name of the private link service.
 
-* `resource_group_name` - (Required) The name of the resource group in which the private link service resides.
+* `resource_group_name` - The name of the resource group in which the private link service resides.
 
 ## Attributes Reference
 

--- a/website/docs/d/private_link_service_endpoint_connections.html.markdown
+++ b/website/docs/d/private_link_service_endpoint_connections.html.markdown
@@ -30,9 +30,9 @@ output "private_endpoint_status" {
 
 The following arguments are supported:
 
-* `service_id` - (Required) The resource ID of the private link service.
+* `service_id` - The resource ID of the private link service.
 
-* `resource_group_name` - (Required) The name of the resource group in which the private link service resides.
+* `resource_group_name` - The name of the resource group in which the private link service resides.
 
 
 ## Attributes Reference

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -97,8 +97,8 @@ output "public_ip_address" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the public IP address.
-* `resource_group_name` - (Required) Specifies the name of the resource group.
+* `name` - Specifies the name of the public IP address.
+* `resource_group_name` - Specifies the name of the resource group.
 
 
 ## Attributes Reference

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -26,8 +26,8 @@ output "public_ip_prefix" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the public IP prefix.
-* `resource_group_name` - (Required) Specifies the name of the resource group.
+* `name` - Specifies the name of the public IP prefix.
+* `resource_group_name` - Specifies the name of the resource group.
 
 ## Attributes Reference
 

--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -21,7 +21,7 @@ data "azurerm_public_ips" "example" {
 
 ## Argument Reference
 
-* `resource_group_name` - (Required) Specifies the name of the resource group.
+* `resource_group_name` - Specifies the name of the resource group.
 * `attached` - (Optional) Filter to include IP Addresses which are attached to a device, such as a VM/LB (`true`) or unattached (`false`).
 * `name_prefix` - (Optional) A prefix match used for the IP Addresses `name` field, case sensitive.
 * `allocation_type` - (Optional) The Allocation Type for the Public IP Address. Possible values include `Static` or `Dynamic`.

--- a/website/docs/d/recovery_services_protection_policy_vm.markdown
+++ b/website/docs/d/recovery_services_protection_policy_vm.markdown
@@ -24,11 +24,11 @@ data "azurerm_recovery_services_protection_policy_vm" "policy" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Recovery Services VM Protection Policy.
+* `name` - Specifies the name of the Recovery Services VM Protection Policy.
 
-* `recovery_vault_name` - (Required) Specifies the name of the Recovery Services Vault.
+* `recovery_vault_name` - Specifies the name of the Recovery Services Vault.
 
-* `resource_group_name` - (Required) The name of the resource group in which the Recovery Services VM Protection Policy resides.
+* `resource_group_name` - The name of the resource group in which the Recovery Services VM Protection Policy resides.
 
 ## Attributes Reference
 

--- a/website/docs/d/recovery_services_vault.markdown
+++ b/website/docs/d/recovery_services_vault.markdown
@@ -23,9 +23,9 @@ data "azurerm_recovery_services_vault" "vault" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Recovery Services Vault.
+* `name` - Specifies the name of the Recovery Services Vault.
 
-* `resource_group_name` - (Required) The name of the resource group in which the Recovery Services Vault resides.
+* `resource_group_name` - The name of the resource group in which the Recovery Services Vault resides.
 
 ## Attributes Reference
 

--- a/website/docs/d/resource_group.html.markdown
+++ b/website/docs/d/resource_group.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_managed_disk" "example" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the resource group.
+* `name` - Specifies the name of the resource group.
 
 ~> **Note:** If the specified location doesn't match the actual resource group location, an error message with the actual location value will be shown.
 

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -24,9 +24,9 @@ data "azurerm_route_table" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Route Table.
+* `name` - The name of the Route Table.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Route Table exists.
+* `resource_group_name` - The name of the Resource Group in which the Route Table exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/scheduler_job_collection.html.markdown
+++ b/website/docs/d/scheduler_job_collection.html.markdown
@@ -29,9 +29,9 @@ output "job_collection_state" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Scheduler Job Collection.
+* `name` - Specifies the name of the Scheduler Job Collection.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group in which the Scheduler Job Collection resides.
+* `resource_group_name` - Specifies the name of the resource group in which the Scheduler Job Collection resides.
 
 ## Attributes Reference
 

--- a/website/docs/d/servicebus_namespace.html.markdown
+++ b/website/docs/d/servicebus_namespace.html.markdown
@@ -25,9 +25,9 @@ output "location" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the ServiceBus Namespace.
+* `name` - Specifies the name of the ServiceBus Namespace.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the ServiceBus Namespace exists.
+* `resource_group_name` - Specifies the name of the Resource Group where the ServiceBus Namespace exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
@@ -26,11 +26,11 @@ output "rule_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the ServiceBus Namespace Authorization Rule.
+* `name` - Specifies the name of the ServiceBus Namespace Authorization Rule.
 
-* `namespace_name` - (Required) Specifies the name of the ServiceBus Namespace.
+* `namespace_name` - Specifies the name of the ServiceBus Namespace.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the ServiceBus Namespace exists.
+* `resource_group_name` - Specifies the name of the Resource Group where the ServiceBus Namespace exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -25,11 +25,11 @@ data "azurerm_shared_image" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Shared Image.
+* `name` - The name of the Shared Image.
 
-* `gallery_name` - (Required) The name of the Shared Image Gallery in which the Shared Image exists.
+* `gallery_name` - The name of the Shared Image Gallery in which the Shared Image exists.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Shared Image Gallery exists.
+* `resource_group_name` - The name of the Resource Group in which the Shared Image Gallery exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/shared_image_gallery.html.markdown
+++ b/website/docs/d/shared_image_gallery.html.markdown
@@ -24,9 +24,9 @@ data "azurerm_shared_image_gallery" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Shared Image Gallery.
+* `name` - The name of the Shared Image Gallery.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Shared Image Gallery exists.
+* `resource_group_name` - The name of the Resource Group in which the Shared Image Gallery exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -26,13 +26,13 @@ data "azurerm_shared_image_version" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Image Version.
+* `name` - The name of the Image Version.
 
-* `image_name` - (Required) The name of the Shared Image in which this Version exists.
+* `image_name` - The name of the Shared Image in which this Version exists.
 
-* `gallery_name` - (Required) The name of the Shared Image in which the Shared Image exists.
+* `gallery_name` - The name of the Shared Image in which the Shared Image exists.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which the Shared Image Gallery exists.
+* `resource_group_name` - The name of the Resource Group in which the Shared Image Gallery exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -23,9 +23,9 @@ data "azurerm_signalr_service" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the SignalR service.
+* `name` - Specifies the name of the SignalR service.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group the SignalR service is located in.
+* `resource_group_name` - Specifies the name of the resource group the SignalR service is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/snapshot.html.markdown
+++ b/website/docs/d/snapshot.html.markdown
@@ -21,9 +21,9 @@ data "azurerm_snapshot" "example" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Snapshot.
+* `name` - Specifies the name of the Snapshot.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group the Snapshot is located in.
+* `resource_group_name` - Specifies the name of the resource group the Snapshot is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/sql_database.html.markdown
+++ b/website/docs/d/sql_database.html.markdown
@@ -26,11 +26,11 @@ output "sql_database_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the SQL Database.
+* `name` - The name of the SQL Database.
 
-* `server_name` - (Required) The name of the SQL Server.
+* `server_name` - The name of the SQL Server.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the Azure SQL Database exists.
+* `resource_group_name` - Specifies the name of the Resource Group where the Azure SQL Database exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/sql_server.html.markdown
+++ b/website/docs/d/sql_server.html.markdown
@@ -25,9 +25,9 @@ output "sql_server_id" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the SQL Server.
+* `name` - The name of the SQL Server.
 
-* `resource_group_name` - (Required) Specifies the name of the Resource Group where the SQL Server exists.
+* `resource_group_name` - Specifies the name of the Resource Group where the SQL Server exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -26,8 +26,8 @@ output "storage_account_tier" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Storage Account
-* `resource_group_name` - (Required) Specifies the name of the resource group the Storage Account is located in.
+* `name` - Specifies the name of the Storage Account
+* `resource_group_name` - Specifies the name of the resource group the Storage Account is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -69,19 +69,19 @@ output "sas_url_query_string" {
 
 ## Argument Reference
 
-* `connection_string` - (Required) The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
+* `connection_string` - The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
 
-* `container_name` - (Required) Name of the container.
+* `container_name` - Name of the container.
 
 * `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
 
 * `ip_address` - (Optional) Single ipv4 address or range (connected with a dash) of ipv4 addresses.
 
-* `start` - (Required) The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
+* `start` - The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
 
-* `expiry` - (Required) The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
+* `expiry` - The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
 
-* `permissions` - (Required) A `permissions` block as defined below.
+* `permissions` - A `permissions` block as defined below.
 
 * `cache_control` - (Optional) The `Cache-Control` response header that is sent when this SAS token is used.
 
@@ -98,17 +98,17 @@ output "sas_url_query_string" {
 A `permissions` block contains:
 
 
-* `read` - (Required) Should Read permissions be enabled for this SAS?
+* `read` - Should Read permissions be enabled for this SAS?
 
-* `add` - (Required) Should Add permissions be enabled for this SAS?
+* `add` - Should Add permissions be enabled for this SAS?
 
-* `create` - (Required) Should Create permissions be enabled for this SAS?
+* `create` - Should Create permissions be enabled for this SAS?
 
-* `write` - (Required) Should Write permissions be enabled for this SAS?
+* `write` - Should Write permissions be enabled for this SAS?
 
-* `delete` - (Required) Should Delete permissions be enabled for this SAS?
+* `delete` - Should Delete permissions be enabled for this SAS?
 
-* `list` - (Required) Should List permissions be enabled for this SAS?
+* `list` - Should List permissions be enabled for this SAS?
 
 Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas)
 for additional details on the fields above.

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -75,13 +75,13 @@ output "sas_url_query_string" {
 
 ## Argument Reference
 
-* `connection_string` - (Required) The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
+* `connection_string` - The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
 * `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
-* `resource_types` - (Required) A `resource_types` block as defined below.
-* `services` - (Required) A `services` block as defined below.
-* `start` - (Required) The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
-* `expiry` - (Required) The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
-* `permissions` - (Required) A `permissions` block as defined below.
+* `resource_types` - A `resource_types` block as defined below.
+* `services` - A `services` block as defined below.
+* `start` - The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.
+* `expiry` - The expiration time and date of this SAS. Must be a valid ISO-8601 format time/date string.
+* `permissions` - A `permissions` block as defined below.
 
 ---
 
@@ -91,9 +91,9 @@ larger scope (affecting all sub-resources) than `object`.
 
 A `resource_types` block contains:
 
-* `service` - (Required) Should permission be granted to the entire service?
-* `container` - (Required) Should permission be granted to the container?
-* `object` - (Required) Should permission be granted only to a specific object?
+* `service` - Should permission be granted to the entire service?
+* `container` - Should permission be granted to the container?
+* `object` - Should permission be granted only to a specific object?
 
 ---
 
@@ -101,24 +101,24 @@ A `resource_types` block contains:
 
 A `services` block contains:
 
-* `blob` - (Required) Should permission be granted to `blob` services within this storage account?
-* `queue` - (Required) Should permission be granted to `queue` services within this storage account?
-* `table` - (Required) Should permission be granted to `table` services within this storage account?
-* `file` - (Required) Should permission be granted to `file` services within this storage account?
+* `blob` - Should permission be granted to `blob` services within this storage account?
+* `queue` - Should permission be granted to `queue` services within this storage account?
+* `table` - Should permission be granted to `table` services within this storage account?
+* `file` - Should permission be granted to `file` services within this storage account?
 
 ---
 
 A `permissions` block contains:
 
 
-* `read` - (Required) Should Read permissions be enabled for this SAS?
-* `write` - (Required) Should Write permissions be enabled for this SAS?
-* `delete` - (Required) Should Delete permissions be enabled for this SAS?
-* `list` - (Required) Should List permissions be enabled for this SAS?
-* `add` - (Required) Should Add permissions be enabled for this SAS?
-* `create` - (Required) Should Create permissions be enabled for this SAS?
-* `update` - (Required) Should Update permissions be enabled for this SAS?
-* `process` - (Required) Should Process permissions be enabled for this SAS?
+* `read` - Should Read permissions be enabled for this SAS?
+* `write` - Should Write permissions be enabled for this SAS?
+* `delete` - Should Delete permissions be enabled for this SAS?
+* `list` - Should List permissions be enabled for this SAS?
+* `add` - Should Add permissions be enabled for this SAS?
+* `create` - Should Create permissions be enabled for this SAS?
+* `update` - Should Update permissions be enabled for this SAS?
+* `process` - Should Process permissions be enabled for this SAS?
 
 Refer to the [SAS creation reference from Azure](https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-an-account-sas)
 for additional details on the fields above.

--- a/website/docs/d/storage_container.html.markdown
+++ b/website/docs/d/storage_container.html.markdown
@@ -23,8 +23,8 @@ data "azurerm_storage_container" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Container.
-* `storage_account_name` - (Required) The name of the Storage Account where the Container was created.
+* `name` - The name of the Container.
+* `storage_account_name` - The name of the Storage Account where the Container was created.
 
 ## Attributes Reference
 

--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -27,7 +27,7 @@ data "azurerm_storage_management_policy" "example" {
 
 The following arguments are supported:
 
-* `storage_account_id` - (Required) Specifies the id of the storage account to retrieve the management policy for.
+* `storage_account_id` - Specifies the id of the storage account to retrieve the management policy for.
 
 ## Attributes Reference
 
@@ -38,8 +38,8 @@ The following arguments are supported:
 
 * `rule` supports the following:
 
-* `name` - (Required) A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy.
-* `enabled` - (Required)  Boolean to specify whether the rule is enabled.
+* `name` - A rule name can contain any combination of alpha numeric characters. Rule name is case-sensitive. It must be unique within a policy.
+* `enabled` -  Boolean to specify whether the rule is enabled.
 * `filters` - A `filter` block as documented below.
 * `actions` - An `actions` block as documented below.
 

--- a/website/docs/d/stream_analytics_job.html.markdown
+++ b/website/docs/d/stream_analytics_job.html.markdown
@@ -26,9 +26,9 @@ output "job_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Stream Analytics Job.
+* `name` - Specifies the name of the Stream Analytics Job.
 
-* `resource_group_name` - (Required) Specifies the name of the resource group the Stream Analytics Job is located in.
+* `resource_group_name` - Specifies the name of the resource group the Stream Analytics Job is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -26,9 +26,9 @@ output "subnet_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Subnet.
-* `virtual_network_name` - (Required) Specifies the name of the Virtual Network this Subnet is located within.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Virtual Network is located in.
+* `name` - Specifies the name of the Subnet.
+* `virtual_network_name` - Specifies the name of the Virtual Network this Subnet is located within.
+* `resource_group_name` - Specifies the name of the resource group the Virtual Network is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/traffic_manager_geographical_location.html.markdown
+++ b/website/docs/d/traffic_manager_geographical_location.html.markdown
@@ -25,7 +25,7 @@ output "location_code" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Location, for example `World`, `Europe` or `Germany`.
+* `name` - Specifies the name of the Location, for example `World`, `Europe` or `Germany`.
 
 ## Attributes Reference
 

--- a/website/docs/d/user_assigned_identity.html.markdown
+++ b/website/docs/d/user_assigned_identity.html.markdown
@@ -30,8 +30,8 @@ output "uai_principal_id" {
 
 ## Argument Reference
 
-* `name` - (Required)  The name of the User Assigned Identity.
-* `resource_group_name` - (Required) The name of the Resource Group in which the User Assigned Identity exists.
+* `name` -  The name of the User Assigned Identity.
+* `resource_group_name` - The name of the Resource Group in which the User Assigned Identity exists.
 
 ## Attributes Reference
 

--- a/website/docs/d/virtual_hub.html.markdown
+++ b/website/docs/d/virtual_hub.html.markdown
@@ -28,9 +28,9 @@ output "virtual_hub_id" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Virtual Hub.
+* `name` - The name of the Virtual Hub.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the Virtual Hub exists.
+* `resource_group_name` - The Name of the Resource Group where the Virtual Hub exists.
 
 
 ## Attributes Reference

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -25,8 +25,8 @@ output "virtual_machine_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Virtual Machine.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Virtual Machine is located in.
+* `name` - Specifies the name of the Virtual Machine.
+* `resource_group_name` - Specifies the name of the resource group the Virtual Machine is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/virtual_network.html.markdown
+++ b/website/docs/d/virtual_network.html.markdown
@@ -25,8 +25,8 @@ output "virtual_network_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Virtual Network.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Virtual Network is located in.
+* `name` - Specifies the name of the Virtual Network.
+* `resource_group_name` - Specifies the name of the resource group the Virtual Network is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -41,7 +41,7 @@ output "virtual_network_gateway_id" {
 * `enable_bgp` - Will BGP (Border Gateway Protocol) will be enabled
     for this Virtual Network Gateway.
 
-* `active_active` - (Optional) Is this an Active-Active Gateway?
+* `active_active` - Is this an Active-Active Gateway?
 
 * `default_local_network_gateway_id` -  The ID of the local network gateway
     through which outbound Internet traffic from the virtual network in which the
@@ -86,13 +86,13 @@ The `vpn_client_configuration` block supports:
 * `revoked_certificate` - One or more `revoked_certificate` blocks which
     are defined below.
 
-* `radius_server_address` - (Optional) The address of the Radius server.
+* `radius_server_address` - The address of the Radius server.
     This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
 
-* `radius_server_secret` - (Optional) The secret used by the Radius server.
+* `radius_server_secret` - The secret used by the Radius server.
     This setting is incompatible with the use of `root_certificate` and `revoked_certificate`.
 
-* `vpn_client_protocols` - (Optional) List of the protocols supported by the vpn client.
+* `vpn_client_protocols` - List of the protocols supported by the vpn client.
     The supported values are `SSTP`, `IkeV2` and `OpenVPN`.
 
 The `bgp_settings` block supports:

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -25,8 +25,8 @@ output "virtual_network_gateway_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Virtual Network Gateway.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Virtual Network Gateway is located in.
+* `name` - Specifies the name of the Virtual Network Gateway.
+* `resource_group_name` - Specifies the name of the resource group the Virtual Network Gateway is located in.
 
 ## Attributes Reference
 

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -72,7 +72,7 @@ output "virtual_network_gateway_connection_id" {
     Only a single policy can be defined for a connection. For details on
     custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/en-us/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
+* `tags` - A mapping of tags to assign to the resource.
 
 The `ipsec_policy` block supports:
 

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -25,8 +25,8 @@ output "virtual_network_gateway_connection_id" {
 
 ## Argument Reference
 
-* `name` - (Required) Specifies the name of the Virtual Network Gateway Connection.
-* `resource_group_name` - (Required) Specifies the name of the resource group the Virtual Network Gateway Connection is located in.
+* `name` - Specifies the name of the Virtual Network Gateway Connection.
+* `resource_group_name` - Specifies the name of the resource group the Virtual Network Gateway Connection is located in.
 
 ## Attributes Reference
 


### PR DESCRIPTION
In a [different PR](https://github.com/terraform-providers/terraform-provider-azurerm/pull/5518#discussion_r370903671) it was requested I remove all _(Required)_ or _(Optional)_ references. 

> @katbyte
we don't need required/optional on data source documentation, and could we use language consistent with the rest of the provider?

This PR cleans up the existing data source documentation to remove _(Required)_ from all **Argument Reference** sections. And _(Optional)_ from all **Attributes Reference** sections