### PR TITLE
Remove resource_group_name from azurerm_storage_container

### DIFF
--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -28,7 +28,6 @@ resource "azurerm_storage_account" "example" {
 
 resource "azurerm_storage_container" "example" {
   name                  = "content"
-  resource_group_name   = azurerm_resource_group.example.name
   storage_account_name  = azurerm_storage_account.example.name
   container_access_type = "private"
 }


### PR DESCRIPTION
The storage container doesn't have that field:
    An argument named "resource_group_name" is not expected here.