### PR TITLE
azurerm_dns_zone doc example - You can't have 2 public zones of the same name

### DIFF
--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -23,7 +23,7 @@ resource "azurerm_dns_zone" "example-public" {
   resource_group_name = azurerm_resource_group.example.name
 }
 
-resource "azurerm_dns_zone" "example-private" {
+resource "azurerm_private_dns_zone" "example-private" {
   name                = "mydomain.com"
   resource_group_name = azurerm_resource_group.example.name
 }


### PR DESCRIPTION
In the docs you have supplied 2 public zone resource declarations, calling one public and one private. This shouldn't be correct, there is a private zone resource - *azurerm_private_dns_zone* , so that's what it should be.