### PR TITLE
azurerm_dns_txt_record  - support records up to 1024 characters in length

### DIFF
--- a/azurerm/internal/services/dns/resource_arm_dns_txt_record.go
+++ b/azurerm/internal/services/dns/resource_arm_dns_txt_record.go
@@ -3,10 +3,12 @@ package dns
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -53,8 +55,9 @@ func resourceArmDnsTxtRecord() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"value": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringLenBetween(1, 1024),
 						},
 					},
 				},
@@ -194,7 +197,7 @@ func flattenAzureRmDnsTxtRecords(records *[]dns.TxtRecord) []map[string]interfac
 			txtRecord := make(map[string]interface{})
 
 			if v := record.Value; v != nil {
-				value := (*v)[0]
+				value := strings.Join(*v, "")
 				txtRecord["value"] = value
 			}
 
@@ -209,9 +212,17 @@ func expandAzureRmDnsTxtRecords(d *schema.ResourceData) *[]dns.TxtRecord {
 	recordStrings := d.Get("record").(*schema.Set).List()
 	records := make([]dns.TxtRecord, len(recordStrings))
 
+	segmentLen := 254
 	for i, v := range recordStrings {
 		record := v.(map[string]interface{})
-		value := []string{record["value"].(string)}
+		v := record["value"].(string)
+
+		var value []string
+		for len(v) > segmentLen {
+			value = append(value, v[:segmentLen])
+			v = v[segmentLen:]
+		}
+		value = append(value, v)
 
 		txtRecord := dns.TxtRecord{
 			Value: &value,

--- a/azurerm/internal/services/dns/tests/resource_arm_dns_txt_record_test.go
+++ b/azurerm/internal/services/dns/tests/resource_arm_dns_txt_record_test.go
@@ -196,7 +196,7 @@ resource "azurerm_dns_txt_record" "test" {
   }
 
   record {
-    value = "Another test txt string"
+    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -218,7 +218,7 @@ resource "azurerm_dns_txt_record" "import" {
   }
 
   record {
-    value = "Another test txt string"
+    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......"
   }
 }
 `, template)
@@ -247,7 +247,7 @@ resource "azurerm_dns_txt_record" "test" {
   }
 
   record {
-    value = "Another test txt string"
+    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......"
   }
 
   record {

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 The `record` block supports:
 
-* `value` - (Required) The value of the record.
+* `value` - (Required) The value of the record. Max length: 1024 characters
 
 ## Attributes Reference
 


### PR DESCRIPTION
fixa #5547 

According to [dns txt record doc](https://docs.microsoft.com/en-us/azure/dns/dns-zones-records#txt-records), a record length can be up to 1024 characters. To align with azure.cli and powershell, I set each record set length to 254 characters

![image](https://user-images.githubusercontent.com/2786738/75013414-369d8100-54bf-11ea-948c-953b5da85d7c.png)
