### PR TITLE
Fix `azurerm_iothub_dps_shared_access_policy`: `primary_connection_string` and `secondary_connection_string`

### DIFF
--- a/azurerm/internal/services/iothub/data_source_iothub_dps_shared_access_policy.go
+++ b/azurerm/internal/services/iothub/data_source_iothub_dps_shared_access_policy.go
@@ -103,8 +103,8 @@ func dataSourceIotHubDPSSharedAccessPolicyRead(d *schema.ResourceData, meta inte
 
 	primaryConnectionString := ""
 	secondaryConnectionString := ""
-	if iothubDps.Properties != nil && iothubDps.Properties.DeviceProvisioningHostName != nil {
-		hostname := iothubDps.Properties.DeviceProvisioningHostName
+	if iothubDps.Properties != nil && iothubDps.Properties.ServiceOperationsHostName != nil {
+		hostname := iothubDps.Properties.ServiceOperationsHostName
 		if primary := accessPolicy.PrimaryKey; primary != nil {
 			primaryConnectionString = getSAPConnectionString(*hostname, keyName, *primary)
 		}

--- a/azurerm/internal/services/iothub/resource_arm_iothub_dps_shared_access_policy.go
+++ b/azurerm/internal/services/iothub/resource_arm_iothub_dps_shared_access_policy.go
@@ -236,8 +236,8 @@ func resourceArmIotHubDPSSharedAccessPolicyRead(d *schema.ResourceData, meta int
 
 	primaryConnectionString := ""
 	secondaryConnectionString := ""
-	if iothubDps.Properties != nil && iothubDps.Properties.DeviceProvisioningHostName != nil {
-		hostname := iothubDps.Properties.DeviceProvisioningHostName
+	if iothubDps.Properties != nil && iothubDps.Properties.ServiceOperationsHostName != nil {
+		hostname := iothubDps.Properties.ServiceOperationsHostName
 		if primary := accessPolicy.PrimaryKey; primary != nil {
 			primaryConnectionString = getSAPConnectionString(*hostname, keyName, *primary)
 		}


### PR DESCRIPTION
Fix **azurerm_iothub_dps_shared_access_policy**'s **primary_connection_string** and **secondary_connection_string**

Current logic in getSAPConnectionString produces an invalid connection string.

_Current:_ HostName=global.azure-devices-provisioning.net;SharedAccessKeyName=defaultName;SharedAccessKey=SECRET VALUE
_Azure Portal:_ HostName=fake-dps.azure-devices-provisioning.net;SharedAccessKeyName=defaultName;SharedAccessKey=SECRET VALUE

We need to use the _ServiceOperationsHostName_ instead of the _DeviceProvisioningHostName_

Result from GET IotHub DPS,
{
...
...
    "serviceOperationsHostName": "fake-dps.azure-devices-provisioning.net",
    "deviceProvisioningHostName": "global.azure-devices-provisioning.net",
...
}

=== RUN   TestAccAzureRMIotHubDpsSharedAccessPolicy_basic
=== PAUSE TestAccAzureRMIotHubDpsSharedAccessPolicy_basic
=== CONT  TestAccAzureRMIotHubDpsSharedAccessPolicy_basic
--- PASS: TestAccAzureRMIotHubDpsSharedAccessPolicy_basic (265.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/iothub/tests        265.913s