### PR TITLE
Add azurerm_network_interface_security_group_association to public ip example

### DIFF
--- a/examples/virtual-machines/linux/public-ip/main.tf
+++ b/examples/virtual-machines/linux/public-ip/main.tf
@@ -45,7 +45,6 @@ resource "azurerm_network_interface" "internal" {
   name                      = "${var.prefix}-nic2"
   resource_group_name       = azurerm_resource_group.main.name
   location                  = azurerm_resource_group.main.location
-  network_security_group_id = azurerm_network_security_group.webserver.id
 
   ip_configuration {
     name                          = "internal"
@@ -69,6 +68,11 @@ resource "azurerm_network_security_group" "webserver" {
     destination_port_range     = "443"
     destination_address_prefix = azurerm_network_interface.main.private_ip_address
   }
+}
+
+resource "azurerm_network_interface_security_group_association" "main" {
+  network_interface_id      = azurerm_network_interface.internal.id
+  network_security_group_id = azurerm_network_security_group.webserver.id
 }
 
 resource "azurerm_linux_virtual_machine" "main" {


### PR DESCRIPTION
Currently the association is done from the network interface, however this does not work anymore. Have added a azurerm_network_interface_security_group_association to fix this.