### PR TITLE
tests: clarifying the features block is required going forward

### DIFF
--- a/azurerm/internal/acceptance/data.go
+++ b/azurerm/internal/acceptance/data.go
@@ -52,7 +52,7 @@ type TestData struct {
 // BuildTestData generates some test data for the given resource
 func BuildTestData(t *testing.T, resourceType string, resourceLabel string) TestData {
 	once.Do(func() {
-		azureProvider := provider.AzureProvider().(*schema.Provider)
+		azureProvider := provider.TestAzureProvider().(*schema.Provider)
 
 		AzureProvider = azureProvider
 		SupportedProviders = map[string]terraform.ResourceProvider{

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -1,13 +1,11 @@
 package provider
 
 import (
-	"os"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
-func schemaFeatures() *schema.Schema {
+func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 	// NOTE: if there's only one nested field these want to be Required (since there's no point
 	//       specifying the block otherwise) - however for 2+ they should be optional
 	features := map[string]*schema.Schema{
@@ -59,8 +57,9 @@ func schemaFeatures() *schema.Schema {
 		},
 	}
 
-	runningAcceptanceTests := os.Getenv("TF_ACC") != ""
-	if runningAcceptanceTests {
+	// this is a temporary hack to enable us to gradually add provider blocks to test configurations
+	// rather than doing it as a big-bang and breaking all open PR's
+	if supportLegacyTestSuite {
 		return &schema.Schema{
 			Type:     schema.TypeList,
 			Optional: true,

--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -15,6 +15,14 @@ import (
 )
 
 func AzureProvider() terraform.ResourceProvider {
+	return azureProvider(false)
+}
+
+func TestAzureProvider() terraform.ResourceProvider {
+	return azureProvider(true)
+}
+
+func azureProvider(supportLegacyTestSuite bool) terraform.ResourceProvider {
 	// avoids this showing up in test output
 	var debugLog = func(f string, v ...interface{}) {
 		if os.Getenv("TF_LOG") == "" {
@@ -149,7 +157,7 @@ func AzureProvider() terraform.ResourceProvider {
 				Description: "This will disable the Terraform Partner ID which is used if a custom `partner_id` isn't specified.",
 			},
 
-			"features": schemaFeatures(),
+			"features": schemaFeatures(supportLegacyTestSuite),
 
 			// Advanced feature flags
 			"skip_credentials_validation": {

--- a/azurerm/internal/provider/provider_test.go
+++ b/azurerm/internal/provider/provider_test.go
@@ -2,23 +2,19 @@ package provider
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func TestProvider(t *testing.T) {
-	if err := AzureProvider().(*schema.Provider).InternalValidate(); err != nil {
+	if err := TestAzureProvider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestDataSourcesSupportCustomTimeouts(t *testing.T) {
-	// this is required until 2.0
-	os.Setenv("ARM_PROVIDER_CUSTOM_TIMEOUTS", "true")
-
-	provider := AzureProvider().(*schema.Provider)
+	provider := TestAzureProvider().(*schema.Provider)
 	for dataSourceName, dataSource := range provider.DataSourcesMap {
 		t.Run(fmt.Sprintf("DataSource/%s", dataSourceName), func(t *testing.T) {
 			t.Logf("[DEBUG] Testing Data Source %q..", dataSourceName)
@@ -54,10 +50,7 @@ func TestDataSourcesSupportCustomTimeouts(t *testing.T) {
 }
 
 func TestResourcesSupportCustomTimeouts(t *testing.T) {
-	// this is required until 2.0
-	os.Setenv("ARM_PROVIDER_CUSTOM_TIMEOUTS", "true")
-
-	provider := AzureProvider().(*schema.Provider)
+	provider := TestAzureProvider().(*schema.Provider)
 	for resourceName, resource := range provider.ResourcesMap {
 		t.Run(fmt.Sprintf("Resource/%s", resourceName), func(t *testing.T) {
 			t.Logf("[DEBUG] Testing Resource %q..", resourceName)


### PR DESCRIPTION
The temporary patch in the provider/test suite allows for us to gradually add provider
blocks to the test suite, rather than doing it in a big-bang (and breaking open PR's).

Unfortunately this workaround was unintentionally available in release binaries, as such
this commit changes this patch to only work for test providers rather than released versions
since this isn't intended to be used by users.

Instead we require that Provider blocks and Feature blocks are both specified to be explicit
about which instance of a provider is being used when provisioning resources.