### PR TITLE
Update data source `azurerm_policy_definition`: Make `name` as a possible input variable

### DIFF
--- a/azurerm/internal/services/policy/data_source_policy_definition.go
+++ b/azurerm/internal/services/policy/data_source_policy_definition.go
@@ -38,7 +38,6 @@ func dataSourceArmPolicyDefinition() *schema.Resource {
 			"management_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				// TODO -- temporary removed this validation, since a management group ID is always not a resource ID. add this back when there is a proper function for validation of mgmt group IDs
 			},
 			"type": {
 				Type:     schema.TypeString,

--- a/azurerm/internal/services/policy/data_source_policy_definition.go
+++ b/azurerm/internal/services/policy/data_source_policy_definition.go
@@ -1,13 +1,13 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/policy"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 )
@@ -23,17 +23,22 @@ func dataSourceArmPolicyDefinition() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"display_name": {
 				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-			"management_group_id": {
-				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: azure.ValidateResourceIDOrEmpty,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				ExactlyOneOf: []string{"name", "display_name"},
 			},
 			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				ExactlyOneOf: []string{"name", "display_name"},
+			},
+			"management_group_id": {
 				Type:     schema.TypeString,
-				Computed: true,
+				Optional: true,
+				// TODO -- temporary removed this validation, since a management group ID is always not a resource ID. add this back when there is a proper function for validation of mgmt group IDs
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -68,39 +73,24 @@ func dataSourceArmPolicyDefinitionRead(d *schema.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	name := d.Get("display_name").(string)
+	displayName := d.Get("display_name").(string)
+	name := d.Get("name").(string)
 	managementGroupID := d.Get("management_group_id").(string)
 
-	var policyDefinitions policy.DefinitionListResultIterator
-	var err error
-
-	if managementGroupID != "" {
-		policyDefinitions, err = client.ListByManagementGroupComplete(ctx, managementGroupID)
-	} else {
-		policyDefinitions, err = client.ListComplete(ctx)
-	}
-
-	if err != nil {
-		return fmt.Errorf("Error loading Policy Definition List: %+v", err)
-	}
-
 	var policyDefinition policy.Definition
-
-	for policyDefinitions.NotDone() {
-		def := policyDefinitions.Value()
-		if def.DisplayName != nil && *def.DisplayName == name {
-			policyDefinition = def
-			break
-		}
-
-		err = policyDefinitions.NextWithContext(ctx)
+	var err error
+	if displayName != "" {
+		policyDefinition, err = getPolicyDefinitionByDisplayName(ctx, client, displayName, managementGroupID)
 		if err != nil {
-			return fmt.Errorf("Error loading Policy Definition List: %s", err)
+			return fmt.Errorf("failed to read Policy Definition (Display Name %q): %+v", displayName, err)
 		}
-	}
-
-	if policyDefinition.ID == nil {
-		return fmt.Errorf("Error loading Policy Definition List: could not find policy '%s'", name)
+	} else if name != "" {
+		policyDefinition, err = getPolicyDefinition(ctx, client, name, managementGroupID)
+		if err != nil {
+			return fmt.Errorf("failed to read Policy Definition %q: %+v", name, err)
+		}
+	} else {
+		return fmt.Errorf("one of `display_name` or `name` must be set")
 	}
 
 	d.SetId(*policyDefinition.ID)
@@ -123,4 +113,31 @@ func dataSourceArmPolicyDefinitionRead(d *schema.ResourceData, meta interface{})
 	}
 
 	return nil
+}
+
+func getPolicyDefinitionByDisplayName(ctx context.Context, client *policy.DefinitionsClient, displayName, managementGroupID string) (policy.Definition, error) {
+	var policyDefinitions policy.DefinitionListResultIterator
+	var err error
+
+	if managementGroupID != "" {
+		policyDefinitions, err = client.ListByManagementGroupComplete(ctx, managementGroupID)
+	} else {
+		policyDefinitions, err = client.ListComplete(ctx)
+	}
+	if err != nil {
+		return policy.Definition{}, fmt.Errorf("failed to load Policy Definition List: %+v", err)
+	}
+
+	for policyDefinitions.NotDone() {
+		def := policyDefinitions.Value()
+		if def.DisplayName != nil && *def.DisplayName == displayName && def.ID != nil {
+			return def, nil
+		}
+
+		if err := policyDefinitions.NextWithContext(ctx); err != nil {
+			return policy.Definition{}, fmt.Errorf("failed to load Policy Definition List: %s", err)
+		}
+	}
+
+	return policy.Definition{}, fmt.Errorf("failed to load Policy Definition List: could not find policy '%s'", displayName)
 }

--- a/azurerm/internal/services/policy/policy.go
+++ b/azurerm/internal/services/policy/policy.go
@@ -1,0 +1,56 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/policy"
+)
+
+func getPolicyDefinitionByDisplayName(ctx context.Context, client *policy.DefinitionsClient, displayName, managementGroupName string) (policy.Definition, error) {
+	var policyDefinitions policy.DefinitionListResultIterator
+	var err error
+
+	if managementGroupName != "" {
+		policyDefinitions, err = client.ListByManagementGroupComplete(ctx, managementGroupName)
+	} else {
+		policyDefinitions, err = client.ListComplete(ctx)
+	}
+	if err != nil {
+		return policy.Definition{}, fmt.Errorf("failed to load Policy Definition List: %+v", err)
+	}
+
+	var results []policy.Definition
+	for policyDefinitions.NotDone() {
+		def := policyDefinitions.Value()
+		if def.DisplayName != nil && *def.DisplayName == displayName && def.ID != nil {
+			results = append(results, def)
+		}
+
+		if err := policyDefinitions.NextWithContext(ctx); err != nil {
+			return policy.Definition{}, fmt.Errorf("failed to load Policy Definition List: %s", err)
+		}
+	}
+
+	// we found none
+	if len(results) == 0 {
+		return policy.Definition{}, fmt.Errorf("failed to load Policy Definition List: could not find policy '%s'", displayName)
+	}
+
+	// we found more than one
+	if len(results) > 1 {
+		return policy.Definition{}, fmt.Errorf("failed to load Policy Definition List: found more than one policy '%s'", displayName)
+	}
+
+	return results[0], nil
+}
+
+func getPolicyDefinitionByName(ctx context.Context, client *policy.DefinitionsClient, name string, managementGroupName string) (res policy.Definition, err error) {
+	if managementGroupName == "" {
+		res, err = client.Get(ctx, name)
+	} else {
+		res, err = client.GetAtManagementGroup(ctx, name, managementGroupName)
+	}
+
+	return res, err
+}

--- a/azurerm/internal/services/policy/resource_arm_policy_definition.go
+++ b/azurerm/internal/services/policy/resource_arm_policy_definition.go
@@ -69,9 +69,20 @@ func resourceArmPolicyDefinition() *schema.Resource {
 			},
 
 			"management_group_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ConflictsWith: []string{"management_group_name"},
+				Deprecated:    "Deprecated in favor of `management_group_name`", // TODO -- remove this in next major version
+			},
+
+			"management_group_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true, // TODO -- remove this when deprecation resolves
+				ConflictsWith: []string{"management_group_id"},
 			},
 
 			"display_name": {
@@ -119,10 +130,16 @@ func resourceArmPolicyDefinitionCreateUpdate(d *schema.ResourceData, meta interf
 	mode := d.Get("mode").(string)
 	displayName := d.Get("display_name").(string)
 	description := d.Get("description").(string)
-	managementGroupID := d.Get("management_group_id").(string)
+	managementGroupName := ""
+	if v, ok := d.GetOk("management_group_name"); ok {
+		managementGroupName = v.(string)
+	}
+	if v, ok := d.GetOk("management_group_id"); ok {
+		managementGroupName = v.(string)
+	}
 
 	if d.IsNewResource() {
-		existing, err := getPolicyDefinition(ctx, client, name, managementGroupID)
+		existing, err := getPolicyDefinitionByName(ctx, client, name, managementGroupName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
 				return fmt.Errorf("Error checking for presence of existing Policy Definition %q: %s", name, err)
@@ -172,10 +189,10 @@ func resourceArmPolicyDefinitionCreateUpdate(d *schema.ResourceData, meta interf
 
 	var err error
 
-	if managementGroupID == "" {
+	if managementGroupName == "" {
 		_, err = client.CreateOrUpdate(ctx, name, definition)
 	} else {
-		_, err = client.CreateOrUpdateAtManagementGroup(ctx, name, definition, managementGroupID)
+		_, err = client.CreateOrUpdateAtManagementGroup(ctx, name, definition, managementGroupName)
 	}
 
 	if err != nil {
@@ -187,7 +204,7 @@ func resourceArmPolicyDefinitionCreateUpdate(d *schema.ResourceData, meta interf
 	stateConf := &resource.StateChangeConf{
 		Pending:                   []string{"404"},
 		Target:                    []string{"200"},
-		Refresh:                   policyDefinitionRefreshFunc(ctx, client, name, managementGroupID),
+		Refresh:                   policyDefinitionRefreshFunc(ctx, client, name, managementGroupName),
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 10,
 	}
@@ -202,7 +219,7 @@ func resourceArmPolicyDefinitionCreateUpdate(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error waiting for Policy Definition %q to become available: %s", name, err)
 	}
 
-	resp, err := getPolicyDefinition(ctx, client, name, managementGroupID)
+	resp, err := getPolicyDefinitionByName(ctx, client, name, managementGroupName)
 	if err != nil {
 		return err
 	}
@@ -222,13 +239,13 @@ func resourceArmPolicyDefinitionRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	managementGroupID := ""
+	managementGroupName := ""
 	switch scopeId := id.PolicyScopeId.(type) {
 	case parse.ScopeAtManagementGroup:
-		managementGroupID = scopeId.ManagementGroupId
+		managementGroupName = scopeId.ManagementGroupId
 	}
 
-	resp, err := getPolicyDefinition(ctx, client, id.Name, managementGroupID)
+	resp, err := getPolicyDefinitionByName(ctx, client, id.Name, managementGroupName)
 
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
@@ -241,7 +258,8 @@ func resourceArmPolicyDefinitionRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("name", resp.Name)
-	d.Set("management_group_id", managementGroupID)
+	d.Set("management_group_id", managementGroupName)
+	d.Set("management_group_name", managementGroupName)
 
 	if props := resp.DefinitionProperties; props != nil {
 		d.Set("policy_type", props.PolicyType)
@@ -301,7 +319,7 @@ func resourceArmPolicyDefinitionDelete(d *schema.ResourceData, meta interface{})
 
 func policyDefinitionRefreshFunc(ctx context.Context, client *policy.DefinitionsClient, name string, managementGroupID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := getPolicyDefinition(ctx, client, name, managementGroupID)
+		res, err := getPolicyDefinitionByName(ctx, client, name, managementGroupID)
 
 		if err != nil {
 			return nil, strconv.Itoa(res.StatusCode), fmt.Errorf("Error issuing read request in policyAssignmentRefreshFunc for Policy Assignment %q: %s", name, err)
@@ -309,16 +327,6 @@ func policyDefinitionRefreshFunc(ctx context.Context, client *policy.Definitions
 
 		return res, strconv.Itoa(res.StatusCode), nil
 	}
-}
-
-func getPolicyDefinition(ctx context.Context, client *policy.DefinitionsClient, name string, managementGroupID string) (res policy.Definition, err error) {
-	if managementGroupID == "" {
-		res, err = client.Get(ctx, name)
-	} else {
-		res, err = client.GetAtManagementGroup(ctx, name, managementGroupID)
-	}
-
-	return res, err
 }
 
 func flattenJSON(stringMap interface{}) string {

--- a/azurerm/internal/services/policy/tests/data_source_policy_definition_test.go
+++ b/azurerm/internal/services/policy/tests/data_source_policy_definition_test.go
@@ -56,8 +56,8 @@ func TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName(t *testing.T) 
 			{
 				Config: testAccDataSourceAzureRMPolicyDefinition_customByDisplayName(data),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "name", fmt.Sprintf("acctestpol-%d", data.RandomInteger)),
-					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("acctestpol-display-%d", data.RandomInteger)),
+					resource.TestCheckResourceAttr(data.ResourceName, "name", fmt.Sprintf("acctestPol-%d", data.RandomInteger)),
+					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("acctestPol-display-%d", data.RandomInteger)),
 					resource.TestCheckResourceAttr(data.ResourceName, "type", "Microsoft.Authorization/policyDefinitions"),
 					resource.TestCheckResourceAttr(data.ResourceName, "policy_type", "Custom"),
 					resource.TestCheckResourceAttr(data.ResourceName, "policy_rule", "{\"if\":{\"not\":{\"field\":\"location\",\"in\":\"[parameters('allowedLocations')]\"}},\"then\":{\"effect\":\"audit\"}}"),
@@ -79,8 +79,8 @@ func TestAccDataSourceAzureRMPolicyDefinition_customByName(t *testing.T) {
 			{
 				Config: testAccDataSourceAzureRMPolicyDefinition_customByName(data),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "name", fmt.Sprintf("acctestpol-%d", data.RandomInteger)),
-					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("acctestpol-display-%d", data.RandomInteger)),
+					resource.TestCheckResourceAttr(data.ResourceName, "name", fmt.Sprintf("acctestPol-%d", data.RandomInteger)),
+					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("acctestPol-display-%d", data.RandomInteger)),
 					resource.TestCheckResourceAttr(data.ResourceName, "type", "Microsoft.Authorization/policyDefinitions"),
 					resource.TestCheckResourceAttr(data.ResourceName, "policy_type", "Custom"),
 					resource.TestCheckResourceAttr(data.ResourceName, "policy_rule", "{\"if\":{\"not\":{\"field\":\"location\",\"in\":\"[parameters('allowedLocations')]\"}},\"then\":{\"effect\":\"audit\"}}"),
@@ -149,10 +149,10 @@ provider "azurerm" {
 }
 
 resource "azurerm_policy_definition" "test_policy" {
-  name         = "acctestpol-%d"
+  name         = "acctestPol-%d"
   policy_type  = "Custom"
   mode         = "All"
-  display_name = "acctestpol-display-%d"
+  display_name = "acctestPol-display-%d"
 
   policy_rule = <<POLICY_RULE
   {

--- a/azurerm/internal/services/policy/tests/data_source_policy_definition_test.go
+++ b/azurerm/internal/services/policy/tests/data_source_policy_definition_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccDataSourceAzureRMPolicyDefinition_builtIn(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { acceptance.PreCheck(t) },
 		Providers: acceptance.SupportedProviders,
@@ -30,6 +31,7 @@ func TestAccDataSourceAzureRMPolicyDefinition_builtIn(t *testing.T) {
 
 func TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { acceptance.PreCheck(t) },
 		Providers: acceptance.SupportedProviders,
@@ -44,17 +46,41 @@ func TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup(t *testi
 	})
 }
 
-func TestAccDataSourceAzureRMPolicyDefinition_custom(t *testing.T) {
+func TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { acceptance.PreCheck(t) },
 		Providers: acceptance.SupportedProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceCustomPolicyDefinition(data),
+				Config: testAccDataSourceAzureRMPolicyDefinition_customByDisplayName(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "name", fmt.Sprintf("acctestpol-%d", data.RandomInteger)),
-					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("acctestpol-%d", data.RandomInteger)),
+					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("acctestpol-display-%d", data.RandomInteger)),
+					resource.TestCheckResourceAttr(data.ResourceName, "type", "Microsoft.Authorization/policyDefinitions"),
+					resource.TestCheckResourceAttr(data.ResourceName, "policy_type", "Custom"),
+					resource.TestCheckResourceAttr(data.ResourceName, "policy_rule", "{\"if\":{\"not\":{\"field\":\"location\",\"in\":\"[parameters('allowedLocations')]\"}},\"then\":{\"effect\":\"audit\"}}"),
+					resource.TestCheckResourceAttr(data.ResourceName, "parameters", "{\"allowedLocations\":{\"metadata\":{\"description\":\"The list of allowed locations for resources.\",\"displayName\":\"Allowed locations\",\"strongType\":\"location\"},\"type\":\"Array\"}}"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "metadata"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMPolicyDefinition_customByName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_policy_definition", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMPolicyDefinition_customByName(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "name", fmt.Sprintf("acctestpol-%d", data.RandomInteger)),
+					resource.TestCheckResourceAttr(data.ResourceName, "display_name", fmt.Sprintf("acctestpol-display-%d", data.RandomInteger)),
 					resource.TestCheckResourceAttr(data.ResourceName, "type", "Microsoft.Authorization/policyDefinitions"),
 					resource.TestCheckResourceAttr(data.ResourceName, "policy_type", "Custom"),
 					resource.TestCheckResourceAttr(data.ResourceName, "policy_rule", "{\"if\":{\"not\":{\"field\":\"location\",\"in\":\"[parameters('allowedLocations')]\"}},\"then\":{\"effect\":\"audit\"}}"),
@@ -94,7 +120,29 @@ data "azurerm_policy_definition" "test" {
 `, name)
 }
 
-func testAccDataSourceCustomPolicyDefinition(data acceptance.TestData) string {
+func testAccDataSourceAzureRMPolicyDefinition_customByDisplayName(data acceptance.TestData) string {
+	template := testAccDataSourceAzureRMPolicyDefinition_template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_policy_definition" "test" {
+  display_name = azurerm_policy_definition.test_policy.display_name
+}
+`, template)
+}
+
+func testAccDataSourceAzureRMPolicyDefinition_customByName(data acceptance.TestData) string {
+	template := testAccDataSourceAzureRMPolicyDefinition_template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_policy_definition" "test" {
+  name = azurerm_policy_definition.test_policy.name
+}
+`, template)
+}
+
+func testAccDataSourceAzureRMPolicyDefinition_template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -104,7 +152,7 @@ resource "azurerm_policy_definition" "test_policy" {
   name         = "acctestpol-%d"
   policy_type  = "Custom"
   mode         = "All"
-  display_name = "acctestpol-%d"
+  display_name = "acctestpol-display-%d"
 
   policy_rule = <<POLICY_RULE
   {
@@ -120,7 +168,6 @@ resource "azurerm_policy_definition" "test_policy" {
   }
 POLICY_RULE
 
-
   parameters = <<PARAMETERS
   {
     "allowedLocations": {
@@ -133,18 +180,6 @@ POLICY_RULE
     }
   }
 PARAMETERS
-
-
-  metadata = <<METADATA
-  {
-	"note":"azurerm acceptance test"
-  }
-METADATA
-
-}
-
-data "azurerm_policy_definition" "test" {
-  display_name = azurerm_policy_definition.test_policy.display_name
 }
 `, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -32,7 +32,7 @@ output "id" {
 
 * `display_name` - Specifies the display name of the Policy Definition. Conflicts with `name`.
 
-~> **NOTE** Since `display_name` does not have uniqueness on Azure, therefore when using `display_name` to retrieve existing policy set definitions, errors may occur when there are multiple policy definitions with same display name. 
+~> **NOTE** As `display_name` is not unique errors may occur when there are multiple policy definitions with same display name. 
 
 * `management_group_name` - (Optional) Only retrieve Policy Definitions from this Management Group.
 

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -28,6 +28,8 @@ output "id" {
 
 * `display_name` - Specifies the display name of the Policy Definition. Conflicts with `name`.
 
+~> **NOTE** Since `display_name` does not have uniqueness on Azure, therefore when using `display_name` to retrieve existing policy set definitions, only one of the policy set definitions with same `display_name` will be retrieved. 
+
 * `management_group_id` - (Optional) Only retrieve Policy Definitions from this Management Group.
 
 

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -13,6 +13,10 @@ Use this data source to access information about a Policy Definition, both custo
 ## Example Usage
 
 ```hcl
+provider "azurerm" {
+  features {}
+}
+
 data "azurerm_policy_definition" "example" {
   display_name = "Allowed resource types"
 }
@@ -28,10 +32,11 @@ output "id" {
 
 * `display_name` - Specifies the display name of the Policy Definition. Conflicts with `name`.
 
-~> **NOTE** Since `display_name` does not have uniqueness on Azure, therefore when using `display_name` to retrieve existing policy set definitions, only one of the policy set definitions with same `display_name` will be retrieved. 
+~> **NOTE** Since `display_name` does not have uniqueness on Azure, therefore when using `display_name` to retrieve existing policy set definitions, errors may occur when there are multiple policy definitions with same display name. 
 
-* `management_group_id` - (Optional) Only retrieve Policy Definitions from this Management Group.
+* `management_group_name` - (Optional) Only retrieve Policy Definitions from this Management Group.
 
+* `management_group_id` - (Optional / **Deprecated in favor of `management_group_name`**) Only retrieve Policy Definitions from this Management Group.
 
 ## Attributes Reference
 

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -24,19 +24,27 @@ output "id" {
 
 ## Argument Reference
 
-* `display_name` - Specifies the name of the Policy Definition.
+* `name` - Specifies the name of the Policy Definition. Conflicts with `display_name`.
+
+* `display_name` - Specifies the display name of the Policy Definition. Conflicts with `name`.
+
 * `management_group_id` - (Optional) Only retrieve Policy Definitions from this Management Group.
 
 
 ## Attributes Reference
 
 * `id` - The ID of the Policy Definition.
-* `name` - The Name of the Policy Definition.
+
 * `type` - The Type of Policy.
+
 * `description` - The Description of the Policy.
-* `policy_type` - The Type of the Policy, such as `Microsoft.Authorization/policyDefinitions`.
+
+* `policy_type` - The Type of the Policy. Possible values are "BuiltIn", "Custom" and "NotSpecified".
+
 * `policy_rule` - The Rule as defined (in JSON) in the Policy.
+
 * `parameters` - Any Parameters defined in the Policy.
+
 * `metadata` - Any Metadata defined in the Policy.
 
 ## Timeouts

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -36,8 +36,6 @@ output "id" {
 
 * `management_group_name` - (Optional) Only retrieve Policy Definitions from this Management Group.
 
-* `management_group_id` - (Optional / **Deprecated in favor of `management_group_name`**) Only retrieve Policy Definitions from this Management Group.
-
 ## Attributes Reference
 
 * `id` - The ID of the Policy Definition.

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the policy definition. Changing this forces a
     new resource to be created.
 
-* `policy_type` - (Required) The policy type. Possible values are "BuiltIn", "Custom" and "NotSpecified". Changing this forces a new resource to be created.
+* `policy_type` - (Required) The policy type. Possible values are `BuiltIn`, `Custom` and `NotSpecified`. Changing this forces a new resource to be created.
 
 * `mode` - (Required) The policy mode that allows you to specify which resource
     types will be evaluated.  The value can be "All", "Indexed" or
@@ -83,10 +83,6 @@ The following arguments are supported:
 * `description` - (Optional) The description of the policy definition.
 
 * `management_group_name` - (Optional) The name of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
-
-* `management_group_id` - (Optional / **Deprecated in favor of `management_group_name`**) The name of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
-
-~> **Note:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `.name` and not `.id`.
 
 * `policy_rule` - (Optional) The policy rule for the policy definition. This
     is a json object representing the rule that contains an if and

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -15,6 +15,10 @@ Policy definitions do not take effect until they are assigned to a scope using a
 ## Example Usage
 
 ```hcl
+provider "azurerm" {
+features {}
+}
+
 resource "azurerm_policy_definition" "policy" {
   name         = "accTestPolicy"
   policy_type  = "Custom"
@@ -78,9 +82,11 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of the policy definition.
 
-* `management_group_id` - (Optional) The ID of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
+* `management_group_name` - (Optional) The name of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
 
-~> **Note:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `.group_id` and not `.id`.
+* `management_group_id` - (Optional / **Deprecated in favor of `management_group_name`**) The name of the Management Group where this policy should be defined. Changing this forces a new resource to be created.
+
+~> **Note:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `.name` and not `.id`.
 
 * `policy_rule` - (Optional) The policy rule for the policy definition. This
     is a json object representing the rule that contains an if and

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -67,8 +67,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the policy definition. Changing this forces a
     new resource to be created.
 
-* `policy_type` - (Required) The policy type.  The value can be "BuiltIn", "Custom"
-    or "NotSpecified". Changing this forces a new resource to be created.
+* `policy_type` - (Required) The policy type. Possible values are "BuiltIn", "Custom" and "NotSpecified". Changing this forces a new resource to be created.
 
 * `mode` - (Required) The policy mode that allows you to specify which resource
     types will be evaluated.  The value can be "All", "Indexed" or

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -16,7 +16,7 @@ Policy definitions do not take effect until they are assigned to a scope using a
 
 ```hcl
 provider "azurerm" {
-features {}
+  features {}
 }
 
 resource "azurerm_policy_definition" "policy" {


### PR DESCRIPTION
Fixes #6249 

And I temporarily removed the validation function of management group id, since it will never be a resource ID here, it should be an UUID or some proper name of a management group, rather than a full ID. (And a mgmt group full ID is also not a valid resource ID) 