### PR TITLE
docs: removing the beta disclaimer for custom timeouts

### DIFF
--- a/website/docs/d/api_management.html.markdown
+++ b/website/docs/d/api_management.html.markdown
@@ -136,8 +136,6 @@ A `sku` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Service.

--- a/website/docs/d/api_management_api.html.markdown
+++ b/website/docs/d/api_management_api.html.markdown
@@ -79,8 +79,6 @@ A `wsdl_selector` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management API.

--- a/website/docs/d/api_management_api_version_set.html.markdown
+++ b/website/docs/d/api_management_api_version_set.html.markdown
@@ -48,8 +48,6 @@ output "api_management_api_version_set_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Version Set.

--- a/website/docs/d/api_management_group.html.markdown
+++ b/website/docs/d/api_management_group.html.markdown
@@ -46,8 +46,6 @@ output "group_type" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Group.

--- a/website/docs/d/api_management_product.html.markdown
+++ b/website/docs/d/api_management_product.html.markdown
@@ -52,8 +52,6 @@ output "product_terms" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Product.

--- a/website/docs/d/api_management_user.html.markdown
+++ b/website/docs/d/api_management_user.html.markdown
@@ -48,8 +48,6 @@ output "notes" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management User.

--- a/website/docs/d/app_service.html.markdown
+++ b/website/docs/d/app_service.html.markdown
@@ -139,8 +139,6 @@ A `ip_restriction` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Service.

--- a/website/docs/d/app_service_certificate.html.markdown
+++ b/website/docs/d/app_service_certificate.html.markdown
@@ -54,8 +54,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Service Certificate.

--- a/website/docs/d/app_service_certificate_order.html.markdown
+++ b/website/docs/d/app_service_certificate_order.html.markdown
@@ -79,8 +79,6 @@ output "certificate_order_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Service Certificate Order.

--- a/website/docs/d/app_service_plan.html.markdown
+++ b/website/docs/d/app_service_plan.html.markdown
@@ -71,8 +71,6 @@ A `properties` block supports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Service Plan.

--- a/website/docs/d/application_insights.html.markdown
+++ b/website/docs/d/application_insights.html.markdown
@@ -40,8 +40,6 @@ output "application_insights_instrumentation_key" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Application Insights component.

--- a/website/docs/d/application_security_group.html.markdown
+++ b/website/docs/d/application_security_group.html.markdown
@@ -43,8 +43,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Application Security Group.

--- a/website/docs/d/automation_account.html.markdown
+++ b/website/docs/d/automation_account.html.markdown
@@ -41,8 +41,6 @@ output "automation_account_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Automation Account.

--- a/website/docs/d/automation_variable_bool.html.markdown
+++ b/website/docs/d/automation_variable_bool.html.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Automation Bool Variable.

--- a/website/docs/d/automation_variable_datetime.html.markdown
+++ b/website/docs/d/automation_variable_datetime.html.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Automation Datetime Variable.

--- a/website/docs/d/automation_variable_int.html.markdown
+++ b/website/docs/d/automation_variable_int.html.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Automation Int Variable.

--- a/website/docs/d/automation_variable_string.html.markdown
+++ b/website/docs/d/automation_variable_string.html.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Automation String Variable.

--- a/website/docs/d/availability_set.html.markdown
+++ b/website/docs/d/availability_set.html.markdown
@@ -49,8 +49,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Availability Set.

--- a/website/docs/d/azuread_application.html.markdown
+++ b/website/docs/d/azuread_application.html.markdown
@@ -52,8 +52,6 @@ output "azure_active_directory_object_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Application within Azure Active Directory.

--- a/website/docs/d/azuread_service_principal.html.markdown
+++ b/website/docs/d/azuread_service_principal.html.markdown
@@ -59,8 +59,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Service Principal.

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -68,8 +68,6 @@ A `key_vault_reference` block have the following properties:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Batch Account.

--- a/website/docs/d/batch_certificate.html.markdown
+++ b/website/docs/d/batch_certificate.html.markdown
@@ -49,8 +49,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the certificate.

--- a/website/docs/d/batch_pool.html.markdown
+++ b/website/docs/d/batch_pool.html.markdown
@@ -183,8 +183,6 @@ A `network_security_group_rules` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Batch Pool.

--- a/website/docs/d/builtin_role_definition.markdown
+++ b/website/docs/d/builtin_role_definition.markdown
@@ -46,8 +46,6 @@ A `permissions` block contains:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Role Definition.

--- a/website/docs/d/cdn_profile.html.markdown
+++ b/website/docs/d/cdn_profile.html.markdown
@@ -39,8 +39,6 @@ output "cdn_profile_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the CDN Profile.

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -44,8 +44,6 @@ There are no arguments available for this data source.
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the client config.

--- a/website/docs/d/container_registry.markdown
+++ b/website/docs/d/container_registry.markdown
@@ -53,8 +53,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Container Registry.

--- a/website/docs/d/cosmosdb_account.html.markdown
+++ b/website/docs/d/cosmosdb_account.html.markdown
@@ -90,8 +90,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the CosmosDB Account.

--- a/website/docs/d/data_factory.html.markdown
+++ b/website/docs/d/data_factory.html.markdown
@@ -88,8 +88,6 @@ A `vsts_configuration` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory.

--- a/website/docs/d/data_lake_store.html.markdown
+++ b/website/docs/d/data_lake_store.html.markdown
@@ -48,8 +48,6 @@ output "data_lake_store_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Data Lake Store.

--- a/website/docs/d/dedicated_host.html.markdown
+++ b/website/docs/d/dedicated_host.html.markdown
@@ -47,8 +47,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Dedicated Host.

--- a/website/docs/d/dedicated_host_group.html.markdown
+++ b/website/docs/d/dedicated_host_group.html.markdown
@@ -48,8 +48,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Dedicated Host Group.

--- a/website/docs/d/dev_test_lab.html.markdown
+++ b/website/docs/d/dev_test_lab.html.markdown
@@ -53,8 +53,6 @@ output "unique_identifier" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Dev Test Lab.

--- a/website/docs/d/dev_test_virtual_network.html.markdown
+++ b/website/docs/d/dev_test_virtual_network.html.markdown
@@ -62,8 +62,6 @@ An `subnets_override` block supports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Dev Test Lab Virtual Network.

--- a/website/docs/d/disk_encryption_set.html.markdown
+++ b/website/docs/d/disk_encryption_set.html.markdown
@@ -30,8 +30,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Disk Encryption Set.

--- a/website/docs/d/dns_zone.html.markdown
+++ b/website/docs/d/dns_zone.html.markdown
@@ -47,8 +47,6 @@ in your subscription that matches `name` will be returned.
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the DNS Zone.

--- a/website/docs/d/eventgrid_topic.html.markdown
+++ b/website/docs/d/eventgrid_topic.html.markdown
@@ -42,8 +42,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the EventGrid Topic.

--- a/website/docs/d/eventhub_consumer_group.html.markdown
+++ b/website/docs/d/eventhub_consumer_group.html.markdown
@@ -41,8 +41,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the EventHub Consumer Group.

--- a/website/docs/d/eventhub_namespace.html.markdown
+++ b/website/docs/d/eventhub_namespace.html.markdown
@@ -59,8 +59,6 @@ The following attributes are exported only if there is an authorization rule nam
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the EventHub Namespace.

--- a/website/docs/d/eventhub_namespace_authorization_rule.html.markdown
+++ b/website/docs/d/eventhub_namespace_authorization_rule.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Authorization Rule.

--- a/website/docs/d/express_route_circuit.html.markdown
+++ b/website/docs/d/express_route_circuit.html.markdown
@@ -75,8 +75,6 @@ output "service_key" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the ExpressRoute circuit.

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -50,8 +50,6 @@ A `ip_configuration` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Firewall.

--- a/website/docs/d/function_app.html.markdown
+++ b/website/docs/d/function_app.html.markdown
@@ -67,8 +67,6 @@ The `site_credential` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Function App.

