### PR TITLE
New Resource: `azurerm_network_interface_security_group_association`

### DIFF
--- a/azurerm/internal/azuresdkhacks/network_interface.go
+++ b/azurerm/internal/azuresdkhacks/network_interface.go
@@ -1,0 +1,105 @@
+package azuresdkhacks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// UpdateNetworkInterfaceAllowingRemovalOfNSG patches our way around a design flaw in the Azure
+// Resource Manager API <-> Azure SDK for Go where it's not possible to remove a Network Security Group
+func UpdateNetworkInterfaceAllowingRemovalOfNSG(ctx context.Context, client *network.InterfacesClient, resourceGroupName string, networkInterfaceName string, parameters network.Interface) (result network.InterfacesCreateOrUpdateFuture, err error) {
+	req, err := updateNetworkInterfaceAllowingRemovalOfNSGPreparer(ctx, client, resourceGroupName, networkInterfaceName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "network.InterfacesClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.CreateOrUpdateSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "network.InterfacesClient", "CreateOrUpdate", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// updateNetworkInterfaceAllowingRemovalOfNSGPreparer prepares the CreateOrUpdate request but applies the
+// necessary patches to be able to remove the NSG if required
+func updateNetworkInterfaceAllowingRemovalOfNSGPreparer(ctx context.Context, client *network.InterfacesClient, resourceGroupName string, networkInterfaceName string, parameters network.Interface) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"networkInterfaceName": autorest.Encode("path", networkInterfaceName),
+		"resourceGroupName":    autorest.Encode("path", resourceGroupName),
+		"subscriptionId":       autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2019-09-01"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	parameters.Etag = nil
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}", pathParameters),
+		withJsonWorkingAroundTheBrokenNetworkAPI(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+func withJsonWorkingAroundTheBrokenNetworkAPI(v network.Interface) autorest.PrepareDecorator {
+	return func(p autorest.Preparer) autorest.Preparer {
+		return autorest.PreparerFunc(func(r *http.Request) (*http.Request, error) {
+			r, err := p.Prepare(r)
+			if err == nil {
+				b, err := json.Marshal(v)
+				if err == nil {
+					// there's a few fields which can be intentionally set to nil - as such here we need to check if they should be nil and force them to be nil
+					var out map[string]interface{}
+					if err := json.Unmarshal(b, &out); err != nil {
+						return r, err
+					}
+
+					// apply the hack
+					out = patchNICUpdateAPIIssue(v, out)
+
+					// then reserialize it as needed
+					b, err = json.Marshal(out)
+					if err == nil {
+						r.ContentLength = int64(len(b))
+						r.Body = ioutil.NopCloser(bytes.NewReader(b))
+					}
+				}
+			}
+			return r, err
+		})
+	}
+}
+
+func patchNICUpdateAPIIssue(nic network.Interface, input map[string]interface{}) map[string]interface{} {
+	if nic.InterfacePropertiesFormat == nil {
+		return input
+	}
+
+	output := input
+
+	if v, ok := output["properties"]; ok {
+		props := v.(map[string]interface{})
+
+		if nic.InterfacePropertiesFormat.NetworkSecurityGroup == nil {
+			var hack *string // a nil-pointered string
+			props["networkSecurityGroup"] = hack
+		}
+
+		output["properties"] = props
+	}
+
+	return output
+}

--- a/azurerm/internal/azuresdkhacks/notes.go
+++ b/azurerm/internal/azuresdkhacks/notes.go
@@ -1,11 +1,11 @@
 package azuresdkhacks
 
 // There's a functional difference that exists between the Azure SDK for Go and Azure Resource Manager API
-// where when performing a delta update unchanged fields are omited from the response when they could
+// where when performing a delta update unchanged fields are omitted from the response when they could
 // also have a legitimate value of `null` (to remove/disable a sub-block).
 //
 // Ultimately the Azure SDK for Go has opted to serialise structs with `json:"name,omitempty"` which
-// means that this value will be omited if nil to allow for delta updates - however this means there's
+// means that this value will be omitted if nil to allow for delta updates - however this means there's
 // no means of removing/resetting a value of a nested object once provided since a `nil` object will be
 // reset
 //

--- a/azurerm/internal/azuresdkhacks/notes.go
+++ b/azurerm/internal/azuresdkhacks/notes.go
@@ -1,0 +1,15 @@
+package azuresdkhacks
+
+// There's a functional difference that exists between the Azure SDK for Go and Azure Resource Manager API
+// where when performing a delta update unchanged fields are omited from the response when they could
+// also have a legitimate value of `null` (to remove/disable a sub-block).
+//
+// Ultimately the Azure SDK for Go has opted to serialise structs with `json:"name,omitempty"` which
+// means that this value will be omited if nil to allow for delta updates - however this means there's
+// no means of removing/resetting a value of a nested object once provided since a `nil` object will be
+// reset
+//
+// As such this set of well intentioned hacks is intended to force this behaviour where necessary.
+//
+// It's worth noting that these hacks are a last resort and the Swagger/API/SDK should almost always be
+// fixed instead.

--- a/azurerm/internal/services/network/network_interface_network_security_group_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_network_security_group_association_resource.go
@@ -1,0 +1,218 @@
+package network
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-09-01/network"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/azuresdkhacks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmNetworkInterfaceSecurityGroupAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmNetworkInterfaceSecurityGroupAssociationCreate,
+		Read:   resourceArmNetworkInterfaceSecurityGroupAssociationRead,
+		Delete: resourceArmNetworkInterfaceSecurityGroupAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"network_interface_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"network_security_group_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+		},
+	}
+}
+
+func resourceArmNetworkInterfaceSecurityGroupAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.InterfacesClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for Network Interface <-> Network Security Group Association creation.")
+
+	networkInterfaceId := d.Get("network_interface_id").(string)
+	networkSecurityGroupId := d.Get("network_security_group_id").(string)
+
+	nicId, err := azure.ParseAzureResourceID(networkInterfaceId)
+	if err != nil {
+		return err
+	}
+
+	networkInterfaceName := nicId.Path["networkInterfaces"]
+	resourceGroup := nicId.ResourceGroup
+
+	locks.ByName(networkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(networkInterfaceName, networkInterfaceResourceName)
+
+	nsgId, err := azure.ParseAzureResourceID(networkSecurityGroupId)
+	if err != nil {
+		return err
+	}
+	nsgName := nsgId.Path["networkSecurityGroups"]
+
+	locks.ByName(nsgName, networkSecurityGroupResourceName)
+	defer locks.UnlockByName(nsgName, networkSecurityGroupResourceName)
+
+	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(read.Response) {
+			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	props := read.InterfacePropertiesFormat
+	if props == nil {
+		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", networkInterfaceName, resourceGroup)
+	}
+
+	// first double-check it doesn't exist
+	resourceId := fmt.Sprintf("%s|%s", networkInterfaceId, networkSecurityGroupId)
+	if features.ShouldResourcesBeImported() {
+		if props.NetworkSecurityGroup != nil {
+			return tf.ImportAsExistsError("azurerm_network_interface_security_group_association", resourceGroup)
+		}
+	}
+
+	props.NetworkSecurityGroup = &network.SecurityGroup{
+		ID: utils.String(networkSecurityGroupId),
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resourceGroup, networkInterfaceName, read)
+	if err != nil {
+		return fmt.Errorf("Error updating Security Group Association for Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for completion of Security Group Association for NIC %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)
+	}
+
+	d.SetId(resourceId)
+
+	return resourceArmNetworkInterfaceSecurityGroupAssociationRead(d, meta)
+}
+
+func resourceArmNetworkInterfaceSecurityGroupAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.InterfacesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	splitId := strings.Split(d.Id(), "|")
+	if len(splitId) != 2 {
+		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}|{networkSecurityGroupId} but got %q", d.Id())
+	}
+
+	nicID, err := azure.ParseAzureResourceID(splitId[0])
+	if err != nil {
+		return err
+	}
+
+	name := nicID.Path["networkInterfaces"]
+	resourceGroup := nicID.ResourceGroup
+
+	read, err := client.Get(ctx, resourceGroup, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(read.Response) {
+			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", name, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	props := read.InterfacePropertiesFormat
+	if props == nil {
+		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", name, resourceGroup)
+	}
+
+	if props.NetworkSecurityGroup == nil || props.NetworkSecurityGroup.ID == nil {
+		log.Printf("Network Interface %q (Resource Group %q) doesn't have a Security Group attached - removing from state!", name, resourceGroup)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("network_interface_id", read.ID)
+
+	// nil-checked above
+	d.Set("network_security_group_id", props.NetworkSecurityGroup.ID)
+
+	return nil
+}
+
+func resourceArmNetworkInterfaceSecurityGroupAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Network.InterfacesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	splitId := strings.Split(d.Id(), "|")
+	if len(splitId) != 2 {
+		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}/{networkSecurityGroup} but got %q", d.Id())
+	}
+
+	nicID, err := azure.ParseAzureResourceID(splitId[0])
+	if err != nil {
+		return err
+	}
+
+	name := nicID.Path["networkInterfaces"]
+	resourceGroup := nicID.ResourceGroup
+
+	locks.ByName(name, networkInterfaceResourceName)
+	defer locks.UnlockByName(name, networkInterfaceResourceName)
+
+	read, err := client.Get(ctx, resourceGroup, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(read.Response) {
+			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", name, resourceGroup)
+		}
+
+		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	props := read.InterfacePropertiesFormat
+	if props == nil {
+		return fmt.Errorf("Error: `properties` was nil for Network Interface %q (Resource Group %q)", name, resourceGroup)
+	}
+
+	props.NetworkSecurityGroup = nil
+	read.InterfacePropertiesFormat = props
+
+	future, err := azuresdkhacks.UpdateNetworkInterfaceAllowingRemovalOfNSG(ctx, client, resourceGroup, name, read)
+	if err != nil {
+		return fmt.Errorf("Error updating Network Interface %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting for update of Network Interface %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/network/registration.go
+++ b/azurerm/internal/services/network/registration.go
@@ -71,6 +71,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_network_interface_application_security_group_association":               resourceArmNetworkInterfaceApplicationSecurityGroupAssociation(),
 		"azurerm_network_interface_backend_address_pool_association":                     resourceArmNetworkInterfaceBackendAddressPoolAssociation(),
 		"azurerm_network_interface_nat_rule_association":                                 resourceArmNetworkInterfaceNatRuleAssociation(),
+		"azurerm_network_interface_security_group_association":                           resourceArmNetworkInterfaceSecurityGroupAssociation(),
 		"azurerm_network_packet_capture":                                                 resourceArmNetworkPacketCapture(),
 		"azurerm_network_profile":                                                        resourceArmNetworkProfile(),
 		"azurerm_packet_capture":                                                         resourceArmPacketCapture(),

--- a/azurerm/internal/services/network/resource_arm_network_interface.go
+++ b/azurerm/internal/services/network/resource_arm_network_interface.go
@@ -56,6 +56,7 @@ func resourceArmNetworkInterface() *schema.Resource {
 			"network_security_group_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: azure.ValidateResourceIDOrEmpty,
 			},
 

--- a/azurerm/internal/services/network/tests/network_interface_network_security_group_association_resource_test.go
+++ b/azurerm/internal/services/network/tests/network_interface_network_security_group_association_resource_test.go
@@ -1,0 +1,281 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/azuresdkhacks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+)
+
+func TestAccAzureRMNetworkInterfaceSecurityGroupAssociation_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_interface_security_group_association", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceSecurityGroupAssociation_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceSecurityGroupAssociationExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterfaceSecurityGroupAssociation_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_network_interface_security_group_association", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceSecurityGroupAssociation_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceSecurityGroupAssociationExists(data.ResourceName),
+				),
+			},
+			{
+				Config:      testAccAzureRMNetworkInterfaceSecurityGroupAssociation_requiresImport(data),
+				ExpectError: acceptance.RequiresImportError("azurerm_network_interface_security_group_association"),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterfaceSecurityGroupAssociation_deleted(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_interface_security_group_association", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceSecurityGroupAssociation_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceSecurityGroupAssociationExists(data.ResourceName),
+					testCheckAzureRMNetworkInterfaceSecurityGroupAssociationDisappears(data.ResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAzureRMNetworkInterfaceSecurityGroupAssociation_updateNIC(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_interface_security_group_association", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		// intentional as this is a Virtual Resource
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterfaceSecurityGroupAssociation_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceSecurityGroupAssociationExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMNetworkInterfaceSecurityGroupAssociation_updateNIC(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceSecurityGroupAssociationExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testCheckAzureRMNetworkInterfaceSecurityGroupAssociationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.InterfacesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		nicID, err := azure.ParseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
+		if err != nil {
+			return err
+		}
+
+		nicName := nicID.Path["networkInterfaces"]
+		resourceGroup := nicID.ResourceGroup
+		networkSecurityGroupId := rs.Primary.Attributes["network_security_group_id"]
+
+		read, err := client.Get(ctx, resourceGroup, nicName, "")
+		if err != nil {
+			return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		found := false
+		if read.InterfacePropertiesFormat != nil {
+			if read.InterfacePropertiesFormat.NetworkSecurityGroup != nil && read.InterfacePropertiesFormat.NetworkSecurityGroup.ID != nil {
+				found = *read.InterfacePropertiesFormat.NetworkSecurityGroup.ID == networkSecurityGroupId
+			}
+		}
+		if !found {
+			return fmt.Errorf("Association between NIC %q and Network Security Group %q was not found!", nicName, networkSecurityGroupId)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMNetworkInterfaceSecurityGroupAssociationDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.InterfacesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		nicID, err := azure.ParseAzureResourceID(rs.Primary.Attributes["network_interface_id"])
+		if err != nil {
+			return err
+		}
+
+		nicName := nicID.Path["networkInterfaces"]
+		resourceGroup := nicID.ResourceGroup
+
+		read, err := client.Get(ctx, resourceGroup, nicName, "")
+		if err != nil {
+			return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		read.InterfacePropertiesFormat.NetworkSecurityGroup = nil
+
+		future, err := azuresdkhacks.UpdateNetworkInterfaceAllowingRemovalOfNSG(ctx, client, resourceGroup, nicName, read)
+		if err != nil {
+			return fmt.Errorf("Error removing Network Security Group Association for Network Interface %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for removal of Network Security Group Association for NIC %q (Resource Group %q): %+v", nicName, resourceGroup, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMNetworkInterfaceSecurityGroupAssociation_basic(data acceptance.TestData) string {
+	template := testAccAzureRMNetworkInterfaceSecurityGroupAssociation_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "test" {
+  network_interface_id      = azurerm_network_interface.test.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMNetworkInterfaceSecurityGroupAssociation_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMNetworkInterfaceSecurityGroupAssociation_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface_security_group_association" "import" {
+  network_interface_id      = azurerm_network_interface_security_group_association.test.network_interface_id
+  network_security_group_id = azurerm_network_interface_security_group_association.test.network_security_group_id
+}
+`, template)
+}
+
+func testAccAzureRMNetworkInterfaceSecurityGroupAssociation_updateNIC(data acceptance.TestData) string {
+	template := testAccAzureRMNetworkInterfaceSecurityGroupAssociation_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    primary                       = true
+  }
+
+  ip_configuration {
+    name                          = "testconfiguration2"
+    private_ip_address_version    = "IPv6"
+    private_ip_address_allocation = "dynamic"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "test" {
+  network_interface_id      = azurerm_network_interface.test.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMNetworkInterfaceSecurityGroupAssociation_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestnsg-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1800,6 +1800,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/network_interface_security_group_association.html">azurerm_network_interface_security_group_association</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/network_packet_capture.html">azurerm_network_packet_capture</a>
                 </li>
 

--- a/website/docs/r/network_interface_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_security_group_association.html.markdown
@@ -1,0 +1,91 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_network_interface_security_group_association"
+description: |-
+  Manages the association between a Network Interface and a Network Security Group.
+
+---
+
+# azurerm_network_interface_security_group_association
+
+Manages the association between a Network Interface and a Network Security Group.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_network_security_group" "example" {
+  name                = "example-nsg"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_network_interface" "example" {
+  name                = "example-nic"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "example" {
+  network_interface_id      = azurerm_network_interface.example.id
+  network_security_group_id = azurerm_network_security_group.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `network_interface_id` - (Required) The ID of the Network Interface. Changing this forces a new resource to be created.
+
+* `network_security_group_id` - (Required) The ID of the Network Security Group which should be attached to the Network Interface. Changing this forces a new resource to be created.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The (Terraform specific) ID of the Association between the Network Interface and the Network Interface.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the association between the Network Interface and the Network Security Group.
+* `update` - (Defaults to 30 minutes) Used when updating the association between the Network Interface and the Network Security Group.
+* `read` - (Defaults to 5 minutes) Used when retrieving the association between the Network Interface and the Network Security Group.
+* `delete` - (Defaults to 30 minutes) Used when deleting the association between the Network Interface and the Network Security Group.
+
+## Import
+
+Associations between Network Interfaces and Network Security Group can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_network_interface_security_group_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1/ipConfigurations/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/networkSecurityGroups/group1
+```
+
+-> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}/|{networkSecurityGroupId}`.


### PR DESCRIPTION
This commit introduces a new resource for linking a Network Interface and a Network Security Group which is required to work around a dependency issue in the Azure API where the NSG must be detached in order to be able to delete dependent resources. By introducing a separate resource to do this we can force this in Terraform which also handily works around the issue in the Azure API.

Due to a design limitation which exists in the Azure SDK for Go <-> Azure Resource Manager API - this PR introduces an override from the Go SDK which allows us to remove the Network Security Group ID - which is required for this resource to work.

Ultimately this resource & a patch to the Application Security Group association resource may need to be backported to 1.x - will confirm on Monday.