### PR TITLE
HPC export `mount_addresses`

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_hpc_cache.go
+++ b/azurerm/internal/services/storage/resource_arm_hpc_cache.go
@@ -76,6 +76,12 @@ func resourceArmHPCCache() *schema.Resource {
 					"Standard_8G",
 				}, false),
 			},
+
+			"mount_addresses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -168,6 +174,7 @@ func resourceArmHPCCacheRead(d *schema.ResourceData, meta interface{}) error {
 	if props := resp.CacheProperties; props != nil {
 		d.Set("cache_size_in_gb", props.CacheSizeGB)
 		d.Set("subnet_id", props.Subnet)
+		d.Set("mount_addresses", utils.FlattenStringSlice(props.MountAddresses))
 	}
 
 	if sku := resp.Sku; sku != nil {

--- a/azurerm/internal/services/storage/tests/resource_arm_hpc_cache_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_hpc_cache_test.go
@@ -24,6 +24,7 @@ func TestAccAzureRMHPCCache_basic(t *testing.T) {
 				Config: testAccAzureRMHPCCache_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMHPCCacheExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "mount_addresses.#"),
 				),
 			},
 			data.ImportStep(),

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -66,7 +66,7 @@ The following attributes are exported:
 
 * `id` - The `id` of the HPC Cache.
 
-* `mount_addresses` - A list of mount addresses of the HPC Cache.
+* `mount_addresses` - A list of IP Addresses where the HPC Cache can be mounted.
 
 ## Timeouts
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -66,6 +66,8 @@ The following attributes are exported:
 
 * `id` - The `id` of the HPC Cache.
 
+* `mount_addresses` - A list of mount addresses of the HPC Cache.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
User need to use `mount_addresses` to be able to mount the hpc cache to other places.

```bash
💤  terraform-provider-azurerm [hpc_export_mount_addr] ⚡  make testacc TEST="./azurerm/internal/services/storage/tests" TESTARGS="-run='TestAccAzureRMHPCCache_basic'"    
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/storage/tests -v -run='TestAccAzureRMHPCCache_basic' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMHPCCache_basic
=== PAUSE TestAccAzureRMHPCCache_basic
=== CONT  TestAccAzureRMHPCCache_basic
--- PASS: TestAccAzureRMHPCCache_basic (1811.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/tests       1811.508s

```