### PR TITLE
azurerm_network_watcher_flow_log  - support for the`interval_in_minutes` property

### DIFF
--- a/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
+++ b/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
@@ -3,6 +3,7 @@ package network
 import (
 	"fmt"
 	"log"
+	"math"
 	"strings"
 	"time"
 
@@ -140,6 +141,13 @@ func resourceArmNetworkWatcherFlowLog() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
+						},
+
+						"interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntAtMost(math.MaxInt32),
+							Default:      60,
 						},
 					},
 				},
@@ -386,6 +394,9 @@ func flattenAzureRmNetworkWatcherFlowLogTrafficAnalytics(input *network.TrafficA
 		if cfg.WorkspaceResourceID != nil {
 			result["workspace_resource_id"] = *cfg.WorkspaceResourceID
 		}
+		if cfg.TrafficAnalyticsInterval != nil {
+			result["interval"] = int(*cfg.TrafficAnalyticsInterval)
+		}
 	}
 
 	return []interface{}{result}
@@ -399,13 +410,15 @@ func expandAzureRmNetworkWatcherFlowLogTrafficAnalytics(d *schema.ResourceData) 
 	workspaceID := v["workspace_id"].(string)
 	workspaceRegion := v["workspace_region"].(string)
 	workspaceResourceID := v["workspace_resource_id"].(string)
+	interval := v["interval"].(int)
 
 	return &network.TrafficAnalyticsProperties{
 		NetworkWatcherFlowAnalyticsConfiguration: &network.TrafficAnalyticsConfigurationProperties{
-			Enabled:             utils.Bool(enabled),
-			WorkspaceID:         utils.String(workspaceID),
-			WorkspaceRegion:     utils.String(workspaceRegion),
-			WorkspaceResourceID: utils.String(workspaceResourceID),
+			Enabled:                  utils.Bool(enabled),
+			WorkspaceID:              utils.String(workspaceID),
+			WorkspaceRegion:          utils.String(workspaceRegion),
+			WorkspaceResourceID:      utils.String(workspaceResourceID),
+			TrafficAnalyticsInterval: utils.Int32(int32(interval)),
 		},
 	}
 }

--- a/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
+++ b/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
@@ -143,7 +143,7 @@ func resourceArmNetworkWatcherFlowLog() *schema.Resource {
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
 						},
 
