### PR TITLE
azurerm_batch_pool - fix import examples

### DIFF
--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -321,5 +321,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Batch Pools can be imported using the `resource id`, e.g.
 
 ```shell
- terraform import azurerm_batch_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/myResourceGroups/myGroup1/providers/Microsoft.Batch/myBatchAccounts/myBatchAccount1/myBatchPools/myBatchPool1
+terraform import azurerm_batch_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.Batch/batchAccounts/myBatchAccount1/pools/myBatchPool1
 ```


### PR DESCRIPTION
The import example contained a lot of wrong path. For instance, half of the "my" elements, such as "myResourceGroups"  were not variable elements. The path really is ResourceGroups then followed by a myGroup1 variable element.  Suggested change make sure the non-variable elements are correctly prefixed.