### PR TITLE
website: generating the list of supported sidebar categories

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ tools:
 	GO111MODULE=off go get -u github.com/bflad/tfproviderdocs
 	GO111MODULE=off go get -u github.com/katbyte/terrafmt
 
-build: fmtcheck
+build: fmtcheck generate
 	go install
 
 build-docker:
@@ -36,6 +36,9 @@ fmt:
 fmtcheck:
 	@sh "$(CURDIR)/scripts/gofmtcheck.sh"
 	@sh "$(CURDIR)/scripts/timeouts.sh"
+
+generate:
+	go generate ./azurerm/internal/provider/
 
 goimports:
 	@echo "==> Fixing imports code with goimports..."

--- a/azurerm/internal/provider/services.go
+++ b/azurerm/internal/provider/services.go
@@ -63,6 +63,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web"
 )
 
+//go:generate go run ../tools/website-categories/main.go -path=../../../website/allowed-subcategories
+
 func SupportedServices() []common.ServiceRegistration {
 	return []common.ServiceRegistration{
 		analysisservices.Registration{},

--- a/azurerm/internal/services/analysisservices/registration.go
+++ b/azurerm/internal/services/analysisservices/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Analysis Services"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Analysis Services",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/apimanagement/registration.go
+++ b/azurerm/internal/services/apimanagement/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "API Management"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"API Management",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/appconfiguration/registration.go
+++ b/azurerm/internal/services/appconfiguration/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "App Configuration"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"App Configuration",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/applicationinsights/registration.go
+++ b/azurerm/internal/services/applicationinsights/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Application Insights"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Application Insights",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/authorization/registration.go
+++ b/azurerm/internal/services/authorization/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Authorization"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Authorization",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/automation/registration.go
+++ b/azurerm/internal/services/automation/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Automation"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Automation",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/batch/registration.go
+++ b/azurerm/internal/services/batch/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Batch"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Batch",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/bot/registration.go
+++ b/azurerm/internal/services/bot/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Bot"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Bot",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/cdn/registration.go
+++ b/azurerm/internal/services/cdn/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Cdn"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"CDN",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/cognitive/registration.go
+++ b/azurerm/internal/services/cognitive/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Cognitive Services"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Cognitive Services",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/common/service_registration.go
+++ b/azurerm/internal/services/common/service_registration.go
@@ -6,6 +6,9 @@ type ServiceRegistration interface {
 	// Name is the name of this Service
 	Name() string
 
+	// WebsiteCategories returns a list of categories which can be used for the sidebar
+	WebsiteCategories() []string
+
 	// SupportedDataSources returns the supported Data Sources supported by this Service
 	SupportedDataSources() map[string]*schema.Resource
 

--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -12,6 +12,13 @@ func (r Registration) Name() string {
 	return "Compute"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Compute",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/containers/registration.go
+++ b/azurerm/internal/services/containers/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Container Services"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Container",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/cosmos/registration.go
+++ b/azurerm/internal/services/cosmos/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "CosmosDB"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"CosmosDB (DocumentDB)",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/databricks/registration.go
+++ b/azurerm/internal/services/databricks/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "DataBricks"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Databricks",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/datafactory/registration.go
+++ b/azurerm/internal/services/datafactory/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Data Factory"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Data Factory",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/datalake/registration.go
+++ b/azurerm/internal/services/datalake/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Data Lake"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Data Lake",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/devspace/registration.go
+++ b/azurerm/internal/services/devspace/registration.go
@@ -4,11 +4,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+// TODO: this can be moved into Container
+
 type Registration struct{}
 
 // Name is the name of this Service
 func (r Registration) Name() string {
 	return "DevSpaces"
+}
+
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"DevSpace",
+	}
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service

--- a/azurerm/internal/services/devtestlabs/registration.go
+++ b/azurerm/internal/services/devtestlabs/registration.go
@@ -8,7 +8,14 @@ type Registration struct{}
 
 // Name is the name of this Service
 func (r Registration) Name() string {
-	return "DevTestLabs"
+	return "Dev Test"
+}
+
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Dev Test",
+	}
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service

--- a/azurerm/internal/services/dns/registration.go
+++ b/azurerm/internal/services/dns/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "DNS"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"DNS",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/eventgrid/registration.go
+++ b/azurerm/internal/services/eventgrid/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "EventGrid"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Messaging",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/eventhub/registration.go
+++ b/azurerm/internal/services/eventhub/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "EventHub"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Messaging",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/frontdoor/registration.go
+++ b/azurerm/internal/services/frontdoor/registration.go
@@ -4,11 +4,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+// TODO: move this to the network one
+
 type Registration struct{}
 
 // Name is the name of this Service
 func (r Registration) Name() string {
 	return "FrontDoor"
+}
+
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Network",
+	}
 }
 
 // SupportedDataSources returns the supported Data Sources supported by this Service

