### PR TITLE
Refine the ID parsing funtion for `azurerm_availability_set`

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_availability_set.go
+++ b/azurerm/internal/services/compute/resource_arm_availability_set.go
@@ -2,7 +2,6 @@ package compute
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"log"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"

--- a/azurerm/internal/services/compute/resource_arm_availability_set.go
+++ b/azurerm/internal/services/compute/resource_arm_availability_set.go
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"log"
 	"strings"
 	"time"
@@ -154,24 +155,22 @@ func resourceArmAvailabilitySetRead(d *schema.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.AvailabilitySetID(d.Id())
 	if err != nil {
 		return err
 	}
-	resGroup := id.ResourceGroup
-	name := id.Path["availabilitySets"]
 
-	resp, err := client.Get(ctx, resGroup, name)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error making Read request on Azure Availability Set %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("Error making Read request on Azure Availability Set %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 
 	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resGroup)
+	d.Set("resource_group_name", id.ResourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
@@ -196,14 +195,12 @@ func resourceArmAvailabilitySetDelete(d *schema.ResourceData, meta interface{}) 
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.AvailabilitySetID(d.Id())
 	if err != nil {
 		return err
 	}
-	resGroup := id.ResourceGroup
-	name := id.Path["availabilitySets"]
 
-	_, err = client.Delete(ctx, resGroup, name)
+	_, err = client.Delete(ctx, id.ResourceGroup, id.Name)
 
 	return err
 }

--- a/azurerm/internal/services/compute/tests/resource_arm_availability_set_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_availability_set_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"fmt"
-	"net/http"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/response"
@@ -188,21 +188,17 @@ func testCheckAzureRMAvailabilitySetExists(resourceName string) resource.TestChe
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		// Name of the actual scale set
-		name := rs.Primary.Attributes["name"]
-
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for availability set: %s", name)
-		}
-
-		vmss, err := client.Get(ctx, resourceGroup, name)
+		id, err := parse.AvailabilitySetID(rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on vmScaleSetClient: %+v", err)
+			return err
 		}
 
-		if vmss.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: VirtualMachineScaleSet %q (resource group: %q) does not exist", name, resourceGroup)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Availability Set %q (Resource Group %q) does not exist", id.Name, id.ResourceGroup)
+			}
+			return fmt.Errorf("Bad: Get on vmScaleSetClient: %+v", err)
 		}
 
 		return nil
@@ -220,13 +216,12 @@ func testCheckAzureRMAvailabilitySetDisappears(resourceName string) resource.Tes
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		availSetName := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for availability set: %s", availSetName)
+		id, err := parse.AvailabilitySetID(rs.Primary.ID)
+		if err != nil {
+			return err
 		}
 
-		resp, err := client.Delete(ctx, resourceGroup, availSetName)
+		resp, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 		if err != nil {
 			if !response.WasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: Delete on availSetClient: %+v", err)
@@ -246,10 +241,12 @@ func testCheckAzureRMAvailabilitySetDestroy(s *terraform.State) error {
 			continue
 		}
 
-		name := rs.Primary.Attributes["name"]
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		id, err := parse.AvailabilitySetID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
 
-		resp, err := client.Get(ctx, resourceGroup, name)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
@@ -258,7 +255,7 @@ func testCheckAzureRMAvailabilitySetDestroy(s *terraform.State) error {
 			return err
 		}
 
-		return fmt.Errorf("Availability Set still exists:\n%#v", resp.AvailabilitySetProperties)
+		return fmt.Errorf("Bad: Availability Set still exists:\n%#v", resp.AvailabilitySetProperties)
 	}
 
 	return nil

--- a/azurerm/internal/services/compute/tests/resource_arm_availability_set_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_availability_set_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"testing"
 
 	"github.com/hashicorp/go-azure-helpers/response"
@@ -11,6 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 


### PR DESCRIPTION
Acceptance tests are passing:
=== RUN   TestAccAzureRMAvailabilitySet_basic
=== PAUSE TestAccAzureRMAvailabilitySet_basic
=== CONT  TestAccAzureRMAvailabilitySet_basic
--- PASS: TestAccAzureRMAvailabilitySet_basic (164.15s)
=== RUN   TestAccAzureRMAvailabilitySet_requiresImport
=== PAUSE TestAccAzureRMAvailabilitySet_requiresImport
=== CONT  TestAccAzureRMAvailabilitySet_requiresImport
--- PASS: TestAccAzureRMAvailabilitySet_requiresImport (128.30s)
=== RUN   TestAccAzureRMAvailabilitySet_disappears
=== PAUSE TestAccAzureRMAvailabilitySet_disappears
=== CONT  TestAccAzureRMAvailabilitySet_disappears
--- PASS: TestAccAzureRMAvailabilitySet_disappears (112.02s)
=== RUN   TestAccAzureRMAvailabilitySet_withTags
=== PAUSE TestAccAzureRMAvailabilitySet_withTags
=== CONT  TestAccAzureRMAvailabilitySet_withTags
--- PASS: TestAccAzureRMAvailabilitySet_withTags (193.10s)
=== RUN   TestAccAzureRMAvailabilitySet_withPPG
=== PAUSE TestAccAzureRMAvailabilitySet_withPPG
=== CONT  TestAccAzureRMAvailabilitySet_withPPG
--- PASS: TestAccAzureRMAvailabilitySet_withPPG (129.13s)
=== RUN   TestAccAzureRMAvailabilitySet_withDomainCounts
=== PAUSE TestAccAzureRMAvailabilitySet_withDomainCounts
=== CONT  TestAccAzureRMAvailabilitySet_withDomainCounts
--- PASS: TestAccAzureRMAvailabilitySet_withDomainCounts (118.58s)
=== RUN   TestAccAzureRMAvailabilitySet_unmanaged
=== PAUSE TestAccAzureRMAvailabilitySet_unmanaged
=== CONT  TestAccAzureRMAvailabilitySet_unmanaged
--- PASS: TestAccAzureRMAvailabilitySet_unmanaged (166.94s)