### PR TITLE
'azurerm_redis_cache' - Support for 'primary_connection_string' and 'secondary_connection_string' to 'resource_arm_redis_cache'

### DIFF
--- a/azurerm/internal/services/redis/data_source_redis_cache.go
+++ b/azurerm/internal/services/redis/data_source_redis_cache.go
@@ -196,6 +196,18 @@ func dataSourceArmRedisCache() *schema.Resource {
 				Sensitive: true,
 			},
 
+			"primary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -233,7 +245,8 @@ func dataSourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("sku_name", sku.Name)
 	}
 
-	if props := resp.Properties; props != nil {
+	props := resp.Properties
+	if props != nil {
 		d.Set("ssl_port", props.SslPort)
 		d.Set("hostname", props.HostName)
 		d.Set("minimum_tls_version", string(props.MinimumTLSVersion))
@@ -274,6 +287,11 @@ func dataSourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("primary_access_key", keys.PrimaryKey)
 	d.Set("secondary_access_key", keys.SecondaryKey)
+
+	if props != nil {
+		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.PrimaryKey, *props.EnableNonSslPort))
+		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.SecondaryKey, *props.EnableNonSslPort))
+	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/azurerm/internal/services/redis/resource_arm_redis_cache.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_cache.go
@@ -257,6 +257,18 @@ func resourceArmRedisCache() *schema.Resource {
 				Sensitive: true,
 			},
 
+			"primary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_connection_string": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -540,7 +552,8 @@ func resourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("sku_name", sku.Name)
 	}
 
-	if props := resp.Properties; props != nil {
+	props := resp.Properties
+	if props != nil {
 		d.Set("ssl_port", props.SslPort)
 		d.Set("hostname", props.HostName)
 		d.Set("minimum_tls_version", string(props.MinimumTLSVersion))
@@ -563,6 +576,11 @@ func resourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("primary_access_key", keysResp.PrimaryKey)
 	d.Set("secondary_access_key", keysResp.SecondaryKey)
+
+	if props != nil {
+		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.PrimaryKey, *props.EnableNonSslPort))
+		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.SecondaryKey, *props.EnableNonSslPort))
+	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }
@@ -909,4 +927,8 @@ func validateRedisBackupFrequency(v interface{}, _ string) (warnings []string, e
 	}
 
 	return warnings, errors
+}
+
+func getRedisConnectionString(redisHostName string, sslPort int32, accessKey string, enableSslPort bool) string {
+	return fmt.Sprintf("%s:%s,password=%s,ssl=%t,abortConnect=False", redisHostName, sslPort, accessKey, enableSslPort)
 }

--- a/azurerm/internal/services/redis/resource_arm_redis_cache.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_cache.go
@@ -930,5 +930,5 @@ func validateRedisBackupFrequency(v interface{}, _ string) (warnings []string, e
 }
 
 func getRedisConnectionString(redisHostName string, sslPort int32, accessKey string, enableSslPort bool) string {
-	return fmt.Sprintf("%s:%s,password=%s,ssl=%t,abortConnect=False", redisHostName, sslPort, accessKey, enableSslPort)
+	return fmt.Sprintf("%s:%d,password=%s,ssl=%t,abortConnect=False", redisHostName, sslPort, accessKey, enableSslPort)
 }

--- a/azurerm/internal/services/redis/tests/data_source_redis_cache_test.go
+++ b/azurerm/internal/services/redis/tests/data_source_redis_cache_test.go
@@ -27,6 +27,8 @@ func TestAccDataSourceAzureRMRedisCache_standard(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "resource_group_name", resourceGroupName),
 					resource.TestCheckResourceAttr(data.ResourceName, "ssl_port", "6380"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.environment", "production"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "secondary_connection_string"),
 				),
 			},
 		},

--- a/azurerm/internal/services/redis/tests/resource_arm_redis_cache_test.go
+++ b/azurerm/internal/services/redis/tests/resource_arm_redis_cache_test.go
@@ -25,6 +25,8 @@ func TestAccAzureRMRedisCache_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRedisCacheExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "minimum_tls_version"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "secondary_connection_string"),
 				),
 			},
 			data.ImportStep(),

--- a/website/docs/d/redis_cache.html.markdown
+++ b/website/docs/d/redis_cache.html.markdown
@@ -63,6 +63,10 @@ output "hostname" {
 
 * `secondary_access_key` - The Secondary Access Key for the Redis Instance
 
+* `primary_connection_string` - The primary connection string of the Redis Instance.
+
+* `secondary_connection_string` - The secondary connection string of the Redis Instance.
+
 * `redis_configuration` - A `redis_configuration` block as defined below.
 
 ---

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -153,6 +153,10 @@ The following attributes are exported:
 
 * `secondary_access_key` - The Secondary Access Key for the Redis Instance
 
+* `primary_connection_string` - The primary connection string of the Redis Instance.
+
+* `secondary_connection_string` - The secondary connection string of the Redis Instance.
+
 * `redis_configuration` - A `redis_configuration` block as defined below:
 
 ---


### PR DESCRIPTION
Add support for **primary_connection_string** and **secondary_connection_string** to the Resource and Data Source for **azurerm_redis_cache**

Resource Acceptance Tests:
=== RUN   TestAccDataSourceAzureRMRedisCache_standard
=== PAUSE TestAccDataSourceAzureRMRedisCache_standard
=== CONT  TestAccDataSourceAzureRMRedisCache_standard
--- PASS: TestAccDataSourceAzureRMRedisCache_standard (2127.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/redis/tests 2127.824s