### PR TITLE
`azurerm_sql_database` - support for `zone_redundant`

### DIFF
--- a/azurerm/internal/services/sql/resource_arm_sql_database.go
+++ b/azurerm/internal/services/sql/resource_arm_sql_database.go
@@ -356,6 +356,7 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 	resourceGroup := d.Get("resource_group_name").(string)
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	createMode := d.Get("create_mode").(string)
+	zoneRedundant := d.Get("zone_redundant").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
@@ -379,7 +380,8 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 	properties := sql.Database{
 		Location: utils.String(location),
 		DatabaseProperties: &sql.DatabaseProperties{
-			CreateMode: sql.CreateMode(createMode),
+			CreateMode:    sql.CreateMode(createMode),
+			ZoneRedundant: utils.Bool(zoneRedundant),
 		},
 		Tags: tags.Expand(t),
 	}
@@ -452,10 +454,6 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 		properties.DatabaseProperties.ReadScale = sql.ReadScaleEnabled
 	} else {
 		properties.DatabaseProperties.ReadScale = sql.ReadScaleDisabled
-	}
-
-	if v, ok := d.GetOkExists("zone_redundant"); ok {
-		properties.DatabaseProperties.ZoneRedundant = utils.Bool(v.(bool))
 	}
 
 	// The requested Service Objective Name does not match the requested Service Objective Id.
@@ -580,8 +578,6 @@ func resourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error 
 			d.Set("read_scale", false)
 		}
 
-		if zoneRedundant := props.ZoneRedundant; zoneRedundant != nil {
-			d.Set("zone_redundant", zoneRedundant)
 		d.Set("zone_redundant", props.ZoneRedundant)
 	}
 

--- a/azurerm/internal/services/sql/resource_arm_sql_database.go
+++ b/azurerm/internal/services/sql/resource_arm_sql_database.go
@@ -318,6 +318,12 @@ func resourceArmSqlDatabase() *schema.Resource {
 				Default:  false,
 			},
 
+			"zone_redundant": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 
@@ -449,6 +455,10 @@ func resourceArmSqlDatabaseCreateUpdate(d *schema.ResourceData, meta interface{}
 		properties.DatabaseProperties.ReadScale = sql.ReadScaleDisabled
 	}
 
+	if v, ok := d.GetOkExists("zone_redundant"); ok {
+		properties.DatabaseProperties.ZoneRedundant = utils.Bool(v.(bool))
+	}
+
 	// The requested Service Objective Name does not match the requested Service Objective Id.
 	if d.HasChange("requested_service_objective_name") && !d.HasChange("requested_service_objective_id") {
 		properties.DatabaseProperties.RequestedServiceObjectiveID = nil
@@ -569,6 +579,10 @@ func resourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error 
 			d.Set("read_scale", true)
 		} else {
 			d.Set("read_scale", false)
+		}
+
+		if zoneRedundant := props.ZoneRedundant; zoneRedundant != nil {
+			d.Set("zone_redundant", zoneRedundant)
 		}
 	}
 

--- a/azurerm/internal/services/sql/resource_arm_sql_database.go
+++ b/azurerm/internal/services/sql/resource_arm_sql_database.go
@@ -582,7 +582,7 @@ func resourceArmSqlDatabaseRead(d *schema.ResourceData, meta interface{}) error 
 
 		if zoneRedundant := props.ZoneRedundant; zoneRedundant != nil {
 			d.Set("zone_redundant", zoneRedundant)
-		}
+		d.Set("zone_redundant", props.ZoneRedundant)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/sql/resource_arm_sql_database.go
+++ b/azurerm/internal/services/sql/resource_arm_sql_database.go
@@ -321,7 +321,6 @@ func resourceArmSqlDatabase() *schema.Resource {
 			"zone_redundant": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 			},
 
 			"tags": tags.Schema(),

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -76,6 +76,8 @@ The following arguments are supported:
 
 * `read_scale` - (Optional) Read-only connections will be redirected to a high-available replica. Please see [Use read-only replicas to load-balance read-only query workloads](https://docs.microsoft.com/en-us/azure/sql-database/sql-database-read-scale-out).
 
+* `zone_redundant` - (Optional) Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 `import` supports the following:


### PR DESCRIPTION
Fixes #5672  

Adds the `zone_redundant` option to the `azurerm_sql_database` resource.

```
=== RUN   TestAccAzureRMSqlDatabase_zoneRedundant
=== PAUSE TestAccAzureRMSqlDatabase_zoneRedundant
=== CONT  TestAccAzureRMSqlDatabase_zoneRedundant
--- PASS: TestAccAzureRMSqlDatabase_zoneRedundant (368.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/sql/tests   368.513s
```