### PR TITLE
arm_public_ip: public_ips can be dynamic for ipv6 addresses

### DIFF
--- a/azurerm/internal/services/network/resource_arm_public_ip.go
+++ b/azurerm/internal/services/network/resource_arm_public_ip.go
@@ -152,12 +152,6 @@ func resourceArmPublicIpCreateUpdate(d *schema.ResourceData, meta interface{}) e
 	ipVersion := network.IPVersion(d.Get("ip_version").(string))
 	ipAllocationMethod := d.Get("allocation_method").(string)
 
-	if strings.EqualFold(string(ipVersion), string(network.IPv6)) {
-		if strings.EqualFold(ipAllocationMethod, "static") {
-			return fmt.Errorf("Cannot specify publicIpAllocationMethod as Static for IPv6 PublicIp")
-		}
-	}
-
 	if strings.EqualFold(sku, "standard") {
 		if !strings.EqualFold(ipAllocationMethod, "static") {
 			return fmt.Errorf("Static IP allocation must be used when creating Standard SKU public IP addresses.")

--- a/azurerm/internal/services/network/tests/resource_arm_public_ip_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_public_ip_test.go
@@ -112,7 +112,7 @@ func TestAccAzureRMPublicIpStatic_basic_withDNSLabel(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMPublicIpStatic_standard_withIPv6_fails(t *testing.T) {
+func TestAccAzureRMPublicIpStatic_standard_withIPv6(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -121,9 +121,13 @@ func TestAccAzureRMPublicIpStatic_standard_withIPv6_fails(t *testing.T) {
 		CheckDestroy: testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAzureRMPublicIPStatic_standard_withIPVersion(data, "IPv6"),
-				ExpectError: regexp.MustCompile("Cannot specify publicIpAllocationMethod as Static for IPv6 PublicIp"),
+				Config: testAccAzureRMPublicIPStatic_standard_withIPVersion(data, "IPv6"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIpExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "ip_version", "IPv6"),
+				),
 			},
+			data.ImportStep(),
 		},
 	})
 }
@@ -168,6 +172,7 @@ func TestAccAzureRMPublicIpStatic_basic_defaultsToIPv4(t *testing.T) {
 		},
 	})
 }
+
 func TestAccAzureRMPublicIpStatic_basic_withIPv4(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip", "test")
 	ipVersion := "IPv4"


### PR DESCRIPTION
This limitation has been relaxed for standard load balancers.

Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/6090.