### PR TITLE
Update name validation rules for `azurerm_(linux|windows)_virtual_machine`

### DIFF
--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -51,7 +51,7 @@ func ValidateLinuxName(i interface{}, k string) (warnings []string, errors []err
 		errors = append(errors, fmt.Errorf("%q cannot contain only numbers", k))
 	}
 
-	return
+	return warnings, errors
 }
 
 func ValidateWindowsName(i interface{}, k string) (warnings []string, errors []error) {
@@ -87,7 +87,7 @@ func ValidateWindowsName(i interface{}, k string) (warnings []string, errors []e
 		errors = append(errors, fmt.Errorf("%q cannot contain only numbers", k))
 	}
 
-	return
+	return warnings, errors
 }
 
 func ValidateScaleSetResourceID(i interface{}, k string) (s []string, es []error) {

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -9,11 +9,85 @@ import (
 )
 
 func ValidateLinuxName(i interface{}, k string) (warnings []string, errors []error) {
-	return validateName(64)(i, k)
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("Expected %q to be a string but it wasn't!", k))
+		return
+	}
+
+	// The value must not be empty.
+	if strings.TrimSpace(v) == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+		return
+	}
+
+	const maxLength = 64
+	// The value must be between 1 and 64 (Linux) characters long.
+	if len(v) > maxLength {
+		errors = append(errors, fmt.Errorf("%q can be at most %d characters, got %d", k, maxLength, len(v)))
+	}
+
+	if strings.HasPrefix(v, "_") {
+		errors = append(errors, fmt.Errorf("%q cannot begin with an underscore", k))
+	}
+
+	if strings.HasSuffix(v, ".") || strings.HasSuffix(v, "-") {
+		errors = append(errors, fmt.Errorf("%q cannot end with an period or dash", k))
+	}
+
+	// Azure resource names cannot contain special characters \/""[]:|<>+=;,?*@& or begin with '_' or end with '.' or '-'
+	specialCharacters := `\/""[]:|<>+=;,?*@&`
+	if strings.ContainsAny(v, specialCharacters) {
+		errors = append(errors, fmt.Errorf("%q cannot contain the special characters: `%s`", k, specialCharacters))
+	}
+
+	// The value can only contain alphanumeric characters and can start with a number.
+	if matched := regexp.MustCompile(`^[a-zA-Z0-9-_.]+$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, dashes and underscores", k))
+	}
+
+	// Portal: Virtual machine name cannot contain only numbers.
+	if matched := regexp.MustCompile(`^\d+$`).Match([]byte(v)); matched {
+		errors = append(errors, fmt.Errorf("%q cannot contain only numbers", k))
+	}
+
+	return
 }
 
 func ValidateWindowsName(i interface{}, k string) (warnings []string, errors []error) {
-	return validateName(16)(i, k)
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("Expected %q to be a string but it wasn't!", k))
+		return
+	}
+
+	// The value must not be empty.
+	if strings.TrimSpace(v) == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+		return
+	}
+
+	const maxLength = 15
+	// The value must be between 1 and 15 (Windows) characters long.
+	if len(v) > maxLength {
+		errors = append(errors, fmt.Errorf("%q can be at most %d characters, got %d", k, maxLength, len(v)))
+	}
+
+	if strings.HasSuffix(v, "-") {
+		errors = append(errors, fmt.Errorf("%q cannot end with dash", k))
+	}
+
+	// A windows computer name can only contain alphanumeric characters and hyphens
+	if matched := regexp.MustCompile(`^[a-zA-Z0-9-]+$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters and dashes", k))
+	}
+
+	// Portal: Virtual machine name cannot contain only numbers.
+	if matched := regexp.MustCompile(`^\d+$`).Match([]byte(v)); matched {
+		errors = append(errors, fmt.Errorf("%q cannot contain only numbers", k))
+	}
+
+	return
 }
 
 func ValidateScaleSetResourceID(i interface{}, k string) (s []string, es []error) {
@@ -35,48 +109,6 @@ func ValidateScaleSetResourceID(i interface{}, k string) (s []string, es []error
 	}
 
 	return
-}
-
-func validateName(maxLength int) func(i interface{}, k string) (warnings []string, errors []error) {
-	return func(i interface{}, k string) (warnings []string, errors []error) {
-		v, ok := i.(string)
-		if !ok {
-			errors = append(errors, fmt.Errorf("Expected %q to be a string but it wasn't!", k))
-			return
-		}
-
-		// The value must not be empty.
-		if strings.TrimSpace(v) == "" {
-			errors = append(errors, fmt.Errorf("%q must not be empty", k))
-			return
-		}
-
-		// The value must be between 1 and 64 (Linux) or 16 (Windows) characters long.
-		if len(v) >= maxLength {
-			errors = append(errors, fmt.Errorf("%q can be at most %d characters, got %d", k, maxLength-1, len(v)))
-		}
-
-		if strings.HasPrefix(v, "_") {
-			errors = append(errors, fmt.Errorf("%q cannot begin with an underscore", k))
-		}
-
-		if strings.HasSuffix(v, ".") || strings.HasSuffix(v, "-") {
-			errors = append(errors, fmt.Errorf("%q cannot end with an period or dash", k))
-		}
-
-		// Azure resource names cannot contain special characters \/""[]:|<>+=;,?*@& or begin with '_' or end with '.' or '-'
-		specialCharacters := `\/""[]:|<>+=;,?*@&`
-		if strings.ContainsAny(v, specialCharacters) {
-			errors = append(errors, fmt.Errorf("%q cannot contain the special characters: `%s`", k, specialCharacters))
-		}
-
-		// The value can only contain alphanumeric characters and cannot start with a number.
-		if matched := regexp.MustCompile(`^[a-zA-Z0-9-_]+$`).Match([]byte(v)); !matched {
-			errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, dashes and underscores", k))
-		}
-
-		return
-	}
 }
 
 func validateDiskEncryptionSetName(i interface{}, k string) (warnings []string, errors []error) {

--- a/azurerm/internal/services/compute/validation_test.go
+++ b/azurerm/internal/services/compute/validation_test.go
@@ -43,18 +43,33 @@ func TestValidateLinuxName(t *testing.T) {
 			expected: false,
 		},
 		{
-			// 63 chars
-			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij",
+			// can have a dot in the middle
+			input: "hello.world",
 			expected: true,
 		},
 		{
-			// 64 chars
+			// start with a number
+			input: "0abc",
+			expected: true,
+		},
+		{
+			// cannot contain only numbers
+			input: "12345",
+			expected: false,
+		},
+		{
+			// 63 chars
 			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk",
 			expected: true,
 		},
 		{
-			// 65 chars
+			// 64 chars
 			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkj",
+			expected: true,
+		},
+		{
+			// 65 chars
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkjl",
 			expected: false,
 		},
 	}