--- a/website/docs/d/hdinsight_cluster.html.markdown
+++ b/website/docs/d/hdinsight_cluster.html.markdown
@@ -64,8 +64,6 @@ A `gateway` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the HDInsight Cluster.

--- a/website/docs/d/healthcare_service.html.markdown
+++ b/website/docs/d/healthcare_service.html.markdown
@@ -63,8 +63,6 @@ A `cors_configuration` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Healthcare Service.

--- a/website/docs/d/image.html.markdown
+++ b/website/docs/d/image.html.markdown
@@ -59,8 +59,6 @@ output "image_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Image.

--- a/website/docs/d/iothub_dps.html.markdown
+++ b/website/docs/d/iothub_dps.html.markdown
@@ -45,8 +45,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the IoT Hub Device Provisioning Service.

--- a/website/docs/d/iothub_dps_shared_access_policy.html.markdown
+++ b/website/docs/d/iothub_dps_shared_access_policy.html.markdown
@@ -46,8 +46,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the IotHub Device Provisioning Service Shared Access Policy.

--- a/website/docs/d/iothub_shared_access_policy.html.markdown
+++ b/website/docs/d/iothub_shared_access_policy.html.markdown
@@ -46,8 +46,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the IotHub Shared Access Policy.

--- a/website/docs/d/key_vault.html.markdown
+++ b/website/docs/d/key_vault.html.markdown
@@ -77,8 +77,6 @@ A `sku` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault.

--- a/website/docs/d/key_vault_access_policy.html.markdown
+++ b/website/docs/d/key_vault_access_policy.html.markdown
@@ -43,8 +43,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Access Policy.

--- a/website/docs/d/key_vault_key.html.markdown
+++ b/website/docs/d/key_vault_key.html.markdown
@@ -60,8 +60,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Key.

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -48,8 +48,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Secret.

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -243,8 +243,6 @@ A `ssh_key` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Managed Kubernetes Cluster (AKS).

--- a/website/docs/d/kubernetes_service_versions.html.markdown
+++ b/website/docs/d/kubernetes_service_versions.html.markdown
@@ -40,8 +40,6 @@ output "latest_version" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the versions.

--- a/website/docs/d/lb.html.markdown
+++ b/website/docs/d/lb.html.markdown
@@ -62,8 +62,6 @@ A `frontend_ip_configuration` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Load Balancer.

--- a/website/docs/d/lb_backend_address_pool.html.markdown
+++ b/website/docs/d/lb_backend_address_pool.html.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Backend Address Pool.

--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -52,8 +52,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Workspace.

--- a/website/docs/d/logic_app_workflow.html.markdown
+++ b/website/docs/d/logic_app_workflow.html.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Logic App Workflow.

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -55,8 +55,6 @@ output "id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Managed Disk.

--- a/website/docs/d/management_group.html.markdown
+++ b/website/docs/d/management_group.html.markdown
@@ -42,8 +42,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Management Group.

--- a/website/docs/d/maps_account.html.markdown
+++ b/website/docs/d/maps_account.html.markdown
@@ -44,8 +44,6 @@ output "maps_account_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Maps Account.

--- a/website/docs/d/mariadb_server.html.markdown
+++ b/website/docs/d/mariadb_server.html.markdown
@@ -68,8 +68,6 @@ A `storage_profile` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the MariaDB Server.

--- a/website/docs/d/monitor_action_group.html.markdown
+++ b/website/docs/d/monitor_action_group.html.markdown
@@ -134,8 +134,6 @@ output "action_group_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Action Group.

--- a/website/docs/d/monitor_diagnostic_categories.html.markdown
+++ b/website/docs/d/monitor_diagnostic_categories.html.markdown
@@ -38,8 +38,6 @@ data "azurerm_monitor_diagnostic_categories" "example" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Monitor Diagnostics Categories.

--- a/website/docs/d/monitor_log_profile.html.markdown
+++ b/website/docs/d/monitor_log_profile.html.markdown
@@ -51,8 +51,6 @@ The `retention_policy` block supports:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Log Profile.

--- a/website/docs/d/mssql_elasticpool.html.markdown
+++ b/website/docs/d/mssql_elasticpool.html.markdown
@@ -50,8 +50,6 @@ output "elasticpool_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the SQL elastic pool.

--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -42,8 +42,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the NAT Gateway.

--- a/website/docs/d/netapp_account.html.markdown
+++ b/website/docs/d/netapp_account.html.markdown
@@ -41,8 +41,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the NetApp Account.

--- a/website/docs/d/netapp_pool.html.markdown
+++ b/website/docs/d/netapp_pool.html.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the NetApp Pool.

--- a/website/docs/d/netapp_snapshot.html.markdown
+++ b/website/docs/d/netapp_snapshot.html.markdown
@@ -48,8 +48,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the NetApp Snapshot.

--- a/website/docs/d/netapp_volume.html.markdown
+++ b/website/docs/d/netapp_volume.html.markdown
@@ -53,8 +53,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the NetApp Volume.

--- a/website/docs/d/network_ddos_protection_plan.html.markdown
+++ b/website/docs/d/network_ddos_protection_plan.html.markdown
@@ -46,8 +46,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Protection Plan.

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -62,8 +62,6 @@ A `ip_configuration` block contains:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Network Interface.

--- a/website/docs/d/network_security_group.html.markdown
+++ b/website/docs/d/network_security_group.html.markdown
@@ -72,8 +72,6 @@ The `security_rule` block supports:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Network Security Group.

--- a/website/docs/d/network_watcher.html.markdown
+++ b/website/docs/d/network_watcher.html.markdown
@@ -39,8 +39,6 @@ output "network_watcher_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Network Watcher.

--- a/website/docs/d/notification_hub.html.markdown
+++ b/website/docs/d/notification_hub.html.markdown
@@ -64,8 +64,6 @@ A `gcm_credential` block exports:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Notification Hub within a Notification Hub Namespace.

--- a/website/docs/d/notification_hub_namespace.html.markdown
+++ b/website/docs/d/notification_hub_namespace.html.markdown
@@ -49,8 +49,6 @@ A `sku` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Notification Hub Namespace.

--- a/website/docs/d/platform_image.html.markdown
+++ b/website/docs/d/platform_image.html.markdown
@@ -40,8 +40,6 @@ output "version" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Platform Image.

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -41,8 +41,6 @@ output "id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Policy Definition.

--- a/website/docs/d/postgresql_server.html.markdown
+++ b/website/docs/d/postgresql_server.html.markdown
@@ -43,8 +43,6 @@ output "postgresql_server_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Azure Database Server.

--- a/website/docs/d/private_endpoint_connection.html.markdown
+++ b/website/docs/d/private_endpoint_connection.html.markdown
@@ -54,8 +54,6 @@ A `private_service_connection` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Private Endpoint.

--- a/website/docs/d/private_link_endpoint_connection.html.markdown
+++ b/website/docs/d/private_link_endpoint_connection.html.markdown
@@ -56,8 +56,6 @@ A `private_service_connection` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Private Link Endpoint.

--- a/website/docs/d/private_link_service.html.markdown
+++ b/website/docs/d/private_link_service.html.markdown
@@ -72,8 +72,6 @@ The `nat_ip_configuration` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Private Link Service.

--- a/website/docs/d/private_link_service_endpoint_connections.html.markdown
+++ b/website/docs/d/private_link_service_endpoint_connections.html.markdown
@@ -57,8 +57,6 @@ The `private_endpoint_connections` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Private Link Service.

--- a/website/docs/d/proximity_placement_group.html.markdown
+++ b/website/docs/d/proximity_placement_group.html.markdown
@@ -39,8 +39,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Proximity Placement Group.

--- a/website/docs/d/public_ip.html.markdown
+++ b/website/docs/d/public_ip.html.markdown
@@ -111,8 +111,6 @@ output "public_ip_address" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Public IP Address.

