### PR TITLE
r/virtual_machine_scale_set: adding a notice about the superseding

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_scale_set.go
@@ -24,6 +24,9 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+// NOTE: the `azurerm_virtual_machine_scale_set` resource has been superseded by the
+//       `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources
+//       and as such this resource is feature-frozen and new functionality will be added to these new resources instead.
 func resourceArmVirtualMachineScaleSet() *schema.Resource {
 	return &schema.Resource{
 		Create:        resourceArmVirtualMachineScaleSetCreateUpdate,


### PR DESCRIPTION
The `azurerm_virtual_machine_scale_set` resource is being superseded by the `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set` resources in 2.0; this adds a matching note to the top of the resource as is present in the VM resource