### PR TITLE
[docs] r/network_interface: deprecation of network_security_group_id

### DIFF
--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -498,6 +498,8 @@ The deprecated `elastic_pool_properties` block will be removed. The fields insid
 
 ### Resource: `azurerm_network_interface`
 
+The deprecated field `network_security_group_id` will be removed. This has been replaced by the `azurerm_network_interface_security_group_association` resource.
+
 The `application_gateway_backend_address_pools_ids` field in the `ip_configuration` block will been removed. This has been replaced by the `azurerm_network_interface_application_gateway_backend_address_pool_association` resource.
 
 The `application_security_group_ids` field in the `ip_configuration` block will been removed. This has been replaced by the `azurerm_network_interface_application_security_group_association` resource.


### PR DESCRIPTION
- Adds note about deprecation of network_security_group_id from
  azurerm_network_interface resource
- https://github.com/terraform-providers/terraform-provider-azurerm/commit/34340db17924ea5709f2d174ca5a1f1240496cf3
- Was removed as part of this change:
  https://github.com/terraform-providers/terraform-provider-azurerm/pull/5784
- https://github.com/terraform-providers/terraform-provider-azurerm/commit/1a18b602c780be2853356b258a62176b46d85672#diff-48bf6bb7ecd6633b3e630a979a1310fcL54-L59
- https://github.com/terraform-providers/terraform-provider-azurerm/commit/cad4978e7f7bd6b670778660dff325a81d84e9b4#diff-3e3cb722044612d9ebfdf8be04ad1520L63