--- a/website/docs/d/public_ip_prefix.html.markdown
+++ b/website/docs/d/public_ip_prefix.html.markdown
@@ -40,8 +40,6 @@ output "public_ip_prefix" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Public IP Prefix.

--- a/website/docs/d/public_ips.html.markdown
+++ b/website/docs/d/public_ips.html.markdown
@@ -39,8 +39,6 @@ A `public_ips` block contains:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Public IP Addresses.

--- a/website/docs/d/recovery_services_protection_policy_vm.markdown
+++ b/website/docs/d/recovery_services_protection_policy_vm.markdown
@@ -41,8 +41,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Recovery Services VM Protection Policy.

--- a/website/docs/d/recovery_services_vault.markdown
+++ b/website/docs/d/recovery_services_vault.markdown
@@ -41,8 +41,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Recovery Services Vault.

--- a/website/docs/d/redis_cache.html.markdown
+++ b/website/docs/d/redis_cache.html.markdown
@@ -101,8 +101,6 @@ A `redis_configuration` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache.

--- a/website/docs/d/resource_group.html.markdown
+++ b/website/docs/d/resource_group.html.markdown
@@ -40,8 +40,6 @@ resource "azurerm_managed_disk" "example" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Resource Group.

--- a/website/docs/d/resources.html.markdown
+++ b/website/docs/d/resources.html.markdown
@@ -80,8 +80,6 @@ The `resource` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Resources.

--- a/website/docs/d/role_definition.html.markdown
+++ b/website/docs/d/role_definition.html.markdown
@@ -74,8 +74,6 @@ A `permissions` block contains:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Role Definition.

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -54,8 +54,6 @@ The `route` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Route Table.

--- a/website/docs/d/scheduler_job_collection.html.markdown
+++ b/website/docs/d/scheduler_job_collection.html.markdown
@@ -59,8 +59,6 @@ The `quota` block supports:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Scheduler Job Collection.

--- a/website/docs/d/servicebus_namespace.html.markdown
+++ b/website/docs/d/servicebus_namespace.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported only if there is an authorization rule nam
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace.

--- a/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/d/servicebus_namespace_authorization_rule.html.markdown
@@ -46,8 +46,6 @@ output "rule_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace Authorization Rule.

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -65,8 +65,6 @@ A `identifier` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Shared Image a Shared Image Gallery.

--- a/website/docs/d/shared_image_gallery.html.markdown
+++ b/website/docs/d/shared_image_gallery.html.markdown
@@ -42,8 +42,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Shared Image Gallery.

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -62,8 +62,6 @@ The `target_region` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Version of a Shared Image within a Shared Image Gallery.

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -53,8 +53,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the SignalR service.

--- a/website/docs/d/snapshot.html.markdown
+++ b/website/docs/d/snapshot.html.markdown
@@ -41,8 +41,6 @@ data "azurerm_snapshot" "example" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Snapshot.

--- a/website/docs/d/sql_database.html.markdown
+++ b/website/docs/d/sql_database.html.markdown
@@ -66,8 +66,6 @@ output "sql_database_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the SQL Azure Database.

--- a/website/docs/d/sql_server.html.markdown
+++ b/website/docs/d/sql_server.html.markdown
@@ -55,8 +55,6 @@ An `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the SQL Azure Database Server.

--- a/website/docs/d/storage_account.html.markdown
+++ b/website/docs/d/storage_account.html.markdown
@@ -133,8 +133,6 @@ output "storage_account_tier" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Storage Account.

--- a/website/docs/d/storage_account_blob_container_sas.html.markdown
+++ b/website/docs/d/storage_account_blob_container_sas.html.markdown
@@ -119,8 +119,6 @@ for additional details on the fields above.
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Blob Container.

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -129,8 +129,6 @@ for additional details on the fields above.
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the SAS Token.

--- a/website/docs/d/storage_container.html.markdown
+++ b/website/docs/d/storage_container.html.markdown
@@ -35,8 +35,6 @@ The following arguments are supported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Storage Container.

--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -73,8 +73,6 @@ The following arguments are supported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Storage Management Policy.

--- a/website/docs/d/stream_analytics_job.html.markdown
+++ b/website/docs/d/stream_analytics_job.html.markdown
@@ -57,8 +57,6 @@ output "job_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Stream Analytics Job.

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -44,8 +44,6 @@ output "subnet_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Subnet located within a Virtual Network.

--- a/website/docs/d/subscription.html.markdown
+++ b/website/docs/d/subscription.html.markdown
@@ -38,8 +38,6 @@ output "current_subscription_display_name" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Subscription.

--- a/website/docs/d/subscriptions.html.markdown
+++ b/website/docs/d/subscriptions.html.markdown
@@ -46,8 +46,6 @@ The `subscription` block contains:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the subscriptions.

--- a/website/docs/d/traffic_manager_geographical_location.html.markdown
+++ b/website/docs/d/traffic_manager_geographical_location.html.markdown
@@ -33,8 +33,6 @@ output "location_code" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Location.

--- a/website/docs/d/user_assigned_identity.html.markdown
+++ b/website/docs/d/user_assigned_identity.html.markdown
@@ -45,8 +45,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the User Assigned Identity.

--- a/website/docs/d/virtual_hub.html.markdown
+++ b/website/docs/d/virtual_hub.html.markdown
@@ -47,8 +47,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Hub.

--- a/website/docs/d/virtual_machine.html.markdown
+++ b/website/docs/d/virtual_machine.html.markdown
@@ -34,8 +34,6 @@ output "virtual_machine_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Machine.

--- a/website/docs/d/virtual_network.html.markdown
+++ b/website/docs/d/virtual_network.html.markdown
@@ -39,8 +39,6 @@ output "virtual_network_id" {
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network.

--- a/website/docs/d/virtual_network_gateway.html.markdown
+++ b/website/docs/d/virtual_network_gateway.html.markdown
@@ -122,8 +122,6 @@ The `root_revoked_certificate` block supports:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network Gateway.

--- a/website/docs/d/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/d/virtual_network_gateway_connection.html.markdown
@@ -104,8 +104,6 @@ The `ipsec_policy` block supports:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network Gateway Connection.

--- a/website/docs/r/advanced_threat_protection.html.markdown
+++ b/website/docs/r/advanced_threat_protection.html.markdown
@@ -54,8 +54,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Advanced Threat Protection.

--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -81,8 +81,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Analysis Services Server.

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -305,8 +305,6 @@ An `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the API Management Service.

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -122,8 +122,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management API.

--- a/website/docs/r/api_management_api_operation.html.markdown
+++ b/website/docs/r/api_management_api_operation.html.markdown
@@ -183,8 +183,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management API Operation.

--- a/website/docs/r/api_management_api_operation_policy.html.markdown
+++ b/website/docs/r/api_management_api_operation_policy.html.markdown
@@ -58,8 +58,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management API Operation Policy.

--- a/website/docs/r/api_management_api_policy.html.markdown
+++ b/website/docs/r/api_management_api_policy.html.markdown
@@ -58,8 +58,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management API Policy.

--- a/website/docs/r/api_management_api_schema.html.markdown
+++ b/website/docs/r/api_management_api_schema.html.markdown
@@ -54,8 +54,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management API Schema.

--- a/website/docs/r/api_management_api_version_set.html.markdown
+++ b/website/docs/r/api_management_api_version_set.html.markdown
@@ -72,8 +72,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management API Version Set.

