### PR TITLE
Update IP Prefix validation

### DIFF
--- a/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
+++ b/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
@@ -59,7 +59,7 @@ func resourceArmPublicIpPrefix() *schema.Resource {
 				Optional:     true,
 				Default:      28,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(24, 31),
+				ValidateFunc: validation.IntBetween(28, 31),
 			},
 
 			"ip_prefix": {


### PR DESCRIPTION
IP Prefix can be deployed as a maximum /28 ip space.  The code would allow a max of /24 which is not correct.  Updated to support /28 as the max.