### PR TITLE
travis: conditionally running the test, lint and tflint steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,14 @@ matrix:
   include:
     - name: "make lintrest"
       script:
-      - GOGC=5 make lintrest
+      - TRAVIS=ci GOGC=5 make lintrest
     # results in a OOM error
     #- name: "make lintunused"
     #  script: GOGC=5 make lintunused
     - name: "make tflint"
-      script: make tflint
+      script: TRAVIS=ci make tflint
     - name: "make test"
-      script: make test
+      script: TRAVIS=ci make test
     - name: "make depscheck"
       script: make depscheck
     - name: "make website-lint"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,8 +45,7 @@ goimports:
 	goimports -w $(PKG_NAME)/
 
 lint:
-	@echo "==> Checking source code against linters..."
-	golangci-lint run ./...
+	./scripts/run-lint.sh
 
 # we have split off static check because it causes travis to fail with an OOM error
 lintunused:
@@ -70,14 +69,7 @@ depscheck:
 		(echo; echo "Unexpected difference in vendor/ directory. Run 'go mod vendor' command or revert any go.mod/go.sum/vendor changes and commit."; exit 1)
 
 tflint:
-	@echo "==> Checking source code against terraform provider linters..."
-	@tfproviderlint \
-        -AT001 -AT005 -AT006 -AT007\
-        -R001 -R002 -R003 -R004 -R006\
-        -S001 -S002 -S003 -S004 -S005 -S006 -S007 -S008 -S009 -S010 -S011 -S012 -S013 -S014 -S015 -S016 -S017 -S018 -S019 -S020\
-        -S021 -S022 -S023 -S024 -S025 -S026 -S027 -S028 -S029 -S030 -S031 -S032 -S033\
-        ./$(PKG_NAME)/...
-	@sh -c "'$(CURDIR)/scripts/terrafmt-acctests.sh'"
+	./scripts/run-tflint.sh
 
 whitespace:
 	@echo "==> Fixing source code with whitespace linter..."
@@ -87,9 +79,7 @@ test-docker:
 	docker run --rm -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm golang:1.13 make test
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
-	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+	@TEST=$(TEST) ./scripts/run-test.sh
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \

--- a/scripts/run-lint.sh
+++ b/scripts/run-lint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function checkForConditionalRun {
+  if [ "$TRAVIS" == "ci" ];
+  then
+    echo "Checking if this should be conditionally run.."
+    result=$(git diff --name-only HEAD | grep azurerm/)
+    if [ "$result" = "" ];
+    then
+      echo "No changes committed to ./azurerm - nothing to lint - exiting"
+      exit 0
+    fi
+  fi
+}
+
+function runLinters {
+  echo "==> Checking source code against linters..."
+  golangci-lint run ./...
+}
+
+function main {
+  checkForConditionalRun
+  runLinters
+}
+
+main

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -16,7 +16,7 @@ function checkForConditionalRun {
 function runTests {
   echo "==> Running Unit Tests..."
   go test -i $TEST || exit 1
-	go test -v $TEST "$TESTARGS" -timeout=30s -parallel=4
+  go test -v $TEST "$TESTARGS" -timeout=30s -parallel=4
 }
 
 function main {

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+function checkForConditionalRun {
+  if [ "$TRAVIS" == "ci" ];
+  then
+    echo "Checking if this should be conditionally run.."
+    result=$(git diff --name-only HEAD | grep azurerm/)
+    if [ "$result" = "" ];
+    then
+      echo "No changes committed to ./azurerm - nothing to lint - exiting"
+      exit 0
+    fi
+  fi
+}
+
+function runTests {
+  echo "==> Running Unit Tests..."
+  go test -i $TEST || exit 1
+	go test -v $TEST "$TESTARGS" -timeout=30s -parallel=4
+}
+
+function main {
+  checkForConditionalRun
+  runTests
+}
+
+main

--- a/scripts/run-tflint.sh
+++ b/scripts/run-tflint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+function checkForConditionalRun {
+  if [ "$TRAVIS" == "ci" ];
+  then
+    echo "Checking if this should be conditionally run.."
+    result=$(git diff --name-only HEAD | grep azurerm/)
+    if [ "$result" = "" ];
+    then
+      echo "No changes committed to ./azurerm - nothing to lint - exiting"
+      exit 0
+    fi
+  fi
+}
+
+function runTests {
+  echo "==> Checking source code against terraform provider linters..."
+	tfproviderlint \
+        -AT001 -AT005 -AT006 -AT007\
+        -R001 -R002 -R003 -R004 -R006\
+        -S001 -S002 -S003 -S004 -S005 -S006 -S007 -S008 -S009 -S010 -S011 -S012 -S013 -S014 -S015 -S016 -S017 -S018 -S019 -S020\
+        -S021 -S022 -S023 -S024 -S025 -S026 -S027 -S028 -S029 -S030 -S031 -S032 -S033\
+        ./azurerm/...
+	bash ./scripts/terrafmt-acctests.sh
+}
+
+function main {
+  checkForConditionalRun
+  runTests
+}
+
+main


### PR DESCRIPTION
This PR conditionally runs the Travis jobs `make lint`, `make test` and `make tflint` only if there are changes within the ./azurerm directory

Assuming no committed/staged changes to the ./azurerm folder:

```
$ TRAVIS=ci make test
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
Checking if this should be conditionally run..
No changes committed to ./azurerm - nothing to lint - exiting
```

When then staging a file:

```
$ git add azurerm/foo.txt

$ TRAVIS=ci make test
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
Checking if this should be conditionally run..
==> Running Unit Tests...
```

Ultimately this should bring the total time for a Travis build down to ~5m rather than ~1h10m when there's no changes to the `./azurerm` folder