### PR TITLE
Fix typo in the version of the Azure Provider

### DIFF
--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -99,7 +99,7 @@ $ export ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000"
 $ export ARM_TENANT_ID="00000000-0000-0000-0000-000000000000"
 ```
 
-The following Provider block can be specified - where `1.21.0` is the version of the Azure Provider that you'd like to use:
+The following Provider block can be specified - where `1.44.0` is the version of the Azure Provider that you'd like to use:
 
 ```hcl
 provider "azurerm" {


### PR DESCRIPTION
In the configuration example below version 1.44.0 is used and not 1.21.0.