### PR TITLE
docs: Adds `id` to Data Source: `azurerm_resource_group`

### DIFF
--- a/website/docs/d/resource_group.html.markdown
+++ b/website/docs/d/resource_group.html.markdown
@@ -35,6 +35,7 @@ resource "azurerm_managed_disk" "example" {
 
 ## Attributes Reference
 
+* `id` - The ID of the Resource Group.
 * `location` - The location of the resource group.
 * `tags` - A mapping of tags assigned to the resource group.
 


### PR DESCRIPTION
Fixes #5686 