### PR TITLE
test configs: cleaning up deprecated fields

### DIFF
--- a/azurerm/internal/services/authorization/tests/resource_arm_role_assignment_test.go
+++ b/azurerm/internal/services/authorization/tests/resource_arm_role_assignment_test.go
@@ -349,7 +349,7 @@ data "azurerm_role_definition" "test" {
 resource "azurerm_role_assignment" "test" {
   scope              = "${data.azurerm_subscription.primary.id}"
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
-  principal_id       = "${data.azurerm_client_config.test.service_principal_object_id}"
+  principal_id       = "${data.azurerm_client_config.test.object_id}"
 }
 `
 }
@@ -364,7 +364,7 @@ resource "azurerm_role_assignment" "test" {
   name                 = "%s"
   scope                = "${data.azurerm_subscription.primary.id}"
   role_definition_name = "Log Analytics Reader"
-  principal_id         = "${data.azurerm_client_config.test.service_principal_object_id}"
+  principal_id         = "${data.azurerm_client_config.test.object_id}"
 }
 `, id)
 }
@@ -392,7 +392,7 @@ resource "azurerm_role_assignment" "test" {
   name                 = "%s"
   scope                = "${data.azurerm_subscription.primary.id}"
   role_definition_name = "Virtual Machine User Login"
-  principal_id         = "${data.azurerm_client_config.test.service_principal_object_id}"
+  principal_id         = "${data.azurerm_client_config.test.object_id}"
 }
 `, id)
 }
@@ -411,7 +411,7 @@ resource "azurerm_role_assignment" "test" {
   name               = "%s"
   scope              = "${data.azurerm_subscription.primary.id}"
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.test.id}"
-  principal_id       = "${data.azurerm_client_config.test.service_principal_object_id}"
+  principal_id       = "${data.azurerm_client_config.test.object_id}"
 }
 `, id)
 }
@@ -442,7 +442,7 @@ resource "azurerm_role_assignment" "test" {
   name               = "%s"
   scope              = "${data.azurerm_subscription.primary.id}"
   role_definition_id = "${azurerm_role_definition.test.id}"
-  principal_id       = "${data.azurerm_client_config.test.service_principal_object_id}"
+  principal_id       = "${data.azurerm_client_config.test.object_id}"
 }
 `, roleDefinitionId, rInt, roleAssignmentId)
 }
@@ -524,7 +524,7 @@ resource "azurerm_management_group" "test" {
 resource "azurerm_role_assignment" "test" {
   scope              = "${azurerm_management_group.test.id}"
   role_definition_id = "${data.azurerm_role_definition.test.id}"
-  principal_id       = "${data.azurerm_client_config.test.service_principal_object_id}"
+  principal_id       = "${data.azurerm_client_config.test.object_id}"
 }
 `, groupId)
 }

--- a/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
+++ b/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
@@ -1067,7 +1067,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "blob"
 }

