### PR TITLE
Fix issue with default_node_pool min/max counts + update documentation

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -68,7 +68,7 @@ func SchemaDefaultNodePool() *schema.Schema {
 				"max_count": {
 					Type:         schema.TypeInt,
 					Optional:     true,
-					ValidateFunc: validation.IntBetween(1, 100),
+					ValidateFunc: validation.IntBetween(0, 100),
 				},
 
 				"max_pods": {
@@ -81,7 +81,7 @@ func SchemaDefaultNodePool() *schema.Schema {
 				"min_count": {
 					Type:         schema.TypeInt,
 					Optional:     true,
-					ValidateFunc: validation.IntBetween(1, 100),
+					ValidateFunc: validation.IntBetween(0, 100),
 				},
 
 				"node_count": {

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -199,15 +199,15 @@ A `default_node_pool` block supports the following:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `vnet_subnet_id` - (Required) The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created.
+* `vnet_subnet_id` - (Optional) The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created.
 
 ~> **NOTE:** A Route Table must be configured on this Subnet.
 
 If `enable_auto_scaling` is set to `true`, then the following fields can also be configured:
 
-* `max_count` - (Required) The maximum number of nodes which should exist in this Node Pool. If specified this must be between `1` and `100`.
+* `max_count` - (Required) The maximum number of nodes which should exist in this Node Pool. If specified this must be between `0` and `100`.
 
-* `min_count` - (Required) The minimum number of nodes which should exist in this Node Pool. If specified this must be between `1` and `100`.
+* `min_count` - (Required) The minimum number of nodes which should exist in this Node Pool. If specified this must be between `0` and `100`.
 
 * `node_count` - (Optional) The initial number of nodes which should exist in this Node Pool. If specified this must be between `1` and `100` and between `min_count` and `max_count`.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -94,9 +94,9 @@ The following arguments are supported:
 
 When `enable_auto_scaling` is set to `true` the following fields are applicable:
 
-* `max_count` - (Required) The maximum number of nodes which should exist within this Node Pool. Valid values are between `1` and `100` and must be greater than or equal to `min_count`.
+* `max_count` - (Required) The maximum number of nodes which should exist within this Node Pool. Valid values are between `0` and `100` and must be greater than or equal to `min_count`.
 
-* `min_count` - (Required) The minimum number of nodes which should exist within this Node Pool. Valid values are between `1` and `100` and must be less than or equal to `max_count`.
+* `min_count` - (Required) The minimum number of nodes which should exist within this Node Pool. Valid values are between `0` and `100` and must be less than or equal to `max_count`.
 
 * `node_count` - (Optional) The initial number of nodes which should exist within this Node Pool. Valid values are between `1` and `100` and must be a value in the range `min_count` - `max_count`.
 


### PR DESCRIPTION
The max/min counts in the default node pool should be in the range of 0 to 100, not 1 and 100. This is a similar issue to that of #6020, but was never fixed for the default node pool.

I have also updated both sets of documentation to reflect these changes.

One minor update I snuck in this PR as well is just fixing the documentation for vnet_subnet_id. It is not required.

EDIT: This is potentially related to #6094 as well.