--- a/website/docs/r/api_management_authorization_server.html.markdown
+++ b/website/docs/r/api_management_authorization_server.html.markdown
@@ -102,8 +102,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Authorization Server.
@@ -120,8 +118,6 @@ terraform import azurerm_api_management_authorization_server.example /subscripti
 ```
 
 ## Timeouts
-
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 

--- a/website/docs/r/api_management_backend.html.markdown
+++ b/website/docs/r/api_management_backend.html.markdown
@@ -137,8 +137,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Backend.

--- a/website/docs/r/api_management_certificate.html.markdown
+++ b/website/docs/r/api_management_certificate.html.markdown
@@ -66,8 +66,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Certificate.

--- a/website/docs/r/api_management_diagnostic.html.markdown
+++ b/website/docs/r/api_management_diagnostic.html.markdown
@@ -57,8 +57,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Diagnostic.

--- a/website/docs/r/api_management_group.html.markdown
+++ b/website/docs/r/api_management_group.html.markdown
@@ -65,8 +65,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Group.

--- a/website/docs/r/api_management_group_user.html.markdown
+++ b/website/docs/r/api_management_group_user.html.markdown
@@ -49,8 +49,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Group User.

--- a/website/docs/r/api_management_identity_provider_aad.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aad.html.markdown
@@ -60,8 +60,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management AAD Identity Provider.

--- a/website/docs/r/api_management_identity_provider_facebook.html.markdown
+++ b/website/docs/r/api_management_identity_provider_facebook.html.markdown
@@ -57,8 +57,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Facebook Identity Provider.

--- a/website/docs/r/api_management_identity_provider_google.html.markdown
+++ b/website/docs/r/api_management_identity_provider_google.html.markdown
@@ -57,8 +57,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Google Identity Provider.

--- a/website/docs/r/api_management_identity_provider_microsoft.html.markdown
+++ b/website/docs/r/api_management_identity_provider_microsoft.html.markdown
@@ -57,8 +57,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Microsoft Identity Provider.

--- a/website/docs/r/api_management_identity_provider_twitter.html.markdown
+++ b/website/docs/r/api_management_identity_provider_twitter.html.markdown
@@ -57,8 +57,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Twitter Identity Provider.

--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -89,8 +89,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Logger.

--- a/website/docs/r/api_management_openid_connect_provider.html.markdown
+++ b/website/docs/r/api_management_openid_connect_provider.html.markdown
@@ -68,8 +68,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management OpenID Connect Provider.

--- a/website/docs/r/api_management_product.html.markdown
+++ b/website/docs/r/api_management_product.html.markdown
@@ -77,8 +77,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Product.

--- a/website/docs/r/api_management_product_api.html.markdown
+++ b/website/docs/r/api_management_product_api.html.markdown
@@ -59,8 +59,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Product API.

--- a/website/docs/r/api_management_product_group.html.markdown
+++ b/website/docs/r/api_management_product_group.html.markdown
@@ -58,8 +58,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Product Group.

--- a/website/docs/r/api_management_product_policy.html.markdown
+++ b/website/docs/r/api_management_product_policy.html.markdown
@@ -59,8 +59,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Product Policy.

--- a/website/docs/r/api_management_property.html.markdown
+++ b/website/docs/r/api_management_property.html.markdown
@@ -67,8 +67,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Property.

--- a/website/docs/r/api_management_subscription.html.markdown
+++ b/website/docs/r/api_management_subscription.html.markdown
@@ -69,8 +69,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management Subscription.

--- a/website/docs/r/api_management_user.html.markdown
+++ b/website/docs/r/api_management_user.html.markdown
@@ -76,8 +76,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the API Management User.

--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -71,8 +71,6 @@ A `access_key` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Configuration.

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -395,8 +395,6 @@ A `source_control` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service.

--- a/website/docs/r/app_service_active_slot.html.markdown
+++ b/website/docs/r/app_service_active_slot.html.markdown
@@ -55,8 +55,6 @@ The following arguments are supported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Active Slot.

--- a/website/docs/r/app_service_certificate.html.markdown
+++ b/website/docs/r/app_service_certificate.html.markdown
@@ -79,8 +79,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Certificate.

--- a/website/docs/r/app_service_certificate_order.html.markdown
+++ b/website/docs/r/app_service_certificate_order.html.markdown
@@ -92,8 +92,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Certificate Order.

--- a/website/docs/r/app_service_custom_hostname_binding.html.markdown
+++ b/website/docs/r/app_service_custom_hostname_binding.html.markdown
@@ -80,8 +80,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Custom Hostname Binding.

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -141,8 +141,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Plan.

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -404,8 +404,6 @@ The `site_credential` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Slot.

--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -34,8 +34,6 @@ The following arguments are supported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Source Control Token.

--- a/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
+++ b/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
@@ -82,8 +82,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the App Service Virtual Network Association.

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -732,8 +732,6 @@ A `rewrite_rule_set` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 minutes) Used when creating the Application Gateway.

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -70,8 +70,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Application Insights Component.

--- a/website/docs/r/application_insights_analytics_item.html.markdown
+++ b/website/docs/r/application_insights_analytics_item.html.markdown
@@ -64,8 +64,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Application Insights Analytics Item.

--- a/website/docs/r/application_insights_api_key.html.markdown
+++ b/website/docs/r/application_insights_api_key.html.markdown
@@ -92,8 +92,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Application Insights API Key.

--- a/website/docs/r/application_insights_web_test.html.markdown
+++ b/website/docs/r/application_insights_web_test.html.markdown
@@ -90,8 +90,6 @@ The following arguments are supported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Application Insights Web Test.

--- a/website/docs/r/application_security_group.html.markdown
+++ b/website/docs/r/application_security_group.html.markdown
@@ -49,8 +49,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Application Security Group.

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -69,8 +69,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Account.

--- a/website/docs/r/automation_certificate.html.markdown
+++ b/website/docs/r/automation_certificate.html.markdown
@@ -62,8 +62,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Certificate.

--- a/website/docs/r/automation_credential.html.markdown
+++ b/website/docs/r/automation_credential.html.markdown
@@ -62,8 +62,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Credential.

--- a/website/docs/r/automation_dsc_configuration.html.markdown
+++ b/website/docs/r/automation_dsc_configuration.html.markdown
@@ -63,8 +63,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation DSC Configuration.

--- a/website/docs/r/automation_dsc_nodeconfiguration.html.markdown
+++ b/website/docs/r/automation_dsc_nodeconfiguration.html.markdown
@@ -89,8 +89,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation DSC Node Configuration.

--- a/website/docs/r/automation_job_schedule.html.markdown
+++ b/website/docs/r/automation_job_schedule.html.markdown
@@ -54,8 +54,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Job Schedule.

--- a/website/docs/r/automation_module.html.markdown
+++ b/website/docs/r/automation_module.html.markdown
@@ -63,8 +63,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Module.

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -126,8 +126,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Runbook.

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -85,8 +85,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Schedule.

--- a/website/docs/r/automation_variable_bool.html.markdown
+++ b/website/docs/r/automation_variable_bool.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Bool Variable.

--- a/website/docs/r/automation_variable_datetime.html.markdown
+++ b/website/docs/r/automation_variable_datetime.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation DateTime Variable.

--- a/website/docs/r/automation_variable_int.html.markdown
+++ b/website/docs/r/automation_variable_int.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation Int Variable.

--- a/website/docs/r/automation_variable_string.html.markdown
+++ b/website/docs/r/automation_variable_string.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Automation String Variable.

--- a/website/docs/r/autoscale_setting.html.markdown
+++ b/website/docs/r/autoscale_setting.html.markdown
@@ -405,8 +405,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the AutoScale Setting.

--- a/website/docs/r/availability_set.html.markdown
+++ b/website/docs/r/availability_set.html.markdown
@@ -62,8 +62,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Availability Set.

--- a/website/docs/r/azuread_application.html.markdown
+++ b/website/docs/r/azuread_application.html.markdown
@@ -52,8 +52,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Azure Active Directory Application.

--- a/website/docs/r/azuread_service_principal.html.markdown
+++ b/website/docs/r/azuread_service_principal.html.markdown
@@ -48,8 +48,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Azure Active Directory Service Principal.

--- a/website/docs/r/azuread_service_principal_password.html.markdown
+++ b/website/docs/r/azuread_service_principal_password.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Azure Active Directory Service Principal Password.

--- a/website/docs/r/backup_container_storage_account.html.markdown
+++ b/website/docs/r/backup_container_storage_account.html.markdown
@@ -62,8 +62,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Backup Storage Account Container.

--- a/website/docs/r/backup_policy_file_share.markdown
+++ b/website/docs/r/backup_policy_file_share.markdown
@@ -87,8 +87,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the File Share Backup Policy.

--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -141,8 +141,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the VM Backup Policy.

--- a/website/docs/r/backup_protected_file_share.markdown
+++ b/website/docs/r/backup_protected_file_share.markdown
@@ -92,8 +92,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 80 minutes) Used when creating the Backup File Share.

--- a/website/docs/r/backup_protected_vm.markdown
+++ b/website/docs/r/backup_protected_vm.markdown
@@ -66,8 +66,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 80 minutes) Used when creating the Backup Protected Virtual Machine.

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -92,8 +92,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Bastion Host.

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -88,8 +88,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Batch Account.

--- a/website/docs/r/batch_application.html.markdown
+++ b/website/docs/r/batch_application.html.markdown
@@ -65,8 +65,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Batch Application.

--- a/website/docs/r/batch_certificate.html.markdown
+++ b/website/docs/r/batch_certificate.html.markdown
@@ -78,8 +78,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Batch Certificate.

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -309,8 +309,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Batch Pool.

--- a/website/docs/r/bot_channel_email.markdown
+++ b/website/docs/r/bot_channel_email.markdown
@@ -63,8 +63,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Email Integration for a Bot Channel.

--- a/website/docs/r/bot_channel_ms_teams.markdown
+++ b/website/docs/r/bot_channel_ms_teams.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Microsoft Teams Integration for a Bot Channel.

--- a/website/docs/r/bot_channel_slack.markdown
+++ b/website/docs/r/bot_channel_slack.markdown
@@ -67,8 +67,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Slack Integration for a Bot Channel.

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -64,8 +64,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Bot Channels Registration.

--- a/website/docs/r/bot_connection.markdown
+++ b/website/docs/r/bot_connection.markdown
@@ -72,8 +72,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Bot Connection.

--- a/website/docs/r/bot_web_app.markdown
+++ b/website/docs/r/bot_web_app.markdown
@@ -68,8 +68,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Bot Web App.

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -109,8 +109,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CDN Endpoint.

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -55,8 +55,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CDN Profile.

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -63,8 +63,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Cognitive Service Account.

--- a/website/docs/r/connection_monitor.html.markdown
+++ b/website/docs/r/connection_monitor.html.markdown
@@ -165,8 +165,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Connection Monitor.

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -255,8 +255,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Container Group.

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -94,8 +94,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Container Registry.

--- a/website/docs/r/container_registry_webhook.html.markdown
+++ b/website/docs/r/container_registry_webhook.html.markdown
@@ -73,8 +73,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Container Registry Webhook.

--- a/website/docs/r/container_service.html.markdown
+++ b/website/docs/r/container_service.html.markdown
@@ -221,8 +221,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 minutes) Used when creating the Container Service.

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -131,8 +131,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 180 minutes) Used when creating the CosmosDB Account.

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -66,8 +66,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB Cassandra KeySpace.

--- a/website/docs/r/cosmosdb_gremlin_database.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_database.html.markdown
@@ -47,8 +47,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB Gremlin Database.

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -104,8 +104,6 @@ The following attributes are exported:
 ``
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB Gremlin Graph.

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -73,8 +73,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB Mongo Collection.

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -47,8 +47,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB Mongo Database.

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB SQL Container.

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -47,8 +47,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB SQL Database.

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -47,8 +47,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the CosmosDB Table.

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -260,8 +260,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Dashboard.

--- a/website/docs/r/data_factory.html.markdown
+++ b/website/docs/r/data_factory.html.markdown
@@ -100,8 +100,6 @@ The `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory.

