### PR TITLE
Update subnets options and add details for endpoint 

### DIFF
--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -88,7 +88,7 @@ resource "azurerm_private_endpoint" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   subnet_id           = azurerm_subnet.endpoint.id
-  
+
   private_service_connection {
     name                           = "example-privateserviceconnection"
     private_connection_resource_id = azurerm_private_link_service.example.id

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -90,9 +90,9 @@ resource "azurerm_private_endpoint" "example" {
   subnet_id           = azurerm_subnet.endpoint.id
   
   private_service_connection {
-  name                           = "example-privateserviceconnection"
-  private_connection_resource_id = azurerm_private_link_service.example.id
-  is_manual_connection           = false
+    name                           = "example-privateserviceconnection"
+    private_connection_resource_id = azurerm_private_link_service.example.id
+    is_manual_connection           = false
   }
 }
 ```

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_subnet" "service" {
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefix       = "10.0.1.0/24"
 
-  disable_private_link_service_network_policy_enforcement = true
+  enforce_private_link_service_network_policies = true
 }
 
 resource "azurerm_subnet" "endpoint" {
@@ -44,7 +44,7 @@ resource "azurerm_subnet" "endpoint" {
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefix       = "10.0.2.0/24"
 
-  disable_private_link_endpoint_network_policy_enforcement = true
+  enforce_private_link_endpoint_network_policies = true
 }
 
 resource "azurerm_public_ip" "example" {
@@ -88,6 +88,12 @@ resource "azurerm_private_endpoint" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   subnet_id           = azurerm_subnet.endpoint.id
+  
+  private_service_connection {
+  name                           = "example-privateserviceconnection"
+  private_connection_resource_id = azurerm_private_link_service.example.id
+  is_manual_connection           = false
+  }
 }
 ```
 


### PR DESCRIPTION
The following changes have been carried out:
- renamed parameter to enforce_private_link_service_network_policies from disable_private_link_service_network_policy_enforcement  for  service and endpoint subnets
- Include private service connection under azurerm_private_endpoint - to provide better view of example.

This is inline with terraform v0.12.20 