### PR TITLE
`azurerm_databricks_workspace`: Support for Trial SKU

### DIFF
--- a/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
+++ b/azurerm/internal/services/databricks/resource_arm_databricks_workspace.go
@@ -59,6 +59,7 @@ func resourceArmDatabricksWorkspace() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"standard",
 					"premium",
+					"trial",
 				}, false),
 			},
 


### PR DESCRIPTION
Added SKU schema validation type of "trial" to allow for setting up a Trial version of the Azure Databricks Workspace.

Fixes #5651
