### PR TITLE
Couple default_node_pool OrchestratorVersion to cluster k8s_version

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -164,10 +164,10 @@ func ExpandDefaultNodePool(d *schema.ResourceData) (*[]containerservice.ManagedC
 		// at this time the default node pool has to be Linux or the AKS cluster fails to provision with:
 		// Pods not in Running status: coredns-7fc597cc45-v5z7x,coredns-autoscaler-7ccc76bfbd-djl7j,metrics-server-cbd95f966-5rl97,tunnelfront-7d9884977b-wpbvn
 		// Windows agents can be configured via the separate node pool resource
-		OsType: containerservice.Linux,
+		OsType:              containerservice.Linux,
+		OrchestratorVersion: utils.String(d.Get("kubernetes_version").(string)),
 
 		//// TODO: support these in time
-		// OrchestratorVersion:    nil,
 		// ScaleSetEvictionPolicy: "",
 		// ScaleSetPriority:       "",
 	}


### PR DESCRIPTION
Per #5541, currently AKS node pool versions can never be updated. This
occurred due to a change in behavior in new ARM behavior now that AKS
clusters can have multiple agent pools.

There's a more involved fix in the discussion on that issue which involves
exposing OrchestratorVersion as a settable attribute on agent_pool_profiles,
but this change focuses on recovering the old behavior.