### PR TITLE
testing: conditionally making the features block optional during testing

### DIFF
--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -1,47 +1,61 @@
 package provider
 
 import (
+	"os"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
 func schemaFeatures() *schema.Schema {
+	features := map[string]*schema.Schema{
+		"virtual_machine": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"delete_os_disk_on_deletion": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+				},
+			},
+		},
+
+		"virtual_machine_scale_set": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"roll_instances_when_required": {
+						Type:     schema.TypeBool,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+
+	runningAcceptanceTests := os.Getenv("TF_ACC") != ""
+	if runningAcceptanceTests {
+		return &schema.Schema{
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: features,
+			},
+		}
+	}
+
 	return &schema.Schema{
 		Type:     schema.TypeList,
 		Required: true,
 		MaxItems: 1,
 		MinItems: 1,
-
 		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"virtual_machine": {
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"delete_os_disk_on_deletion": {
-								Type:     schema.TypeBool,
-								Required: true,
-							},
-						},
-					},
-				},
-
-				"virtual_machine_scale_set": {
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"roll_instances_when_required": {
-								Type:     schema.TypeBool,
-								Required: true,
-							},
-						},
-					},
-				},
-			},
+			Schema: features,
 		},
 	}
 }

--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -253,9 +253,6 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 		// replaces the context between tests
 		p.MetaReset = func() error {
-			// hack to allow the test suite to run without defining `features{}` everywhere
-			client.Features = expandFeatures([]interface{}{})
-
 			client.StopContext = p.StopContext()
 			return nil
 		}

--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -253,6 +253,9 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 
 		// replaces the context between tests
 		p.MetaReset = func() error {
+			// hack to allow the test suite to run without defining `features{}` everywhere
+			client.Features = expandFeatures([]interface{}{})
+
 			client.StopContext = p.StopContext()
 			return nil
 		}


### PR DESCRIPTION
I figured the test framework would allow us to hook into the features block dynamically, but alas not - as such this make this block conditional when running the test suite 

<img width="574" alt="Screenshot 2020-02-13 at 14 06 41" src="https://user-images.githubusercontent.com/666005/74438285-12f88c00-4e6a-11ea-8caa-ead1967b1516.png">

In time we should probably go through all the tests and add an empty features block since this varies per-test then revert this - but for now this is a "good enough" hack