### PR TITLE
Changed management policy to only send set properties

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_management_policy.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_management_policy.go
@@ -294,33 +294,21 @@ func expandStorageManagementPolicyRule(d *schema.ResourceData, ruleIndex int) (s
 		if _, ok := d.GetOk(fmt.Sprintf("rule.%d.actions.0.base_blob", ruleIndex)); ok {
 			baseBlob := &storage.ManagementPolicyBaseBlob{}
 			if v, ok := d.GetOk(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_cool_after_days_since_modification_greater_than", ruleIndex)); ok {
-				if v == nil {
-					baseBlob.TierToCool = &storage.DateAfterModification{
-						DaysAfterModificationGreaterThan: nil,
-					}
-				} else {
+				if v != nil {
 					baseBlob.TierToCool = &storage.DateAfterModification{
 						DaysAfterModificationGreaterThan: utils.Float(float64(v.(int))),
 					}
 				}
 			}
 			if v, ok := d.GetOk(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_archive_after_days_since_modification_greater_than", ruleIndex)); ok {
-				if v == nil {
-					baseBlob.TierToArchive = &storage.DateAfterModification{
-						DaysAfterModificationGreaterThan: nil,
-					}
-				} else {
+				if v != nil {
 					baseBlob.TierToArchive = &storage.DateAfterModification{
 						DaysAfterModificationGreaterThan: utils.Float(float64(v.(int))),
 					}
 				}
 			}
 			if v, ok := d.GetOk(fmt.Sprintf("rule.%d.actions.0.base_blob.0.delete_after_days_since_modification_greater_than", ruleIndex)); ok {
-				if v == nil {
-					baseBlob.Delete = &storage.DateAfterModification{
-						DaysAfterModificationGreaterThan: nil,
-					}
-				} else {
+				if v != nil {
 					baseBlob.Delete = &storage.DateAfterModification{
 						DaysAfterModificationGreaterThan: utils.Float(float64(v.(int))),
 					}


### PR DESCRIPTION
There's an issue when any of the optional properties are not set on a management policy. These were being sent to Azure & it was interpreting these as set with a value of zero.

Looking at what the Azure portal does, if these are not intended to be set they should not be sent. I've modified the resource to only add the 3 properties if they are not nil.