### PR TITLE
Bug: `azurerm_frontdoor_firewall_policy` add validation for Frontdoor WAF Name Restrictions

### DIFF
--- a/azurerm/internal/services/frontdoor/resource_arm_frontdoor_firewall_policy.go
+++ b/azurerm/internal/services/frontdoor/resource_arm_frontdoor_firewall_policy.go
@@ -41,7 +41,7 @@ func resourceArmFrontDoorFirewallPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: ValidateFrontDoorWAFName,
 			},
 
 			"location": azure.SchemaLocationForDataSource(),

--- a/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_firewall_policy_test.go
+++ b/azurerm/internal/services/frontdoor/tests/resource_arm_front_door_firewall_policy_test.go
@@ -9,8 +9,93 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/frontdoor"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
+
+func TestAccAzureRMFrontDoorFirewallPolicy_validateName(t *testing.T) {
+	cases := []struct {
+		Name        string
+		Input       string
+		ExpectError bool
+	}{
+		{
+			Name:        "Empty String",
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			Name:        "Starst with Numeric",
+			Input:       "1WellThisIsAllWrong",
+			ExpectError: true,
+		},
+		{
+			Name:        "Has Spaces",
+			Input:       "What part of no spaces do you not understand",
+			ExpectError: true,
+		},
+		{
+			Name:        "Has Hyphens",
+			Input:       "What-part-of-no-hyphens-do-you-not-understand",
+			ExpectError: true,
+		},
+		{
+			Name:        "Special Characters",
+			Input:       "WellArn`tTheseSpecialCharacters?!",
+			ExpectError: true,
+		},
+		{
+			Name:        "Mixed Case Alpha and Numeric",
+			Input:       "ThisNameIsAPerfectlyFine1",
+			ExpectError: false,
+		},
+		{
+			Name:        "Too Long",
+			Input:       "OhMyLordyThisNameIsWayToLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog",
+			ExpectError: true,
+		},
+		{
+			Name:        "Max Length",
+			Input:       "NowThisNameIsThePerfectLengthForAFrontdoorFireWallPolicyDontYouThinkAnyLongerWouldBeJustWayToLoooooooooooooooooooongDontYouThink",
+			ExpectError: false,
+		},
+		{
+			Name:        "Minimum Length Upper",
+			Input:       "A",
+			ExpectError: false,
+		},
+		{
+			Name:        "Minimum Length Lower",
+			Input:       "a",
+			ExpectError: false,
+		},
+		{
+			Name:        "Mixed Case Alpha no Numeric",
+			Input:       "LookMomNoNumbers",
+			ExpectError: false,
+		},
+		{
+			Name:        "All Upper Alpha with Numeric",
+			Input:       "OU812",
+			ExpectError: false,
+		},
+		{
+			Name:        "All lower no Numeric",
+			Input:       "heythisisalllowercase",
+			ExpectError: false,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := frontdoor.ValidateFrontDoorWAFName(tc.Input, tc.Name)
+
+		hasError := len(errors) > 0
+
+		if tc.ExpectError && !hasError {
+			t.Fatalf("Expected the FrontDoor WAF Name to trigger a validation error for '%s'", tc.Name)
+		}
+	}
+}
 
 func TestAccAzureRMFrontDoorFirewallPolicy_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_frontdoor_firewall_policy", "test")

--- a/azurerm/internal/services/frontdoor/validate.go
+++ b/azurerm/internal/services/frontdoor/validate.go
@@ -15,6 +15,14 @@ func ValidateFrontDoorName(i interface{}, k string) (_ []string, errors []error)
 	return nil, errors
 }
 
+func ValidateFrontDoorWAFName(i interface{}, k string) (_ []string, errors []error) {
+	if m, regexErrs := validate.RegExHelper(i, k, `(^[a-zA-Z])([\da-zA-Z]{0,127})$`); !m {
+		errors = append(regexErrs, fmt.Errorf(`%q must be between 1 and 128 characters in length, must begin with a letter and may only contain letters and numbers.`, k))
+	}
+
+	return nil, errors
+}
+
 func ValidateBackendPoolRoutingRuleName(i interface{}, k string) (_ []string, errors []error) {
 	if m, regexErrs := validate.RegExHelper(i, k, `(^[\da-zA-Z])([-\da-zA-Z]{1,88})([\da-zA-Z]$)`); !m {
 		errors = append(regexErrs, fmt.Errorf(`%q must be between 1 and 90 characters in length and begin with a letter or number, end with a letter or number and may contain only letters, numbers or hyphens.`, k))


### PR DESCRIPTION
(fixes #5932)