### PR TITLE
add different create_mode for resource `azurerm_postgresql_server`

### DIFF
--- a/azurerm/internal/services/postgres/parse/postgresql_server.go
+++ b/azurerm/internal/services/postgres/parse/postgresql_server.go
@@ -1,0 +1,33 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type PostgresqlServerId struct {
+	ResourceGroup string
+	Name          string
+}
+
+func PostgresqlServerID(input string) (*PostgresqlServerId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Postgresql Server ID %q: %+v", input, err)
+	}
+
+	set := PostgresqlServerId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if set.Name, err = id.PopSegment("servers"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &set, nil
+}

--- a/azurerm/internal/services/postgres/validate/postgresql_server.go
+++ b/azurerm/internal/services/postgres/validate/postgresql_server.go
@@ -1,0 +1,22 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/postgres/parse"
+)
+
+func PostgresqlServerID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if _, err := parse.PostgresqlServerID(v); err != nil {
+		errors = append(errors, fmt.Errorf("Can not parse %q as a resource id: %v", k, err))
+		return
+	}
+
+	return warnings, errors
+}

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -51,15 +51,21 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this PostgreSQL Server. The name of the SKU, follows the `tier` + `family` + `cores` pattern (e.g. `B_Gen4_1`, `GP_Gen5_8`). For more information see the [product documentation](https://docs.microsoft.com/en-us/rest/api/postgresql/servers/create#sku).
 
-* `storage_profile` - (Required) A `storage_profile` block as defined below.
-
-* `administrator_login` - (Required) The Administrator Login for the PostgreSQL Server. Changing this forces a new resource to be created.
-
-* `administrator_login_password` - (Required) The Password associated with the `administrator_login` for the PostgreSQL Server.
+* `create_mode` - (Optional) Specifies how to create the PostgreSQL Server. Valid values are: `Default`, `GeoRestore`, `PointInTimeRestore` or `Replica`. Must be `Default` to create a new database. Defaults to `Default`. Please see [Azure PostgreSQL Server REST API](https://docs.microsoft.com/en-us/rest/api/postgresql/servers/create)
 
 * `version` - (Required) Specifies the version of PostgreSQL to use. Valid values are `9.5`, `9.6`, `10`, `10.0`, and `11`. Changing this forces a new resource to be created.
 
 * `ssl_enforcement` - (Required) Specifies if SSL should be enforced on connections. Possible values are `Enabled` and `Disabled`.
+
+* `storage_profile` - (Optional) A `storage_profile` block as defined below. `create_mode` must be set to `Default`
+
+* `administrator_login` - (Optional) The Administrator Login for the PostgreSQL Server. Applies only if `create_mode` is `Default`. Changing this forces a new resource to be created.
+
+* `administrator_login_password` - (Optional) The Password associated with the `administrator_login` for the PostgreSQL Server. Applies only if `create_mode` is `Default`
+
+* `source_server_id` - (Optional) The resource ID of the source postgresql server if `create_mode` value is `GeoRestore`, `PointInTimeRestore` or `Replica`.
+
+* `restore_point_in_time` - (Optional) The point in time for the restore. Only applies if `create_mode` is `PointInTimeRestore` e.g. 2013-11-08T22:00:40Z
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
add support of geo_restore, PointInTimeRestore and replica create for resource `azurerm_postgresql_server`.

fix #6180 

![2020-03-25_150521](https://user-images.githubusercontent.com/2786738/77511373-e9d90b80-6eab-11ea-98f3-028684867d27.png)
