### PR TITLE
Fixing destroy when role scope is a Management Group

### DIFF
--- a/azurerm/internal/services/authorization/parse/role_definition.go
+++ b/azurerm/internal/services/authorization/parse/role_definition.go
@@ -1,0 +1,40 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RoleDefinitionID struct {
+	ResourceID string
+	Scope      string
+	RoleID     string
+}
+
+// RoleDefinitionId is a pseudo ID for storing Scope parameter as this it not retrievable from API
+// It is formed of the Azure Resource ID for the Role and the Scope it is created against
+func RoleDefinitionId(input string) (*RoleDefinitionID, error) {
+	parts := strings.Split(input, "|")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("could not parse Role Definition ID, invalid format %q", input)
+	}
+
+	idParts := strings.Split(parts[0], "roleDefinitions/")
+
+	if !strings.HasPrefix(parts[1], "/subscriptions/") && !strings.HasPrefix(parts[1], "/providers/Microsoft.Management/managementGroups/") {
+		return nil, fmt.Errorf("failed to parse scope from Role Definition ID %q", input)
+	}
+
+	roleDefinitionID := RoleDefinitionID{
+		ResourceID: parts[0],
+		Scope:      parts[1],
+	}
+
+	if len(idParts) < 1 {
+		return nil, fmt.Errorf("failed to parse Role Definition ID from resource ID %q", input)
+	} else {
+		roleDefinitionID.RoleID = idParts[1]
+	}
+
+	return &roleDefinitionID, nil
+}

--- a/azurerm/internal/services/authorization/role_definition_migration.go
+++ b/azurerm/internal/services/authorization/role_definition_migration.go
@@ -1,0 +1,104 @@
+package authorization
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceArmRoleDefinitionV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"role_definition_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"permissions": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"actions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"not_actions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"data_actions": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Set: schema.HashString,
+						},
+						"not_data_actions": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Set: schema.HashString,
+						},
+					},
+				},
+			},
+
+			"assignable_scopes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceArmRoleDefinitionStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Println("[DEBUG] Migrating ID from v0 to v1 format")
+
+	oldID := rawState["id"].(string)
+	if oldID == "" {
+		return nil, fmt.Errorf("failed to migrate state: old ID empty")
+	}
+	scope := rawState["scope"].(string)
+	if scope == "" {
+		return nil, fmt.Errorf("failed to migrate state: scope missing")
+	}
+
+	newID := fmt.Sprintf("%s|%s", oldID, scope)
+
+	rawState["id"] = newID
+
+	return rawState, nil
+}

--- a/azurerm/internal/services/authorization/role_definition_migration_test.go
+++ b/azurerm/internal/services/authorization/role_definition_migration_test.go
@@ -1,0 +1,42 @@
+package authorization
+
+import (
+	"testing"
+)
+
+func TestAzureRMRoleDefinitionMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion    int
+		InputAttributes map[string]interface{}
+		ExpectedNewID   string
+	}{
+		"subscription_scope": {
+			StateVersion: 0,
+			InputAttributes: map[string]interface{}{
+				"id":                 "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/11111111-1111-1111-1111-111111111111",
+				"name":               "roleName",
+				"role_definition_id": "11111111-1111-1111-1111-111111111111",
+				"scope":              "/subscriptions/00000000-0000-0000-0000-000000000000",
+			},
+			ExpectedNewID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/11111111-1111-1111-1111-111111111111|/subscriptions/00000000-0000-0000-0000-000000000000",
+		},
+		"managementGroup_scope": {
+			StateVersion: 0,
+			InputAttributes: map[string]interface{}{
+				"id":                 "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/11111111-1111-1111-1111-111111111111",
+				"name":               "roleName",
+				"role_definition_id": "11111111-1111-1111-1111-111111111111",
+				"scope":              "/providers/Microsoft.Management/managementGroups/22222222-2222-2222-2222-222222222222",
+			},
+			ExpectedNewID: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleDefinitions/11111111-1111-1111-1111-111111111111|/providers/Microsoft.Management/managementGroups/22222222-2222-2222-2222-222222222222",
+		},
+	}
+
+	for _, tc := range cases {
+		newID, _ := resourceArmRoleDefinitionStateUpgradeV0(tc.InputAttributes, nil)
+
+		if newID["id"].(string) != tc.ExpectedNewID {
+			t.Fatalf("ID migration failed, expected %q, got: %q", tc.ExpectedNewID, newID["id"].(string))
+		}
+	}
+}

