### PR TITLE
On metric alert rule creation, the 'autoMitigate' property should be set to true by default

### DIFF
--- a/azurerm/internal/services/monitor/resource_arm_monitor_metric_alert.go
+++ b/azurerm/internal/services/monitor/resource_arm_monitor_metric_alert.go
@@ -166,7 +166,7 @@ func resourceArmMonitorMetricAlert() *schema.Resource {
 			"auto_mitigate": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 
 			"description": {

--- a/azurerm/internal/services/monitor/tests/resource_arm_monitor_metric_alert_test.go
+++ b/azurerm/internal/services/monitor/tests/resource_arm_monitor_metric_alert_test.go
@@ -80,7 +80,7 @@ func TestAccAzureRMMonitorMetricAlert_complete(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMonitorMetricAlertExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "severity", "4"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", "This is a complete metric alert resource."),
 					resource.TestCheckResourceAttr(data.ResourceName, "frequency", "PT30M"),
@@ -128,7 +128,7 @@ func TestAccAzureRMMonitorMetricAlert_basicAndCompleteUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMonitorMetricAlertExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "severity", "3"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", ""),
 					resource.TestCheckResourceAttr(data.ResourceName, "frequency", "PT1M"),
@@ -149,7 +149,7 @@ func TestAccAzureRMMonitorMetricAlert_basicAndCompleteUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMonitorMetricAlertExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "severity", "4"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", "This is a complete metric alert resource."),
 					resource.TestCheckResourceAttr(data.ResourceName, "frequency", "PT30M"),
@@ -184,7 +184,7 @@ func TestAccAzureRMMonitorMetricAlert_basicAndCompleteUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMonitorMetricAlertExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_mitigate", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "severity", "3"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", ""),
 					resource.TestCheckResourceAttr(data.ResourceName, "frequency", "PT1M"),
@@ -288,7 +288,7 @@ resource "azurerm_monitor_metric_alert" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
   scopes              = ["${azurerm_storage_account.test.id}"]
   enabled             = true
-  auto_mitigate       = true
+  auto_mitigate       = false
   severity            = 4
   description         = "This is a complete metric alert resource."
   frequency           = "PT30M"

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 * `criteria` - (Required) One or more `criteria` blocks as defined below.
 * `action` - (Optional) One or more `action` blocks as defined below.
 * `enabled` - (Optional) Should this Metric Alert be enabled? Defaults to `true`.
-* `auto_mitigate` - (Optional) Should the alerts in this Metric Alert be auto resolved? Defaults to `false`.
+* `auto_mitigate` - (Optional) Should the alerts in this Metric Alert be auto resolved? Defaults to `true`.
 * `description` - (Optional) The description of this Metric Alert.
 * `frequency` - (Optional) The evaluation frequency of this Metric Alert, represented in ISO 8601 duration format. Possible values are `PT1M`, `PT5M`, `PT15M`, `PT30M` and `PT1H`. Defaults to `PT1M`.
 * `severity` - (Optional) The severity of this Metric Alert. Possible values are `0`, `1`, `2`, `3` and `4`. Defaults to `3`.


### PR DESCRIPTION
On metric alert rule creation, the 'autoMitigate' property should be set to true by default.
When 'autoMitigate' is set to false monitor condition not changing from 'Fired' to 'Resolved' automatically as the customers are expected.

