### PR TITLE
azurerm_windows_virtual_machine - Add WinRM protocol to documentation

### DIFF
--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -254,7 +254,9 @@ A `secret` block supports the following:
 ---
 
 A `winrm_listener` block supports the following:
+
 * `Protocol` - (Required) Specifies Specifies the protocol of listener. Possible values are `Http` or `Https`
+
 * `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`.
 
 ## Attributes Reference

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -254,7 +254,7 @@ A `secret` block supports the following:
 ---
 
 A `winrm_listener` block supports the following:
-
+* `Protocol` - (Required) Specifies Specifies the protocol of listener. Possible values are `Http` or `Https`
 * `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`.
 
 ## Attributes Reference


### PR DESCRIPTION
Protocol argument inside winrm_listener is missing on the azurerm_windows_virtual_machine resource