### PR TITLE
location: moving to it's own package/making this strongly typed

### DIFF
--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -41,7 +42,7 @@ func SchemaHDInsightTier() *schema.Schema {
 			string(hdinsight.Premium),
 		}, false),
 		// TODO: file a bug about this
-		DiffSuppressFunc: SuppressLocationDiff,
+		DiffSuppressFunc: location.DiffSuppressFunc,
 	}
 }
 

--- a/azurerm/helpers/azure/location.go
+++ b/azurerm/helpers/azure/location.go
@@ -1,53 +1,27 @@
 package azure
 
 import (
-	"strings"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 )
 
 func SchemaLocation() *schema.Schema {
-	return &schema.Schema{
-		Type:             schema.TypeString,
-		Required:         true,
-		ForceNew:         true,
-		StateFunc:        NormalizeLocation,
-		DiffSuppressFunc: SuppressLocationDiff,
-	}
+	return location.Schema()
 }
 
 func SchemaLocationOptional() *schema.Schema {
-	return &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		ForceNew:         true,
-		StateFunc:        NormalizeLocation,
-		DiffSuppressFunc: SuppressLocationDiff,
-	}
+	return location.SchemaOptional()
 }
 
-// todo should we change this to SchemaLocationComputed
 func SchemaLocationForDataSource() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeString,
-		Computed: true,
-	}
+	return location.SchemaComputed()
 }
 
 // azure.NormalizeLocation is a function which normalises human-readable region/location
 // names (e.g. "West US") to the values used and returned by the Azure API (e.g. "westus").
 // In state we track the API internal version as it is easier to go from the human form
 // to the canonical form than the other way around.
