### PR TITLE
Use BlobContainersClient for blob container operations

### DIFF
--- a/azurerm/internal/services/storage/client/client.go
+++ b/azurerm/internal/services/storage/client/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	CachesClient             *storagecache.CachesClient
 	StorageTargetsClient     *storagecache.StorageTargetsClient
 	SubscriptionId           string
+	StorageUseAzureAD        bool
 
 	environment   az.Environment
 	storageAdAuth *autorest.Authorizer
@@ -72,6 +73,7 @@ func NewClient(options *common.ClientOptions) *Client {
 
 	if options.StorageUseAzureAD {
 		client.storageAdAuth = &options.StorageAuthorizer
+		client.StorageUseAzureAD = true
 	}
 
 	return &client

--- a/azurerm/internal/services/storage/client/client.go
+++ b/azurerm/internal/services/storage/client/client.go
@@ -25,6 +25,7 @@ type Client struct {
 	FileSystemsClient        *filesystems.Client
 	ManagementPoliciesClient storage.ManagementPoliciesClient
 	BlobServicesClient       storage.BlobServicesClient
+	BlobContainersClient     storage.BlobContainersClient
 	CachesClient             *storagecache.CachesClient
 	StorageTargetsClient     *storagecache.StorageTargetsClient
 	SubscriptionId           string
@@ -46,6 +47,9 @@ func NewClient(options *common.ClientOptions) *Client {
 	blobServicesClient := storage.NewBlobServicesClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
 	options.ConfigureClient(&blobServicesClient.Client, options.ResourceManagerAuthorizer)
 
+	blobContainersClient := storage.NewBlobContainersClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
+	options.ConfigureClient(&blobContainersClient.Client, options.ResourceManagerAuthorizer)
+
 	cachesClient := storagecache.NewCachesClientWithBaseURI(options.ResourceManagerEndpoint, options.SubscriptionId)
 	options.ConfigureClient(&cachesClient.Client, options.ResourceManagerAuthorizer)
 
@@ -59,6 +63,7 @@ func NewClient(options *common.ClientOptions) *Client {
 		FileSystemsClient:        &fileSystemsClient,
 		ManagementPoliciesClient: managementPoliciesClient,
 		BlobServicesClient:       blobServicesClient,
+		BlobContainersClient:     blobContainersClient,
 		CachesClient:             &cachesClient,
 		SubscriptionId:           options.SubscriptionId,
 		StorageTargetsClient:     &storageTargetsClient,

--- a/azurerm/internal/services/storage/data_source_storage_container.go
+++ b/azurerm/internal/services/storage/data_source_storage_container.go
@@ -71,11 +71,11 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Unable to locate Account %q for Storage Container %q", accountName, containerName)
 	}
 
-	client := storageClient.BlobContainersClient
+	azureClient := storageClient.BlobContainersClient
 
 	d.SetId(getAzureResourceID(meta.(*clients.Client).Account.Environment.StorageEndpointSuffix, accountName, containerName))
 
-	props, err := client.Get(ctx, account.ResourceGroup, accountName, containerName)
+	props, err := azureClient.Get(ctx, account.ResourceGroup, accountName, containerName)
 	if err != nil {
 		if utils.ResponseWasNotFound(props.Response) {
 			return fmt.Errorf("Container %q was not found in Account %q / Resource Group %q", containerName, accountName, account.ResourceGroup)

--- a/azurerm/internal/services/storage/data_source_storage_container.go
+++ b/azurerm/internal/services/storage/data_source_storage_container.go
@@ -98,7 +98,6 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 
 		resourceManagerId := giovanniClient.GetResourceManagerResourceID(storageClient.SubscriptionId, account.ResourceGroup, accountName, containerName)
 		d.Set("resource_manager_id", resourceManagerId)
-
 	} else {
 		gvnProps, err := giovanniClient.GetProperties(ctx, accountName, containerName)
 		if err != nil {
@@ -118,7 +117,6 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 
 			resourceManagerId := giovanniClient.GetResourceManagerResourceID(storageClient.SubscriptionId, account.ResourceGroup, accountName, containerName)
 			d.Set("resource_manager_id", resourceManagerId)
-
 		} else {
 			gvnPropsErr := setContainerPropertiesByGiovanni(gvnProps, d)
 			if gvnPropsErr != nil {

--- a/azurerm/internal/services/storage/data_source_storage_container.go
+++ b/azurerm/internal/services/storage/data_source_storage_container.go
@@ -73,7 +73,7 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 
 	client := storageClient.BlobContainersClient
 
-	d.SetId(getResourceID(meta.(*clients.Client).Account.Environment.StorageEndpointSuffix, accountName, containerName))
+	d.SetId(getAzureResourceID(meta.(*clients.Client).Account.Environment.StorageEndpointSuffix, accountName, containerName))
 
 	props, err := client.Get(ctx, account.ResourceGroup, accountName, containerName)
 	if err != nil {
@@ -88,13 +88,13 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("storage_account_name", accountName)
 
-	accessLevel, err := flattenStorageContainerAccessLevel(props.PublicAccess)
+	accessLevel, err := flattenAzureStorageContainerAccessLevel(props.PublicAccess)
 	if err != nil {
 		return fmt.Errorf("Error setting access level: %+v", err)
 	}
 	d.Set("container_access_type", accessLevel)
 
-	if err := d.Set("metadata", flattenMetaData(props.Metadata)); err != nil {
+	if err := d.Set("metadata", flattenAzureMetaData(props.Metadata)); err != nil {
 		return fmt.Errorf("Error setting `metadata`: %+v", err)
 	}
 

--- a/azurerm/internal/services/storage/data_source_storage_container.go
+++ b/azurerm/internal/services/storage/data_source_storage_container.go
@@ -92,10 +92,7 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("storage_account_name", accountName)
 
-	accessLevel, err := flattenAzureStorageContainerAccessLevel(props.PublicAccess)
-	if err != nil {
-		return fmt.Errorf("Error setting access level: %+v", err)
-	}
+	accessLevel := flattenAzureStorageContainerAccessLevel(props.PublicAccess)
 	d.Set("container_access_type", accessLevel)
 
 	if err := d.Set("metadata", flattenAzureMetaData(props.Metadata)); err != nil {

--- a/azurerm/internal/services/storage/data_source_storage_container.go
+++ b/azurerm/internal/services/storage/data_source_storage_container.go
@@ -72,8 +72,12 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 	}
 
 	azureClient := storageClient.BlobContainersClient
+	giovanniClient, err := storageClient.ContainersClient(ctx, *account)
+	if err != nil {
+		return fmt.Errorf("Error building Containers Client: %s", err)
+	}
 
-	d.SetId(getAzureResourceID(meta.(*clients.Client).Account.Environment.StorageEndpointSuffix, accountName, containerName))
+	d.SetId(giovanniClient.GetResourceID(accountName, containerName))
 
 	props, err := azureClient.Get(ctx, account.ResourceGroup, accountName, containerName)
 	if err != nil {

--- a/azurerm/internal/services/storage/parsers/container_id.go
+++ b/azurerm/internal/services/storage/parsers/container_id.go
@@ -1,0 +1,35 @@
+package parsers
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type ContainerID struct {
+	ContainerName string
+	AccountName   string
+}
+
+func ParseContainerID(id string) (*ContainerID, error) {
+	if id == "" {
+		return nil, fmt.Errorf("`id` is empty")
+	}
+
+	uri, err := url.Parse(id)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing ID as a URL: %s", err)
+	}
+
+	accountName, err := getAccountNameFromEndpoint(uri.Host)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing Account Name: %s", err)
+	}
+
+	containerName := strings.TrimPrefix(uri.Path, "/")
+	return &ContainerID{
+		AccountName:   *accountName,
+		ContainerName: containerName,
+	}, nil
+}

--- a/azurerm/internal/services/storage/parsers/container_id_test.go
+++ b/azurerm/internal/services/storage/parsers/container_id_test.go
@@ -1,0 +1,46 @@
+package parsers
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func TestParseResourceID(t *testing.T) {
+	testData := []struct {
+		Environment azure.Environment
+		Input       string
+	}{
+		{
+			Environment: azure.ChinaCloud,
+			Input:       "https://account1.blob.core.chinacloudapi.cn/container1",
+		},
+		{
+			Environment: azure.GermanCloud,
+			Input:       "https://account1.blob.core.cloudapi.de/container1",
+		},
+		{
+			Environment: azure.PublicCloud,
+			Input:       "https://account1.blob.core.windows.net/container1",
+		},
+		{
+			Environment: azure.USGovernmentCloud,
+			Input:       "https://account1.blob.core.usgovcloudapi.net/container1",
+		},
+	}
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing Environment %q", v.Environment.Name)
+		actual, err := ParseContainerID(v.Input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if actual.AccountName != "account1" {
+			t.Fatalf("Expected the account name to be `account1` but got %q", actual.AccountName)
+		}
+
+		if actual.ContainerName != "container1" {
+			t.Fatalf("Expected the container name to be `container1` but got %q", actual.ContainerName)
+		}
+	}
+}

--- a/azurerm/internal/services/storage/parsers/helpers.go
+++ b/azurerm/internal/services/storage/parsers/helpers.go
@@ -13,27 +13,27 @@ func getAccountNameFromEndpoint(endpoint string) (*string, error) {
 	return &segments[0], nil
 }
 
-// getBlobEndpoint returns the endpoint for Blob API Operations on this storage account
-func getBlobEndpoint(baseUri string, accountName string) string {
+// GetBlobEndpoint returns the endpoint for Blob API Operations on this storage account
+func GetBlobEndpoint(baseUri string, accountName string) string {
 	return fmt.Sprintf("https://%s.blob.%s", accountName, baseUri)
 }
 
-// getDataLakeStoreEndpoint returns the endpoint for Data Lake Store API Operations on this storage account
-func getDataLakeStoreEndpoint(baseUri string, accountName string) string {
+// GetDataLakeStoreEndpoint returns the endpoint for Data Lake Store API Operations on this storage account
+func GetDataLakeStoreEndpoint(baseUri string, accountName string) string {
 	return fmt.Sprintf("https://%s.dfs.%s", accountName, baseUri)
 }
 
-// getFileEndpoint returns the endpoint for File Share API Operations on this storage account
-func getFileEndpoint(baseUri string, accountName string) string {
+// GetFileEndpoint returns the endpoint for File Share API Operations on this storage account
+func GetFileEndpoint(baseUri string, accountName string) string {
 	return fmt.Sprintf("https://%s.file.%s", accountName, baseUri)
 }
 
-// getQueueEndpoint returns the endpoint for Queue API Operations on this storage account
-func getQueueEndpoint(baseUri string, accountName string) string {
+// GetQueueEndpoint returns the endpoint for Queue API Operations on this storage account
+func GetQueueEndpoint(baseUri string, accountName string) string {
 	return fmt.Sprintf("https://%s.queue.%s", accountName, baseUri)
 }
 
-// getTableEndpoint returns the endpoint for Table API Operations on this storage account
-func getTableEndpoint(baseUri string, accountName string) string {
+// GetTableEndpoint returns the endpoint for Table API Operations on this storage account
+func GetTableEndpoint(baseUri string, accountName string) string {
 	return fmt.Sprintf("https://%s.table.%s", accountName, baseUri)
 }

--- a/azurerm/internal/services/storage/parsers/helpers.go
+++ b/azurerm/internal/services/storage/parsers/helpers.go
@@ -1,0 +1,39 @@
+package parsers
+
+import (
+	"fmt"
+	"strings"
+)
+
+func getAccountNameFromEndpoint(endpoint string) (*string, error) {
+	segments := strings.Split(endpoint, ".")
+	if len(segments) == 0 {
+		return nil, fmt.Errorf("The Endpoint contained no segments")
+	}
+	return &segments[0], nil
+}
+
+// getBlobEndpoint returns the endpoint for Blob API Operations on this storage account
+func getBlobEndpoint(baseUri string, accountName string) string {
+	return fmt.Sprintf("https://%s.blob.%s", accountName, baseUri)
+}
+
+// getDataLakeStoreEndpoint returns the endpoint for Data Lake Store API Operations on this storage account
+func getDataLakeStoreEndpoint(baseUri string, accountName string) string {
+	return fmt.Sprintf("https://%s.dfs.%s", accountName, baseUri)
+}
+
+// getFileEndpoint returns the endpoint for File Share API Operations on this storage account
+func getFileEndpoint(baseUri string, accountName string) string {
+	return fmt.Sprintf("https://%s.file.%s", accountName, baseUri)
+}
+
+// getQueueEndpoint returns the endpoint for Queue API Operations on this storage account
+func getQueueEndpoint(baseUri string, accountName string) string {
+	return fmt.Sprintf("https://%s.queue.%s", accountName, baseUri)
+}
+
+// getTableEndpoint returns the endpoint for Table API Operations on this storage account
+func getTableEndpoint(baseUri string, accountName string) string {
+	return fmt.Sprintf("https://%s.table.%s", accountName, baseUri)
+}

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -224,7 +224,7 @@ func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 
 	accessLevel, err := flattenStorageContainerAccessLevel(props.PublicAccess)
 	if err != nil {
-		fmt.Errorf("Error retrieving public access Container %q (Account %q / Resource Group %q): %s", id.ContainerName, id.AccountName, account.ResourceGroup, err)
+		return fmt.Errorf("Error retrieving public access Container %q (Account %q / Resource Group %q): %s", id.ContainerName, id.AccountName, account.ResourceGroup, err)
 	}
 
 	d.Set("container_access_type", accessLevel)

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -192,7 +192,7 @@ func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := containers.ParseResourceID(d.Id())
+	id, err := parsers.ParseContainerID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -15,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers"
 )
 
 func resourceArmStorageContainer() *schema.Resource {
@@ -248,7 +247,7 @@ func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := containers.ParseResourceID(d.Id())
+	id, err := parsers.ParseContainerID(d.Id())
 	if err != nil {
 		return err
 	}
@@ -261,12 +260,9 @@ func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	client, err := storageClient.ContainersClient(ctx, *account)
-	if err != nil {
-		return fmt.Errorf("Error building Containers Client for Storage Account %q (Resource Group %q): %s", id.AccountName, account.ResourceGroup, err)
-	}
+	client := storageClient.BlobContainersClient
 
-	if _, err := client.Delete(ctx, id.AccountName, id.ContainerName); err != nil {
+	if _, err := client.Delete(ctx, account.ResourceGroup, id.AccountName, id.ContainerName); err != nil {
 		return fmt.Errorf("Error deleting Container %q (Storage Account %q / Resource Group %q): %s", id.ContainerName, id.AccountName, account.ResourceGroup, err)
 	}
 

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -287,6 +287,17 @@ func getAzureBlobContainerProperties(accessLevelRaw string, metaDataRaw map[stri
 	}, nil
 }
 
+func getGiovanniBlobContainerProperties(accessLevelRaw string, metaDataRaw map[string]interface{}) containers.CreateInput {
+	accessLevel := expandGiovanniStorageContainerAccessLevel(accessLevelRaw)
+
+	metaData := ExpandMetaData(metaDataRaw)
+
+	return containers.CreateInput{
+		AccessLevel: accessLevel,
+		MetaData:    metaData,
+	}
+}
+
 func expandAzureStorageContainerAccessLevel(input string) storage.PublicAccess {
 	switch input {
 	case "private":
@@ -338,4 +349,24 @@ func flattenAzureMetaData(input map[string]*string) map[string]interface{} {
 	}
 
 	return output
+}
+
+func expandGiovanniStorageContainerAccessLevel(input string) containers.AccessLevel {
+	// for historical reasons, "private" above is an empty string in the API
+	// so the enum doesn't 1:1 match. You could argue the SDK should handle this
+	// but this is suitable for now
+	if input == "private" {
+		return containers.Private
+	}
+
+	return containers.AccessLevel(input)
+}
+
+func flattenGiovanniStorageContainerAccessLevel(input containers.AccessLevel) string {
+	// for historical reasons, "private" above is an empty string in the API
+	if input == containers.Private {
+		return "private"
+	}
+
+	return string(input)
 }

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -315,7 +315,7 @@ func flattenMetaData(input map[string]*string) map[string]interface{} {
 	output := make(map[string]interface{})
 
 	for k, v := range input {
-		output[k] = &v
+		output[k] = v
 	}
 
 	return output

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -300,7 +300,7 @@ func getBlobContainerPropertiesByAzure(accessLevelRaw string, metaDataRaw map[st
 	// It does not seem to be a good way, but it is the cost to use switch.
 	accessLevel := expandStorageContainerAccessLevelByAzure(accessLevelRaw)
 	if string(accessLevel) == "" {
-		return nil, fmt.Errorf("Error parse %q to a Azure blob container access level")
+		return nil, fmt.Errorf("Error parse %q to a Azure blob container access level", accessLevelRaw)
 	}
 
 	metaData := expandMetaDataByAzure(metaDataRaw)

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -110,7 +110,7 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error building Containers Client: %s", err)
 	}
 
-	id := client.GetResourceID(accountName, containerName)
+	id := getResourceID(meta.(*clients.Client).Account.Environment.StorageEndpointSuffix, accountName, containerName)
 	if features.ShouldResourcesBeImported() {
 		existing, err := client.GetProperties(ctx, accountName, containerName)
 		if err != nil {

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -57,8 +57,8 @@ func resourceArmStorageContainer() *schema.Resource {
 				Optional: true,
 				Default:  "private",
 				ValidateFunc: validation.StringInSlice([]string{
-					string(containers.Blob),
-					string(containers.Container),
+					"blob",
+					"container",
 					"private",
 				}, false),
 			},

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -95,11 +95,11 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 	accountName := d.Get("storage_account_name").(string)
 
 	accessLevelRaw := d.Get("container_access_type").(string)
-	azureAccessLevel := expandAzureStorageContainerAccessLevel(accessLevelRaw)
-	giovanniAccessLevel := expandGiovanniStorageContainerAccessLevel(accessLevelRaw)
+	azureAccessLevel := expandStorageContainerAccessLevelByAzure(accessLevelRaw)
+	giovanniAccessLevel := expandStorageContainerAccessLevelByGiovanni(accessLevelRaw)
 
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
-	azureMetaData := expandAzureMetaData(metaDataRaw)
+	azureMetaData := expandMetaDataByAzure(metaDataRaw)
 	giovanniMetaData := ExpandMetaData(metaDataRaw)
 
 	account, err := storageClient.FindAccount(ctx, accountName)
@@ -193,11 +193,11 @@ func resourceArmStorageContainerUpdate(d *schema.ResourceData, meta interface{})
 
 	log.Printf("[DEBUG] Computing the Access Control for Container %q (Storage Account %q / Resource Group %q)..", id.ContainerName, id.AccountName, account.ResourceGroup)
 	accessLevelRaw := d.Get("container_access_type").(string)
-	accessLevel := expandAzureStorageContainerAccessLevel(accessLevelRaw)
+	accessLevel := expandStorageContainerAccessLevelByAzure(accessLevelRaw)
 
 	log.Printf("[DEBUG] Computing the MetaData for Container %q (Storage Account %q / Resource Group %q)..", id.ContainerName, id.AccountName, account.ResourceGroup)
 	metaDataRaw := d.Get("metadata").(map[string]interface{})
-	metaData := expandAzureMetaData(metaDataRaw)
+	metaData := expandMetaDataByAzure(metaDataRaw)
 
 	if d.HasChange("container_access_type") || d.HasChange("metadata") {
 		input := storage.BlobContainer{
@@ -292,18 +292,18 @@ func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func getAzureBlobContainerProperties(accessLevelRaw string, metaDataRaw map[string]interface{}) (*storage.BlobContainer, error) {
+func getBlobContainerPropertiesByAzure(accessLevelRaw string, metaDataRaw map[string]interface{}) (*storage.BlobContainer, error) {
 	// For backward compatibility, raw access value has to be converted.
 	// expandAzureStorageContainerAccessLevel will an empty string if it cannot find a value
 	// that maps to a storage.PublicAccess value.
 	// Therefore, if parsed value is an empty string, we are facing an error.
 	// It does not seem to be a good way, but it is the cost to use switch.
-	accessLevel := expandAzureStorageContainerAccessLevel(accessLevelRaw)
+	accessLevel := expandStorageContainerAccessLevelByAzure(accessLevelRaw)
 	if string(accessLevel) == "" {
 		return nil, fmt.Errorf("Error parse %q to a Azure blob container access level")
 	}
 
-	metaData := expandAzureMetaData(metaDataRaw)
+	metaData := expandMetaDataByAzure(metaDataRaw)
 
 	return &storage.BlobContainer{
 		ContainerProperties: &storage.ContainerProperties{
@@ -313,8 +313,8 @@ func getAzureBlobContainerProperties(accessLevelRaw string, metaDataRaw map[stri
 	}, nil
 }
 
-func getGiovanniBlobContainerProperties(accessLevelRaw string, metaDataRaw map[string]interface{}) containers.CreateInput {
-	accessLevel := expandGiovanniStorageContainerAccessLevel(accessLevelRaw)
+func getBlobContainerPropertiesByGiovanni(accessLevelRaw string, metaDataRaw map[string]interface{}) containers.CreateInput {
+	accessLevel := expandStorageContainerAccessLevelByGiovanni(accessLevelRaw)
 
 	metaData := ExpandMetaData(metaDataRaw)
 
@@ -324,7 +324,7 @@ func getGiovanniBlobContainerProperties(accessLevelRaw string, metaDataRaw map[s
 	}
 }
 
-func expandAzureStorageContainerAccessLevel(input string) storage.PublicAccess {
+func expandStorageContainerAccessLevelByAzure(input string) storage.PublicAccess {
 	switch input {
 	case "private":
 		return storage.PublicAccessNone
@@ -337,7 +337,7 @@ func expandAzureStorageContainerAccessLevel(input string) storage.PublicAccess {
 	}
 }
 
-func flattenAzureStorageContainerAccessLevel(input storage.PublicAccess) string {
+func flattenStorageContainerAccessLevelByAzure(input storage.PublicAccess) string {
 	switch input {
 	case storage.PublicAccessNone:
 		return "private"
@@ -350,13 +350,13 @@ func flattenAzureStorageContainerAccessLevel(input storage.PublicAccess) string 
 	}
 }
 
-func getAzureResourceID(baseUri, accountName, containerName string) string {
+func getResourceIdByAzure(baseUri, accountName, containerName string) string {
 	// For backforward compatible, generate resource ID in the same way as giovanni's.
 	domain := parsers.GetBlobEndpoint(baseUri, accountName)
 	return fmt.Sprintf("%s/%s", domain, containerName)
 }
 
-func expandAzureMetaData(input map[string]interface{}) map[string]*string {
+func expandMetaDataByAzure(input map[string]interface{}) map[string]*string {
 	output := make(map[string]*string)
 
 	for k, v := range input {
@@ -367,7 +367,7 @@ func expandAzureMetaData(input map[string]interface{}) map[string]*string {
 	return output
 }
 
-func flattenAzureMetaData(input map[string]*string) map[string]interface{} {
+func flattenMetaDataByAzure(input map[string]*string) map[string]interface{} {
 	output := make(map[string]interface{})
 
 	for k, v := range input {
@@ -377,7 +377,7 @@ func flattenAzureMetaData(input map[string]*string) map[string]interface{} {
 	return output
 }
 
-func expandGiovanniStorageContainerAccessLevel(input string) containers.AccessLevel {
+func expandStorageContainerAccessLevelByGiovanni(input string) containers.AccessLevel {
 	// for historical reasons, "private" above is an empty string in the API
 	// so the enum doesn't 1:1 match. You could argue the SDK should handle this
 	// but this is suitable for now
@@ -388,7 +388,7 @@ func expandGiovanniStorageContainerAccessLevel(input string) containers.AccessLe
 	return containers.AccessLevel(input)
 }
 
-func flattenGiovanniStorageContainerAccessLevel(input containers.AccessLevel) string {
+func flattenStorageContainerAccessLevelByGiovanni(input containers.AccessLevel) string {
 	// for historical reasons, "private" above is an empty string in the API
 	if input == containers.Private {
 		return "private"
@@ -450,9 +450,9 @@ func readBlobContainerByAzure(ctx context.Context, azClient storage.BlobContaine
 		return fmt.Errorf("Error retrieving Container %q (Account %q / Resource Group %q): %s", containerName, accountName, resourceGroup, err)
 	}
 
-	d.Set("container_access_type", flattenAzureStorageContainerAccessLevel(props.PublicAccess))
+	d.Set("container_access_type", flattenStorageContainerAccessLevelByAzure(props.PublicAccess))
 
-	if err := d.Set("metadata", flattenAzureMetaData(props.Metadata)); err != nil {
+	if err := d.Set("metadata", flattenMetaDataByAzure(props.Metadata)); err != nil {
 		return fmt.Errorf("Error setting `metadata`: %+v", err)
 	}
 	d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
@@ -472,7 +472,7 @@ func readBlobContainerByGiovanni(ctx context.Context, gvnClient containers.Clien
 		return fmt.Errorf("Error retrieving Container %q (Account %q / Resource Group %q): %s", containerName, accountName, resourceGroup, err)
 	}
 
-	d.Set("container_access_type", flattenGiovanniStorageContainerAccessLevel(props.AccessLevel))
+	d.Set("container_access_type", flattenStorageContainerAccessLevelByGiovanni(props.AccessLevel))
 
 	if err := d.Set("metadata", FlattenMetaData(props.MetaData)); err != nil {
 		return fmt.Errorf("Error setting `metadata`: %+v", err)

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -109,11 +109,11 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 	}
 
-	client := storageClient.BlobContainersClient
+	azureClient := storageClient.BlobContainersClient
 
 	id := getAzureResourceID(meta.(*clients.Client).Account.Environment.StorageEndpointSuffix, accountName, containerName)
 	if features.ShouldResourcesBeImported() {
-		existing, err := client.Get(ctx, account.ResourceGroup, accountName, containerName)
+		existing, err := azureClient.Get(ctx, account.ResourceGroup, accountName, containerName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
 				return fmt.Errorf("Error checking for existence of existing Container %q (Account %q / Resource Group %q): %+v", containerName, accountName, account.ResourceGroup, err)
@@ -132,7 +132,7 @@ func resourceArmStorageContainerCreate(d *schema.ResourceData, meta interface{})
 			Metadata:     metaData,
 		},
 	}
-	if _, err := client.Create(ctx, account.ResourceGroup, accountName, containerName, input); err != nil {
+	if _, err := azureClient.Create(ctx, account.ResourceGroup, accountName, containerName, input); err != nil {
 		return fmt.Errorf("Error creating Container %q (Account %q / Resource Group %q): %s", containerName, accountName, account.ResourceGroup, err)
 	}
 
@@ -158,7 +158,7 @@ func resourceArmStorageContainerUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	client := storageClient.BlobContainersClient
+	azureClient := storageClient.BlobContainersClient
 
 	log.Printf("[DEBUG] Computing the Access Control for Container %q (Storage Account %q / Resource Group %q)..", id.ContainerName, id.AccountName, account.ResourceGroup)
 	accessLevelRaw := d.Get("container_access_type").(string)
@@ -178,7 +178,7 @@ func resourceArmStorageContainerUpdate(d *schema.ResourceData, meta interface{})
 				Metadata:     metaData,
 			},
 		}
-		if _, err := client.Update(ctx, account.ResourceGroup, id.AccountName, id.ContainerName, input); err != nil {
+		if _, err := azureClient.Update(ctx, account.ResourceGroup, id.AccountName, id.ContainerName, input); err != nil {
 			return fmt.Errorf("Error updating Container %q (Storage Account %q / Resource Group %q): %s", id.ContainerName, id.AccountName, account.ResourceGroup, err)
 		}
 	}
@@ -206,9 +206,9 @@ func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	client := storageClient.BlobContainersClient
+	azureClient := storageClient.BlobContainersClient
 
-	props, err := client.Get(ctx, account.ResourceGroup, id.AccountName, id.ContainerName)
+	props, err := azureClient.Get(ctx, account.ResourceGroup, id.AccountName, id.ContainerName)
 	if err != nil {
 		if utils.ResponseWasNotFound(props.Response) {
 			log.Printf("[DEBUG] Container %q was not found in Account %q / Resource Group %q - assuming removed & removing from state", id.ContainerName, id.AccountName, account.ResourceGroup)
@@ -260,9 +260,9 @@ func resourceArmStorageContainerDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Unable to locate Storage Account %q!", id.AccountName)
 	}
 
-	client := storageClient.BlobContainersClient
+	azureClient := storageClient.BlobContainersClient
 
-	if _, err := client.Delete(ctx, account.ResourceGroup, id.AccountName, id.ContainerName); err != nil {
+	if _, err := azureClient.Delete(ctx, account.ResourceGroup, id.AccountName, id.ContainerName); err != nil {
 		return fmt.Errorf("Error deleting Container %q (Storage Account %q / Resource Group %q): %s", id.ContainerName, id.AccountName, account.ResourceGroup, err)
 	}
 

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 	"github.com/tombuildsstuff/giovanni/storage/2018-11-09/blob/containers"
@@ -286,4 +287,9 @@ func flattenStorageContainerAccessLevel(input containers.AccessLevel) string {
 	}
 
 	return string(input)
+}
+
+func getResourceID(baseUri, accountName, containerName string) string {
+	domain := parsers.GetBlobEndpoint(baseUri, accountName)
+	return fmt.Sprintf("%s/%s", domain, containerName)
 }

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -293,3 +293,24 @@ func getResourceID(baseUri, accountName, containerName string) string {
 	domain := parsers.GetBlobEndpoint(baseUri, accountName)
 	return fmt.Sprintf("%s/%s", domain, containerName)
 }
+
+func expandMetaData(input map[string]interface{}) map[string]*string {
+	output := make(map[string]*string)
+
+	for k, v := range input {
+		temp := v.(string)
+		output[k] = &temp
+	}
+
+	return output
+}
+
+func flattenMetaData(input map[string]*string) map[string]interface{} {
+	output := make(map[string]interface{})
+
+	for k, v := range input {
+		output[k] = &v
+	}
+
+	return output
+}

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
@@ -282,12 +282,9 @@ func testCheckAzureRMStorageContainerDestroy(s *terraform.State) error {
 			return nil
 		}
 
-		client, err := storageClient.ContainersClient(ctx, *account)
-		if err != nil {
-			return fmt.Errorf("Error building Containers Client: %s", err)
-		}
+		client := storageClient.BlobContainersClient
 
-		props, err := client.GetProperties(ctx, accountName, containerName)
+		props, err := client.Get(ctx, account.ResourceGroup, accountName, containerName)
 		if err != nil {
 			return nil
 		}

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
@@ -252,12 +252,9 @@ func testAccARMStorageContainerDisappears(resourceName string) resource.TestChec
 			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.ContainersClient(ctx, *account)
-		if err != nil {
-			return fmt.Errorf("Error building Containers Client: %s", err)
-		}
+		client := storageClient.BlobContainersClient
 
-		if _, err := client.Delete(ctx, accountName, containerName); err != nil {
+		if _, err := client.Delete(ctx, account.ResourceGroup, accountName, containerName); err != nil {
 			return fmt.Errorf("Error deleting Container %q (Account %q): %s", containerName, accountName, err)
 		}
 

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
@@ -310,13 +310,12 @@ resource "azurerm_storage_container" "test" {
 
 func testAccAzureRMStorageContainer_basicAzureADAuth(data acceptance.TestData) string {
 	template := testAccAzureRMStorageContainer_basic(data)
-	return fmt.Sprintf(`
-provider "azurerm" {
-  storage_use_azuread = true
-}
-
-%s
-`, template)
+	testResource := strings.Replace(
+		template,
+		"features {}",
+		`features {}
+		 storage_use_azuread = true`, 1)
+	return testResource
 }
 
 func testAccAzureRMStorageContainer_requiresImport(data acceptance.TestData) string {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
@@ -216,12 +216,9 @@ func testCheckAzureRMStorageContainerExists(resourceName string) resource.TestCh
 			return fmt.Errorf("Unable to locate Storage Account %q!", accountName)
 		}
 
-		client, err := storageClient.ContainersClient(ctx, *account)
-		if err != nil {
-			return fmt.Errorf("Error building Containers Client: %s", err)
-		}
+		client := storageClient.BlobContainersClient
 
-		resp, err := client.GetProperties(ctx, accountName, containerName)
+		resp, err := client.Get(ctx, account.ResourceGroup, accountName, containerName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("Bad: Container %q (Account %q / Resource Group %q) does not exist", containerName, accountName, account.ResourceGroup)


### PR DESCRIPTION
The pull request replaces custom storage blob container client `giovanni` with the one from Azure Go SDK.
Functions and tests are duplicated from `giovanni` for generating and parsing ID for a blob container, to ensure backward compatibility. Several local functions are added to container resource file to limit changes to local file.

Also `testAccAzureRMStorageContainer_basicAzureADAuth` is changed since the provider blocks are duplicated. `strings.Replace` looks dirty, so I am open to any suggestion to avoid it. 

With those effort, #2977 is possible to fix and containers could have immutability policy and legal holds.

Last but not least, thank you @tombuildsstuff for the custom storage client. It is a great work.