### PR TITLE
azurerm_storage_management_policy  - Correct doc import typo

### DIFF
--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -135,5 +135,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Storage Account Management Policies can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_storage_management_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Storage/storageAccounts/myaccountname/managementPoliices/default
+terraform import azurerm_storage_management_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Storage/storageAccounts/myaccountname/managementPolicies/default
 ```


### PR DESCRIPTION
Just a typo in the documentation.