-func NormalizeLocation(location interface{}) string {
-	input := location.(string)
-	return strings.Replace(strings.ToLower(input), " ", "", -1)
-}
-
-func SuppressLocationDiff(_, old, new string, _ *schema.ResourceData) bool {
-	return NormalizeLocation(old) == NormalizeLocation(new)
-}
-
-func HashAzureLocation(location interface{}) int {
-	return hashcode.String(NormalizeLocation(location.(string)))
+func NormalizeLocation(input interface{}) string {
+	loc := input.(string)
+	return location.NormalizeLocation(loc)
 }

--- a/azurerm/helpers/azure/location.go
+++ b/azurerm/helpers/azure/location.go
@@ -23,5 +23,5 @@ func SchemaLocationForDataSource() *schema.Schema {
 // to the canonical form than the other way around.
 func NormalizeLocation(input interface{}) string {
 	loc := input.(string)
-	return location.NormalizeLocation(loc)
+	return location.Normalize(loc)
 }

--- a/azurerm/internal/location/normalize.go
+++ b/azurerm/internal/location/normalize.go
@@ -1,0 +1,19 @@
+package location
+
+import "strings"
+
+// NormalizeLocation transforms the human readable Azure Region/Location names (e.g. `West US`)
+// into the canonical value to allow comparisons between user-code and API Responses
+func NormalizeLocation(input string) string {
+	return strings.Replace(strings.ToLower(input), " ", "", -1)
+}
+
+// NormalizeNilableLocation normalizes the Location field even if it's nil to ensure this field
+// can always have a value
+func NormalizeNilableLocation(input *string) string {
+	if input == nil {
+		return ""
+	}
+
+	return NormalizeLocation(*input)
+}

--- a/azurerm/internal/location/normalize.go
+++ b/azurerm/internal/location/normalize.go
@@ -2,18 +2,18 @@ package location
 
 import "strings"
 
-// NormalizeLocation transforms the human readable Azure Region/Location names (e.g. `West US`)
+// Normalize transforms the human readable Azure Region/Location names (e.g. `West US`)
 // into the canonical value to allow comparisons between user-code and API Responses
-func NormalizeLocation(input string) string {
+func Normalize(input string) string {
 	return strings.Replace(strings.ToLower(input), " ", "", -1)
 }
 
-// NormalizeNilableLocation normalizes the Location field even if it's nil to ensure this field
+// NormalizeNilable normalizes the Location field even if it's nil to ensure this field
 // can always have a value
-func NormalizeNilableLocation(input *string) string {
+func NormalizeNilable(input *string) string {
 	if input == nil {
 		return ""
 	}
 
-	return NormalizeLocation(*input)
+	return Normalize(*input)
 }

--- a/azurerm/internal/location/normalize_test.go
+++ b/azurerm/internal/location/normalize_test.go
@@ -26,7 +26,7 @@ func TestNormalizeLocation(t *testing.T) {
 	}
 
 	for _, v := range cases {
-		actual := NormalizeLocation(v.input)
+		actual := Normalize(v.input)
 		if v.expected != actual {
 			t.Fatalf("Expected %q but got %q", v.expected, actual)
 		}
@@ -57,7 +57,7 @@ func TestNormalizeNilableLocation(t *testing.T) {
 	}
 
 	for _, v := range cases {
-		actual := NormalizeNilableLocation(v.input)
+		actual := NormalizeNilable(v.input)
 		if v.expected != actual {
 			t.Fatalf("Expected %q but got %q", v.expected, actual)
 		}

--- a/azurerm/internal/location/normalize_test.go
+++ b/azurerm/internal/location/normalize_test.go
@@ -1,0 +1,65 @@
+package location
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestNormalizeLocation(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "West US",
+			expected: "westus",
+		},
+		{
+			input:    "South East Asia",
+			expected: "southeastasia",
+		},
+		{
+			input:    "southeastasia",
+			expected: "southeastasia",
+		},
+	}
+
+	for _, v := range cases {
+		actual := NormalizeLocation(v.input)
+		if v.expected != actual {
+			t.Fatalf("Expected %q but got %q", v.expected, actual)
+		}
+	}
+}
+
+func TestNormalizeNilableLocation(t *testing.T) {
+	cases := []struct {
+		input    *string
+		expected string
+	}{
+		{
+			input:    utils.String("West US"),
+			expected: "westus",
+		},
+		{
+			input:    utils.String("South East Asia"),
+			expected: "southeastasia",
+		},
+		{
+			input:    utils.String("southeastasia"),
+			expected: "southeastasia",
+		},
+		{
+			input:    nil,
+			expected: "",
+		},
+	}
+
+	for _, v := range cases {
+		actual := NormalizeNilableLocation(v.input)
+		if v.expected != actual {
+			t.Fatalf("Expected %q but got %q", v.expected, actual)
+		}
+	}
+}

--- a/azurerm/internal/location/schema.go
+++ b/azurerm/internal/location/schema.go
@@ -1,0 +1,52 @@
+package location
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate"
+)
+
+// Schema returns the default Schema which should be used for Location fields
+// where these are Required and Cannot be Changed
+func Schema() *schema.Schema {
+	return &schema.Schema{
+		Type:             schema.TypeString,
+		Required:         true,
+		ForceNew:         true,
+		ValidateFunc:     validate.NoEmptyStrings,
+		StateFunc:        StateFunc,
+		DiffSuppressFunc: DiffSuppressFunc,
+	}
+}
+
+// SchemaOptional returns the Schema for a Location field where this can be optionally specified
+func SchemaOptional() *schema.Schema {
+	return &schema.Schema{
+		Type:             schema.TypeString,
+		Optional:         true,
+		ForceNew:         true,
+		StateFunc:        StateFunc,
+		DiffSuppressFunc: DiffSuppressFunc,
+	}
+}
+
+func SchemaComputed() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+}
+
+func DiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
+	return NormalizeLocation(old) == NormalizeLocation(new)
+}
+
+func HashCode(location interface{}) int {
+	loc := location.(string)
+	return hashcode.String(NormalizeLocation(loc))
+}
+
+func StateFunc(location interface{}) string {
+	input := location.(string)
+	return NormalizeLocation(input)
+}

--- a/azurerm/internal/location/schema.go
+++ b/azurerm/internal/location/schema.go
@@ -38,15 +38,15 @@ func SchemaComputed() *schema.Schema {
 }
 
 func DiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
-	return NormalizeLocation(old) == NormalizeLocation(new)
+	return Normalize(old) == Normalize(new)
 }
 
 func HashCode(location interface{}) int {
 	loc := location.(string)
-	return hashcode.String(NormalizeLocation(loc))
+	return hashcode.String(Normalize(loc))
 }
 
 func StateFunc(location interface{}) string {
 	input := location.(string)
-	return NormalizeLocation(input)
+	return Normalize(input)
 }

--- a/azurerm/internal/services/applicationinsights/resource_arm_application_insights_webtests.go
+++ b/azurerm/internal/services/applicationinsights/resource_arm_application_insights_webtests.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -100,8 +101,8 @@ func resourceArmApplicationInsightsWebTests() *schema.Resource {
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
 					ValidateFunc:     validation.StringIsNotEmpty,
-					StateFunc:        azure.NormalizeLocation,
-					DiffSuppressFunc: azure.SuppressLocationDiff,
+					StateFunc:        location.StateFunc,
+					DiffSuppressFunc: location.DiffSuppressFunc,
 				},
 			},
 