--- a/azurerm/internal/services/authorization/tests/role_definition_resource_test.go
+++ b/azurerm/internal/services/authorization/tests/role_definition_resource_test.go
@@ -26,12 +26,7 @@ func TestAccAzureRMRoleDefinition_basic(t *testing.T) {
 					testCheckAzureRMRoleDefinitionExists(data.ResourceName),
 				),
 			},
-			{
-				ResourceName:            data.ResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"role_definition_id", "scope"},
-			},
+			data.ImportStep(),
 		},
 	})
 }
@@ -91,23 +86,16 @@ func TestAccAzureRMRoleDefinition_update(t *testing.T) {
 				Config: testAccAzureRMRoleDefinition_basic(id, data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRoleDefinitionExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.0", "*"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.not_actions.#", "0"),
 				),
 			},
+			data.ImportStep(),
 			{
 				Config: testAccAzureRMRoleDefinition_updated(id, data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRoleDefinitionExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.0", "*"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.not_actions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.not_actions.0", "Microsoft.Authorization/*/read"),
 				),
 			},
+			data.ImportStep(),
 		},
 	})
 }
@@ -124,23 +112,16 @@ func TestAccAzureRMRoleDefinition_updateEmptyId(t *testing.T) {
 				Config: testAccAzureRMRoleDefinition_emptyId(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRoleDefinitionExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.0", "*"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.not_actions.#", "0"),
 				),
 			},
+			data.ImportStep(),
 			{
 				Config: testAccAzureRMRoleDefinition_updateEmptyId(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRoleDefinitionExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.actions.0", "*"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.not_actions.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "permissions.0.not_actions.0", "Microsoft.Authorization/*/read"),
 				),
 			},
+			data.ImportStep(),
 		},
 	})
 }
@@ -157,10 +138,9 @@ func TestAccAzureRMRoleDefinition_emptyName(t *testing.T) {
 				Config: testAccAzureRMRoleDefinition_emptyId(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRoleDefinitionExists(data.ResourceName),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "id"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "name"),
 				),
 			},
+			data.ImportStep(),
 		},
 	})
 }
@@ -177,10 +157,9 @@ func TestAccAzureRMRoleDefinition_managementGroup(t *testing.T) {
 				Config: testAccAzureRMRoleDefinition_managementGroup(uuid.New().String(), data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMRoleDefinitionExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "scope", "/providers/Microsoft.Management/managementGroups/testMG"),
-					resource.TestCheckResourceAttr(data.ResourceName, "assignable_scopes.0", "/providers/Microsoft.Management/managementGroups/testMG"),
 				),
 			},
+			data.ImportStep("scope"),
 		},
 	})
 }
@@ -255,10 +234,6 @@ resource "azurerm_role_definition" "test" {
     actions     = ["*"]
     not_actions = []
   }
-
-  assignable_scopes = [
-    data.azurerm_subscription.primary.id,
-  ]
 }
 `, id, data.RandomInteger)
 }
@@ -396,17 +371,16 @@ provider "azurerm" {
   features {}
 }
 
-resource "azurerm_management_group" "test" {
+data "azurerm_subscription" "primary" {
 }
 
-locals {
-  scope = azurerm_management_group.test.id
+resource "azurerm_management_group" "test" {
 }
 
 resource "azurerm_role_definition" "test" {
   role_definition_id = "%s"
   name               = "acctestrd-%d"
-  scope              = local.scope
+  scope              = azurerm_management_group.test.id
 
   permissions {
     actions     = ["*"]
@@ -414,7 +388,8 @@ resource "azurerm_role_definition" "test" {
   }
 
   assignable_scopes = [
-    local.scope
+    azurerm_management_group.test.id,
+    data.azurerm_subscription.primary.id,
   ]
 }
 `, id, data.RandomInteger)

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -47,7 +47,9 @@ The following arguments are supported:
 
 * `permissions` - (Required) A `permissions` block as defined below.
 
-* `assignable_scopes` - (Required) One or more assignable scopes for this Role Definition, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`.
+* `assignable_scopes` - (Optional) One or more assignable scopes for this Role Definition, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`.
+
+~> **NOTE:** The value for `scope` is automatically included in this list.
 
 A `permissions` block as the following properties:
 


### PR DESCRIPTION
Fixes #5125: When using **azurerm_role_definition** to create a role scoped to a Management  Group instead to a Subscription or Resource Group, `terraform destroy` failed cause the scope sent to the API was empty.

This was caused by the *parseRoleDefinitionId* function which asumes that every roleDefinitionId starts with the scope which is not the case for Roles scoped to a Management Group.