### PR TITLE
service_principal in aks no longer required

### DIFF
--- a/azurerm/internal/services/containers/resource_arm_kubernetes_cluster.go
+++ b/azurerm/internal/services/containers/resource_arm_kubernetes_cluster.go
@@ -112,7 +112,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 
 			"service_principal": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Fixes #6178. `service_principal` is no longer required, as Managed Identity is now GA: https://github.com/Azure/AKS/releases/tag/2020-03-16

Been a while since I've contributed here, so probably other files that needs to be updated?

Looks like version `2019-11-01/containerservice` (which is the current in terraform) already support managed identities, but there are newer API versions available which I have not studied in detail.