### PR TITLE
azurerm_mssql_virtual_machine appeared twice in website sidebar

### DIFF
--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1211,10 +1211,6 @@
                 </li>
 
                 <li>
-                  <a href="/docs/providers/azurerm/r/mssql_virtual_machine.html">azurerm_mssql_virtual_machine</a>
-                </li>
-
-                <li>
                   <a href="/docs/providers/azurerm/r/sql_failover_group.html">azurerm_sql_failover_group</a>
                 </li>
 
@@ -1241,6 +1237,7 @@
                 <li>
                   <a href="/docs/providers/azurerm/r/mssql_database_vulnerability_assessment_rule_baseline.html">azurerm_mssql_database_vulnerability_assessment_rule_baseline</a>
                 </li>
+
                 <li>
                   <a href="/docs/providers/azurerm/r/mssql_virtual_machine.html">azurerm_mssql_virtual_machine</a>
                 </li>


### PR DESCRIPTION
`azurerm_mssql_virtual_machine` appeared twice in website sidebar, remove one of them. I keep the last one for consistency of the ordering (seems like mssql unique resources are put at last and ordered in alphabetic).