### PR TITLE
provider: making the `features` block required

### DIFF
--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -7,10 +7,11 @@ import (
 
 func schemaFeatures() *schema.Schema {
 	return &schema.Schema{
-		Type: schema.TypeList,
-		// TODO: make this Required in 2.0
-		Optional: true,
+		Type:     schema.TypeList,
+		Required: true,
 		MaxItems: 1,
+		MinItems: 1,
+
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"virtual_machine": {
@@ -46,14 +47,6 @@ func schemaFeatures() *schema.Schema {
 }
 
 func expandFeatures(input []interface{}) features.UserFeatures {
-	// TODO: in 2.0 when Required this can become:
-	//val := input[0].(map[string]interface{})
-
-	var val map[string]interface{}
-	if len(input) > 0 {
-		val = input[0].(map[string]interface{})
-	}
-
 	// these are the defaults if omitted from the config
 	features := features.UserFeatures{
 		// NOTE: ensure all nested objects are fully populated
@@ -64,6 +57,12 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			RollInstancesWhenRequired: true,
 		},
 	}
+
+	if len(input) == 0 || input[0] == nil {
+		return features
+	}
+
+	val := input[0].(map[string]interface{})
 
 	if raw, ok := val["virtual_machine"]; ok {
 		items := raw.([]interface{})

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -32,7 +32,7 @@ We recommend using either a Service Principal or Managed Service Identity when r
 provider "azurerm" {
   # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
   version = "=2.0.0"
-  features { }
+  features {}
 }
 
 # Create a resource group

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -31,18 +31,19 @@ We recommend using either a Service Principal or Managed Service Identity when r
 # Configure the Azure Provider
 provider "azurerm" {
   # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
-  version = "=1.44.0"
+  version = "=2.0.0"
+  features { }
 }
 
 # Create a resource group
 resource "azurerm_resource_group" "example" {
-  name     = "production"
-  location = "West US"
+  name     = "example-resources"
+  location = "West Europe"
 }
 
 # Create a virtual network within the resource group
 resource "azurerm_virtual_network" "example" {
-  name                = "production-network"
+  name                = "example-network"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   address_space       = ["10.0.0.0/16"]
@@ -80,10 +81,11 @@ If you have configuration questions, or general questions about using the provid
 * [Terraform's community resources](https://www.terraform.io/docs/extend/community/index.html)
 * [HashiCorp support](https://support.hashicorp.com) for Terraform Enterprise customers
 
-
 ## Argument Reference
 
 The following arguments are supported:
+
+* `features` - (Required) A `features` block as defined below which can be used to customize the behaviour of certain Azure Provider resources.
 
 * `client_id` - (Optional) The Client ID which should be used. This can also be sourced from the `ARM_CLIENT_ID` Environment Variable.
 
@@ -145,7 +147,9 @@ It's also possible to use multiple Provider blocks within a single Terraform con
 
 ## Features
 
-It's possible to customise the behaviour of certain Azure Provider resources using the `features` block. This block is Optional in 1.x versions of the Azure Provider but will become Required from 2.0 onwards.
+It's possible to configure the behaviour of certain resources using the `features` block - more details can be found below.
+
+## Features
 
 The `features` block supports the following:
 


### PR DESCRIPTION
At first this might seem like an odd choice - but since this block contains switches which can alter
the behaviour of certain resources (including destructive behaviour) - we intentionally want
to highlight the presence of this block.

Whilst the `features` block itself is required - the inner elements are not, thus is a user
wishes to use the default features they can specify:

```
provider "azurerm" {
  version = "=2.0.0"

  features {}
}
```

However it's also possible to override certain features, for example:

```
provider "azurerm" {
  version = "=2.0.0"

  features {
    virtual_machine {
      delete_os_disk_on_deletion = false
    }
  }
}
```

Since this block is Required this'll also mean that Provider blocks need to be threaded through
to modules (which they should be being today, but this'll make this explicit).