--- a/website/docs/r/data_factory_dataset_mysql.html.markdown
+++ b/website/docs/r/data_factory_dataset_mysql.html.markdown
@@ -84,8 +84,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory MySQL Dataset.

--- a/website/docs/r/data_factory_dataset_postgresql.html.markdown
+++ b/website/docs/r/data_factory_dataset_postgresql.html.markdown
@@ -83,8 +83,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory PostgreSQL Dataset.

--- a/website/docs/r/data_factory_dataset_sql_server_table.html.markdown
+++ b/website/docs/r/data_factory_dataset_sql_server_table.html.markdown
@@ -84,8 +84,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory SQL Server Table Dataset.

--- a/website/docs/r/data_factory_integration_runtime_managed.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_managed.html.markdown
@@ -98,8 +98,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory Integration Managed Runtime.

--- a/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
+++ b/website/docs/r/data_factory_linked_service_data_lake_storage_gen2.html.markdown
@@ -76,8 +76,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory Data Lake Storage Gen2 Linked Service.

--- a/website/docs/r/data_factory_linked_service_mysql.html.markdown
+++ b/website/docs/r/data_factory_linked_service_mysql.html.markdown
@@ -64,8 +64,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory MySql Linked Service.

--- a/website/docs/r/data_factory_linked_service_postgresql.html.markdown
+++ b/website/docs/r/data_factory_linked_service_postgresql.html.markdown
@@ -64,8 +64,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory PostgreSQL Linked Service.

--- a/website/docs/r/data_factory_linked_service_sql_server.html.markdown
+++ b/website/docs/r/data_factory_linked_service_sql_server.html.markdown
@@ -64,8 +64,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory SQL Server Linked Service.

--- a/website/docs/r/data_factory_pipeline.html.markdown
+++ b/website/docs/r/data_factory_pipeline.html.markdown
@@ -57,8 +57,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory Pipeline.

--- a/website/docs/r/data_factory_trigger_schedule.html.markdown
+++ b/website/docs/r/data_factory_trigger_schedule.html.markdown
@@ -73,8 +73,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Factory Schedule Trigger.

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -292,8 +292,6 @@ The `site_credential` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Function App.

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -72,8 +72,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Load Balancer.

--- a/website/docs/r/lb_backend_address_pool.html.markdown
+++ b/website/docs/r/lb_backend_address_pool.html.markdown
@@ -65,8 +65,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Load Balancer Backend Address Pool.

--- a/website/docs/r/lb_nat_pool.html.markdown
+++ b/website/docs/r/lb_nat_pool.html.markdown
@@ -73,8 +73,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Load Balancer NAT Pool.

--- a/website/docs/r/lb_nat_rule.html.markdown
+++ b/website/docs/r/lb_nat_rule.html.markdown
@@ -74,8 +74,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Load Balancer NAT Rule.

--- a/website/docs/r/lb_outbound_rule.html.markdown
+++ b/website/docs/r/lb_outbound_rule.html.markdown
@@ -85,8 +85,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Load Balancer Outbound Rule.

--- a/website/docs/r/lb_probe.html.markdown
+++ b/website/docs/r/lb_probe.html.markdown
@@ -68,8 +68,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Load Balancer Probe.

--- a/website/docs/r/lb_rule.html.markdown
+++ b/website/docs/r/lb_rule.html.markdown
@@ -76,8 +76,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Load Balancer Rule.

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -286,8 +286,6 @@ An `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 45 minutes) Used when creating the Linux Virtual Machine.

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -398,8 +398,6 @@ An `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Linux Virtual Machine Scale Set.

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -71,8 +71,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Local Network Gateway.

--- a/website/docs/r/log_analytics_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_linked_service.html.markdown
@@ -79,8 +79,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Workspace.

--- a/website/docs/r/log_analytics_solution.html.markdown
+++ b/website/docs/r/log_analytics_solution.html.markdown
@@ -76,8 +76,6 @@ A `plan` block includes:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Solution.

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Workspace.

--- a/website/docs/r/log_analytics_workspace_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_workspace_linked_service.html.markdown
@@ -82,8 +82,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Workspace Linked Service.

--- a/website/docs/r/logic_app_action_custom.html.markdown
+++ b/website/docs/r/logic_app_action_custom.html.markdown
@@ -70,8 +70,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Logic App Custom Action.

