### PR TITLE
azurerm_service_fabric_cluster - support for Client Certificate by common names (#4528)

### DIFF
--- a/azurerm/internal/services/servicefabric/resource_arm_service_fabric_cluster.go
+++ b/azurerm/internal/services/servicefabric/resource_arm_service_fabric_cluster.go
@@ -225,12 +225,12 @@ func resourceArmServiceFabricCluster() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"certificate_common_name": {
+						"common_name": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
-						"certificate_issuer_thumbprint": {
+						"issuer_thumbprint": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
@@ -881,8 +881,8 @@ func expandServiceFabricClusterClientCertificateCommonNames(input []interface{})
 	for _, v := range input {
 		val := v.(map[string]interface{})
 
-		certificate_common_name := val["certificate_common_name"].(string)
-		certificate_issuer_thumbprint := val["certificate_issuer_thumbprint"].(string)
+		certificate_common_name := val["common_name"].(string)
+		certificate_issuer_thumbprint := val["issuer_thumbprint"].(string)
 		isAdmin := val["is_admin"].(bool)
 
 		result := servicefabric.ClientCertificateCommonName{
@@ -907,11 +907,11 @@ func flattenServiceFabricClusterClientCertificateCommonNames(input *[]servicefab
 		result := make(map[string]interface{})
 
 		if certificate_common_name := v.CertificateCommonName; certificate_common_name != nil {
-			result["certificate_common_name"] = *certificate_common_name
+			result["common_name"] = *certificate_common_name
 		}
 
 		if certificate_issuer_thumbprint := v.CertificateIssuerThumbprint; certificate_issuer_thumbprint != nil {
-			result["certificate_issuer_thumbprint"] = *certificate_issuer_thumbprint
+			result["issuer_thumbprint"] = *certificate_issuer_thumbprint
 		}
 
 		if isAdmin := v.IsAdmin; isAdmin != nil {

--- a/azurerm/internal/services/servicefabric/resource_arm_service_fabric_cluster.go
+++ b/azurerm/internal/services/servicefabric/resource_arm_service_fabric_cluster.go
@@ -220,6 +220,29 @@ func resourceArmServiceFabricCluster() *schema.Resource {
 				},
 			},
 
+			"client_certificate_common_name": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"certificate_common_name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"certificate_issuer_thumbprint": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"is_admin": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+					},
+				},
+			},
+
 			"diagnostics_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -415,9 +438,6 @@ func resourceArmServiceFabricClusterCreateUpdate(d *schema.ResourceData, meta in
 	reverseProxyCertificateRaw := d.Get("reverse_proxy_certificate").([]interface{})
 	reverseProxyCertificate := expandServiceFabricClusterReverseProxyCertificate(reverseProxyCertificateRaw)
 
-	clientCertificateThumbprintRaw := d.Get("client_certificate_thumbprint").([]interface{})
-	clientCertificateThumbprints := expandServiceFabricClusterClientCertificateThumbprints(clientCertificateThumbprintRaw)
-
 	diagnosticsRaw := d.Get("diagnostics_config").([]interface{})
 	diagnostics := expandServiceFabricClusterDiagnosticsConfig(diagnosticsRaw)
 
@@ -435,7 +455,6 @@ func resourceArmServiceFabricClusterCreateUpdate(d *schema.ResourceData, meta in
 			AzureActiveDirectory:            azureActiveDirectory,
 			CertificateCommonNames:          expandServiceFabricClusterCertificateCommonNames(d),
 			ReverseProxyCertificate:         reverseProxyCertificate,
-			ClientCertificateThumbprints:    clientCertificateThumbprints,
 			DiagnosticsStorageAccountConfig: diagnostics,
 			FabricSettings:                  fabricSettings,
 			ManagementEndpoint:              utils.String(managementEndpoint),
@@ -449,6 +468,16 @@ func resourceArmServiceFabricClusterCreateUpdate(d *schema.ResourceData, meta in
 	if certificateRaw, ok := d.GetOk("certificate"); ok {
 		certificate := expandServiceFabricClusterCertificate(certificateRaw.([]interface{}))
 		cluster.ClusterProperties.Certificate = certificate
+	}
+
+	if clientCertificateThumbprintRaw, ok := d.GetOk("client_certificate_thumbprint"); ok {
+		clientCertificateThumbprints := expandServiceFabricClusterClientCertificateThumbprints(clientCertificateThumbprintRaw.([]interface{}))
+		cluster.ClusterProperties.ClientCertificateThumbprints = clientCertificateThumbprints
+	}
+
+	if clientCertificateCommonNamesRaw, ok := d.GetOk("client_certificate_common_name"); ok {
+		clientCertificateCommonNames := expandServiceFabricClusterClientCertificateCommonNames(clientCertificateCommonNamesRaw.([]interface{}))
+		cluster.ClusterProperties.ClientCertificateCommonNames = clientCertificateCommonNames
 	}
 
 	if clusterCodeVersion != "" {
@@ -540,6 +569,11 @@ func resourceArmServiceFabricClusterRead(d *schema.ResourceData, meta interface{
 		clientCertificateThumbprints := flattenServiceFabricClusterClientCertificateThumbprints(props.ClientCertificateThumbprints)
 		if err := d.Set("client_certificate_thumbprint", clientCertificateThumbprints); err != nil {
 			return fmt.Errorf("Error setting `client_certificate_thumbprint`: %+v", err)
+		}
+
+		clientCertificateCommonNames := flattenServiceFabricClusterClientCertificateCommonNames(props.ClientCertificateCommonNames)
+		if err := d.Set("client_certificate_common_name", clientCertificateCommonNames); err != nil {
+			return fmt.Errorf("Error setting `client_certificate_common_name`: %+v", err)
 		}
 
 		diagnostics := flattenServiceFabricClusterDiagnosticsConfig(props.DiagnosticsStorageAccountConfig)
@@ -835,6 +869,54 @@ func flattenServiceFabricClusterClientCertificateThumbprints(input *[]servicefab
 			result["is_admin"] = *isAdmin
 		}
 
+		results = append(results, result)
+	}
+
+	return results
+}
+
+func expandServiceFabricClusterClientCertificateCommonNames(input []interface{}) *[]servicefabric.ClientCertificateCommonName {
+	results := make([]servicefabric.ClientCertificateCommonName, 0)
+
+	for _, v := range input {
+		val := v.(map[string]interface{})
+
+		certificate_common_name := val["certificate_common_name"].(string)
+		certificate_issuer_thumbprint := val["certificate_issuer_thumbprint"].(string)
+		isAdmin := val["is_admin"].(bool)
+
+		result := servicefabric.ClientCertificateCommonName{
+			CertificateCommonName:       utils.String(certificate_common_name),
+			CertificateIssuerThumbprint: utils.String(certificate_issuer_thumbprint),
+			IsAdmin:                     utils.Bool(isAdmin),
+		}
+		results = append(results, result)
+	}
+
+	return &results
+}
+
+func flattenServiceFabricClusterClientCertificateCommonNames(input *[]servicefabric.ClientCertificateCommonName) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	results := make([]interface{}, 0)
+
+	for _, v := range *input {
+		result := make(map[string]interface{})
+
+		if certificate_common_name := v.CertificateCommonName; certificate_common_name != nil {
+			result["certificate_common_name"] = *certificate_common_name
+		}
+
+		if certificate_issuer_thumbprint := v.CertificateIssuerThumbprint; certificate_issuer_thumbprint != nil {
+			result["certificate_issuer_thumbprint"] = *certificate_issuer_thumbprint
+		}
+
+		if isAdmin := v.IsAdmin; isAdmin != nil {
+			result["is_admin"] = *isAdmin
+		}
 		results = append(results, result)
 	}
 

--- a/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
@@ -123,7 +123,7 @@ func TestAccAzureRMServiceFabricCluster_requiresImport(t *testing.T) {
 
 func TestAccAzureRMServiceFabricCluster_manualClusterCodeVersion(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_service_fabric_cluster", "test")
-	codeVersion := "6.4.637.9590"
+	codeVersion := "6.5.676.9590"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -205,7 +205,7 @@ func TestAccAzureRMServiceFabricCluster_certificate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
@@ -230,10 +230,10 @@ func TestAccAzureRMServiceFabricCluster_reverseProxyCertificate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
@@ -307,10 +307,10 @@ func TestAccAzureRMServiceFabricCluster_reverseProxyUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "reverse_proxy_certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
@@ -352,10 +352,43 @@ func TestAccAzureRMServiceFabricCluster_clientCertificateThumbprint(t *testing.T
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.is_admin", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.#", "0"),
+					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.name", "Security"),
+					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
+					resource.TestCheckResourceAttr(data.ResourceName, "management_endpoint", "https://example:80"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMServiceFabricCluster_clientCertificateCommonNames(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_service_fabric_cluster", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMServiceFabricClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMServiceFabricCluster_clientCertificateCommonNames(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.0.certificate_common_name", "firstcertcommonname"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.0.is_admin", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.0.certificate_issuer_thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.1.certificate_common_name", "secondcertcommonname"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.1.is_admin", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.1.certificate_issuer_thumbprint", ""),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.is_admin", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
@@ -380,13 +413,14 @@ func TestAccAzureRMServiceFabricCluster_readerAdminClientCertificateThumbprint(t
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.#", "2"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.0.is_admin", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.1.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.1.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.1.is_admin", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.#", "0"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.name", "Security"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.parameters.ClusterProtectionLevel", "EncryptAndSign"),
 					resource.TestCheckResourceAttr(data.ResourceName, "management_endpoint", "https://example:80"),
@@ -434,7 +468,7 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectory(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "azure_active_directory.#", "1"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "azure_active_directory.0.tenant_id"),
@@ -463,7 +497,7 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectoryDelete(t *testing.T)
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "azure_active_directory.#", "1"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "azure_active_directory.0.tenant_id"),
@@ -479,7 +513,7 @@ func TestAccAzureRMServiceFabricCluster_azureActiveDirectoryDelete(t *testing.T)
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceFabricClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
 					resource.TestCheckResourceAttr(data.ResourceName, "certificate.0.x509_store_name", "My"),
 					resource.TestCheckResourceAttr(data.ResourceName, "azure_active_directory.#", "0"),
 					resource.TestCheckResourceAttr(data.ResourceName, "fabric_settings.0.name", "Security"),
@@ -957,7 +991,7 @@ resource "azurerm_service_fabric_cluster" "test" {
   management_endpoint = "https://example:80"
 
   certificate {
-    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     x509_store_name = "My"
   }
 
@@ -1001,12 +1035,12 @@ resource "azurerm_service_fabric_cluster" "test" {
   management_endpoint = "https://example:80"
 
   certificate {
-    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     x509_store_name = "My"
   }
 
   reverse_proxy_certificate {
-    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     x509_store_name = "My"
   }
 
@@ -1051,12 +1085,68 @@ resource "azurerm_service_fabric_cluster" "test" {
   management_endpoint = "https://example:80"
 
   certificate {
-    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     x509_store_name = "My"
   }
 
   client_certificate_thumbprint {
-    thumbprint = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+    is_admin   = true
+  }
+
+  fabric_settings {
+    name = "Security"
+
+    parameters = {
+      "ClusterProtectionLevel" = "EncryptAndSign"
+    }
+  }
+
+  node_type {
+    name                 = "first"
+    instance_count       = 3
+    is_primary           = true
+    client_endpoint_port = 2020
+    http_endpoint_port   = 80
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMServiceFabricCluster_clientCertificateCommonNames(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_service_fabric_cluster" "test" {
+  name                = "acctest-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  reliability_level   = "Bronze"
+  upgrade_mode        = "Automatic"
+  vm_image            = "Windows"
+  management_endpoint = "https://example:80"
+
+  certificate {
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+    x509_store_name = "My"
+  }
+
+  client_certificate_common_name {
+    certificate_common_name = "firstcertcommonname"
+	is_admin   = true
+	certificate_issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+  }
+
+  client_certificate_common_name {
+	certificate_common_name = "secondcertcommonname"
+	is_admin   = false
+  }
+
+  client_certificate_thumbprint {
+    thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     is_admin   = true
   }
 
@@ -1100,17 +1190,17 @@ resource "azurerm_service_fabric_cluster" "test" {
   management_endpoint = "https://example:80"
 
   certificate {
-    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     x509_store_name = "My"
   }
 
   client_certificate_thumbprint {
-    thumbprint = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     is_admin   = true
   }
 
   client_certificate_thumbprint {
-    thumbprint = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     is_admin   = false
   }
 
@@ -1260,7 +1350,7 @@ resource "azurerm_service_fabric_cluster" "test" {
   management_endpoint = "https://example:19080"
 
   certificate {
-    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     x509_store_name = "My"
   }
 
@@ -1313,7 +1403,7 @@ resource "azurerm_service_fabric_cluster" "test" {
   management_endpoint = "https://example:19080"
 
   certificate {
-    thumbprint      = "33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
     x509_store_name = "My"
   }
 

--- a/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
@@ -1116,56 +1116,56 @@ resource "azurerm_service_fabric_cluster" "test" {
 func testAccAzureRMServiceFabricCluster_clientCertificateCommonNames(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
+	name     = "acctestRG-%d"
+	location = "%s"
+	}
 
-resource "azurerm_service_fabric_cluster" "test" {
-  name                = "acctest-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  reliability_level   = "Bronze"
-  upgrade_mode        = "Automatic"
-  vm_image            = "Windows"
-  management_endpoint = "https://example:80"
+	resource "azurerm_service_fabric_cluster" "test" {
+	name                = "acctest-%d"
+	resource_group_name = azurerm_resource_group.test.name
+	location            = azurerm_resource_group.test.location
+	reliability_level   = "Bronze"
+	upgrade_mode        = "Automatic"
+	vm_image            = "Windows"
+	management_endpoint = "https://example:80"
 
-  certificate {
-    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
-    x509_store_name = "My"
-  }
+	certificate {
+		thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+		x509_store_name = "My"
+	}
 
-  client_certificate_common_name {
-    certificate_common_name = "firstcertcommonname"
-	is_admin   = true
-	certificate_issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
-  }
+	client_certificate_common_name {
+		certificate_common_name       = "firstcertcommonname"
+		is_admin                      = true
+		certificate_issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+	}
 
-  client_certificate_common_name {
-	certificate_common_name = "secondcertcommonname"
-	is_admin   = false
-  }
+	client_certificate_common_name {
+		certificate_common_name = "secondcertcommonname"
+		is_admin                = false
+	}
 
-  client_certificate_thumbprint {
-    thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
-    is_admin   = true
-  }
+	client_certificate_thumbprint {
+		thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+		is_admin   = true
+	}
 
-  fabric_settings {
-    name = "Security"
+	fabric_settings {
+		name = "Security"
 
-    parameters = {
-      "ClusterProtectionLevel" = "EncryptAndSign"
-    }
-  }
+		parameters = {
+		"ClusterProtectionLevel" = "EncryptAndSign"
+		}
+	}
 
-  node_type {
-    name                 = "first"
-    instance_count       = 3
-    is_primary           = true
-    client_endpoint_port = 2020
-    http_endpoint_port   = 80
-  }
-}
+	node_type {
+		name                 = "first"
+		instance_count       = 3
+		is_primary           = true
+		client_endpoint_port = 2020
+		http_endpoint_port   = 80
+	}
+	}
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 

--- a/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
@@ -1116,55 +1116,55 @@ resource "azurerm_service_fabric_cluster" "test" {
 func testAccAzureRMServiceFabricCluster_clientCertificateCommonNames(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
-	name     = "acctestRG-%d"
-	location = "%s"
-	}
+  name     = "acctestRG-%d"
+  location = "%s"
+}
 
-	resource "azurerm_service_fabric_cluster" "test" {
-	name                = "acctest-%d"
-	resource_group_name = azurerm_resource_group.test.name
-	location            = azurerm_resource_group.test.location
-	reliability_level   = "Bronze"
-	upgrade_mode        = "Automatic"
-	vm_image            = "Windows"
-	management_endpoint = "https://example:80"
+resource "azurerm_service_fabric_cluster" "test" {
+  name                = "acctest-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  reliability_level   = "Bronze"
+  upgrade_mode        = "Automatic"
+  vm_image            = "Windows"
+  management_endpoint = "https://example:80"
 
-	certificate {
-		thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
-		x509_store_name = "My"
-	}
+  certificate {
+    thumbprint      = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+    x509_store_name = "My"
+  }
 
-	client_certificate_common_name {
-		certificate_common_name       = "firstcertcommonname"
-		is_admin                      = true
-		certificate_issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
-	}
+  client_certificate_common_name {
+    certificate_common_name       = "firstcertcommonname"
+    is_admin                      = true
+    certificate_issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+  }
 
-	client_certificate_common_name {
-		certificate_common_name = "secondcertcommonname"
-		is_admin                = false
-	}
+  client_certificate_common_name {
+    certificate_common_name = "secondcertcommonname"
+    is_admin                = false
+  }
 
-	client_certificate_thumbprint {
-		thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
-		is_admin   = true
-	}
+  client_certificate_thumbprint {
+    thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+    is_admin   = true
+  }
 
-	fabric_settings {
-		name = "Security"
+  fabric_settings {
+    name = "Security"
 
-		parameters = {
-		"ClusterProtectionLevel" = "EncryptAndSign"
-		}
-	}
+    parameters = {
+      "ClusterProtectionLevel" = "EncryptAndSign"
+    }
+  }
 
-	node_type {
-		name                 = "first"
-		instance_count       = 3
-		is_primary           = true
-		client_endpoint_port = 2020
-		http_endpoint_port   = 80
-	}
+  node_type {
+    name                 = "first"
+    instance_count       = 3
+    is_primary           = true
+    client_endpoint_port = 2020
+    http_endpoint_port   = 80
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
@@ -383,8 +383,8 @@ func TestAccAzureRMServiceFabricCluster_clientCertificateCommonNames(t *testing.
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.#", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.0.certificate_common_name", "firstcertcommonname"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.0.is_admin", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.0.certificate_issuer_thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.1.certificate_common_name", "secondcertcommonname"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.0.issuer_thumbprint", "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.1.common_name", "secondcertcommonname"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.1.is_admin", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_common_name.1.certificate_issuer_thumbprint", ""),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_certificate_thumbprint.#", "1"),
@@ -1135,9 +1135,9 @@ resource "azurerm_service_fabric_cluster" "test" {
   }
 
   client_certificate_common_name {
-    certificate_common_name       = "firstcertcommonname"
-    is_admin                      = true
-    certificate_issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+    common_name       = "firstcertcommonname"
+    issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
+    is_admin          = true
   }
 
   client_certificate_common_name {

--- a/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
+++ b/azurerm/internal/services/servicefabric/tests/resource_arm_service_fabric_cluster_test.go
@@ -1165,7 +1165,7 @@ resource "azurerm_resource_group" "test" {
 		client_endpoint_port = 2020
 		http_endpoint_port   = 80
 	}
-	}
+}
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -73,7 +73,9 @@ The following arguments are supported:
 
 * `reverse_proxy_certificate` - (Optional) A `reverse_proxy_certificate` block as defined below.
 
-* `client_certificate_thumbprint` - (Optional) One or two `client_certificate_thumbprint` blocks as defined below.
+* `client_certificate_thumbprint` - (Optional) One or two `client_certificate_thumbprint` blocks as defined below. 
+
+* `client_certificate_common_name` - (Optional) A `client_certificate_common_name` block as defined below. 
 
 -> **NOTE:** If Client Certificates are enabled then at a Certificate must be configured on the cluster.
 
@@ -136,6 +138,18 @@ A `reverse_proxy_certificate` block supports the following:
 A `client_certificate_thumbprint` block supports the following:
 
 * `thumbprint` - (Required) The Thumbprint associated with the Client Certificate.
+
+* `is_admin` - (Required) Does the Client Certificate have Admin Access to the cluster? Non-admin clients can only perform read only operations on the cluster.
+
+---
+
+A `client_certificate_common_name` block supports the following:
+
+* `certificate_common_name` - (Required) The common or subject name of the certificate.
+
+* `certificate_issuer_thumbprint` - (Optional) The Issuer Thumbprint of the Certificate.
+
+-> **NOTE:** Certificate Issuer Thumbprint may become required in the future, `https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-create-cluster-using-cert-cn#download-and-update-a-sample-template`.
 
 * `is_admin` - (Required) Does the Client Certificate have Admin Access to the cluster? Non-admin clients can only perform read only operations on the cluster.
 


### PR DESCRIPTION
Addressing #4528

Added support in azurerm_service_fabric_cluster for client_certificate_common_name  block. Example block:

```
client_certificate_common_name {
  certificate_common_name = "CertificateCommonName"
  is_admin   = true
  certificate_issuer_thumbprint = "3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE"
}
```

Change also required updating unit tests for Cluster Code Version (previous was no longer supported) as well as updating thumbprints from `"33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE"`
 to 
`"3341DB6CF2AF72C611DF3BE3721A653AF1D43ECD50F584F828793DBE9103C3EE" `
to fix error of

`Error: Error creating Service Fabric Cluster "acctest-200312100109887030" (Resource Group "acctestRG-200312100109887030"): servicefabric.ClustersClient#Create: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidCertificateThumbprint" Message="Certificate thumbprint '33:41:DB:6C:F2:AF:72:C6:11:DF:3B:E3:72:1A:65:3A:F1:D4:3E:CD:50:F5:84:F8:28:79:3D:BE:91:03:C3:EE' is invalid." Details=[]
`