### PR TITLE
Update azurerm_managed_disk.disk_encryption_set_id without recreating the resource

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_managed_disk.go
+++ b/azurerm/internal/services/compute/resource_arm_managed_disk.go
@@ -361,6 +361,17 @@ func resourceArmManagedDiskUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
+	if d.HasChange("disk_encryption_set_id") {
+		if diskEncryptionSetId := d.Get("disk_encryption_set_id").(string); diskEncryptionSetId != "" {
+			diskUpdate.Encryption = &compute.Encryption{
+				Type:                compute.EncryptionAtRestWithCustomerKey,
+				DiskEncryptionSetID: utils.String(diskEncryptionSetId),
+			}
+		} else {
+			return fmt.Errorf("Once a customer-managed key is used, you can’t change the selection back to a platform-managed key")
+		}
+	}
+
 	// if we are attached to a VM we bring down the VM as necessary for the operations which are not allowed while it's online
 	if disk.ManagedBy != nil {
 		virtualMachine, err := ParseVirtualMachineID(*disk.ManagedBy)

--- a/azurerm/internal/services/compute/resource_arm_managed_disk.go
+++ b/azurerm/internal/services/compute/resource_arm_managed_disk.go
@@ -134,9 +134,6 @@ func resourceArmManagedDisk() *schema.Resource {
 			"disk_encryption_set_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				// Support for rotating the Disk Encryption Set is (apparently) coming a few months following GA
-				// Code="PropertyChangeNotAllowed" Message="Changing property 'encryption.diskEncryptionSetId' is not allowed."
-				ForceNew: true,
 				// TODO: make this case-sensitive once this bug in the Azure API has been fixed:
 				//       https://github.com/Azure/azure-rest-api-specs/issues/8132
 				DiffSuppressFunc: suppress.CaseDifference,

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 ---
 
-* `disk_encryption_set_id` - (Optional) The ID of a Disk Encryption Set which should be used to encrypt this Managed Disk. Changing this forces a new resource to be created.
+* `disk_encryption_set_id` - (Optional) The ID of a Disk Encryption Set which should be used to encrypt this Managed Disk.
 
 -> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-azurerm/issues/6184

CMK encryption can be enabled without recreating (requires VM to be stopped): https://docs.microsoft.com/en-us/azure/virtual-machines/linux/disk-encryption#enable-on-an-existing-disk