--- a/website/docs/r/logic_app_action_http.html.markdown
+++ b/website/docs/r/logic_app_action_http.html.markdown
@@ -58,8 +58,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Logic App HTTP Action.

--- a/website/docs/r/logic_app_trigger_custom.html.markdown
+++ b/website/docs/r/logic_app_trigger_custom.html.markdown
@@ -63,8 +63,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Logic App Custom Trigger.

--- a/website/docs/r/logic_app_trigger_http_request.html.markdown
+++ b/website/docs/r/logic_app_trigger_http_request.html.markdown
@@ -70,8 +70,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Logic App HTTP Request Trigger.

--- a/website/docs/r/logic_app_trigger_recurrence.html.markdown
+++ b/website/docs/r/logic_app_trigger_recurrence.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Logic App Recurrence Trigger.

--- a/website/docs/r/logic_app_workflow.html.markdown
+++ b/website/docs/r/logic_app_workflow.html.markdown
@@ -55,8 +55,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Logic App Workflow.

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -159,8 +159,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Managed Disk.

--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -55,8 +55,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Management Group.

--- a/website/docs/r/management_lock.html.markdown
+++ b/website/docs/r/management_lock.html.markdown
@@ -87,8 +87,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Management Lock.

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -56,8 +56,6 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Maps Account.

--- a/website/docs/r/mariadb_configuration.html.markdown
+++ b/website/docs/r/mariadb_configuration.html.markdown
@@ -65,8 +65,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MariaDB Configuration.

--- a/website/docs/r/mariadb_database.html.markdown
+++ b/website/docs/r/mariadb_database.html.markdown
@@ -69,8 +69,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the MariaDB Database.

--- a/website/docs/r/mariadb_firewall_rule.html.markdown
+++ b/website/docs/r/mariadb_firewall_rule.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MariaDB Firewall Rule.

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -87,8 +87,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the MariaDB Server.

--- a/website/docs/r/mariadb_virtual_network_rule.html.markdown
+++ b/website/docs/r/mariadb_virtual_network_rule.html.markdown
@@ -88,8 +88,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MariaDB Virtual Network Rule.

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -38,8 +38,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Marketplace Agreement.

--- a/website/docs/r/media_services_account.html.markdown
+++ b/website/docs/r/media_services_account.html.markdown
@@ -68,8 +68,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Media Services Account.

--- a/website/docs/r/metric_alertrule.html.markdown
+++ b/website/docs/r/metric_alertrule.html.markdown
@@ -151,8 +151,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Alert Rule.

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -215,8 +215,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Action Group.

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -103,8 +103,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Activity Log Alert.

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -403,8 +403,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the AutoScale Setting.

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -134,8 +134,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Diagnostics Setting.

--- a/website/docs/r/monitor_log_profile.html.markdown
+++ b/website/docs/r/monitor_log_profile.html.markdown
@@ -94,8 +94,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Log Profile.

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -114,8 +114,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Metric Alert.

--- a/website/docs/r/monitor_metric_alertrule.html.markdown
+++ b/website/docs/r/monitor_metric_alertrule.html.markdown
@@ -149,8 +149,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Metric Alert Rule.

--- a/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
+++ b/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
@@ -115,8 +115,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Database Vulnerability Assessment Rule Baseline.

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -102,8 +102,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MS SQL Elastic Pool.

--- a/website/docs/r/mssql_server_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_server_security_alert_policy.html.markdown
@@ -83,8 +83,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MSSQL Server Security Alert Policy.

--- a/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
@@ -96,8 +96,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MSSQL Server Vulnerability Assessment.

--- a/website/docs/r/mysql_configuration.html.markdown
+++ b/website/docs/r/mysql_configuration.html.markdown
@@ -65,8 +65,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MySQL Configuration.

--- a/website/docs/r/mysql_database.html.markdown
+++ b/website/docs/r/mysql_database.html.markdown
@@ -68,8 +68,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the MySQL Database.

--- a/website/docs/r/mysql_firewall_rule.html.markdown
+++ b/website/docs/r/mysql_firewall_rule.html.markdown
@@ -74,8 +74,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MySQL Firewall Rule.

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -85,8 +85,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the MySQL Server.

--- a/website/docs/r/mysql_virtual_network_rule.html.markdown
+++ b/website/docs/r/mysql_virtual_network_rule.html.markdown
@@ -88,8 +88,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the MySQL Virtual Network Rule.

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -80,8 +80,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the NAT Gateway.

--- a/website/docs/r/netapp_account.html.markdown
+++ b/website/docs/r/netapp_account.html.markdown
@@ -74,8 +74,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the NetApp Account.

--- a/website/docs/r/netapp_pool.html.markdown
+++ b/website/docs/r/netapp_pool.html.markdown
@@ -60,8 +60,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the NetApp Pool.

--- a/website/docs/r/netapp_snapshot.html.markdown
+++ b/website/docs/r/netapp_snapshot.html.markdown
@@ -104,8 +104,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the NetApp Snapshot.

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -121,8 +121,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the NetApp Volume.

--- a/website/docs/r/network_connection_monitor.html.markdown
+++ b/website/docs/r/network_connection_monitor.html.markdown
@@ -163,8 +163,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Network Connection Monitor.

--- a/website/docs/r/network_ddos_protection_plan.html.markdown
+++ b/website/docs/r/network_ddos_protection_plan.html.markdown
@@ -50,8 +50,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the DDoS Protection Plan.

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -121,8 +121,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Network Interface.

--- a/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_application_gateway_backend_address_pool_association.html.markdown
@@ -148,8 +148,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Application Gateway Backend Address Pool.

--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -77,8 +77,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Application Security Group.

--- a/website/docs/r/network_interface_backend_address_pool_association.html.markdown
+++ b/website/docs/r/network_interface_backend_address_pool_association.html.markdown
@@ -94,8 +94,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Load Balancers Backend Address Pool.

--- a/website/docs/r/network_interface_nat_rule_association.html.markdown
+++ b/website/docs/r/network_interface_nat_rule_association.html.markdown
@@ -98,8 +98,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Load Balancers NAT Rule.

--- a/website/docs/r/network_packet_capture.html.markdown
+++ b/website/docs/r/network_packet_capture.html.markdown
@@ -180,8 +180,6 @@ A `storage_location` block contains:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Packet Capture.

--- a/website/docs/r/network_profile.html.markdown
+++ b/website/docs/r/network_profile.html.markdown
@@ -98,8 +98,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Network Profile.

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -104,8 +104,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Network Security Group.

--- a/website/docs/r/network_security_rule.html.markdown
+++ b/website/docs/r/network_security_rule.html.markdown
@@ -92,8 +92,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Network Security Rule.

--- a/website/docs/r/network_watcher.html.markdown
+++ b/website/docs/r/network_watcher.html.markdown
@@ -46,8 +46,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Network Watcher.

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -114,8 +114,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Network Watcher Flow Log.

--- a/website/docs/r/notification_hub.html.markdown
+++ b/website/docs/r/notification_hub.html.markdown
@@ -84,8 +84,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Notification Hub.

--- a/website/docs/r/notification_hub_authorization_rule.html.markdown
+++ b/website/docs/r/notification_hub_authorization_rule.html.markdown
@@ -78,8 +78,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Notification Hub Authorization Rule.

--- a/website/docs/r/notification_hub_namespace.html.markdown
+++ b/website/docs/r/notification_hub_namespace.html.markdown
@@ -63,8 +63,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Notification Hub Namespace.

--- a/website/docs/r/packet_capture.html.markdown
+++ b/website/docs/r/packet_capture.html.markdown
@@ -182,8 +182,6 @@ A `storage_location` block contains:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Packet Capture.

--- a/website/docs/r/point_to_site_vpn_gateway.html.markdown
+++ b/website/docs/r/point_to_site_vpn_gateway.html.markdown
@@ -66,8 +66,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 minutes) Used when creating the Point-to-Site VPN Gateway.

