### PR TITLE
Changing osDisk.Name is not allowed

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine.go
@@ -242,6 +242,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 
 						"vhd_uri": {

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -334,7 +334,7 @@ The following properties apply when using Unmanaged Disks:
 
 A `storage_os_disk` block supports the following:
 
-* `name` - (Required) Specifies the name of the OS Disk.
+* `name` - (Required) Specifies the name of the OS Disk. Changing this forces a new resource to be created.
 
 * `create_option` - (Required) Specifies how the OS Disk should be created. Possible values are `Attach` (managed disks only) and `FromImage`.
 


### PR DESCRIPTION
```
Error: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="PropertyChangeNotAllowed" Message="Changing property 'osDisk.name' is not allowed." Target="osDisk.name"
```