### PR TITLE
storage: exposing the `resource_manager_id` field

### DIFF
--- a/azurerm/internal/services/storage/client/client.go
+++ b/azurerm/internal/services/storage/client/client.go
@@ -26,6 +26,7 @@ type Client struct {
 	ManagementPoliciesClient storage.ManagementPoliciesClient
 	BlobServicesClient       storage.BlobServicesClient
 	CachesClient             *storagecache.CachesClient
+	SubscriptionId           string
 
 	environment   az.Environment
 	storageAdAuth *autorest.Authorizer
@@ -55,6 +56,7 @@ func NewClient(options *common.ClientOptions) *Client {
 		ManagementPoliciesClient: managementPoliciesClient,
 		BlobServicesClient:       blobServicesClient,
 		CachesClient:             &cachesClient,
+		SubscriptionId:           options.SubscriptionId,
 		environment:              options.Environment,
 	}
 

--- a/azurerm/internal/services/storage/data_source_storage_container.go
+++ b/azurerm/internal/services/storage/data_source_storage_container.go
@@ -46,6 +46,11 @@ func dataSourceArmStorageContainer() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
+			"resource_manager_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -94,6 +99,9 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 	d.Set("has_legal_hold", props.HasLegalHold)
+
+	resourceManagerId := client.GetResourceManagerResourceID(storageClient.SubscriptionId, account.ResourceGroup, id.AccountName, id.ContainerName)
+	d.Set("resource_manager_id", resourceManagerId)
 
 	return nil
 }

--- a/azurerm/internal/services/storage/data_source_storage_container.go
+++ b/azurerm/internal/services/storage/data_source_storage_container.go
@@ -100,7 +100,7 @@ func dataSourceArmStorageContainerRead(d *schema.ResourceData, meta interface{})
 	d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 	d.Set("has_legal_hold", props.HasLegalHold)
 
-	resourceManagerId := client.GetResourceManagerResourceID(storageClient.SubscriptionId, account.ResourceGroup, id.AccountName, id.ContainerName)
+	resourceManagerId := client.GetResourceManagerResourceID(storageClient.SubscriptionId, account.ResourceGroup, accountName, containerName)
 	d.Set("resource_manager_id", resourceManagerId)
 
 	return nil

--- a/azurerm/internal/services/storage/resource_arm_storage_container.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_container.go
@@ -74,6 +74,11 @@ func resourceArmStorageContainer() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+
+			"resource_manager_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -226,6 +231,9 @@ func resourceArmStorageContainerRead(d *schema.ResourceData, meta interface{}) e
 
 	d.Set("has_immutability_policy", props.HasImmutabilityPolicy)
 	d.Set("has_legal_hold", props.HasLegalHold)
+
+	resourceManagerId := client.GetResourceManagerResourceID(storageClient.SubscriptionId, account.ResourceGroup, id.AccountName, id.ContainerName)
+	d.Set("resource_manager_id", resourceManagerId)
 
 	return nil
 }

--- a/azurerm/internal/services/storage/resource_arm_storage_share.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_share.go
@@ -106,6 +106,11 @@ func resourceArmStorageShare() *schema.Resource {
 				},
 			},
 
+			"resource_manager_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -226,6 +231,9 @@ func resourceArmStorageShareRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("acl", flattenStorageShareACLs(acls)); err != nil {
 		return fmt.Errorf("Error flattening `acl`: %+v", err)
 	}
+
+	resourceManagerId := client.GetResourceManagerResourceID(storageClient.SubscriptionId, account.ResourceGroup, id.AccountName, id.ShareName)
+	d.Set("resource_manager_id", resourceManagerId)
 
 	return nil
 }

--- a/website/docs/d/storage_container.html.markdown
+++ b/website/docs/d/storage_container.html.markdown
@@ -24,14 +24,20 @@ data "azurerm_storage_container" "example" {
 The following arguments are supported:
 
 * `name` - The name of the Container.
-* `storage_account_name` - The name of the Storage Account where the Container was created.
+
+* `storage_account_name` - The name of the Storage Account where the Container exists.
 
 ## Attributes Reference
 
 * `container_access_type` - The Access Level configured for this Container.
+
 * `has_immutability_policy` - Is there an Immutability Policy configured on this Storage Container?
+
 * `has_legal_hold` - Is there a Legal Hold configured on this Storage Container?
+
 * `metadata`  - A mapping of MetaData for this Container.
+
+* `resource_manager_id` - The Resource Manager ID of this Storage Container.
 
 ## Timeouts
 

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -59,6 +59,8 @@ The following attributes are exported in addition to the arguments listed above:
 
 * `has_legal_hold` - Is there a Legal Hold configured on this Storage Container?
 
+* `resource_manager_id` - The Resource Manager ID of this Storage Container.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -71,6 +71,9 @@ A `access_policy` block supports the following:
 The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The ID of the File Share.
+
+* `resource_manager_id` - The Resource Manager ID of this File Share.
+
 * `url` - The URL of the File Share
 
 ## Timeouts


### PR DESCRIPTION
This PR exposes the Resource Manager ID field since certain Storage Resources can be managed/referenced via either the Data Plane or Resource Manager API's

* Data Source `azurerm_storage_container` - exposing the `resource_manager_id` field
* `azurerm_storage_container` - exposing the `resource_manager_id` field
* `azurerm_storage_share` - exposing the `resource_manager_id` field

Dependent on #6169
Fixes #4442