--- a/website/docs/r/policy_assignment.html.markdown
+++ b/website/docs/r/policy_assignment.html.markdown
@@ -126,8 +126,6 @@ An `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Policy Assignment.

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -102,8 +102,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Policy Definition.

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -80,8 +80,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Policy Set Definition.

--- a/website/docs/r/postgresql_configuration.html.markdown
+++ b/website/docs/r/postgresql_configuration.html.markdown
@@ -65,8 +65,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Configuration.

--- a/website/docs/r/postgresql_database.html.markdown
+++ b/website/docs/r/postgresql_database.html.markdown
@@ -69,8 +69,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the PostgreSQL Database.

--- a/website/docs/r/postgresql_firewall_rule.html.markdown
+++ b/website/docs/r/postgresql_firewall_rule.html.markdown
@@ -78,8 +78,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Firewall Rule.

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -85,8 +85,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the PostgreSQL Server.

--- a/website/docs/r/postgresql_virtual_network_rule.html.markdown
+++ b/website/docs/r/postgresql_virtual_network_rule.html.markdown
@@ -90,8 +90,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Virtual Network Rule.

--- a/website/docs/r/private_dns_a_record.html.markdown
+++ b/website/docs/r/private_dns_a_record.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS A Record.

--- a/website/docs/r/private_dns_aaaa_record.html.markdown
+++ b/website/docs/r/private_dns_aaaa_record.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS AAAA Record.

--- a/website/docs/r/private_dns_cname_record.html.markdown
+++ b/website/docs/r/private_dns_cname_record.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS CNAME Record.

--- a/website/docs/r/private_dns_mx_record.html.markdown
+++ b/website/docs/r/private_dns_mx_record.html.markdown
@@ -77,8 +77,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS MX Record.

--- a/website/docs/r/private_dns_ptr_record.html.markdown
+++ b/website/docs/r/private_dns_ptr_record.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS PTR Record.

--- a/website/docs/r/private_dns_srv_record.html.markdown
+++ b/website/docs/r/private_dns_srv_record.html.markdown
@@ -85,8 +85,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS SRV Record.

--- a/website/docs/r/private_dns_zone.html.markdown
+++ b/website/docs/r/private_dns_zone.html.markdown
@@ -45,8 +45,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS Zone.

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -55,8 +55,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Private DNS Zone Virtual Network Link.

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -143,8 +143,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Private Endpoint.

--- a/website/docs/r/private_link_endpoint.html.markdown
+++ b/website/docs/r/private_link_endpoint.html.markdown
@@ -146,8 +146,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Private Link Endpoint.

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -134,8 +134,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Private Link Service.

--- a/website/docs/r/proximity_placement_group.html.markdown
+++ b/website/docs/r/proximity_placement_group.html.markdown
@@ -50,8 +50,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Proximity Placement Group.

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -81,8 +81,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Public IP.

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -64,8 +64,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Public IP Prefix.

--- a/website/docs/r/recovery_network_mapping.html.markdown
+++ b/website/docs/r/recovery_network_mapping.html.markdown
@@ -98,8 +98,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Networking Mapping.

--- a/website/docs/r/recovery_services_fabric.html.markdown
+++ b/website/docs/r/recovery_services_fabric.html.markdown
@@ -60,8 +60,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Services Fabric.

--- a/website/docs/r/recovery_services_protected_vm.markdown
+++ b/website/docs/r/recovery_services_protected_vm.markdown
@@ -68,8 +68,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 80 minutes) Used when creating the Recovery Services Protected VM.

--- a/website/docs/r/recovery_services_protection_container.html.markdown
+++ b/website/docs/r/recovery_services_protection_container.html.markdown
@@ -67,8 +67,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Recovery Services Protection Container.

--- a/website/docs/r/recovery_services_protection_container_mapping.html.markdown
+++ b/website/docs/r/recovery_services_protection_container_mapping.html.markdown
@@ -105,8 +105,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Recovery Services Protection Container Mapping.

--- a/website/docs/r/recovery_services_protection_policy_vm.markdown
+++ b/website/docs/r/recovery_services_protection_policy_vm.markdown
@@ -143,8 +143,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Recovery Services VM Protection Policy.

--- a/website/docs/r/recovery_services_replicated_vm.html.markdown
+++ b/website/docs/r/recovery_services_replicated_vm.html.markdown
@@ -216,8 +216,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 80 minutes) Used when creating the Recovery Services Replicated VM.

--- a/website/docs/r/recovery_services_replication_policy.html.markdown
+++ b/website/docs/r/recovery_services_replication_policy.html.markdown
@@ -58,8 +58,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Recovery Services Replication Policy.

--- a/website/docs/r/recovery_services_vault.markdown
+++ b/website/docs/r/recovery_services_vault.markdown
@@ -52,8 +52,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Recovery Services Vault.

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -167,8 +167,6 @@ A `redis_configuration` block exports the following:
 
 ## Timeouts
 
- ~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
  The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
  * `create` - (Defaults to 90 minutes) Used when creating the Redis Cache.

--- a/website/docs/r/redis_firewall_rule.html.markdown
+++ b/website/docs/r/redis_firewall_rule.html.markdown
@@ -76,8 +76,6 @@ The following attributes are exported:
 
 ## Timeouts
 
- ~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
  The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
  * `create` - (Defaults to 30 minutes) Used when creating the Redis Firewall Rule.

--- a/website/docs/r/relay_hybrid_connection.html.markdown
+++ b/website/docs/r/relay_hybrid_connection.html.markdown
@@ -62,8 +62,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Relay Hybrid Connection.

--- a/website/docs/r/relay_namespace.html.markdown
+++ b/website/docs/r/relay_namespace.html.markdown
@@ -74,8 +74,6 @@ The following attributes are exported only if there is an authorization rule nam
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Relay Namespace.

--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -44,8 +44,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 minutes) Used when creating the Resource Group.

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -154,8 +154,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Role Assignment.

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -67,8 +67,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Role Definition.

--- a/website/docs/r/route.html.markdown
+++ b/website/docs/r/route.html.markdown
@@ -61,8 +61,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Route.

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -72,8 +72,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Route Table.

--- a/website/docs/r/scheduler_job.html.markdown
+++ b/website/docs/r/scheduler_job.html.markdown
@@ -264,8 +264,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Scheduler Job.

--- a/website/docs/r/scheduler_job_collection.html.markdown
+++ b/website/docs/r/scheduler_job_collection.html.markdown
@@ -69,8 +69,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Scheduler Job Collection.

--- a/website/docs/r/search_service.html.markdown
+++ b/website/docs/r/search_service.html.markdown
@@ -70,8 +70,6 @@ A `query_keys` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Search Service.

--- a/website/docs/r/security_center_contact.markdown
+++ b/website/docs/r/security_center_contact.markdown
@@ -41,8 +41,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Security Center Contact.

--- a/website/docs/r/security_center_subscription_pricing.markdown
+++ b/website/docs/r/security_center_subscription_pricing.markdown
@@ -38,8 +38,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Security Center Subscription Pricing.

--- a/website/docs/r/security_center_workspace.markdown
+++ b/website/docs/r/security_center_workspace.markdown
@@ -51,8 +51,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Security Center Workspace.

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -214,8 +214,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Service Fabric Cluster.

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -71,8 +71,6 @@ The following attributes are exported only if there is an authorization rule nam
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace.

--- a/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_namespace_authorization_rule.html.markdown
@@ -74,8 +74,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace Authorization Rule.

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -104,8 +104,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Queue.

--- a/website/docs/r/servicebus_queue_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_queue_authorization_rule.html.markdown
@@ -85,8 +85,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Queue Authorization Rule.

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -105,8 +105,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Subscription.

--- a/website/docs/r/servicebus_subscription_rule.html.markdown
+++ b/website/docs/r/servicebus_subscription_rule.html.markdown
@@ -157,8 +157,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Subscription Rule.

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -99,8 +99,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Topic.

--- a/website/docs/r/servicebus_topic_authorization_rule.html.markdown
+++ b/website/docs/r/servicebus_topic_authorization_rule.html.markdown
@@ -82,8 +82,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Topic Authorization Rule.

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -92,8 +92,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Shared Image.

--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -56,8 +56,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Shared Image Gallery.

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -83,8 +83,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Shared Image Version.

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -103,8 +103,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the SignalR Service.

--- a/website/docs/r/site_recovery_fabric.html.markdown
+++ b/website/docs/r/site_recovery_fabric.html.markdown
@@ -58,8 +58,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Fabric.

--- a/website/docs/r/site_recovery_network_mapping.html.markdown
+++ b/website/docs/r/site_recovery_network_mapping.html.markdown
@@ -96,8 +96,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Network Mapping.

--- a/website/docs/r/site_recovery_protection_container.html.markdown
+++ b/website/docs/r/site_recovery_protection_container.html.markdown
@@ -65,8 +65,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Protection Container.

--- a/website/docs/r/site_recovery_protection_container_mapping.html.markdown
+++ b/website/docs/r/site_recovery_protection_container_mapping.html.markdown
@@ -103,8 +103,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Protection Container Mapping.

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -214,8 +214,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 80 minutes) Used when creating the Site Recovery Replicated VM.

--- a/website/docs/r/site_recovery_replication_policy.html.markdown
+++ b/website/docs/r/site_recovery_replication_policy.html.markdown
@@ -56,8 +56,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Site Recovery Replication Policy.

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -71,8 +71,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Snapshot.

--- a/website/docs/r/sql_active_directory_administrator.markdown
+++ b/website/docs/r/sql_active_directory_administrator.markdown
@@ -60,8 +60,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the SQL Active Directory Administrator.

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -111,8 +111,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the SQL Database.

--- a/website/docs/r/sql_elasticpool.html.markdown
+++ b/website/docs/r/sql_elasticpool.html.markdown
@@ -78,8 +78,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the SQL Elastic Pool.

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -108,8 +108,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the SQL Failover Group.

--- a/website/docs/r/sql_firewall_rule.html.markdown
+++ b/website/docs/r/sql_firewall_rule.html.markdown
@@ -60,8 +60,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the SQL Firewall Rule.

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -82,8 +82,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the SQL Server.

--- a/website/docs/r/sql_virtual_network_rule.html.markdown
+++ b/website/docs/r/sql_virtual_network_rule.html.markdown
@@ -79,8 +79,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the SQL Virtual Network Rule.

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -315,8 +315,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Storage Account.

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -86,8 +86,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the  Network Rules for this Storage Account.

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -88,8 +88,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Blob.

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -66,8 +66,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Container.

--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -60,8 +60,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Lake Gen2 File System.

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -123,8 +123,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Account Management Policy.

--- a/website/docs/r/storage_queue.html.markdown
+++ b/website/docs/r/storage_queue.html.markdown
@@ -53,8 +53,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Queue.

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -78,8 +78,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Share.

--- a/website/docs/r/storage_share_directory.html.markdown
+++ b/website/docs/r/storage_share_directory.html.markdown
@@ -59,8 +59,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Share Directory.

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -73,8 +73,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Table.

--- a/website/docs/r/storage_table_entity.html.markdown
+++ b/website/docs/r/storage_table_entity.html.markdown
@@ -70,8 +70,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Storage Table Entity.

--- a/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
@@ -80,8 +80,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics JavaScript UDF Function.

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -83,8 +83,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Job.

--- a/website/docs/r/stream_analytics_output_blob.html.markdown
+++ b/website/docs/r/stream_analytics_output_blob.html.markdown
@@ -106,8 +106,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output Blob Storage.

--- a/website/docs/r/stream_analytics_output_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_output_eventhub.html.markdown
@@ -99,8 +99,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output EventHub.

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -81,8 +81,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output Microsoft SQL Server Database.

--- a/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
@@ -97,8 +97,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output ServiceBus Queue.

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -97,8 +97,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Output ServiceBus Topic.

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -101,8 +101,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Reference Input Blob.

--- a/website/docs/r/stream_analytics_stream_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_blob.html.markdown
@@ -101,8 +101,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Stream Input Blob.

--- a/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
@@ -106,8 +106,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Stream Input EventHub.

--- a/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
@@ -94,8 +94,6 @@ The following attributes are exported in addition to the arguments listed above:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Stream Analytics Stream Input IoTHub.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -112,8 +112,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Subnet.

--- a/website/docs/r/subnet_nat_gateway_association.html.markdown
+++ b/website/docs/r/subnet_nat_gateway_association.html.markdown
@@ -60,8 +60,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Subnet NAT Gateway Association.

--- a/website/docs/r/subnet_network_security_group_association.html.markdown
+++ b/website/docs/r/subnet_network_security_group_association.html.markdown
@@ -76,8 +76,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Subnet Network Security Group Association.

--- a/website/docs/r/subnet_route_table_association.html.markdown
+++ b/website/docs/r/subnet_route_table_association.html.markdown
@@ -71,8 +71,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Subnet Route Table Association.

--- a/website/docs/r/template_deployment.html.markdown
+++ b/website/docs/r/template_deployment.html.markdown
@@ -135,8 +135,6 @@ Terraform does not know about the individual resources created by Azure using a 
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 3 hours) Used when creating the Template Deployment.

--- a/website/docs/r/traffic_manager_endpoint.html.markdown
+++ b/website/docs/r/traffic_manager_endpoint.html.markdown
@@ -142,8 +142,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Traffic Manager Endpoint.

--- a/website/docs/r/traffic_manager_profile.html.markdown
+++ b/website/docs/r/traffic_manager_profile.html.markdown
@@ -117,8 +117,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Traffic Manager Profile.

--- a/website/docs/r/user_assigned_identity.markdown
+++ b/website/docs/r/user_assigned_identity.markdown
@@ -53,8 +53,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the User Assigned Identity.

--- a/website/docs/r/virtual_hub.html.markdown
+++ b/website/docs/r/virtual_hub.html.markdown
@@ -71,8 +71,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Virtual Hub.

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -404,8 +404,6 @@ A `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Virtual Machine.