--- a/azurerm/internal/services/bot/tests/resource_arm_bot_channels_registration_test.go
+++ b/azurerm/internal/services/bot/tests/resource_arm_bot_channels_registration_test.go
@@ -185,7 +185,7 @@ resource "azurerm_bot_channels_registration" "test" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 
   tags = {
     environment = "production"
@@ -208,7 +208,7 @@ resource "azurerm_bot_channels_registration" "test" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 
   tags = {
     environment = "production"
@@ -243,7 +243,7 @@ resource "azurerm_bot_channels_registration" "test" {
   name                = "acctestdf%d"
   location            = "global"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
   sku                 = "F0"
 
   endpoint                              = "https://example.com"

--- a/azurerm/internal/services/bot/tests/resource_arm_bot_web_app_test.go
+++ b/azurerm/internal/services/bot/tests/resource_arm_bot_web_app_test.go
@@ -146,7 +146,7 @@ resource "azurerm_bot_web_app" "test" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 
   tags = {
     environment = "production"
@@ -169,7 +169,7 @@ resource "azurerm_bot_web_app" "test" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.test.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 
   tags = {
     environment = "production"
@@ -204,7 +204,7 @@ resource "azurerm_bot_web_app" "test" {
   name                = "acctestdf%d"
   location            = "global"
   resource_group_name = "${azurerm_resource_group.test.name}"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
   sku                 = "F0"
 
   endpoint                              = "https://example.com"

--- a/azurerm/internal/services/compute/tests/data_source_snapshot_test.go
+++ b/azurerm/internal/services/compute/tests/data_source_snapshot_test.go
@@ -106,7 +106,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
@@ -480,7 +480,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.service_principal_object_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_other_test.go
@@ -781,7 +781,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_disk_encryption_set_test.go
@@ -236,7 +236,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_disk_data_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_disk_data_test.go
@@ -456,7 +456,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.service_principal_object_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_disk_os_test.go
@@ -326,7 +326,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.service_principal_object_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_other_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_linux_virtual_machine_scale_set_other_test.go
@@ -978,7 +978,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_managed_disk_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_managed_disk_test.go
@@ -697,7 +697,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -867,7 +867,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.service_principal_object_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_snapshot_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_snapshot_test.go
@@ -359,7 +359,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_virtual_machine_managed_disks_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_virtual_machine_managed_disks_test.go
@@ -820,7 +820,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "backup",

--- a/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_disk_data_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_disk_data_test.go
@@ -503,7 +503,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.service_principal_object_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_disk_os_test.go
@@ -326,7 +326,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.service_principal_object_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_other_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_windows_virtual_machine_scale_set_other_test.go
@@ -1169,7 +1169,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",
@@ -1519,7 +1519,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "backup",

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
@@ -503,7 +503,7 @@ resource "azurerm_key_vault" "test" {
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.service_principal_object_id
+  object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_other_test.go
@@ -1122,7 +1122,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",
@@ -1509,7 +1509,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "backup",

--- a/azurerm/internal/services/eventgrid/tests/resource_arm_eventgrid_event_subscription_test.go
+++ b/azurerm/internal/services/eventgrid/tests/resource_arm_eventgrid_event_subscription_test.go
@@ -202,7 +202,6 @@ resource "azurerm_storage_queue" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }
@@ -263,13 +262,11 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_queue" "test" {
   name                 = "mysamplequeue-%d"
-  resource_group_name  = "${azurerm_resource_group.test.name}"
   storage_account_name = "${azurerm_storage_account.test.name}"
 }
 
 resource "azurerm_storage_container" "test" {
   name                  = "vhds"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }
@@ -277,7 +274,6 @@ resource "azurerm_storage_container" "test" {
 resource "azurerm_storage_blob" "test" {
   name = "herpderp1.vhd"
 
-  resource_group_name    = "${azurerm_resource_group.test.name}"
   storage_account_name   = "${azurerm_storage_account.test.name}"
   storage_container_name = "${azurerm_storage_container.test.name}"
 

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_hbase_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_hbase_cluster_test.go
@@ -606,7 +606,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_interactive_query_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_interactive_query_cluster_test.go
@@ -608,7 +608,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_kafka_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_kafka_cluster_test.go
@@ -617,7 +617,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_ml_services_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_ml_services_cluster_test.go
@@ -564,7 +564,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_rserver_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_rserver_cluster_test.go
@@ -564,7 +564,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_spark_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_spark_cluster_test.go
@@ -608,7 +608,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_storm_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_storm_cluster_test.go
@@ -528,7 +528,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "acctest"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/healthcare/tests/resource_arm_healthcare_service_test.go
+++ b/azurerm/internal/services/healthcare/tests/resource_arm_healthcare_service_test.go
@@ -148,7 +148,7 @@ resource "azurerm_healthcare_service" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   access_policy_object_ids = [
-    "${data.azurerm_client_config.current.service_principal_object_id}",
+    "${data.azurerm_client_config.current.object_id}",
   ]
 }
 `, data.RandomInteger, location, data.RandomIntOfLength(17)) //name can only be 24 chars long
@@ -165,7 +165,7 @@ resource "azurerm_healthcare_service" "import" {
   resource_group_name = azurerm_healthcare_service.test.resource_group_name
 
   access_policy_object_ids = [
-    "${data.azurerm_client_config.current.service_principal_object_id}",
+    "${data.azurerm_client_config.current.object_id}",
   ]
 }
 `, template)
@@ -194,7 +194,7 @@ resource "azurerm_healthcare_service" "test" {
   }
 
   access_policy_object_ids = [
-    "${data.azurerm_client_config.current.service_principal_object_id}",
+    "${data.azurerm_client_config.current.object_id}",
   ]
 
   authentication_configuration {

--- a/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_access_policy_test.go
@@ -213,7 +213,7 @@ resource "azurerm_key_vault_access_policy" "test" {
   ]
 
   tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-  object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+  object_id = "${data.azurerm_client_config.current.object_id}"
 }
 `, template)
 }
@@ -265,7 +265,7 @@ resource "azurerm_key_vault_access_policy" "test_with_application_id" {
 
   application_id = "${data.azurerm_client_config.current.service_principal_application_id}"
   tenant_id      = "${data.azurerm_client_config.current.tenant_id}"
-  object_id      = "${data.azurerm_client_config.current.service_principal_object_id}"
+  object_id      = "${data.azurerm_client_config.current.object_id}"
 }
 
 resource "azurerm_key_vault_access_policy" "test_no_application_id" {
@@ -304,7 +304,7 @@ resource "azurerm_key_vault_access_policy" "test_no_application_id" {
   ]
 
   tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-  object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+  object_id = "${data.azurerm_client_config.current.object_id}"
 }
 `, template)
 }
@@ -325,7 +325,7 @@ resource "azurerm_key_vault_access_policy" "test" {
   secret_permissions = []
 
   tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-  object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+  object_id = "${data.azurerm_client_config.current.object_id}"
 }
 `, template)
 }
@@ -381,7 +381,7 @@ resource "azurerm_key_vault_access_policy" "test" {
   key_vault_id = "${azurerm_key_vault.test.id}NOPE"
 
   tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-  object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+  object_id = "${data.azurerm_client_config.current.object_id}"
 
   key_permissions = [
     "get",

--- a/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_access_policy_test.go
+++ b/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_access_policy_test.go
@@ -263,7 +263,7 @@ resource "azurerm_key_vault_access_policy" "test_with_application_id" {
     "delete",
   ]
 
-  application_id = "${data.azurerm_client_config.current.service_principal_application_id}"
+  application_id = "${data.azurerm_client_config.current.client_id}"
   tenant_id      = "${data.azurerm_client_config.current.tenant_id}"
   object_id      = "${data.azurerm_client_config.current.object_id}"
 }

--- a/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_certificate_test.go
+++ b/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_certificate_test.go
@@ -353,7 +353,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     certificate_permissions = [
       "delete",
@@ -453,7 +453,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     certificate_permissions = [
       "create",
@@ -543,7 +543,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     certificate_permissions = [
       "create",
@@ -640,7 +640,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     certificate_permissions = [
       "create",
@@ -730,7 +730,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     certificate_permissions = [
       "create",
@@ -826,7 +826,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     certificate_permissions = [
       "create",

--- a/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_key_test.go
+++ b/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_key_test.go
@@ -369,7 +369,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -441,7 +441,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -499,7 +499,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -556,7 +556,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -619,7 +619,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -676,7 +676,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -729,7 +729,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",

--- a/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_secret_test.go
+++ b/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_secret_test.go
@@ -293,7 +293,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "get",
@@ -351,7 +351,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",
@@ -403,7 +403,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     key_permissions = [
       "create",

--- a/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_test.go
+++ b/azurerm/internal/services/keyvault/tests/resource_arm_key_vault_test.go
@@ -881,7 +881,7 @@ resource "azurerm_key_vault" "test" {
   access_policy {
     tenant_id      = "${data.azurerm_client_config.current.tenant_id}"
     object_id      = "${data.azurerm_client_config.current.client_id}"
-    application_id = "${data.azurerm_client_config.current.service_principal_application_id}"
+    application_id = "${data.azurerm_client_config.current.client_id}"
 
     certificate_permissions = [
       "get",

--- a/azurerm/internal/services/maps/resource_arm_maps_account.go
+++ b/azurerm/internal/services/maps/resource_arm_maps_account.go
@@ -53,8 +53,8 @@ func resourceArmMapsAccount() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"s0",
-					"s1",
+					"S0",
+					"S1",
 				}, false),
 			},
 

--- a/azurerm/internal/services/mariadb/tests/resource_arm_mariadb_server_test.go
+++ b/azurerm/internal/services/mariadb/tests/resource_arm_mariadb_server_test.go
@@ -34,28 +34,6 @@ func TestAccAzureRMMariaDbServer_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMMariaDbServer_basicOldSku(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_mariadb_server", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMMariaDbServerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMMariaDbServer_basicOldSku(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMMariaDbServerExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "administrator_login", "acctestun"),
-					resource.TestCheckResourceAttr(data.ResourceName, "version", "10.2"),
-					resource.TestCheckResourceAttr(data.ResourceName, "ssl_enforcement", "Enabled"),
-				),
-			},
-			data.ImportStep("administrator_login_password"), // not returned as sensitive
-		},
-	})
-}
-
 func TestAccAzureRMMariaDbServer_requiresImport(t *testing.T) {
 	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -331,39 +309,6 @@ resource "azurerm_mariadb_server" "test" {
   resource_group_name = "${azurerm_resource_group.test.name}"
 
   sku_name = "B_Gen5_2"
-
-  storage_profile {
-    storage_mb            = 51200
-    backup_retention_days = 7
-    geo_redundant_backup  = "Disabled"
-  }
-
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  version                      = "10.2"
-  ssl_enforcement              = "Enabled"
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
-}
-
-func testAccAzureRMMariaDbServer_basicOldSku(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_mariadb_server" "test" {
-  name                = "acctestmariadbsvr-%d"
-  location            = "${azurerm_resource_group.test.location}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-
-  sku {
-    name     = "B_Gen5_2"
-    capacity = 2
-    tier     = "Basic"
-    family   = "Gen5"
-  }
 
   storage_profile {
     storage_mb            = 51200

--- a/azurerm/internal/services/mariadb/tests/resource_arm_mariadb_virtual_network_rule_test.go
+++ b/azurerm/internal/services/mariadb/tests/resource_arm_mariadb_virtual_network_rule_test.go
@@ -255,13 +255,7 @@ resource "azurerm_mariadb_server" "test" {
   administrator_login_password = "H@Sh1CoR3!"
   version                      = "10.2"
   ssl_enforcement              = "Enabled"
-
-  sku {
-    name     = "GP_Gen5_2"
-    capacity = 2
-    tier     = "GeneralPurpose"
-    family   = "Gen5"
-  }
+  sku_name                     = "GP_Gen5_2"
 
   storage_profile {
     storage_mb            = 51200
@@ -330,13 +324,7 @@ resource "azurerm_mariadb_server" "test" {
   administrator_login_password = "H@Sh1CoR3!"
   version                      = "10.2"
   ssl_enforcement              = "Enabled"
-
-  sku {
-    name     = "GP_Gen5_2"
-    capacity = 2
-    tier     = "GeneralPurpose"
-    family   = "Gen5"
-  }
+  sku_name                     = "GP_Gen5_2"
 
   storage_profile {
     storage_mb            = 51200
@@ -392,13 +380,7 @@ resource "azurerm_mariadb_server" "test" {
   administrator_login_password = "H@Sh1CoR3!"
   version                      = "10.2"
   ssl_enforcement              = "Enabled"
-
-  sku {
-    name     = "GP_Gen5_2"
-    capacity = 2
-    tier     = "GeneralPurpose"
-    family   = "Gen5"
-  }
+  sku_name                     = "GP_Gen5_2"
 
   storage_profile {
     storage_mb            = 51200
@@ -469,13 +451,7 @@ resource "azurerm_mariadb_server" "test" {
   administrator_login_password = "H@Sh1CoR3!"
   version                      = "10.2"
   ssl_enforcement              = "Enabled"
-
-  sku {
-    name     = "GP_Gen5_2"
-    capacity = 2
-    tier     = "GeneralPurpose"
-    family   = "Gen5"
-  }
+  sku_name                     = "GP_Gen5_2"
 
   storage_profile {
     storage_mb            = 51200

--- a/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
@@ -1686,7 +1686,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id               = "${data.azurerm_client_config.test.tenant_id}"
-    object_id               = "${data.azurerm_client_config.test.service_principal_object_id}"
+    object_id               = "${data.azurerm_client_config.test.object_id}"
     secret_permissions      = ["delete", "get", "set"]
     certificate_permissions = ["create", "delete", "get", "import"]
   }

--- a/azurerm/internal/services/network/tests/resource_arm_network_interface_backend_address_pool_association_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_interface_backend_address_pool_association_test.go
@@ -321,7 +321,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id     = "${azurerm_lb.test.id}"
   name                = "acctestpool"

--- a/azurerm/internal/services/resource/tests/resource_arm_template_deployment_test.go
+++ b/azurerm/internal/services/resource/tests/resource_arm_template_deployment_test.go
@@ -634,7 +634,6 @@ output "test" {
 
 resource "azurerm_storage_container" "using-outputs" {
   name                  = "vhds"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_template_deployment.test.outputs["accountName"]}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/resource/tests/resource_arm_template_deployment_test.go
+++ b/azurerm/internal/services/resource/tests/resource_arm_template_deployment_test.go
@@ -505,7 +505,7 @@ resource "azurerm_key_vault" "test-kv" {
 
   access_policy {
     key_permissions = []
-    object_id       = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id       = "${data.azurerm_client_config.current.object_id}"
 
     secret_permissions = [
       "delete",

--- a/azurerm/internal/services/sql/tests/resource_arm_sql_database_test.go
+++ b/azurerm/internal/services/sql/tests/resource_arm_sql_database_test.go
@@ -684,7 +684,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "bacpac"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_blob_test.go
+++ b/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_blob_test.go
@@ -258,7 +258,6 @@ resource "azurerm_storage_account" "updated" {
 
 resource "azurerm_storage_container" "updated" {
   name                  = "example"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.updated.name}"
   container_access_type = "private"
 }
@@ -318,7 +317,6 @@ resource "azurerm_storage_account" "test" {
 
 resource "azurerm_storage_container" "test" {
   name                  = "example"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_reference_input_blob_test.go
+++ b/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_reference_input_blob_test.go
@@ -258,7 +258,6 @@ resource "azurerm_storage_account" "updated" {
 
 resource "azurerm_storage_container" "updated" {
   name                  = "example2"
-  resource_group_name   = "${azurerm_resource_group.test.name}"
   storage_account_name  = "${azurerm_storage_account.test.name}"
   container_access_type = "private"
 }

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_custom_hostname_binding_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_custom_hostname_binding_test.go
@@ -289,7 +289,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id               = "${data.azurerm_client_config.test.tenant_id}"
-    object_id               = "${data.azurerm_client_config.test.service_principal_object_id}"
+    object_id               = "${data.azurerm_client_config.test.object_id}"
     secret_permissions      = ["delete", "get", "set"]
     certificate_permissions = ["create", "delete", "get", "import"]
   }

--- a/examples/managed-disks/encrypted/main.tf
+++ b/examples/managed-disks/encrypted/main.tf
@@ -2,7 +2,7 @@
 resource "azurerm_key_vault_access_policy" "service-principal" {
   key_vault_id = azurerm_key_vault.test.id
   tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azurerm_client_config.current.service_principal_object_id
+  object_id = data.azurerm_client_config.current.object_id
 
   key_permissions = [
     "create",

--- a/examples/virtual-machines/virtual_machine/provisioners/windows/2-certificates.tf
+++ b/examples/virtual-machines/virtual_machine/provisioners/windows/2-certificates.tf
@@ -15,7 +15,7 @@ resource "azurerm_key_vault" "example" {
 
   access_policy {
     tenant_id = "${data.azurerm_client_config.current.tenant_id}"
-    object_id = "${data.azurerm_client_config.current.service_principal_object_id}"
+    object_id = "${data.azurerm_client_config.current.object_id}"
 
     certificate_permissions = [
       "create",

--- a/examples/vm-scale-set/windows/service-fabric/2-key-vault.tf
+++ b/examples/vm-scale-set/windows/service-fabric/2-key-vault.tf
@@ -10,7 +10,7 @@ resource "azurerm_key_vault" "main" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -17,7 +17,7 @@ data "azurerm_client_config" "current" {
 }
 
 output "account_id" {
-  value = data.azurerm_client_config.current.service_principal_application_id
+  value = data.azurerm_client_config.current.client_id
 }
 ```
 

--- a/website/docs/r/bot_channel_email.markdown
+++ b/website/docs/r/bot_channel_email.markdown
@@ -27,7 +27,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.example.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_channel_Email" "example" {

--- a/website/docs/r/bot_channel_ms_teams.markdown
+++ b/website/docs/r/bot_channel_ms_teams.markdown
@@ -27,7 +27,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.example.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_channel_ms_teams" "example" {

--- a/website/docs/r/bot_channel_slack.markdown
+++ b/website/docs/r/bot_channel_slack.markdown
@@ -27,7 +27,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.example.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_channel_slack" "example" {

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -25,7 +25,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.example.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 ```
 

--- a/website/docs/r/bot_connection.markdown
+++ b/website/docs/r/bot_connection.markdown
@@ -25,7 +25,7 @@ resource "azurerm_bot_channels_registration" "example" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.example.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_connection" "example" {

--- a/website/docs/r/bot_web_app.markdown
+++ b/website/docs/r/bot_web_app.markdown
@@ -25,7 +25,7 @@ resource "azurerm_bot_web_app" "example" {
   location            = "global"
   resource_group_name = "${azurerm_resource_group.example.name}"
   sku                 = "F0"
-  microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 ```
 

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_key_vault" "example" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -28,7 +28,6 @@ resource "azurerm_storage_account" "example" {
 
 resource "azurerm_storage_container" "example" {
   name                  = "hdinsight"
-  resource_group_name   = azurerm_resource_group.example.name
   storage_account_name  = azurerm_storage_account.example.name
   container_access_type = "private"
 }

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_key_vault" "example" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",
@@ -136,7 +136,7 @@ resource "azurerm_key_vault" "example" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -40,7 +40,7 @@ resource "azurerm_key_vault" "example" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_key_vault" "example" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.service_principal_object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "create",

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -21,7 +21,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_maps_account" "example" {
   name                = "example-maps-account"
   resource_group_name = azurerm_resource_group.example.name
-  sku_name            = "s1"
+  sku_name            = "S1"
 
   tags = {
     environment = "Test"
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the Azure Maps Account should exist. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The sku of the Azure Maps Account. Possible values are `s0` and `s1`.
+* `sku_name` - (Required) The sku of the Azure Maps Account. Possible values are `S0` and `S1`.
 
 * `tags` - (Optional) A mapping of tags to assign to the Azure Maps Account.
 

--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -23,7 +23,7 @@ data "azurerm_client_config" "example" {
 resource "azurerm_role_assignment" "example" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "Reader"
-  principal_id         = data.azurerm_client_config.example.service_principal_object_id
+  principal_id         = data.azurerm_client_config.example.object_id
 }
 ```
 
@@ -55,7 +55,7 @@ resource "azurerm_role_assignment" "example" {
   name               = "00000000-0000-0000-0000-000000000000"
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = azurerm_role_definition.example.id
-  principal_id       = data.azurerm_client_config.example.service_principal_object_id
+  principal_id       = data.azurerm_client_config.example.object_id
 }
 ```
 


### PR DESCRIPTION
The test suite identified several fields which have been removed which are still being used - this PR updates a selection of them