### PR TITLE
Update azurerm_virtual_machine_scale_set_extension type_handler_version docs

### DIFF
--- a/website/docs/r/virtual_machine_scale_set_extension.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set_extension.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `type` - (Required) Specifies the Type of the Extension. Changing this forces a new resource to be created.
 
-* `type_handler_version` - (Required) Specifies the version of the Script Handler which should be used.
+* `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
 
 ---
 


### PR DESCRIPTION
The `type_handler_version`  docs on `azurerm_virtual_machine_scale_set_extension` referred to the ScriptHandler extension explicitly.

I have copied the `type_handler_version` docs from `azurerm_virtual_machine_extension` to make it consistent between both.

 