### PR TITLE
azurerm_role_definition: Add recommendation for scope parameter value

### DIFF
--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Role Definition. Changing this forces a new resource to be created.
 
-* `scope` - (Required) The scope at which the Role Definition applies too, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`. Changing this forces a new resource to be created.
+* `scope` - (Required) The scope at which the Role Definition applies too, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`. It is recommended to use the first entry of the `assignable_scopes`. Changing this forces a new resource to be created.
 
 * `description` - (Optional) A description of the Role Definition.
 


### PR DESCRIPTION
I have added a recommendationfor the scope parameter value. One should use the first entry of the assignable_scopes parameter. It is sourced from the microsoft docs. Section 4 in the following howto: https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles-rest#create-a-custom-role

This should hopefully help with the decision what to put for the scope parameter, since it is generally not required when creating custom roles any other way than Terraform.
See also my comment on https://github.com/terraform-providers/terraform-provider-azurerm/issues/4247:

> The scope seems to be generally insignificant for the end user. It is not necessary or shown when using PowerShell of the CLI.
The REST API How-to advises that when creating a custom role one should "replace {scope} with the first assignableScopes of the custom role".
I think ideally the Terraform provider should adopt the PowerShell/CLI way of setting the scope for the user. If this is not possible/desirable the docs should at least mention the recommendation of setting the scope to the first assignableScopes of the custom role.