### PR TITLE
azurerm_application_gateway - support 125 for V2 sku capacity

### DIFF
--- a/azurerm/internal/services/network/resource_arm_application_gateway.go
+++ b/azurerm/internal/services/network/resource_arm_application_gateway.go
@@ -662,7 +662,7 @@ func resourceArmApplicationGateway() *schema.Resource {
 						"capacity": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 32),
+							ValidateFunc: validation.IntBetween(1, 125),
 						},
 					},
 				},

--- a/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
@@ -4517,7 +4517,7 @@ resource "azurerm_application_gateway" "test" {
   }
 
   backend_address_pool {
-    name                  = "${local.backend_address_pool_name}"
+    name = "${local.backend_address_pool_name}"
   }
 
   backend_http_settings {

--- a/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
@@ -891,6 +891,28 @@ func TestAccAzureRMApplicationGateway_UserAssignedIdentity(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMApplicationGateway_V2SKUCapacity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApplicationGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApplicationGateway_v2SKUCapacity(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationGatewayExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku.0.name", "Standard_v2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku.0.tier", "Standard_v2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku.0.capacity", "124"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMApplicationGatewayExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Network.ApplicationGatewaysClient
@@ -4417,6 +4439,85 @@ resource "azurerm_application_gateway" "test" {
 
   backend_address_pool {
     name = "${local.backend_address_pool_name}"
+  }
+
+  backend_http_settings {
+    name                  = "${local.http_setting_name}"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = "${local.listener_name}"
+    frontend_ip_configuration_name = "${local.frontend_ip_configuration_name}"
+    frontend_port_name             = "${local.frontend_port_name}"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "${local.request_routing_rule_name}"
+    rule_type                  = "Basic"
+    http_listener_name         = "${local.listener_name}"
+    backend_address_pool_name  = "${local.backend_address_pool_name}"
+    backend_http_settings_name = "${local.http_setting_name}"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMApplicationGateway_v2SKUCapacity(data acceptance.TestData) string {
+	template := testAccAzureRMApplicationGateway_template(data)
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-%d-standard"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 124
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = "${azurerm_subnet.test.id}"
+  }
+
+  frontend_port {
+    name = "${local.frontend_port_name}"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "${local.frontend_ip_configuration_name}"
+    public_ip_address_id = "${azurerm_public_ip.test_standard.id}"
+  }
+
+  backend_address_pool {
+    name                  = "${local.backend_address_pool_name}"
   }
 
   backend_http_settings {

--- a/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_application_gateway_test.go
@@ -3103,10 +3103,6 @@ resource "azurerm_application_gateway" "test" {
     capacity = 1
   }
 
-  disabled_ssl_protocols = [
-    "TLSv1_0",
-  ]
-
   waf_configuration {
     enabled                  = true
     firewall_mode            = "Detection"

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -380,7 +380,7 @@ A `sku` block supports the following:
 
 * `tier` - (Required) The Tier of the SKU to use for this Application Gateway. Possible values are `Standard`, `Standard_v2`, `WAF` and `WAF_v2`.
 
-* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway - which must be between 1 and 10, optional if `autoscale_configuration` is set
+* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway - which must be between 1 and 125, optional if `autoscale_configuration` is set
 
 ---
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -380,7 +380,7 @@ A `sku` block supports the following:
 
 * `tier` - (Required) The Tier of the SKU to use for this Application Gateway. Possible values are `Standard`, `Standard_v2`, `WAF` and `WAF_v2`.
 
-* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway. Possible values for V1 SKU must be between 1 and 32, and for V2 SKU must be between 1 and 125, optional if `autoscale_configuration` is set.
+* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway. When using a V1 SKU this value must be between 1 and 32, and  1 to 125 for a V2 SKU. This property is optional if `autoscale_configuration` is set.
 
 ---
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -380,7 +380,7 @@ A `sku` block supports the following:
 
 * `tier` - (Required) The Tier of the SKU to use for this Application Gateway. Possible values are `Standard`, `Standard_v2`, `WAF` and `WAF_v2`.
 
-* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway - which must be between 1 and 125, optional if `autoscale_configuration` is set
+* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway. Possible values for V1 SKU must be between 1 and 32, and for V2 SKU must be between 1 and 125, optional if `autoscale_configuration` is set.
 
 ---
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -380,7 +380,7 @@ A `sku` block supports the following:
 
 * `tier` - (Required) The Tier of the SKU to use for this Application Gateway. Possible values are `Standard`, `Standard_v2`, `WAF` and `WAF_v2`.
 
-* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway. When using a V1 SKU this value must be between 1 and 32, and  1 to 125 for a V2 SKU. This property is optional if `autoscale_configuration` is set.
+* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway. When using a V1 SKU this value must be between 1 and 32, and 1 to 125 for a V2 SKU. This property is optional if `autoscale_configuration` is set.
 
 ---
 


### PR DESCRIPTION
Issue:
Allow sku.capacity up to 125 when using standard_v2 in the azurerm_application_gateway resource since sku.capacity is limited to 32 currently.

Description:
The Capacity of the SKU to use for this Application Gateway. Possible values for V1 SKU must be between 1 and 32, and for V2 SKU must be between 1 and 125.

SKU Reference doc: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=%2fazure%2fapplication-gateway%2ftoc.json#application-gateway-limits