### PR TITLE
azurerm_[linux|windows]_virtual_machine - if the `priority` property on read is empty assume it to be `Regular`

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -566,8 +566,13 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error setting `secret`: %+v", err)
 		}
 	}
-
-	d.Set("priority", string(props.Priority))
+	// Resources created with azurerm_virtual_machine have priority set to ""
+	// We need to treat "" as equal to "Regular" to allow migration azurerm_virtual_machine -> azurerm_linux_virtual_machine
+	priority := props.Priority
+	if priority == "" {
+		priority = compute.Regular
+	}
+	d.Set("priority", string(priority))
 	proximityPlacementGroupId := ""
 	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
 		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -568,11 +568,11 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 	}
 	// Resources created with azurerm_virtual_machine have priority set to ""
 	// We need to treat "" as equal to "Regular" to allow migration azurerm_virtual_machine -> azurerm_linux_virtual_machine
-	priority := props.Priority
-	if priority == "" {
-		priority = compute.Regular
+	priority := string(compute.Regular)
+	if props.Priority != "" {
+		priority = string(props.Priority)
 	}
-	d.Set("priority", string(priority))
+	d.Set("priority", priority)
 	proximityPlacementGroupId := ""
 	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
 		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -592,8 +592,13 @@ func resourceWindowsVirtualMachineRead(d *schema.ResourceData, meta interface{})
 			return fmt.Errorf("Error setting `secret`: %+v", err)
 		}
 	}
-
-	d.Set("priority", string(props.Priority))
+	// Resources created with azurerm_virtual_machine have priority set to ""
+	// We need to treat "" as equal to "Regular" to allow migration azurerm_virtual_machine -> azurerm_linux_virtual_machine
+	priority := string(compute.Regular)
+	if props.Priority != "" {
+		priority = string(props.Priority)
+	}
+	d.Set("priority", priority)
 	proximityPlacementGroupId := ""
 	if props.ProximityPlacementGroup != nil && props.ProximityPlacementGroup.ID != nil {
 		proximityPlacementGroupId = *props.ProximityPlacementGroup.ID


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-azurerm/issues/6300