### PR TITLE
Add `azurerm_resources.id` and `azurerm_resources.resources[*].resource_group`

### DIFF
--- a/azurerm/internal/services/resource/data_source_resources.go
+++ b/azurerm/internal/services/resource/data_source_resources.go
@@ -185,8 +185,13 @@ func transformResource(res resources.GenericResource) *map[string]interface{} {
 	}
 
 	resID := ""
+	resGroup := ""
 	if res.ID != nil {
 		resID = *res.ID
+		parsedID, err := azure.ParseAzureResourceID(*res.ID)
+		if err == nil {
+			resGroup = parsedID.ResourceGroup
+		}
 	}
 
 	resType := ""
@@ -211,6 +216,7 @@ func transformResource(res resources.GenericResource) *map[string]interface{} {
 
 	return &map[string]interface{}{
 		"name":           resName,
+		"resource_group": resGroup,
 		"id":             resID,
 		"type":           resType,
 		"location":       resLocation,

--- a/azurerm/internal/services/resource/data_source_resources.go
+++ b/azurerm/internal/services/resource/data_source_resources.go
@@ -1,11 +1,13 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -22,6 +24,11 @@ func dataSourceArmResources() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -71,17 +78,46 @@ func dataSourceArmResourcesRead(d *schema.ResourceData, meta interface{}) error 
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	resourceID := d.Get("id").(string)
 	resourceGroupName := d.Get("resource_group_name").(string)
 	resourceName := d.Get("name").(string)
 	resourceType := d.Get("type").(string)
 	requiredTags := d.Get("required_tags").(map[string]interface{})
 
-	if resourceGroupName == "" && resourceName == "" && resourceType == "" {
-		return fmt.Errorf("At least one of `name`, `resource_group_name` or `type` must be specified")
+	if resourceID == "" && resourceGroupName == "" && resourceName == "" && resourceType == "" {
+		return fmt.Errorf("At least one of `id`, `name`, `resource_group_name` or `type` must be specified")
 	}
 
-	var filter string
+	var resources []map[string]interface{}
 
+	if resourceID != "" {
+		resource, err := client.GetByID(ctx, resourceID, "")
+
+		if err != nil {
+			return fmt.Errorf("Error fetching resources: %+v", err)
+		}
+
+		resources = append(resources, *transformResource(resource))
+	} else {
+		resourceMap, err := getResourcesByFilter(ctx, client, resourceGroupName, resourceName, resourceType, requiredTags)
+
+		if err != nil {
+			return err
+		}
+
+		resources = resourceMap
+	}
+
+	d.SetId("resource-" + uuid.New().String())
+	if err := d.Set("resources", resources); err != nil {
+		return fmt.Errorf("Error setting `resources`: %+v", err)
+	}
+
+	return nil
+}
+
+func getResourcesByFilter(ctx context.Context, client *resources.Client, resourceGroupName, resourceName, resourceType string, requiredTags map[string]interface{}) ([]map[string]interface{}, error) {
+	var filter string
 	if resourceGroupName != "" {
 		v := fmt.Sprintf("resourceGroup eq '%s'", resourceGroupName)
 		filter = filter + v
@@ -102,11 +138,10 @@ func dataSourceArmResourcesRead(d *schema.ResourceData, meta interface{}) error 
 		v := fmt.Sprintf("resourceType eq '%s'", resourceType)
 		filter = filter + v
 	}
-
 	resources := make([]map[string]interface{}, 0)
 	resourcesResp, err := client.ListComplete(ctx, filter, "", nil)
 	if err != nil {
-		return fmt.Errorf("Error getting resources: %+v", err)
+		return nil, fmt.Errorf("Error getting resources: %+v", err)
 	}
 
 	for resourcesResp.NotDone() {
@@ -129,57 +164,56 @@ func dataSourceArmResourcesRead(d *schema.ResourceData, meta interface{}) error 
 		}
 
 		if tagMatches == len(requiredTags) {
-			resName := ""
-			if res.Name != nil {
-				resName = *res.Name
-			}
-
-			resID := ""
-			if res.ID != nil {
-				resID = *res.ID
-			}
-
-			resType := ""
-			if res.Type != nil {
-				resType = *res.Type
-			}
-
-			resLocation := ""
-			if res.Location != nil {
-				resLocation = *res.Location
-			}
-
-			resTags := make(map[string]interface{})
-			if res.Tags != nil {
-				resTags = make(map[string]interface{}, len(res.Tags))
-				for key, value := range res.Tags {
-					if value != nil {
-						resTags[key] = *value
-					}
-				}
-			}
-
-			resources = append(resources, map[string]interface{}{
-				"name":     resName,
-				"id":       resID,
-				"type":     resType,
-				"location": resLocation,
-				"tags":     resTags,
-			})
+			resources = append(resources, *transformResource(res))
 		} else {
 			log.Printf("[DEBUG] azurerm_resources - resources %q (id: %q) skipped as a required tag is not set or has the wrong value.", *res.Name, *res.ID)
 		}
 
 		err = resourcesResp.NextWithContext(ctx)
 		if err != nil {
-			return fmt.Errorf("Error loading Resource List: %s", err)
+			return nil, fmt.Errorf("Error loading Resource List: %s", err)
 		}
 	}
 
-	d.SetId("resource-" + uuid.New().String())
-	if err := d.Set("resources", resources); err != nil {
-		return fmt.Errorf("Error setting `resources`: %+v", err)
+	return resources, nil
+}
+
+func transformResource(res resources.GenericResource) *map[string]interface{} {
+	resName := ""
+	if res.Name != nil {
+		resName = *res.Name
 	}
 
-	return nil
+	resID := ""
+	if res.ID != nil {
+		resID = *res.ID
+	}
+
+	resType := ""
+	if res.Type != nil {
+		resType = *res.Type
+	}
+
+	resLocation := ""
+	if res.Location != nil {
+		resLocation = *res.Location
+	}
+
+	resTags := make(map[string]interface{})
+	if res.Tags != nil {
+		resTags = make(map[string]interface{}, len(res.Tags))
+		for key, value := range res.Tags {
+			if value != nil {
+				resTags[key] = *value
+			}
+		}
+	}
+
+	return &map[string]interface{}{
+		"name":           resName,
+		"id":             resID,
+		"type":           resType,
+		"location":       resLocation,
+		"tags":           resTags,
+	}
 }


### PR DESCRIPTION
This PR adds to the `azurerm_resources` data source, such that:

* it is possible to provide the Azure resource ID of a resource (e.g. `subscriptions/SUBSCRIPTION/resourceGroup/RESOURCEGROUP/PROVIDER/RESOURCENAME`) in lieu of resourceGroup/provider/name. This is helpful in cases where a Terraform resource implicitly encompasses several Azure resources, and only provides the subscription ID of those implicit resources (e.g. the `public_ip` that is automatically created when creating a k8s cluster).
* each returned resource now also provides its resource group. This is helpful when attempting to perform logical organization of explicitly-managed Azure resources alongside non- or implicitly-managed Azure resources (e.g. when trying to create a new IP address that can be associated with a `kubernetes_cluster`, which requires it to be in the `MC_*` resource group that the original IP address was created in).