### PR TITLE
azurerm_cosmosdb_mongo_collection: Remove deprecated and removed block from example

### DIFF
--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -33,16 +33,6 @@ resource "azurerm_cosmosdb_mongo_collection" "example" {
   default_ttl_seconds = "777"
   shard_key           = "uniqueKey"
   throughput          = 400
-
-  indexes {
-    key    = "aKey"
-    unique = false
-  }
-
-  indexes {
-    key    = "uniqueKey"
-    unique = true
-  }
 }
 ```
 


### PR DESCRIPTION
The indexes block was removed in PR #5853, but the example wasn't
updated.