### PR TITLE
r/virtual_machine_data_disk_attachment: handling the VM being deleted

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_virtual_machine_data_disk_attachment.go
+++ b/azurerm/internal/services/compute/resource_arm_virtual_machine_data_disk_attachment.go
@@ -211,7 +211,9 @@ func resourceArmVirtualMachineDataDiskAttachmentRead(d *schema.ResourceData, met
 	virtualMachine, err := client.Get(ctx, resourceGroup, virtualMachineName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(virtualMachine.Response) {
-			return fmt.Errorf("Virtual Machine %q (Resource Group %q) was not found", virtualMachineName, resourceGroup)
+			log.Printf("[DEBUG] Virtual Machine %q was not found (Resource Group %q) therefore Data Disk Attachment cannot exist - removing from state", virtualMachineName, resourceGroup)
+			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("Error loading Virtual Machine %q (Resource Group %q): %+v", virtualMachineName, resourceGroup, err)

--- a/azurerm/internal/services/compute/tests/resource_arm_virtual_machine_data_disk_attachment_test.go
+++ b/azurerm/internal/services/compute/tests/resource_arm_virtual_machine_data_disk_attachment_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -58,6 +59,26 @@ func TestAccAzureRMVirtualMachineDataDiskAttachment_requiresImport(t *testing.T)
 			{
 				Config:      testAccAzureRMVirtualMachineDataDiskAttachment_requiresImport(data),
 				ExpectError: acceptance.RequiresImportError("azurerm_virtual_machine_data_disk_attachment"),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineDataDiskAttachment_destroy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_machine_data_disk_attachment", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDataDiskAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMVirtualMachineDataDiskAttachment_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineDataDiskAttachmentExists(data.ResourceName),
+					testCheckAzureRMVirtualMachineDataDiskAttachmentDisappears(data.ResourceName),
+				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -300,6 +321,72 @@ func testCheckAzureRMVirtualMachineDataDiskAttachmentDestroy(s *terraform.State)
 	}
 
 	return nil
+}
+
+func testCheckAzureRMVirtualMachineDataDiskAttachmentDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Compute.VMClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		virtualMachineId := rs.Primary.Attributes["virtual_machine_id"]
+
+		id, err := azure.ParseAzureResourceID(virtualMachineId)
+		if err != nil {
+			return err
+		}
+
+		virtualMachineName := id.Path["virtualMachines"]
+		resourceGroup := id.ResourceGroup
+
+		resp, err := client.Get(ctx, resourceGroup, virtualMachineName, "")
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return fmt.Errorf("Bad: Get on vmClient: %+v", err)
+		}
+
+		diskId, err := azure.ParseAzureResourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		diskName := diskId.Path["dataDisks"]
+
+		outputDisks := make([]compute.DataDisk, 0)
+		for _, disk := range *resp.StorageProfile.DataDisks {
+			// deliberately not using strings.Equals as this is case sensitive
+			if *disk.Name == diskName {
+				continue
+			}
+
+			outputDisks = append(outputDisks, disk)
+		}
+		resp.StorageProfile.DataDisks = &outputDisks
+
+		// fixes #2485
+		resp.Identity = nil
+		// fixes #1600
+		resp.Resources = nil
+
+		future, err := client.CreateOrUpdate(ctx, resourceGroup, virtualMachineName, resp)
+		if err != nil {
+			return fmt.Errorf("Error updating Virtual Machine %q (Resource Group %q) with Disk %q: %+v", virtualMachineName, resourceGroup, diskName, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("Error waiting for Virtual Machine %q (Resource Group %q) to finish updating Disk %q: %+v", virtualMachineName, resourceGroup, diskName, err)
+		}
+
+		return nil
+	}
 }
 
 func testAccAzureRMVirtualMachineDataDiskAttachment_basic(data acceptance.TestData) string {


### PR DESCRIPTION
Updates the Read function to mark the Attachment as gone when the VM
has been deleted

Tests pass:

```
$ TF_ACC=1 go test -v ./azurerm/internal/services/compute/tests/ -timeout=60m -run=TestAccAzureRMVirtualMachineDataDiskAttachment_destroy
=== RUN   TestAccAzureRMVirtualMachineDataDiskAttachment_destroy
=== PAUSE TestAccAzureRMVirtualMachineDataDiskAttachment_destroy
=== CONT  TestAccAzureRMVirtualMachineDataDiskAttachment_destroy
--- PASS: TestAccAzureRMVirtualMachineDataDiskAttachment_destroy (566.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/tests	566.040s
```

Fixes #6226
Fixes #5254