### PR TITLE
Documentation changed based on observed terraform and Azure API behavior

### DIFF
--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -437,7 +437,7 @@ output "principal_id" {
 
 * `name` - (Required) Specifies name of the IP configuration.
 * `subnet_id` - (Required) Specifies the identifier of the subnet.
-* `application_gateway_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of application gateways. A scale set can reference backend address pools of multiple application gateways. Multiple scale sets cannot use the same application gateway.
+* `application_gateway_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of application gateways. A scale set can reference backend address pools of multiple application gateways. Multiple scale sets can use the same application gateway.
 * `load_balancer_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of load balancers. A scale set can reference backend address pools of one public and one internal load balancer. Multiple scale sets cannot use the same load balancer.
 
 -> **NOTE:** When using this field you'll also need to configure a Rule for the Load Balancer, and use a `depends_on` between this resource and the Load Balancer Rule.


### PR DESCRIPTION
Microsoft's documentation is incorrect here, and terraform is mirroring that documentation.  I have a PR for the Microsoft documentation here:

https://github.com/Azure/azure-rest-api-specs/pull/8365

I am correcting this as well in Terraform's Azure documentation.  Simple change.  We have tested that you can create multiple scale sets on the same Application Gateway v2 from the Azure Portal, Azure API, and Terraform itself.