### PR TITLE
Corrected Prefix Length

### DIFF
--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 -> **Note** Public IP Prefix can only be created with Standard SKUs at this time.
 
-* `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 24 (256 addresses) and 31 (2 addresses). Changing this forces a new resource to be created.
+* `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 28 (16 addresses) and 31 (2 addresses). Changing this forces a new resource to be created.
 
 -> **Please Note:**: There may be Public IP address limits on the subscription . [More information available here](https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits?toc=%2fazure%2fvirtual-network%2ftoc.json#publicip-address)
 


### PR DESCRIPTION
The maximum IP prefix length that can be reserved (according to docs.microsoft) is `/28` or 16 usable addresses.

https://docs.microsoft.com/en-us/azure/virtual-network/public-ip-address-prefix#constraints