### PR TITLE
Update AD domain regex for azure netapp files account to allow dash (-)

### DIFF
--- a/azurerm/internal/services/netapp/resource_arm_netapp_account.go
+++ b/azurerm/internal/services/netapp/resource_arm_netapp_account.go
@@ -68,7 +68,7 @@ func resourceArmNetAppAccount() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringMatch(
-								regexp.MustCompile(`^[(\da-zA-Z)\.]{1,255}$`),
+								regexp.MustCompile(`^[(\da-zA-Z-)\.]{1,255}$`),
 								`The domain name must end with a letter or number before dot and start with a letter or number after dot and can not be longer than 255 characters in length.`,
 							),
 						},


### PR DESCRIPTION
Azure AD domain services allows a dash - in the domain name, but the regex that validates the domain name does not.  I changed the regex from: ^[(\da-zA-Z)\.]{1,255}$ 
to:  ^[(\da-zA-Z-)\.]{1,255}$
It's a subtle change, but we can't use the ANF provider until it is fixed, because our domain name contains a dash -