### PR TITLE
azurerm_policy_definition- Fixed import regex when using management groups

### DIFF
--- a/azurerm/internal/services/policy/resource_arm_policy_definition.go
+++ b/azurerm/internal/services/policy/resource_arm_policy_definition.go
@@ -301,7 +301,7 @@ func parsePolicyDefinitionNameFromId(id string) (string, error) {
 }
 
 func parseManagementGroupIdFromPolicyId(id string) string {
-	r, _ := regexp.Compile("managementgroups/(.+)/providers/.*$")
+	r, _ := regexp.Compile("managementGroups/(.+)/providers/.*$")
 
 	if r.MatchString(id) {
 		parms := r.FindAllStringSubmatch(id, -1)[0]


### PR DESCRIPTION
There is a typo in the regex to parse the management group id out of the policy definition id during an import. This fixes the case and allows the management group id to be correctly pulled, otherwise terraform always thinks the policy definition lives at the subscription level which always results in an error. 

Policy definition id structure: `/providers/Microsoft.Management/managementGroups/<group id>/providers/Microsoft.Authorization/policyDefinitions/<id>`