-						"interval": {
+						"interval_in_ minutes": {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntAtMost(math.MaxInt32),

--- a/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
+++ b/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
@@ -3,7 +3,6 @@ package network
 import (
 	"fmt"
 	"log"
-	"math"
 	"strings"
 	"time"
 
@@ -143,10 +142,10 @@ func resourceArmNetworkWatcherFlowLog() *schema.Resource {
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
 						},
 
-						"interval_in_ minutes": {
+						"interval_in_minutes": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntAtMost(math.MaxInt32),
+							ValidateFunc: validation.IntInSlice([]int{10, 60}),
 							Default:      60,
 						},
 					},
@@ -395,7 +394,7 @@ func flattenAzureRmNetworkWatcherFlowLogTrafficAnalytics(input *network.TrafficA
 			result["workspace_resource_id"] = *cfg.WorkspaceResourceID
 		}
 		if cfg.TrafficAnalyticsInterval != nil {
-			result["interval"] = int(*cfg.TrafficAnalyticsInterval)
+			result["interval_in_minutes"] = int(*cfg.TrafficAnalyticsInterval)
 		}
 	}
 
@@ -410,7 +409,7 @@ func expandAzureRmNetworkWatcherFlowLogTrafficAnalytics(d *schema.ResourceData) 
 	workspaceID := v["workspace_id"].(string)
 	workspaceRegion := v["workspace_region"].(string)
 	workspaceResourceID := v["workspace_resource_id"].(string)
-	interval := v["interval"].(int)
+	interval := v["interval_in_minutes"].(int)
 
 	return &network.TrafficAnalyticsProperties{
 		NetworkWatcherFlowAnalyticsConfiguration: &network.TrafficAnalyticsConfigurationProperties{

--- a/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
@@ -228,6 +228,7 @@ func testAccAzureRMNetworkWatcherFlowLog_trafficAnalytics(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
 				),
 			},
+			data.ImportStep(),
 			{
 				Config: testAccAzureRMNetworkWatcherFlowLog_TrafficAnalyticsEnabledConfig(data),
 				Check: resource.ComposeTestCheckFunc(
@@ -242,6 +243,28 @@ func testAccAzureRMNetworkWatcherFlowLog_trafficAnalytics(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.interval", "60"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_region"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_resource_id"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMNetworkWatcherFlowLog_TrafficAnalyticsUpdateInterval(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkWatcherFlowLogExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network_watcher_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "resource_group_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network_security_group_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "storage_account_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "retention_policy.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "retention_policy.0.enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "retention_policy.0.days", "7"),
+					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.interval", "10"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_id"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_region"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_resource_id"),
@@ -483,6 +506,41 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
     workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
     workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"
+  }
+}
+`, testAccAzureRMNetworkWatcherFlowLog_prerequisites(data), data.RandomInteger)
+}
+
+func testAccAzureRMNetworkWatcherFlowLog_TrafficAnalyticsUpdateInterval(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_network_watcher_flow_log" "test" {
+  network_watcher_name = "${azurerm_network_watcher.test.name}"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+
+  network_security_group_id = "${azurerm_network_security_group.test.id}"
+  storage_account_id        = "${azurerm_storage_account.test.id}"
+  enabled                   = true
+
+  retention_policy {
+    enabled = true
+    days    = 7
+  }
+
+  traffic_analytics {
+    enabled               = true
+    workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
+    workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
+    workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"
+	interval              = 10
   }
 }
 `, testAccAzureRMNetworkWatcherFlowLog_prerequisites(data), data.RandomInteger)

--- a/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
@@ -540,7 +540,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
     workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
     workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"
-	interval              = 10
+    interval              = 10
   }
 }
 `, testAccAzureRMNetworkWatcherFlowLog_prerequisites(data), data.RandomInteger)

--- a/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_network_watcher_flow_log_test.go
@@ -243,7 +243,7 @@ func testAccAzureRMNetworkWatcherFlowLog_trafficAnalytics(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.interval", "60"),
+					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.interval_in_minutes", "60"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_id"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_region"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_resource_id"),
@@ -264,7 +264,7 @@ func testAccAzureRMNetworkWatcherFlowLog_trafficAnalytics(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.enabled", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.interval", "10"),
+					resource.TestCheckResourceAttr(data.ResourceName, "traffic_analytics.0.interval_in_minutes", "10"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_id"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_region"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "traffic_analytics.0.workspace_resource_id"),
@@ -540,7 +540,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_id          = "${azurerm_log_analytics_workspace.test.workspace_id}"
     workspace_region      = "${azurerm_log_analytics_workspace.test.location}"
     workspace_resource_id = "${azurerm_log_analytics_workspace.test.id}"
-    interval              = 10
+    interval_in_minutes   = 10
   }
 }
 `, testAccAzureRMNetworkWatcherFlowLog_prerequisites(data), data.RandomInteger)

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -67,7 +67,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_id          = azurerm_log_analytics_workspace.test.workspace_id
     workspace_region      = azurerm_log_analytics_workspace.test.location
     workspace_resource_id = azurerm_log_analytics_workspace.test.id
-    interval              = 10
+    interval_in_minutes   = 10
   }
 }
 ```
@@ -107,7 +107,7 @@ The following arguments are supported:
 * `workspace_id` - (Required) The resource guid of the attached workspace.
 * `workspace_region` - (Required) The location of the attached workspace.
 * `workspace_resource_id` - (Required) The resource ID of the attached workspace.
-* `interval` - (Optional) How frequently service should do flow analytics in minutes.
+* `interval_in_minutes` - (Optional) How frequently service should do flow analytics in minutes.
 
 ## Attributes Reference
 

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -107,7 +107,7 @@ The following arguments are supported:
 * `workspace_id` - (Required) The resource guid of the attached workspace.
 * `workspace_region` - (Required) The location of the attached workspace.
 * `workspace_resource_id` - (Required) The resource ID of the attached workspace.
-* `interval` - (Optional) The interval in minutes which would decide how frequently service should do flow analytics.
+* `interval` - (Optional) How frequently service should do flow analytics in minutes.
 
 ## Attributes Reference
 

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -37,6 +37,7 @@ resource "azurerm_storage_account" "test" {
   location            = azurerm_resource_group.test.location
 
   account_tier              = "Standard"
+  account_kind              = "StorageV2"
   account_replication_type  = "LRS"
   enable_https_traffic_only = true
 }
@@ -66,6 +67,7 @@ resource "azurerm_network_watcher_flow_log" "test" {
     workspace_id          = azurerm_log_analytics_workspace.test.workspace_id
     workspace_region      = azurerm_log_analytics_workspace.test.location
     workspace_resource_id = azurerm_log_analytics_workspace.test.id
+    interval              = 10
   }
 }
 ```
@@ -105,6 +107,7 @@ The following arguments are supported:
 * `workspace_id` - (Required) The resource guid of the attached workspace.
 * `workspace_region` - (Required) The location of the attached workspace.
 * `workspace_resource_id` - (Required) The resource ID of the attached workspace.
+* `interval` - (Optional) The interval in minutes which would decide how frequently service should do flow analytics.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR fix issue #5830 

Additionally, fix one bug of example in document, which lacks of specifying `account_kind` to `StorageV2` (which defaults to v1) for storage account, which is required by azurerm_log_analytics_workspace.