### PR TITLE
azurerm_virtual_wan  - support for the `type` property

### DIFF
--- a/azurerm/internal/services/network/resource_arm_virtual_wan.go
+++ b/azurerm/internal/services/network/resource_arm_virtual_wan.go
@@ -77,6 +77,12 @@ func resourceArmVirtualWan() *schema.Resource {
 				Default: string(network.OfficeTrafficCategoryNone),
 			},
 
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Standard",
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -96,6 +102,7 @@ func resourceArmVirtualWanCreateUpdate(d *schema.ResourceData, meta interface{})
 	allowBranchToBranchTraffic := d.Get("allow_branch_to_branch_traffic").(bool)
 	allowVnetToVnetTraffic := d.Get("allow_vnet_to_vnet_traffic").(bool)
 	office365LocalBreakoutCategory := d.Get("office365_local_breakout_category").(string)
+	virtualWanType := d.Get("type").(string)
 	t := d.Get("tags").(map[string]interface{})
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
@@ -119,6 +126,7 @@ func resourceArmVirtualWanCreateUpdate(d *schema.ResourceData, meta interface{})
 			AllowBranchToBranchTraffic:     utils.Bool(allowBranchToBranchTraffic),
 			AllowVnetToVnetTraffic:         utils.Bool(allowVnetToVnetTraffic),
 			Office365LocalBreakoutCategory: network.OfficeTrafficCategory(office365LocalBreakoutCategory),
+			Type:                           utils.String(virtualWanType),
 		},
 	}
 
@@ -177,6 +185,7 @@ func resourceArmVirtualWanRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("allow_branch_to_branch_traffic", props.AllowBranchToBranchTraffic)
 		d.Set("allow_vnet_to_vnet_traffic", props.AllowVnetToVnetTraffic)
 		d.Set("office365_local_breakout_category", props.Office365LocalBreakoutCategory)
+		d.Set("type", props.Type)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/network/tests/resource_arm_virtual_wan_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_virtual_wan_test.go
@@ -179,6 +179,7 @@ resource "azurerm_virtual_wan" "test" {
   allow_branch_to_branch_traffic    = true
   allow_vnet_to_vnet_traffic        = true
   office365_local_breakout_category = "All"
+  type                              = "Standard"
 
   tags = {
     Hello = "There"

--- a/website/docs/r/virtual_wan.html.markdown
+++ b/website/docs/r/virtual_wan.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 
 * `office365_local_breakout_category` - (Optional) Specifies the Office365 local breakout category. Possible values include: `Optimize`, `OptimizeAndAllow`, `All`, `None`. Defaults to `None`.
 
+* `type` - (Optional) Specifies the Virtual WAN type. Possible Values include: `Basic` and `Standard`. Defaults to `Standard`.
+
 * `tags` - (Optional) A mapping of tags to assign to the Virtual WAN.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR has been raised to add the ability to specify a 'type' for Azure Virtual WAN resources. Additional information concerning the different types can be found here: [Basic and Standard Virtual WANs - Microsoft documentation](https://docs.microsoft.com/en-us/azure/virtual-wan/virtual-wan-about#basicstandard).

I have added a `type` argument to the `azurerm_virtual_wan` resource and updated corresponding tests & documentation.

Manual testing with the existing behaviour indicates that `Standard` is now the default type, as opposed to `Basic` which was what I observed a few months ago.