### PR TITLE
Enhancement: `azurerm_private_endpoint ` expose `private_ip_address` as computed attribute

### DIFF
--- a/azurerm/internal/services/network/tests/resource_arm_private_endpoint_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_private_endpoint_test.go
@@ -24,6 +24,7 @@ func TestAccAzureRMPrivateEndpoint_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPrivateEndpointExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "private_service_connection.0.private_ip_address"),
 				),
 			},
 			data.ImportStep(),

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -141,6 +141,8 @@ See the product [documentation](https://docs.microsoft.com/en-us/azure/private-l
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The request message can be a maximum of `140` characters in length. Only valid if `is_manual_connection` is set to `true`.
 
+* `private_ip_address` - The private IP address associated with the private endpoint, note that you will have a private IP address assigned to the private endpoint even if the connection request was `Rejected`.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -141,7 +141,7 @@ See the product [documentation](https://docs.microsoft.com/en-us/azure/private-l
 
 * `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource. The request message can be a maximum of `140` characters in length. Only valid if `is_manual_connection` is set to `true`.
 
-* `private_ip_address` - The private IP address associated with the private endpoint, note that you will have a private IP address assigned to the private endpoint even if the connection request was `Rejected`.
+* `private_ip_address` - (Computed) The private IP address associated with the private endpoint, note that you will have a private IP address assigned to the private endpoint even if the connection request was `Rejected`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
fixes #5622 
fixes #5208 

add `private_ip_address` just like data source `azurerm_private_endpoint_connection`.

Because `azurerm_private_link_endpoint` use the same flatten function, So I set this field outside this flatten function