### PR TITLE
Make azurerm_linux_virtual_machine's custom_data field sensitive

### DIFF
--- a/azurerm/internal/tf/base64/schema.go
+++ b/azurerm/internal/tf/base64/schema.go
@@ -13,6 +13,7 @@ func OptionalSchema(isVirtualMachine bool) *schema.Schema {
 		Type:         schema.TypeString,
 		Optional:     true,
 		ForceNew:     isVirtualMachine,
+		Sensitive:    true,
 		ValidateFunc: validation.StringIsBase64,
 	}
 }


### PR DESCRIPTION
Addresses: https://github.com/terraform-providers/terraform-provider-azurerm/issues/6185

Main motivation is to match ARM1.X's ability to not leak sensitive custom_data to plan output. Additional advantage is avoiding polluting plan with outputs that are not human-readable.