--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -129,8 +129,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual Machine Data Disk Attachment.

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -183,8 +183,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual Machine Extension.

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -536,8 +536,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Virtual Machine Scale Set.

--- a/website/docs/r/virtual_machine_scale_set_extension.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_extension.html.markdown
@@ -73,8 +73,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual Machine Scale Set Extension.

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -138,8 +138,6 @@ The `subnet` block exports:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual Network.

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -234,8 +234,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 60 minutes) Used when creating the Virtual Network Gateway.

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -300,8 +300,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual Network Gateway Connection.

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -154,8 +154,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual Network Peering.

--- a/website/docs/r/virtual_wan.html.markdown
+++ b/website/docs/r/virtual_wan.html.markdown
@@ -54,8 +54,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual WAN.

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -91,8 +91,6 @@ A `bgp_settings` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 minutes) Used when creating the VPN Gateway.

--- a/website/docs/r/vpn_server_configuration.html.markdown
+++ b/website/docs/r/vpn_server_configuration.html.markdown
@@ -176,8 +176,6 @@ In addition to the arguments above, the following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 minutes) Used when creating the VPN Server Configuration.

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -138,8 +138,6 @@ The following attributes are exported:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Web Application Firewall Policy.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -286,8 +286,6 @@ An `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 45 minutes) Used when creating the Windows Virtual Machine.

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -400,8 +400,6 @@ An `identity` block exports the following:
 
 ## Timeouts
 
-~> **Note:** Custom Timeouts are available [as an opt-in Beta in version 1.43 & 1.44 of the Azure Provider](/docs/providers/azurerm/guides/2.0-beta.html) and will be enabled by default in version 2.0 of the Azure Provider.
-
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Windows Virtual Machine Scale Set.


### PR DESCRIPTION
This PR removes the "Beta" section in each Data Source/Resources documentation regarding the Beta, since this is no longer in Beta as of 2.0