### PR TITLE
r/network_interface_application_security_group_association: removing `ip_configuration_name`

### DIFF
--- a/azurerm/internal/services/network/network_interface_application_security_group_association_migration.go
+++ b/azurerm/internal/services/network/network_interface_application_security_group_association_migration.go
@@ -1,0 +1,43 @@
+package network
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+func resourceNetworkInterfaceApplicationSecurityGroupAssociationUpgradeV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"network_interface_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"application_security_group_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+		},
+	}
+}
+
+func resourceNetworkInterfaceApplicationSecurityGroupAssociationUpgradeV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	// after shipping support for this Resource Azure's since changed the behaviour to require that all IP Configurations
+	// are connected to the same Application Security Group
+	applicationSecurityGroupId := rawState["application_security_group_id"].(string)
+	networkInterfaceId := rawState["network_interface_id"].(string)
+
+	oldID := rawState["id"].(string)
+	newID := fmt.Sprintf("%s|%s", networkInterfaceId, applicationSecurityGroupId)
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldID, newID)
+
+	rawState["id"] = newID
+	return rawState, nil
+}

--- a/azurerm/internal/services/network/resource_arm_firewall.go
+++ b/azurerm/internal/services/network/resource_arm_firewall.go
@@ -32,10 +32,10 @@ func resourceArmFirewall() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(40 * time.Minute),
+			Create: schema.DefaultTimeout(90 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(40 * time.Minute),
-			Delete: schema.DefaultTimeout(40 * time.Minute),
+			Update: schema.DefaultTimeout(90 * time.Minute),
+			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/azurerm/internal/services/network/tests/network_interface_application_security_group_association_resource_test.go
+++ b/azurerm/internal/services/network/tests/network_interface_application_security_group_association_resource_test.go
@@ -249,7 +249,6 @@ resource "azurerm_network_interface" "test" {
 
 resource "azurerm_network_interface_application_security_group_association" "test" {
   network_interface_id          = azurerm_network_interface.test.id
-  ip_configuration_name         = "testconfiguration1"
   application_security_group_id = azurerm_application_security_group.test.id
 }
 `, template, data.RandomInteger)
@@ -292,7 +291,6 @@ resource "azurerm_network_interface" "test" {
 
 resource "azurerm_network_interface_application_security_group_association" "test" {
   network_interface_id          = azurerm_network_interface.test.id
-  ip_configuration_name         = "testconfiguration1"
   application_security_group_id = azurerm_application_security_group.test.id
 }
 `, template, data.RandomInteger)
@@ -324,7 +322,6 @@ resource "azurerm_network_interface" "test" {
 
 resource "azurerm_network_interface_application_security_group_association" "test" {
   network_interface_id          = azurerm_network_interface.test.id
-  ip_configuration_name         = "testconfiguration1"
   application_security_group_id = azurerm_application_security_group.test.id
 }
 `, template, data.RandomInteger)

--- a/azurerm/internal/services/network/tests/network_interface_application_security_group_association_resource_test.go
+++ b/azurerm/internal/services/network/tests/network_interface_application_security_group_association_resource_test.go
@@ -273,6 +273,7 @@ resource "azurerm_network_interface" "test" {
     name                          = "testconfiguration1"
     subnet_id                     = azurerm_subnet.test.id
     private_ip_address_allocation = "Dynamic"
+    primary                       = true
   }
 
   ip_configuration {

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -438,6 +438,10 @@ The `load_balancer_backend_address_pools_ids` field in the `ip_configuration` bl
 
 The `load_balancer_inbound_nat_rules_ids` field in the `ip_configuration` block will been removed. This has been replaced by the `azurerm_network_interface_nat_rule_association` resource.
 
+### Resource: `azurerm_network_interface_application_security_group_association`
+
+The field `ip_configuration_name` has been removed since the same Application Security Group must now be assigned to all (IPv4) IP Configurations.
+
 ### Resource: `azurerm_notification_hub_namespace`
 
 The deprecated `sku` block has been replaced by the `sku_name` field and will be removed.

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -108,10 +108,10 @@ A `ip_configuration` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 40 minutes) Used when creating the Firewall.
-* `update` - (Defaults to 40 minutes) Used when updating the Firewall.
+* `create` - (Defaults to 90 minutes) Used when creating the Firewall.
+* `update` - (Defaults to 90 minutes) Used when updating the Firewall.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Firewall.
-* `delete` - (Defaults to 40 minutes) Used when deleting the Firewall.
+* `delete` - (Defaults to 90 minutes) Used when deleting the Firewall.
 
 ## Import
 

--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -54,7 +54,6 @@ resource "azurerm_network_interface" "example" {
 
 resource "azurerm_network_interface_application_security_group_association" "example" {
   network_interface_id          = azurerm_network_interface.example.id
-  ip_configuration_name         = "testconfiguration1"
   application_security_group_id = azurerm_application_security_group.example.id
 }
 ```
@@ -64,8 +63,6 @@ resource "azurerm_network_interface_application_security_group_association" "exa
 The following arguments are supported:
 
 * `network_interface_id` - (Required) The ID of the Network Interface. Changing this forces a new resource to be created.
-
-* `ip_configuration_name` - (Required) The Name of the IP Configuration within the Network Interface which should be connected to the Application Security Group. Changing this forces a new resource to be created.
 
 * `application_security_group_id` - (Required) The ID of the Application Security Group which this Network Interface which should be connected to. Changing this forces a new resource to be created.
 
@@ -88,9 +85,8 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 Associations between Network Interfaces and Application Security Groups can be imported using the `resource id`, e.g.
 
-
 ```shell
-terraform import azurerm_network_interface_application_security_group_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1/ipConfigurations/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/applicationSecurityGroups/securityGroup1
+terraform import azurerm_network_interface_application_security_group_association.association1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/applicationSecurityGroups/securityGroup1"
 ```
 
--> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}/ipConfigurations/{ipConfigurationName}|{applicationSecurityGroupId}`.
+-> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}|{applicationSecurityGroupId}`.


### PR DESCRIPTION
There's been a breaking behavioural change in the Networking API where all IPv4 IP Configurations are now required to share the same Application Security Group - as such this PR updates this resource to account for this no longer being tied to a specific IP Configuration.

Fixes #5591