### PR TITLE
Update versions of AKS in use for tests

### DIFF
--- a/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 )
 
-var olderKubernetesVersion = "1.14.8"
-var currentKubernetesVersion = "1.15.5"
+var olderKubernetesVersion = "1.15.10"
+var currentKubernetesVersion = "1.16.7"
 
 func TestAccAzureRMKubernetes_all(t *testing.T) {
 	// we can conditionally run tests tests individually, or combined


### PR DESCRIPTION
Supported versions have moved on in primary testing locaiton.
```
az aks get-versions -l westeurope -otable
KubernetesVersion    Upgrades
-------------------  -----------------------
1.17.3(preview)      None available
1.16.7               1.17.3(preview)
1.15.10              1.16.7
1.15.7               1.15.10, 1.16.7
1.14.8               1.15.7, 1.15.10
1.14.7               1.14.8, 1.15.7, 1.15.10
1.13.12              1.14.7, 1.14.8
1.13.11              1.13.12, 1.14.7, 1.14.8
```