### PR TITLE
netapp_volume: allow up to 102400 MB for the storage_quota_in_gb property

### DIFF
--- a/azurerm/internal/services/compute/tests/resource_arm_managed_disk_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_managed_disk_test.go
@@ -1022,12 +1022,12 @@ resource "azurerm_role_assignment" "disk-encryption-read-keyvault" {
 }
 
 resource "azurerm_managed_disk" "test" {
-  name                   = "acctestd-%d"
-  location               = azurerm_resource_group.test.location
-  resource_group_name    = azurerm_resource_group.test.name
-  storage_account_type   = "Standard_LRS"
-  create_option          = "Empty"
-  disk_size_gb           = 1
+  name                 = "acctestd-%d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 1
   %s
 
   depends_on = [

--- a/azurerm/internal/services/netapp/resource_arm_netapp_volume.go
+++ b/azurerm/internal/services/netapp/resource_arm_netapp_volume.go
@@ -110,7 +110,7 @@ func resourceArmNetAppVolume() *schema.Resource {
 			"storage_quota_in_gb": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(100, 4096),
+				ValidateFunc: validation.IntBetween(100, 102400),
 			},
 
 			"export_policy_rule": {


### PR DESCRIPTION
Fixing bug related to 4TiB volume size limit to ANF's current limit of 100TiB.