### PR TITLE
azurerm_linux_virtual_machine_scale_set - correct source_image_id validation

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_linux_virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/resource_arm_linux_virtual_machine_scale_set.go
@@ -196,9 +196,13 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 			},
 
 			"source_image_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: computeValidate.ImageID,
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.Any(
+					computeValidate.ImageID,
+					computeValidate.SharedImageID,
+					computeValidate.SharedImageVersionID,
+				),
 			},
 
 			"source_image_reference": sourceImageReferenceSchema(false),


### PR DESCRIPTION
this PR applies the same fixes for linux VMs which was merged here: https://github.com/terraform-providers/terraform-provider-azurerm/pull/5640 but for linux scalesets