@@ -91,6 +106,11 @@ func TestValidateWindowsName(t *testing.T) {
 			expected: false,
 		},
 		{
+			// can't contain underscore
+			input: "hello_world",
+			expected: false,
+		},
+		{
 			// can't end with a dash
 			input:    "hello-",
 			expected: false,
@@ -108,6 +128,21 @@ func TestValidateWindowsName(t *testing.T) {
 		{
 			// can't end with a period
 			input:    "hello.",
+			expected: false,
+		},
+		{
+			// can't contain dot
+			input: "hello.world",
+			expected: false,
+		},
+		{
+			// start with a number
+			input: "0abc",
+			expected: true,
+		},
+		{
+			// cannot contain only numbers
+			input: "12345",
 			expected: false,
 		},
 		{

--- a/azurerm/internal/services/compute/validation_test.go
+++ b/azurerm/internal/services/compute/validation_test.go
@@ -44,17 +44,17 @@ func TestValidateLinuxName(t *testing.T) {
 		},
 		{
 			// can have a dot in the middle
-			input: "hello.world",
+			input:    "hello.world",
 			expected: true,
 		},
 		{
 			// start with a number
-			input: "0abc",
+			input:    "0abc",
 			expected: true,
 		},
 		{
 			// cannot contain only numbers
-			input: "12345",
+			input:    "12345",
 			expected: false,
 		},
 		{
@@ -107,7 +107,7 @@ func TestValidateWindowsName(t *testing.T) {
 		},
 		{
 			// can't contain underscore
-			input: "hello_world",
+			input:    "hello_world",
 			expected: false,
 		},
 		{
@@ -132,17 +132,17 @@ func TestValidateWindowsName(t *testing.T) {
 		},
 		{
 			// can't contain dot
-			input: "hello.world",
+			input:    "hello.world",
 			expected: false,
 		},
 		{
 			// start with a number
-			input: "0abc",
+			input:    "0abc",
 			expected: true,
 		},
 		{
 			// cannot contain only numbers
-			input: "12345",
+			input:    "12345",
 			expected: false,
 		},
 		{


### PR DESCRIPTION
Fixes #5944 