### PR TITLE
Fix provider "kubernetes" link documentation for azurerm_kubernetes_cluster resources

### DIFF
--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -165,6 +165,7 @@ The `kube_admin_config` and `kube_config` blocks exports the following:
 
 ```
 provider "kubernetes" {
+  load_config_file       = "false"
   host                   = "${data.azurerm_kubernetes_cluster.main.kube_config.0.host}"
   username               = "${data.azurerm_kubernetes_cluster.main.kube_config.0.username}"
   password               = "${data.azurerm_kubernetes_cluster.main.kube_config.0.password}"

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -390,6 +390,7 @@ The `kube_admin_config` and `kube_config` blocks export the following:
 
 ```
 provider "kubernetes" {
+  load_config_file       = "false"
   host                   = "${azurerm_kubernetes_cluster.main.kube_config.0.host}"
   username               = "${azurerm_kubernetes_cluster.main.kube_config.0.username}"
   password               = "${azurerm_kubernetes_cluster.main.kube_config.0.password}"


### PR DESCRIPTION
Otherwise it tries to load the default `kubeconfig` file, not the parameters provided.