### PR TITLE
Use location from resource group in application insights example

### DIFF
--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_application_insights" "example" {
   name                = "tf-test-appinsights"
-  location            = "West Europe"
+  location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   application_type    = "web"
 }


### PR DESCRIPTION
Instead of hardcoding the location, this change would use the location from the resource group to be more consistent with the other examples and in line with best practice.