### PR TITLE
azurerm_servicebus_subscription : Fixed default_message_ttl format in docs

### DIFF
--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
     [TimeSpan](#timespan-format) format.
 
 * `default_message_ttl` - (Optional) The TTL of messages sent to this Subscription
-    if no TTL value is set on the message itself. Provided in the [TimeSpan](#timespan-format)
+    if no TTL value is set on the message itself. Provided in the ISO8601 [TimeSpan](#timespan-format)
     format.
 
 * `lock_duration` - (Optional) The lock duration for the subscription, maximum
@@ -92,7 +92,7 @@ The following arguments are supported:
 
 ### TimeSpan Format
 
-Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. The supported format is documented [here](https://msdn.microsoft.com/en-us/library/se73z7b9(v=vs.110).aspx#Anchor_2)
+Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. The supported format is documented [here](https://docs.microsoft.com/en-us/cli/azure/servicebus/topic/subscription?view=azure-cli-latest#az-servicebus-topic-subscription-update). Example value: "P3DT0H0M0.0S" (for 3days)
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -65,15 +65,13 @@ The following arguments are supported:
 * `max_delivery_count` - (Required) The maximum number of deliveries.
 
 * `auto_delete_on_idle` - (Optional) The idle interval after which the
-    Subscription is automatically deleted, minimum of 5 minutes. Provided in the
-    [TimeSpan](#timespan-format) format.
+    Subscription is automatically deleted, minimum of 5 minutes. Provided in the [ISO8601](#ISO8601-format) format.
 
-* `default_message_ttl` - (Optional) The TTL of messages sent to this Subscription
-    in ISO8601 format, if no TTL value is set on the message itself.
-    format.
+* `default_message_ttl` - (Optional) The TTL of messages sent to this Subscription,
+    if no TTL value is set on the message itself. Provided in the [ISO8601](#ISO8601-format) format.
 
 * `lock_duration` - (Optional) The lock duration for the subscription, maximum
-    supported value is 5 minutes. Defaults to 1 minute.
+    supported value is 5 minutes. Defaults to 1 minute. Provided in the [ISO8601](#ISO8601-format) format.
 
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls
     whether the Subscription has dead letter support when a message expires. Defaults
@@ -90,9 +88,9 @@ The following arguments are supported:
 
 * `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward Dead Letter messages to.
 
-### TimeSpan Format
+### ISO8601 Format
 
-Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. The supported format is documented [here](https://docs.microsoft.com/cli/azure/servicebus/topic/subscription?view=azure-cli-latest#az-servicebus-topic-subscription-update). Example value: "P3DT0H0M0.0S" (for 3days)
+Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. Azure uses ISO 8601 as the supported format and it is documented here: [Azure REST - Subscriptions - Create Or Update](https://docs.microsoft.com/en-us/rest/api/servicebus/subscriptions/createorupdate#request-body). Example value: "P3DT0H0M0.0S" (for 3days)
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
     [TimeSpan](#timespan-format) format.
 
 * `default_message_ttl` - (Optional) The TTL of messages sent to this Subscription
-    if no TTL value is set on the message itself. Provided in the ISO8601 [TimeSpan](#timespan-format)
+    in ISO8601 format, if no TTL value is set on the message itself.
     format.
 
 * `lock_duration` - (Optional) The lock duration for the subscription, maximum

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -65,13 +65,13 @@ The following arguments are supported:
 * `max_delivery_count` - (Required) The maximum number of deliveries.
 
 * `auto_delete_on_idle` - (Optional) The idle interval after which the
-    Subscription is automatically deleted, minimum of 5 minutes. Provided in the [ISO8601](#ISO8601-format) format.
+    Subscription is automatically deleted, minimum of 5 minutes. Provided in the ISO8601 format.
 
 * `default_message_ttl` - (Optional) The TTL of messages sent to this Subscription,
-    if no TTL value is set on the message itself. Provided in the [ISO8601](#ISO8601-format) format.
+    if no TTL value is set on the message itself. Provided in the ISO8601 format.
 
 * `lock_duration` - (Optional) The lock duration for the subscription, maximum
-    supported value is 5 minutes. Defaults to 1 minute. Provided in the [ISO8601](#ISO8601-format) format.
+    supported value is 5 minutes. Defaults to 1 minute. Provided in the ISO8601 format.
 
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls
     whether the Subscription has dead letter support when a message expires. Defaults
@@ -87,30 +87,6 @@ The following arguments are supported:
 * `forward_to` - (Optional) The name of a Queue or Topic to automatically forward messages to.
 
 * `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward Dead Letter messages to.
-
-### ISO8601 Format
-
-Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. Azure uses ISO 8601 as the supported format and it is documented here: [Azure REST - Subscriptions - Create Or Update](https://docs.microsoft.com/en-us/rest/api/servicebus/subscriptions/createorupdate#request-body).
-
-#### Examples:
-
-1. 3 Days
-    
-    "P3D" or
-    "P3DT0H0M0.0S"
-    
-1. 7 Days 6 Hours
-    
-    "P7DT6H"
-
-1. 9 Days 12 hours 30 minutes 10 seconds
-
-    "P9DT12H30M10S"
-
-1. 5 minutes
-
-    "PT5M"
-
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -64,14 +64,11 @@ The following arguments are supported:
 
 * `max_delivery_count` - (Required) The maximum number of deliveries.
 
-* `auto_delete_on_idle` - (Optional) The idle interval after which the
-    Subscription is automatically deleted, minimum of 5 minutes. Provided in the ISO8601 format.
+* `auto_delete_on_idle` - (Optional) ISO 8061 timeSpan idle interval after which the topic is automatically deleted. The minimum duration is 5 minutes.
 
-* `default_message_ttl` - (Optional) The TTL of messages sent to this Subscription,
-    if no TTL value is set on the message itself. Provided in the ISO8601 format.
+* `default_message_ttl` - (Optional) ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 
-* `lock_duration` - (Optional) The lock duration for the subscription, maximum
-    supported value is 5 minutes. Defaults to 1 minute. Provided in the ISO8601 format.
+* `lock_duration` - (Optional) ISO 8061 lock duration timespan for the subscription. The default value is 1 minute.
 
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls
     whether the Subscription has dead letter support when a message expires. Defaults

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 
 ### TimeSpan Format
 
-Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. The supported format is documented [here](https://docs.microsoft.com/en-us/cli/azure/servicebus/topic/subscription?view=azure-cli-latest#az-servicebus-topic-subscription-update). Example value: "P3DT0H0M0.0S" (for 3days)
+Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. The supported format is documented [here](https://docs.microsoft.com/cli/azure/servicebus/topic/subscription?view=azure-cli-latest#az-servicebus-topic-subscription-update). Example value: "P3DT0H0M0.0S" (for 3days)
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -50,36 +50,27 @@ resource "azurerm_servicebus_subscription" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the ServiceBus Subscription resource.
-    Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the ServiceBus Subscription resource. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) The name of the ServiceBus Namespace to create
-    this Subscription in. Changing this forces a new resource to be created.
+* `namespace_name` - (Required) The name of the ServiceBus Namespace to create this Subscription in. Changing this forces a new resource to be created.
 
-* `topic_name` - (Required) The name of the ServiceBus Topic to create
-    this Subscription in. Changing this forces a new resource to be created.
+* `topic_name` - (Required) The name of the ServiceBus Topic to create this Subscription in. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the namespace. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the namespace. Changing this forces a new resource to be created.
 
 * `max_delivery_count` - (Required) The maximum number of deliveries.
 
-* `auto_delete_on_idle` - (Optional) ISO 8061 timeSpan idle interval after which the topic is automatically deleted. The minimum duration is 5 minutes.
+* `auto_delete_on_idle` - (Optional) The idle interval after which the topic is automatically deleted as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The minimum duration is `5` minutes or `P5M`.
 
-* `default_message_ttl` - (Optional) ISO 8061 Default message timespan to live value. This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
+* `default_message_ttl` - (Optional) The Default message timespan to live as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). This is the duration after which the message expires, starting from when the message is sent to Service Bus. This is the default value used when TimeToLive is not set on a message itself.
 
-* `lock_duration` - (Optional) ISO 8061 lock duration timespan for the subscription. The default value is 1 minute.
+* `lock_duration` - (Optional) The lock duration for the subscription as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). The default value is `1` minute or `P1M`.
 
-* `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls
-    whether the Subscription has dead letter support when a message expires. Defaults
-    to false.
+* `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls whether the Subscription has dead letter support when a message expires. Defaults to `false`.
 
-* `enable_batched_operations` - (Optional) Boolean flag which controls whether the
-    Subscription supports batched operations. Defaults to false.
+* `enable_batched_operations` - (Optional) Boolean flag which controls whether the Subscription supports batched operations. Defaults to `false`.
 
-* `requires_session` - (Optional) Boolean flag which controls whether this Subscription
-    supports the concept of a session. Defaults to false. Changing this forces a
-    new resource to be created.
+* `requires_session` - (Optional) Boolean flag which controls whether this Subscription supports the concept of a session. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `forward_to` - (Optional) The name of a Queue or Topic to automatically forward messages to.
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -90,7 +90,27 @@ The following arguments are supported:
 
 ### ISO8601 Format
 
-Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. Azure uses ISO 8601 as the supported format and it is documented here: [Azure REST - Subscriptions - Create Or Update](https://docs.microsoft.com/en-us/rest/api/servicebus/subscriptions/createorupdate#request-body). Example value: "P3DT0H0M0.0S" (for 3days)
+Some arguments for this resource are required in the TimeSpan format which is used to represent a length of time. Azure uses ISO 8601 as the supported format and it is documented here: [Azure REST - Subscriptions - Create Or Update](https://docs.microsoft.com/en-us/rest/api/servicebus/subscriptions/createorupdate#request-body).
+
+#### Examples:
+
+1. 3 Days
+    
+    "P3D" or
+    "P3DT0H0M0.0S"
+    
+1. 7 Days 6 Hours
+    
+    "P7DT6H"
+
+1. 9 Days 12 hours 30 minutes 10 seconds
+
+    "P9DT12H30M10S"
+
+1. 5 minutes
+
+    "PT5M"
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Its no longer based on Timespan, but needs to be ISO8601 format.