### PR TITLE
azurerm_managed_disk - DOC: Update disk encryption attribute

### DIFF
--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -149,7 +149,7 @@ The `key_encryption_key` block supports:
 
 * `key_url` - (Required) The URL to the Key Vault Key used as the Key Encryption Key. This can be found as `id` on the `azurerm_key_vault_key` resource.
 
-* `source_vault_id` - (Required) The URL of the Key Vault. This can be found as `vault_uri` on the `azurerm_key_vault` resource.
+* `source_vault_id` - (Required) The ID of the source Key Vault.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The `encryption_settings`'s `key_encryption_key` block's `source_vault_id` attribute needs to point to the ID of the source vault, rather than the URI. Following such documentation results in an apply failure.