--- a/azurerm/internal/services/hdinsight/registration.go
+++ b/azurerm/internal/services/hdinsight/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "HDInsight"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"HDInsight",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/healthcare/registration.go
+++ b/azurerm/internal/services/healthcare/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Health Care"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Healthcare",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/iothub/registration.go
+++ b/azurerm/internal/services/iothub/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "IoT Hub"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"IoT Hub",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/keyvault/registration.go
+++ b/azurerm/internal/services/keyvault/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "KeyVault"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Key Vault",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/kusto/registration.go
+++ b/azurerm/internal/services/kusto/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Kusto"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Data Explorer",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/loganalytics/registration.go
+++ b/azurerm/internal/services/loganalytics/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Log Analytics"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Log Analytics",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/logic/registration.go
+++ b/azurerm/internal/services/logic/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Logic"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Logic App",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/managementgroup/registration.go
+++ b/azurerm/internal/services/managementgroup/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Management Group"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Management",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/maps/registration.go
+++ b/azurerm/internal/services/maps/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Maps"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Maps",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/mariadb/registration.go
+++ b/azurerm/internal/services/mariadb/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "MariaDB"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Database",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/media/registration.go
+++ b/azurerm/internal/services/media/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Media"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Media",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/monitor/registration.go
+++ b/azurerm/internal/services/monitor/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Monitor"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Monitor",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/msi/registration.go
+++ b/azurerm/internal/services/msi/registration.go
@@ -13,6 +13,13 @@ func (r Registration) Name() string {
 	return "Managed Service Identities"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Authorization",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/mssql/registration.go
+++ b/azurerm/internal/services/mssql/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Microsoft SQL Server / SQL Azure"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Database",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/mysql/registration.go
+++ b/azurerm/internal/services/mysql/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "MySQL"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Database",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/netapp/registration.go
+++ b/azurerm/internal/services/netapp/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "NetApp"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"NetApp",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/network/registration.go
+++ b/azurerm/internal/services/network/registration.go
@@ -11,6 +11,14 @@ func (r Registration) Name() string {
 	return "Network"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Load Balancer",
+		"Network",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/notificationhub/registration.go
+++ b/azurerm/internal/services/notificationhub/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Notification Hub"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Messaging",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/policy/registration.go
+++ b/azurerm/internal/services/policy/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Policy"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Policy",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/portal/registration.go
+++ b/azurerm/internal/services/portal/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Portal"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Portal",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/postgres/registration.go
+++ b/azurerm/internal/services/postgres/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "PostgreSQL"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Database",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/privatedns/registration.go
+++ b/azurerm/internal/services/privatedns/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Private DNS"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Private DNS",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/recoveryservices/registration.go
+++ b/azurerm/internal/services/recoveryservices/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Recovery Services"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Recovery Services",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/redis/registration.go
+++ b/azurerm/internal/services/redis/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Redis"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Redis",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/relay/registration.go
+++ b/azurerm/internal/services/relay/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Relay"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Messaging",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/resource/registration.go
+++ b/azurerm/internal/services/resource/registration.go
@@ -11,6 +11,15 @@ func (r Registration) Name() string {
 	return "Resources"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Base",
+		"Management",
+		"Template",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/search/registration.go
+++ b/azurerm/internal/services/search/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Search"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Search",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/securitycenter/registration.go
+++ b/azurerm/internal/services/securitycenter/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Security Center"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Security Center",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/servicebus/registration.go
+++ b/azurerm/internal/services/servicebus/registration.go
@@ -11,6 +11,14 @@ func (r Registration) Name() string {
 	return "ServiceBus"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		// TODO: change this to ServiceBus
+		"Messaging",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/servicefabric/registration.go
+++ b/azurerm/internal/services/servicefabric/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Service Fabric"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Service Fabric",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{}

--- a/azurerm/internal/services/signalr/registration.go
+++ b/azurerm/internal/services/signalr/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "SignalR"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Messaging",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/sql/registration.go
+++ b/azurerm/internal/services/sql/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "SQL"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Database",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/storage/registration.go
+++ b/azurerm/internal/services/storage/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Storage"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Storage",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/streamanalytics/registration.go
+++ b/azurerm/internal/services/streamanalytics/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Stream Analytics"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Stream Analytics",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/subscription/registration.go
+++ b/azurerm/internal/services/subscription/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Subscription"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Base",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/trafficmanager/registration.go
+++ b/azurerm/internal/services/trafficmanager/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Traffic Manager"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"Network",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/services/web/registration.go
+++ b/azurerm/internal/services/web/registration.go
@@ -11,6 +11,13 @@ func (r Registration) Name() string {
 	return "Web"
 }
 
+// WebsiteCategories returns a list of categories which can be used for the sidebar
+func (r Registration) WebsiteCategories() []string {
+	return []string{
+		"App Service (Web Apps)",
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{

--- a/azurerm/internal/tools/website-categories/README.md
+++ b/azurerm/internal/tools/website-categories/README.md
@@ -1,0 +1,18 @@
+## Website Categories
+
+This tool generates files necessary for the website from the provide registrations which already exist in code.
+
+This is run via go:generate whenever the "SupportedServices" array is changed so that this is kept up-to-date.
+
+## Example Usage
+
+```
+go run main.go -path=/path/to/output/file
+```
+
+## Arguments
+
+* `help` - Show help?
+
+* `path` - The Relative Path to the `allowed-subcategories` file used for the website
+

--- a/azurerm/internal/tools/website-categories/README.md
+++ b/azurerm/internal/tools/website-categories/README.md
@@ -1,6 +1,6 @@
 ## Website Categories
 
-This tool generates files necessary for the website from the provide registrations which already exist in code.
+This tool generates files necessary for the website from the service registrations which already exist in code.
 
 This is run via go:generate whenever the "SupportedServices" array is changed so that this is kept up-to-date.
 

--- a/azurerm/internal/tools/website-categories/main.go
+++ b/azurerm/internal/tools/website-categories/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/provider"
+)
+
+func main() {
+	filePath := flag.String("path", "", "The relative path to the output file")
+	showHelp := flag.Bool("help", false, "Display this message")
+
+	flag.Parse()
+
+	if *showHelp {
+		flag.Usage()
+		return
+	}
+
+	if err := run(*filePath); err != nil {
+		panic(err)
+	}
+}
+
+func run(outputFileName string) error {
+	websiteCategories := make([]string, 0)
+
+	// get a distinct list
+	for _, service := range provider.SupportedServices() {
+		for _, category := range service.WebsiteCategories() {
+			if contains(websiteCategories, category) {
+				continue
+			}
+
+			websiteCategories = append(websiteCategories, category)
+		}
+	}
+
+	// sort them
+	sort.Strings(websiteCategories)
+
+	outputPath, err := filepath.Abs(outputFileName)
+	if err != nil {
+		panic(err)
+	}
+
+	// output that string to the file
+	file, err := os.Create(outputPath)
+	if err != nil {
+		panic(err)
+	}
+	if os.IsExist(err) {
+		os.Remove(outputPath)
+		file, err = os.Create(outputPath)
+		if err != nil {
+			panic(err)
+		}
+	}
+	defer file.Close()
+
+	// dump them to a file
+	for _, category := range websiteCategories {
+		file.WriteString(fmt.Sprintf("%s\n", category))
+	}
+
+	return file.Sync()
+}
+
+func contains(input []string, value string) bool {
+	for _, v := range input {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/azurerm/internal/tools/website-categories/main.go
+++ b/azurerm/internal/tools/website-categories/main.go
@@ -45,19 +45,19 @@ func run(outputFileName string) error {
 
 	outputPath, err := filepath.Abs(outputFileName)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// output that string to the file
 	file, err := os.Create(outputPath)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	if os.IsExist(err) {
 		os.Remove(outputPath)
 		file, err = os.Create(outputPath)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 	defer file.Close()

--- a/azurerm/internal/tools/website-categories/main.go
+++ b/azurerm/internal/tools/website-categories/main.go
@@ -64,7 +64,7 @@ func run(outputFileName string) error {
 
 	// dump them to a file
 	for _, category := range websiteCategories {
-		file.WriteString(fmt.Sprintf("%s\n", category))
+		_, _ = file.WriteString(fmt.Sprintf("%s\n", category))
 	}
 
 	return file.Sync()

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -5,10 +5,8 @@ App Service (Web Apps)
 Application Insights
 Authorization
 Automation
-Azure Active Directory
 Base
 Batch
-Beta
 Bot
 CDN
 Cognitive Services
@@ -23,7 +21,6 @@ Database
 Databricks
 Dev Test
 DevSpace
-Front Door
 HDInsight
 Healthcare
 IoT Hub
@@ -43,7 +40,6 @@ Portal
 Private DNS
 Recovery Services
 Redis
-Scheduler
 Search
 Security Center
 Service Fabric

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Front Door"
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor"
 description: |-

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Front Door"
+subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_firewall_policy"
 description: |-


### PR DESCRIPTION
This PR adds a `WebsiteCategories()` method to the Service Registration block which is used to generate the list of acceptable categories used for the website - which means this'll no longer need to be maintained by hand