### PR TITLE
New Resource: `azurerm_log_analytics_workspace_datasource_iis`

### DIFF
--- a/azurerm/internal/services/loganalytics/registration.go
+++ b/azurerm/internal/services/loganalytics/registration.go
@@ -30,6 +30,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_log_analytics_linked_service":                         resourceArmLogAnalyticsLinkedService(),
 		"azurerm_log_analytics_solution":                               resourceArmLogAnalyticsSolution(),
 		"azurerm_log_analytics_workspace":                              resourceArmLogAnalyticsWorkspace(),
+		"azurerm_log_analytics_datasource_iis":                         resourceArmLogAnalyticsDataSourceIIS(),
 		"azurerm_log_analytics_datasource_windows_event":               resourceArmLogAnalyticsDataSourceWindowsEvent(),
 		"azurerm_log_analytics_datasource_windows_performance_counter": resourceArmLogAnalyticsDataSourceWindowsPerformanceCounter(),
 	}

--- a/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_iis.go
+++ b/azurerm/internal/services/loganalytics/resource_arm_log_analytics_datasource_iis.go
@@ -1,0 +1,184 @@
+package loganalytics
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/operationalinsights/mgmt/2015-11-01-preview/operationalinsights"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmLogAnalyticsDataSourceIIS() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLogAnalyticsDataSourceIISCreateUpdate,
+		Read:   resourceArmLogAnalyticsDataSourceIISRead,
+		Update: resourceArmLogAnalyticsDataSourceIISCreateUpdate,
+		Delete: resourceArmLogAnalyticsDataSourceIISDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImportThen(func(id string) error {
+			_, err := parse.LogAnalyticsDataSourceID(id)
+			return err
+		}, importLogAnalyticsDataSource(operationalinsights.IISLogs)),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"workspace_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     ValidateAzureRmLogAnalyticsWorkspaceName,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(dataSourceIISStateOnPremiseEnabled),
+					string(dataSourceIISStateOnPremiseDisabled),
+				}, false),
+			},
+		},
+	}
+}
+
+type dataSourceIISState string
+
+const (
+	dataSourceIISStateOnPremiseEnabled  dataSourceIISState = "OnPremiseEnabled"
+	dataSourceIISStateOnPremiseDisabled dataSourceIISState = "OnPremiseDisabled"
+)
+
+type dataSourceIISProperty struct {
+	State dataSourceIISState `json:"state"`
+}
+
+func resourceArmLogAnalyticsDataSourceIISCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	workspaceName := d.Get("workspace_name").(string)
+
+	if d.IsNewResource() {
+		resp, err := client.Get(ctx, resourceGroup, workspaceName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("failed to check for existing Log Analytics Data Source IIS %q (Resource Group %q / Workspace: %q): %+v", name, resourceGroup, workspaceName, err)
+			}
+		}
+
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return tf.ImportAsExistsError("azurerm_log_analytics_datasource_iis", *resp.ID)
+		}
+	}
+
+	param := operationalinsights.DataSource{
+		Kind: operationalinsights.IISLogs,
+		Properties: &dataSourceIISProperty{
+			State: dataSourceIISState(d.Get("state").(string)),
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, workspaceName, name, param); err != nil {
+		return fmt.Errorf("failed to create Log Analytics DataSource IIS %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, workspaceName, name)
+	if err != nil {
+		return fmt.Errorf("failed to retrieving Log Analytics Data Source IIS %q (Resource Group %q / Workspace %q): %+v", name, resourceGroup, workspaceName, err)
+	}
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("Cannot read Log Analytics Data Source IIS %q (Resource Group %q / Workspace: %q) ID", name, resourceGroup, workspaceName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmLogAnalyticsDataSourceIISRead(d, meta)
+}
+
+func resourceArmLogAnalyticsDataSourceIISRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LogAnalyticsDataSourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Log Analytics Data Source IIS %q was not found in Resource Group %q in Workspace %q - removing from state!", id.Name, id.ResourceGroup, id.Workspace)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("failed to retrieve Log Analytics Data Source IIS %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("workspace_name", id.Workspace)
+	if props := resp.Properties; props != nil {
+		propStr, err := structure.FlattenJsonToString(props.(map[string]interface{}))
+		if err != nil {
+			return fmt.Errorf("failed to flatten properties map to json for Log Analytics DataSource IIS %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+		}
+
+		prop := &dataSourceIISProperty{}
+		if err := json.Unmarshal([]byte(propStr), &prop); err != nil {
+			return fmt.Errorf("failed to decode properties json for Log Analytics DataSource IIS %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+		}
+
+		d.Set("state", prop.State)
+	}
+
+	return nil
+}
+
+func resourceArmLogAnalyticsDataSourceIISDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LogAnalyticsDataSourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+		return fmt.Errorf("failed to delete Log Analytics Data Source IIS %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_iis_test.go
+++ b/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_iis_test.go
@@ -160,10 +160,10 @@ func testAccAzureRMLogAnalyticsDataSourceIIS_basic(data acceptance.TestData) str
 %s
 
 resource "azurerm_log_analytics_datasource_iis" "test" {
-  name = "acctestLADS-IIS-%d"
+  name                = "acctestLADS-IIS-%d"
   resource_group_name = azurerm_resource_group.test.name
-  workspace_name = azurerm_log_analytics_workspace.test.name
-  state = "OnPremiseEnabled"
+  workspace_name      = azurerm_log_analytics_workspace.test.name
+  on_premise_enabled  = true
 }
 `, template, data.RandomInteger)
 }
@@ -174,10 +174,10 @@ func testAccAzureRMLogAnalyticsDataSourceIIS_complete(data acceptance.TestData) 
 %s
 
 resource "azurerm_log_analytics_datasource_iis" "test" {
-  name = "acctestLADS-IIS-%d"
+  name                = "acctestLADS-IIS-%d"
   resource_group_name = azurerm_resource_group.test.name
-  workspace_name = azurerm_log_analytics_workspace.test.name
-  state = "OnPremiseDisabled"
+  workspace_name      = azurerm_log_analytics_workspace.test.name
+  on_premise_enabled  = false
 }
 `, template, data.RandomInteger)
 }
@@ -188,10 +188,10 @@ func testAccAzureRMLogAnalyticsDataSourceIIS_requiresImport(data acceptance.Test
 %s
 
 resource "azurerm_log_analytics_datasource_iis" "import" {
-  name = azurerm_log_analytics_datasource_iis.test.name
+  name                = azurerm_log_analytics_datasource_iis.test.name
   resource_group_name = azurerm_log_analytics_datasource_iis.test.resource_group_name
-  workspace_name = azurerm_log_analytics_datasource_iis.test.workspace_name
-  state = azurerm_log_analytics_datasource_iis.test.state
+  workspace_name      = azurerm_log_analytics_datasource_iis.test.workspace_name
+  on_premise_enabled  = azurerm_log_analytics_datasource_iis.test.on_premise_enabled
 }
 `, template)
 }

--- a/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_iis_test.go
+++ b/azurerm/internal/services/loganalytics/tests/resource_arm_log_analytics_datasource_iis_test.go
@@ -1,0 +1,217 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMLogAnalyticsDataSourceIIS_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_iis", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceIISDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceIIS_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceIISExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMLogAnalyticsDataSourceIIS_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_iis", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceIISDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceIIS_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceIISExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMLogAnalyticsDataSourceIIS_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_iis", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceIISDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceIIS_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceIISExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceIIS_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceIISExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceIIS_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceIISExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMLogAnalyticsDataSourceIIS_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_iis", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceIISDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceIIS_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceIISExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMLogAnalyticsDataSourceIIS_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMLogAnalyticsDataSourceIISExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).LogAnalytics.DataSourcesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Log Analytics Data Source IIS not found: %s", resourceName)
+		}
+
+		id, err := parse.LogAnalyticsDataSourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Log Analytics Data Source IIS %q (Resource Group %q) does not exist", id.Name, id.ResourceGroup)
+			}
+			return fmt.Errorf("failed to get on LogAnalytics.DataSources: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLogAnalyticsDataSourceIISDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_log_analytics_datasource_iis" {
+			continue
+		}
+
+		id, err := parse.LogAnalyticsDataSourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("failed to get on LogAnalytics.DataSources: %+v", err)
+			}
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMLogAnalyticsDataSourceIIS_basic(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceIIS_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_iis" "test" {
+  name = "acctestLADS-IIS-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name = azurerm_log_analytics_workspace.test.name
+  state = "OnPremiseEnabled"
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceIIS_complete(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceIIS_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_iis" "test" {
+  name = "acctestLADS-IIS-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name = azurerm_log_analytics_workspace.test.name
+  state = "OnPremiseDisabled"
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceIIS_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceIIS_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_iis" "import" {
+  name = azurerm_log_analytics_datasource_iis.test.name
+  resource_group_name = azurerm_log_analytics_datasource_iis.test.resource_group_name
+  workspace_name = azurerm_log_analytics_datasource_iis.test.workspace_name
+  state = azurerm_log_analytics_datasource_iis.test.state
+}
+`, template)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceIIS_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-la-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1618,6 +1618,10 @@
               <a href="#">Log Analytics Resources</a>
               <ul class="nav">
                 <li>
+                  <a href="/docs/providers/azurerm/r/log_analytics_datasource_iis.html">azurerm_log_analytics_datasource_iis</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/log_analytics_datasource_windows_event.html">azurerm_log_analytics_datasource_windows_event</a>
                 </li>
 

--- a/website/docs/r/log_analytics_datasource_iis.html.markdown
+++ b/website/docs/r/log_analytics_datasource_iis.html.markdown
@@ -1,0 +1,73 @@
+---
+subcategory: "Log Analytics"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_log_analytics_datasource_iis"
+description: |-
+  Manages a Log Analytics IIS DataSource.
+---
+
+# azurerm_log_analytics_datasource_iis
+
+Manages a Log Analytics IIS DataSource.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-law"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_log_analytics_datasource_iis" "example" {
+  name                = "example-lad-iis"
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
+  state = "OnPremiseEnabled"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Log Analytics IIS DataSource. Changing this forces a new Log Analytics IIS DataSource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Log Analytics IIS DataSource should exist. Changing this forces a new Log Analytics IIS DataSource to be created.
+
+* `workspace_name` - (Required) The name of the Log Analytics Workspace where the Log Analytics IIS DataSource should exist. Changing this forces a new Log Analytics Windows Event DataSource to be created.
+
+* `state` - (Required) The state of Log Analytics IIS DataSource. Possible values are "OnPremiseEnabled" and "OnPremiseDisabled".
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Log Analytics IIS DataSource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Log Analytics IIS DataSource.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Log Analytics IIS DataSource.
+* `update` - (Defaults to 30 minutes) Used when updating the Log Analytics IIS DataSource.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Log Analytics IIS DataSource.
+
+## Import
+
+Log Analytics IIS DataSources can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_log_analytics_datasource_iis.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/datasources/datasource1
+```

--- a/website/docs/r/log_analytics_datasource_iis.html.markdown
+++ b/website/docs/r/log_analytics_datasource_iis.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `workspace_name` - (Required) The name of the Log Analytics Workspace where the Log Analytics IIS DataSource should exist. Changing this forces a new Log Analytics Windows Event DataSource to be created.
 
-* `on_premise_enabled` - (Required) Whether enable collecting IIS log files?
+* `on_premise_enabled` - (Required) Should collecting IIS log files be enabled?
 
 ## Attributes Reference
 

--- a/website/docs/r/log_analytics_datasource_iis.html.markdown
+++ b/website/docs/r/log_analytics_datasource_iis.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_log_analytics_datasource_iis" "example" {
   name                = "example-lad-iis"
   resource_group_name = azurerm_resource_group.example.name
   workspace_name      = azurerm_log_analytics_workspace.example.name
-  state = "OnPremiseEnabled"
+  on_premise_enabled  = true
 }
 ```
 
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `workspace_name` - (Required) The name of the Log Analytics Workspace where the Log Analytics IIS DataSource should exist. Changing this forces a new Log Analytics Windows Event DataSource to be created.
 
-* `state` - (Required) The state of Log Analytics IIS DataSource. Possible values are "OnPremiseEnabled" and "OnPremiseDisabled".
+* `on_premise_enabled` - (Required) Whether enable collecting IIS log files?
 
 ## Attributes Reference
 


### PR DESCRIPTION
This implements one of the log analytics workspace data sources required in #3182

Test result:

```bash
> make testacc TEST=./azurerm/internal/services/loganalytics/tests TESTARGS="-run='TestAccAzureRMLogAnalyticsDataSourceIIS_'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/loganalytics/tests -v -run='TestAccAzureRMLogAnalyticsDataSourceIIS_' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLogAnalyticsDataSourceIIS_basic
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceIIS_basic
=== RUN   TestAccAzureRMLogAnalyticsDataSourceIIS_complete
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceIIS_complete
=== RUN   TestAccAzureRMLogAnalyticsDataSourceIIS_update
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceIIS_update
=== RUN   TestAccAzureRMLogAnalyticsDataSourceIIS_requiresImport
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceIIS_requiresImport
=== CONT  TestAccAzureRMLogAnalyticsDataSourceIIS_basic
=== CONT  TestAccAzureRMLogAnalyticsDataSourceIIS_requiresImport
=== CONT  TestAccAzureRMLogAnalyticsDataSourceIIS_update
=== CONT  TestAccAzureRMLogAnalyticsDataSourceIIS_complete
--- PASS: TestAccAzureRMLogAnalyticsDataSourceIIS_complete (195.06s)
--- PASS: TestAccAzureRMLogAnalyticsDataSourceIIS_requiresImport (223.45s)
--- PASS: TestAccAzureRMLogAnalyticsDataSourceIIS_basic (390.64s)
--- PASS: TestAccAzureRMLogAnalyticsDataSourceIIS_update (500.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/tests  500.324s
```