### PR TITLE
Added loadbalancer name-addresses map attribute

### DIFF
--- a/azurerm/internal/services/network/resource_arm_lb.go
+++ b/azurerm/internal/services/network/resource_arm_lb.go
@@ -164,6 +164,14 @@ func resourceArmLoadBalancer() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"names_private_ip_addresses": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Set: schema.HashString,
+			},
 
 			"tags": tags.Schema(),
 		},
@@ -270,6 +278,7 @@ func resourceArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 
 			privateIpAddress := ""
 			privateIpAddresses := make([]string, 0)
+			namesPrivateIpAddresses := make(map[string]string)
 			for _, config := range *feipConfigs {
 				if feipProps := config.FrontendIPConfigurationPropertiesFormat; feipProps != nil {
 					if ip := feipProps.PrivateIPAddress; ip != nil {
@@ -278,12 +287,16 @@ func resourceArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 						}
 
 						privateIpAddresses = append(privateIpAddresses, *feipProps.PrivateIPAddress)
+						if config.Name != nil {
+							namesPrivateIpAddresses[*config.Name] = *feipProps.PrivateIPAddress
+						}
 					}
 				}
 			}
 
 			d.Set("private_ip_address", privateIpAddress)
 			d.Set("private_ip_addresses", privateIpAddresses)
+			d.Set("names_private_ip_addresses", namesPrivateIpAddresses)
 		}
 	}
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -68,6 +68,7 @@ The following attributes are exported:
 * `id` - The Load Balancer ID.
 * `private_ip_address` - The first private IP address assigned to the load balancer in `frontend_ip_configuration` blocks, if any.
 * `private_ip_addresses` - The list of private IP address assigned to the load balancer in `frontend_ip_configuration` blocks, if any.
+* `names_private_ip_addresses` - The map of name - private IP address assigned to the load balancer in `frontend_ip_configuration` blocks, if any.
 * `id` - The id of the Frontend IP Configuration.
 
 ## Timeouts


### PR DESCRIPTION
This adds a new attribute to get a name-private_ip_address mapping
of the frontend_ip_configurations, defined on the loadbalancer.
Helpful, if you have manny frontend_ip_configurations, created with a
dynamic loop and need these mapping for further steps or outputs,
otherwise you just rely on the list order.