### PR TITLE
Support address_prefixes for multiple prefixes in subnet and virtualnetwork (ipv6)

### DIFF
--- a/azurerm/internal/services/network/tests/resource_arm_virtual_network_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_virtual_network_test.go
@@ -51,6 +51,27 @@ func TestAccAzureRMVirtualNetwork_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualNetwork_basic_addressPrefixes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualNetwork_basic_addressPrefixes(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualNetworkExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "subnet.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "subnet.1472110187.id"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMVirtualNetwork_basicUpdated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network", "test")
 
@@ -310,6 +331,25 @@ resource "azurerm_virtual_network" "test" {
   subnet {
     name           = "subnet1"
     address_prefix = "10.0.1.0/24"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMVirtualNetwork_basic_addressPrefixes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-n-%d"
+  location = "%s"
+}
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  subnet {
+    name             = "subnet1"
+    address_prefixes = ["10.0.1.0/24", "10.0.2.0/24"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -53,14 +53,14 @@ resource "azurerm_virtual_network" "example" {
   }
 
   subnet {
-    name           = "subnet2"
-    address_prefix = "10.0.2.0/24"
+    name             = "subnet2"
+    address_prefixes = ["10.0.2.0/24"]
   }
 
   subnet {
-    name           = "subnet3"
-    address_prefix = "10.0.3.0/24"
-    security_group = azurerm_network_security_group.example.id
+    name             = "subnet3"
+    address_prefixes = ["10.0.3.0/24"]
+    security_group   = azurerm_network_security_group.example.id
   }
 
   tags = {
@@ -111,10 +111,14 @@ The `subnet` block supports:
 
 * `name` - (Required) The name of the subnet.
 
-* `address_prefix` - (Required) The address prefix to use for the subnet.
-
 * `security_group` - (Optional) The Network Security Group to associate with
     the subnet. (Referenced by `id`, ie. `azurerm_network_security_group.example.id`)
+
+* `address_prefix` - (Optional / **Deprecated in favour of `address_prefixes`**) The address prefix to use for the subnet.
+
+* `address_prefixes` - (Optional) The address prefixes to use for the subnet.
+
+-> **NOTE:** One of `address_prefix` or `address_prefixes` is required.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The azure subnet resource supports addressPrefix when one prefix is available and addressPrefixes when two or or more are set (for instance, when configuring an ipv4 and ipv6 dual stack configuration for a network). Update azurerm_subnet to allow either address_prefix or address_prefixes as input, where the latter is a list of string. Check that at least one is set, and mark the older address_prefix as deprecated.

The virtual network resource allows inline subnets, but does not currently support this argument. When the address_prefixes argument is used, address_prefix will be null when terraform refreshes its state causing terraform to panic. This code updates also the virtual network resource to allow
address_prefixes to be used and for address_prefix to be null.

Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/5140
Takes over https://github.com/terraform-providers/terraform-provider-azurerm/pull/5139