### PR TITLE
support `public_ips` for resource `azurerm_batch_pool`

### DIFF
--- a/azurerm/helpers/azure/batch_account.go
+++ b/azurerm/helpers/azure/batch_account.go
@@ -3,7 +3,7 @@ package azure
 import (
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 )
 
 // ExpandBatchAccountKeyVaultReference expands Batch account KeyVault reference

--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -571,6 +571,15 @@ func ExpandBatchPoolNetworkConfiguration(list []interface{}) (*batch.NetworkConf
 		}
 	}
 
+	if v, ok := networkConfigValue["public_ips"]; ok {
+		confPublicIPs := v.([]interface{})
+		publicIPs := make([]string, 0, len(confPublicIPs))
+		for _, publicIP := range confPublicIPs {
+			publicIPs = append(publicIPs, publicIP.(string))
+		}
+		networkConfiguration.PublicIPs = &publicIPs
+	}
+
 	if v, ok := networkConfigValue["endpoint_configuration"]; ok {
 		endpoint, err := ExpandBatchPoolEndpointConfiguration(v.([]interface{}))
 		if err != nil {
@@ -659,6 +668,10 @@ func FlattenBatchPoolNetworkConfiguration(networkConfig *batch.NetworkConfigurat
 
 	if networkConfig.SubnetID != nil {
 		result["subnet_id"] = *networkConfig.SubnetID
+	}
+
+	if networkConfig.PublicIPs != nil {
+		result["public_ips"] = *networkConfig.PublicIPs
 	}
 
 	if cfg := networkConfig.EndpointConfiguration; cfg != nil && cfg.InboundNatPools != nil && len(*cfg.InboundNatPools) != 0 {

--- a/azurerm/helpers/azure/batch_pool.go
+++ b/azurerm/helpers/azure/batch_pool.go
@@ -572,12 +572,8 @@ func ExpandBatchPoolNetworkConfiguration(list []interface{}) (*batch.NetworkConf
 	}
 
 	if v, ok := networkConfigValue["public_ips"]; ok {
-		confPublicIPs := v.([]interface{})
-		publicIPs := make([]string, 0, len(confPublicIPs))
-		for _, publicIP := range confPublicIPs {
-			publicIPs = append(publicIPs, publicIP.(string))
-		}
-		networkConfiguration.PublicIPs = &publicIPs
+		publicIPsRaw := v.(*schema.Set).List()
+		networkConfiguration.PublicIPs = utils.ExpandStringSlice(publicIPsRaw)
 	}
 
 	if v, ok := networkConfigValue["endpoint_configuration"]; ok {
@@ -671,7 +667,7 @@ func FlattenBatchPoolNetworkConfiguration(networkConfig *batch.NetworkConfigurat
 	}
 
 	if networkConfig.PublicIPs != nil {
-		result["public_ips"] = *networkConfig.PublicIPs
+		result["public_ips"] = schema.NewSet(schema.HashString, utils.FlattenStringSlice(networkConfig.PublicIPs))
 	}
 
 	if cfg := networkConfig.EndpointConfiguration; cfg != nil && cfg.InboundNatPools != nil && len(*cfg.InboundNatPools) != 0 {

--- a/azurerm/internal/services/batch/client/client.go
+++ b/azurerm/internal/services/batch/client/client.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 )
 

--- a/azurerm/internal/services/batch/data_source_batch_account.go
+++ b/azurerm/internal/services/batch/data_source_batch_account.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"

--- a/azurerm/internal/services/batch/resource_arm_batch_account.go
+++ b/azurerm/internal/services/batch/resource_arm_batch_account.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/azurerm/internal/services/batch/resource_arm_batch_application.go
+++ b/azurerm/internal/services/batch/resource_arm_batch_application.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"

--- a/azurerm/internal/services/batch/resource_arm_batch_certificate.go
+++ b/azurerm/internal/services/batch/resource_arm_batch_certificate.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/azurerm/internal/services/batch/resource_arm_batch_pool.go
+++ b/azurerm/internal/services/batch/resource_arm_batch_pool.go
@@ -744,6 +744,7 @@ func resourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	if props := resp.PoolProperties; props != nil {
 		d.Set("vm_size", props.VMSize)
+		d.Set("max_tasks_per_node", props.MaxTasksPerNode)
 
 		if scaleSettings := props.ScaleSettings; scaleSettings != nil {
 			if err := d.Set("auto_scale", azure.FlattenBatchPoolAutoScaleSettings(scaleSettings.AutoScale)); err != nil {

--- a/azurerm/internal/services/batch/resource_arm_batch_pool.go
+++ b/azurerm/internal/services/batch/resource_arm_batch_pool.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch"
+	"github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -396,6 +396,14 @@ func resourceArmBatchPool() *schema.Resource {
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"public_ips": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 						"endpoint_configuration": {
 							Type:     schema.TypeList,

--- a/azurerm/internal/services/batch/resource_arm_batch_pool.go
+++ b/azurerm/internal/services/batch/resource_arm_batch_pool.go
@@ -745,7 +745,6 @@ func resourceArmBatchPoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	if props := resp.PoolProperties; props != nil {
 		d.Set("vm_size", props.VMSize)
-		d.Set("max_tasks_per_node", props.MaxTasksPerNode)
 
 		if scaleSettings := props.ScaleSettings; scaleSettings != nil {
 			if err := d.Set("auto_scale", azure.FlattenBatchPoolAutoScaleSettings(scaleSettings.AutoScale)); err != nil {

--- a/azurerm/internal/services/batch/resource_arm_batch_pool.go
+++ b/azurerm/internal/services/batch/resource_arm_batch_pool.go
@@ -398,12 +398,13 @@ func resourceArmBatchPool() *schema.Resource {
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 						"public_ips": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							ForceNew: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+							Set: schema.HashString,
 						},
 						"endpoint_configuration": {
 							Type:     schema.TypeList,

--- a/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
+++ b/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
@@ -392,6 +392,20 @@ func TestAccAzureRMBatchPool_frontEndPortRanges(t *testing.T) {
 				Config: testaccAzureRMBatchPool_networkConfiguration(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMBatchPoolExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "vm_size", "STANDARD_A1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "node_agent_sku_id", "batch.node.ubuntu 16.04"),
+					resource.TestCheckResourceAttr(data.ResourceName, "account_name", fmt.Sprintf("testaccbatch%s", data.RandomString)),
+					resource.TestCheckResourceAttr(data.ResourceName, "storage_image_reference.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "storage_image_reference.0.publisher", "Canonical"),
+					resource.TestCheckResourceAttr(data.ResourceName, "storage_image_reference.0.sku", "16.04.0-LTS"),
+					resource.TestCheckResourceAttr(data.ResourceName, "storage_image_reference.0.offer", "UbuntuServer"),
+					resource.TestCheckResourceAttr(data.ResourceName, "auto_scale.#", "0"),
+					resource.TestCheckResourceAttr(data.ResourceName, "fixed_scale.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "fixed_scale.0.target_dedicated_nodes", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "start_task.#", "0"),
+					resource.TestCheckResourceAttr(data.ResourceName, "network_configuration.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "network_configuration.0.subnet_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "network_configuration.0.public_ips.#", "1"),
 				),
 			},
 			data.ImportStep("stop_pending_resize_operation"),
@@ -1247,6 +1261,8 @@ resource "azurerm_public_ip" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
+  sku                 = "Standard"
+  domain_name_label   = "acctest-publicip"
 }
 
 resource "azurerm_batch_account" "test" {

--- a/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
+++ b/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
@@ -1290,7 +1290,8 @@ resource "azurerm_batch_pool" "test" {
   }
 
   network_configuration {
-    subnet_id = "${azurerm_subnet.test.id}"
+    subnet_id  = "${azurerm_subnet.test.id}"
+    public_ips = [azurerm_public_ip.test.id]
 
     endpoint_configuration {
       name                = "SSH"

--- a/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
+++ b/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
@@ -1242,6 +1242,13 @@ resource "azurerm_subnet" "test" {
   address_prefix       = "10.0.2.0/24"
 }
 
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpublicip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+}
+
 resource "azurerm_batch_account" "test" {
   name                = "testaccbatch%s"
   resource_group_name = "${azurerm_resource_group.test.name}"
@@ -1283,5 +1290,5 @@ resource "azurerm_batch_pool" "test" {
     }
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomString, data.RandomString)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomString)
 }

--- a/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
+++ b/azurerm/internal/services/batch/tests/resource_arm_batch_pool_test.go
@@ -1290,7 +1290,7 @@ resource "azurerm_batch_pool" "test" {
   }
 
   network_configuration {
-    subnet_id  = "${azurerm_subnet.test.id}"
+    subnet_id  = azurerm_subnet.test.id
     public_ips = [azurerm_public_ip.test.id]
 
     endpoint_configuration {

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/account.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/account.go
@@ -102,7 +102,7 @@ func (client AccountClient) CreatePreparer(ctx context.Context, resourceGroupNam
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -189,7 +189,7 @@ func (client AccountClient) DeletePreparer(ctx context.Context, resourceGroupNam
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -279,7 +279,7 @@ func (client AccountClient) GetPreparer(ctx context.Context, resourceGroupName s
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -366,7 +366,7 @@ func (client AccountClient) GetKeysPreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -439,7 +439,7 @@ func (client AccountClient) ListPreparer(ctx context.Context) (*http.Request, er
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -552,7 +552,7 @@ func (client AccountClient) ListByResourceGroupPreparer(ctx context.Context, res
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -675,7 +675,7 @@ func (client AccountClient) RegenerateKeyPreparer(ctx context.Context, resourceG
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -763,7 +763,7 @@ func (client AccountClient) SynchronizeAutoStorageKeysPreparer(ctx context.Conte
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -848,7 +848,7 @@ func (client AccountClient) UpdatePreparer(ctx context.Context, resourceGroupNam
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/application.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/application.go
@@ -100,7 +100,7 @@ func (client ApplicationClient) CreatePreparer(ctx context.Context, resourceGrou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -196,7 +196,7 @@ func (client ApplicationClient) DeletePreparer(ctx context.Context, resourceGrou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -286,7 +286,7 @@ func (client ApplicationClient) GetPreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -373,7 +373,7 @@ func (client ApplicationClient) ListPreparer(ctx context.Context, resourceGroupN
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -505,7 +505,7 @@ func (client ApplicationClient) UpdatePreparer(ctx context.Context, resourceGrou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/applicationpackage.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/applicationpackage.go
@@ -41,7 +41,8 @@ func NewApplicationPackageClientWithBaseURI(baseURI string, subscriptionID strin
 	return ApplicationPackageClient{NewWithBaseURI(baseURI, subscriptionID)}
 }
 
-// Activate activates the specified application package.
+// Activate activates the specified application package. This should be done after the `ApplicationPackage` was created
+// and uploaded. This needs to be done before an `ApplicationPackage` can be used on Pools or Tasks
 // Parameters:
 // resourceGroupName - the name of the resource group that contains the Batch account.
 // accountName - the name of the Batch account.
@@ -108,7 +109,7 @@ func (client ApplicationPackageClient) ActivatePreparer(ctx context.Context, res
 		"versionName":       autorest.Encode("path", versionName),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -143,7 +144,9 @@ func (client ApplicationPackageClient) ActivateResponder(resp *http.Response) (r
 	return
 }
 
-// Create creates an application package record.
+// Create creates an application package record. The record contains the SAS where the package should be uploaded to.
+// Once it is uploaded the `ApplicationPackage` needs to be activated using `ApplicationPackageActive` before it can be
+// used.
 // Parameters:
 // resourceGroupName - the name of the resource group that contains the Batch account.
 // accountName - the name of the Batch account.
@@ -208,7 +211,7 @@ func (client ApplicationPackageClient) CreatePreparer(ctx context.Context, resou
 		"versionName":       autorest.Encode("path", versionName),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -310,7 +313,7 @@ func (client ApplicationPackageClient) DeletePreparer(ctx context.Context, resou
 		"versionName":       autorest.Encode("path", versionName),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -406,7 +409,7 @@ func (client ApplicationPackageClient) GetPreparer(ctx context.Context, resource
 		"versionName":       autorest.Encode("path", versionName),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -499,7 +502,7 @@ func (client ApplicationPackageClient) ListPreparer(ctx context.Context, resourc
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/certificate.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/certificate.go
@@ -104,7 +104,7 @@ func (client CertificateClient) CancelDeletionPreparer(ctx context.Context, reso
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -198,7 +198,7 @@ func (client CertificateClient) CreatePreparer(ctx context.Context, resourceGrou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -300,7 +300,7 @@ func (client CertificateClient) DeletePreparer(ctx context.Context, resourceGrou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -397,7 +397,7 @@ func (client CertificateClient) GetPreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -488,7 +488,7 @@ func (client CertificateClient) ListByBatchAccountPreparer(ctx context.Context, 
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -629,7 +629,7 @@ func (client CertificateClient) UpdatePreparer(ctx context.Context, resourceGrou
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/client.go
@@ -1,4 +1,4 @@
-// Package batch implements the Azure ARM Batch service API version 2018-12-01.
+// Package batch implements the Azure ARM Batch service API version 2019-08-01.
 //
 //
 package batch

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/location.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/location.go
@@ -91,7 +91,7 @@ func (client LocationClient) CheckNameAvailabilityPreparer(ctx context.Context, 
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -168,7 +168,7 @@ func (client LocationClient) GetQuotasPreparer(ctx context.Context, locationName
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/operations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/operations.go
@@ -76,7 +76,7 @@ func (client OperationsClient) List(ctx context.Context) (result OperationListRe
 
 // ListPreparer prepares the List request.
 func (client OperationsClient) ListPreparer(ctx context.Context) (*http.Request, error) {
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/pool.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/pool.go
@@ -135,7 +135,7 @@ func (client PoolClient) CreatePreparer(ctx context.Context, resourceGroupName s
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -236,7 +236,7 @@ func (client PoolClient) DeletePreparer(ctx context.Context, resourceGroupName s
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -332,7 +332,7 @@ func (client PoolClient) DisableAutoScalePreparer(ctx context.Context, resourceG
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -423,7 +423,7 @@ func (client PoolClient) GetPreparer(ctx context.Context, resourceGroupName stri
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -525,7 +525,7 @@ func (client PoolClient) ListByBatchAccountPreparer(ctx context.Context, resourc
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -666,7 +666,7 @@ func (client PoolClient) StopResizePreparer(ctx context.Context, resourceGroupNa
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -761,7 +761,7 @@ func (client PoolClient) UpdatePreparer(ctx context.Context, resourceGroupName s
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-08-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch/version.go
@@ -21,7 +21,7 @@ import "github.com/Azure/azure-sdk-for-go/version"
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/" + version.Number + " batch/2018-12-01"
+	return "Azure-SDK-For-Go/" + version.Number + " batch/2019-08-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2018-01-01/apimana
 github.com/Azure/azure-sdk-for-go/services/appconfiguration/mgmt/2019-10-01/appconfiguration
 github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2015-05-01/insights
 github.com/Azure/azure-sdk-for-go/services/automation/mgmt/2015-10-31/automation
-github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2018-12-01/batch
+github.com/Azure/azure-sdk-for-go/services/batch/mgmt/2019-08-01/batch
 github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2017-10-12/cdn
 github.com/Azure/azure-sdk-for-go/services/cognitiveservices/mgmt/2017-04-18/cognitiveservices
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -275,6 +275,8 @@ A `network_configuration` block supports the following:
 
 * `subnet_id` - (Optional) The ARM resource identifier of the virtual network subnet which the compute nodes of the pool will join. Changing this forces a new resource to be created.
 
+* `public_ips` - (Optional) A list of public ip ids that will be allocated to nodes
+
 * `endpoint_configuration` - (Optional) A list of inbound NAT pools that can be used to address specific ports on an individual compute node externally. Set as documented in the inbound_nat_pools block below. Changing this forces a new resource to be created.
 
 ---

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -275,7 +275,7 @@ A `network_configuration` block supports the following:
 
 * `subnet_id` - (Optional) The ARM resource identifier of the virtual network subnet which the compute nodes of the pool will join. Changing this forces a new resource to be created.
 
-* `public_ips` - (Optional) A list of public ip ids that will be allocated to nodes
+* `public_ips` - (Optional) A list of public ip ids that will be allocated to nodes. Changing this forces a new resource to be created.
 
 * `endpoint_configuration` - (Optional) A list of inbound NAT pools that can be used to address specific ports on an individual compute node externally. Set as documented in the inbound_nat_pools block below. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
fix #5920 

the original sdk version 2018-12-01 does not support fields `public_ips`, so I upgraded the version to 2019-08-01