--- a/azurerm/internal/services/compute/resource_arm_shared_image_version.go
+++ b/azurerm/internal/services/compute/resource_arm_shared_image_version.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -75,8 +76,8 @@ func resourceArmSharedImageVersion() *schema.Resource {
 						"name": {
 							Type:             schema.TypeString,
 							Required:         true,
-							StateFunc:        azure.NormalizeLocation,
-							DiffSuppressFunc: azure.SuppressLocationDiff,
+							StateFunc:        location.StateFunc,
+							DiffSuppressFunc: location.DiffSuppressFunc,
 						},
 
 						"regional_replica_count": {

--- a/azurerm/internal/services/containers/resource_arm_container_registry.go
+++ b/azurerm/internal/services/containers/resource_arm_container_registry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -80,7 +81,7 @@ func resourceArmContainerRegistry() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
-				Set: azure.HashAzureLocation,
+				Set: location.HashCode,
 			},
 
 			"storage_account_id": {

--- a/azurerm/internal/services/monitor/resource_arm_monitor_action_group.go
+++ b/azurerm/internal/services/monitor/resource_arm_monitor_action_group.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -110,7 +111,7 @@ func resourceArmMonitorActionGroup() *schema.Resource {
 							Type:             schema.TypeString,
 							Required:         true,
 							ValidateFunc:     validation.StringIsNotEmpty,
-							DiffSuppressFunc: azure.SuppressLocationDiff,
+							DiffSuppressFunc: location.DiffSuppressFunc,
 						},
 					},
 				},

--- a/azurerm/internal/services/monitor/resource_arm_monitor_log_profile.go
+++ b/azurerm/internal/services/monitor/resource_arm_monitor_log_profile.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -60,8 +61,8 @@ func resourceArmMonitorLogProfile() *schema.Resource {
 				Required: true,
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
-					StateFunc:        azure.NormalizeLocation,
-					DiffSuppressFunc: azure.SuppressLocationDiff,
+					StateFunc:        location.StateFunc,
+					DiffSuppressFunc: location.DiffSuppressFunc,
 				},
 				Set: schema.HashString,
 			},

--- a/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
+++ b/azurerm/internal/services/network/resource_arm_network_watcher_flow_log.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -132,8 +133,8 @@ func resourceArmNetworkWatcherFlowLog() *schema.Resource {
 						"workspace_region": {
 							Type:             schema.TypeString,
 							Required:         true,
-							StateFunc:        azure.NormalizeLocation,
-							DiffSuppressFunc: azure.SuppressLocationDiff,
+							StateFunc:        location.StateFunc,
+							DiffSuppressFunc: location.DiffSuppressFunc,
 						},
 
 						"workspace_resource_id": {

--- a/azurerm/internal/services/resource/resource_arm_resource_group.go
+++ b/azurerm/internal/services/resource/resource_arm_resource_group.go
@@ -5,17 +5,17 @@ import (
 	"log"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
-
-	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
-	"github.com/hashicorp/go-azure-helpers/response"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -53,7 +53,7 @@ func resourceArmResourceGroupCreateUpdate(d *schema.ResourceData, meta interface
 	defer cancel()
 
 	name := d.Get("name").(string)
-	location := azure.NormalizeLocation(d.Get("location").(string))
+	location := location.NormalizeLocation(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
@@ -110,9 +110,7 @@ func resourceArmResourceGroupRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("name", resp.Name)
-	if location := resp.Location; location != nil {
-		d.Set("location", azure.NormalizeLocation(*location))
-	}
+	d.Set("location", location.NormalizeNilableLocation(resp.Location))
 	return tags.FlattenAndSet(d, resp.Tags)
 }
 

--- a/azurerm/internal/services/resource/resource_arm_resource_group.go
+++ b/azurerm/internal/services/resource/resource_arm_resource_group.go
@@ -53,7 +53,7 @@ func resourceArmResourceGroupCreateUpdate(d *schema.ResourceData, meta interface
 	defer cancel()
 
 	name := d.Get("name").(string)
-	location := location.NormalizeLocation(d.Get("location").(string))
+	location := location.Normalize(d.Get("location").(string))
 	t := d.Get("tags").(map[string]interface{})
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
@@ -110,7 +110,7 @@ func resourceArmResourceGroupRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("name", resp.Name)
-	d.Set("location", location.NormalizeNilableLocation(resp.Location))
+	d.Set("location", location.NormalizeNilable(resp.Location))
 	return tags.FlattenAndSet(d, resp.Tags)
 }
 

--- a/azurerm/internal/services/trafficmanager/resource_arm_traffic_manager_endpoint.go
+++ b/azurerm/internal/services/trafficmanager/resource_arm_traffic_manager_endpoint.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -106,8 +107,8 @@ func resourceArmTrafficManagerEndpoint() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				StateFunc:        azure.NormalizeLocation,
-				DiffSuppressFunc: azure.SuppressLocationDiff,
+				StateFunc:        location.StateFunc,
+				DiffSuppressFunc: location.DiffSuppressFunc,
 			},
 
 			"min_child_endpoints": {


### PR DESCRIPTION
This commit makes the NormalizeLocation field more strict - by introducing
a new method for the StateFunc. In addition this adds validation to the
`location` field which ensures this isn't an empty string for the Default
Schema which fixes #5594.

This new package is called from the older package, so we can gradually move things over as time allows - but this has the benefit of being stricter so we can lean on the Go compiler to check types here.

In addition this switches the `azurerm_resource_group` resource over to using this new method, as an example.

Supersedes #6240