### PR TITLE
Changes `database` to `container` for `azurerm_cosmosdb_sql_container`

### DIFF
--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `unique_key` - (Optional) One or more `unique_key` blocks as defined below. Changing this forces a new resource to be created.
 
-* `throughput` - (Optional) The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+* `throughput` - (Optional) The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon container creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 


### PR DESCRIPTION
I'm pretty sure this should state container and not database.