### PR TITLE
azurerm_machine_learning_workspace - fix: #6339 sku_name

### DIFF
--- a/azurerm/internal/services/machinelearning/resource_arm_machine_learning_workspace.go
+++ b/azurerm/internal/services/machinelearning/resource_arm_machine_learning_workspace.go
@@ -173,7 +173,10 @@ func resourceArmMachineLearningWorkspaceCreate(d *schema.ResourceData, meta inte
 		Name:     &name,
 		Location: &location,
 		Tags:     tags.Expand(t),
-		Sku:      &machinelearningservices.Sku{Name: utils.String(skuName)},
+		Sku: &machinelearningservices.Sku{
+			Name: utils.String(skuName),
+			Tier: utils.String(skuName),
+		},
 		Identity: expandArmMachineLearningWorkspaceIdentity(d.Get("identity").([]interface{})),
 		WorkspaceProperties: &machinelearningservices.WorkspaceProperties{
 			StorageAccount:      &storageAccountId,
@@ -291,6 +294,7 @@ func resourceArmMachineLearningWorkspaceUpdate(d *schema.ResourceData, meta inte
 		skuName := d.Get("sku_name").(string)
 		update.Sku = &machinelearningservices.Sku{
 			Name: &skuName,
+			Tier: &skuName,
 		}
 	}
 

--- a/azurerm/internal/services/machinelearning/tests/resource_arm_machine_learning_workspace_test.go
+++ b/azurerm/internal/services/machinelearning/tests/resource_arm_machine_learning_workspace_test.go
@@ -96,6 +96,7 @@ func TestAccAzureRMMachineLearningWorkspace_complete(t *testing.T) {
 					testCheckAzureRMMachineLearningWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "friendly_name", "test-workspace"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", "Test machine learning workspace"),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku_name", "Enterprise"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
 				),
 			},
@@ -118,6 +119,7 @@ func TestAccAzureRMMachineLearningWorkspace_completeUpdate(t *testing.T) {
 					testCheckAzureRMMachineLearningWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "friendly_name", "test-workspace"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", "Test machine learning workspace"),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku_name", "Enterprise"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "1"),
 				),
 			},
@@ -128,6 +130,7 @@ func TestAccAzureRMMachineLearningWorkspace_completeUpdate(t *testing.T) {
 					testCheckAzureRMMachineLearningWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "friendly_name", "test-workspace-updated"),
 					resource.TestCheckResourceAttr(data.ResourceName, "description", "Test machine learning workspace update"),
+					resource.TestCheckResourceAttr(data.ResourceName, "sku_name", "Enterprise"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "2"),
 				),
 			},
@@ -257,10 +260,12 @@ resource "azurerm_machine_learning_workspace" "test" {
   key_vault_id            = azurerm_key_vault.test.id
   storage_account_id      = azurerm_storage_account.test.id
   container_registry_id   = azurerm_container_registry.test.id
+  sku_name                = "Enterprise"
 
   identity {
     type = "SystemAssigned"
   }
+
 
   tags = {
     ENV = "Test"
@@ -292,6 +297,7 @@ resource "azurerm_machine_learning_workspace" "test" {
   key_vault_id            = azurerm_key_vault.test.id
   storage_account_id      = azurerm_storage_account.test.id
   container_registry_id   = azurerm_container_registry.test.id
+  sku_name                = "Enterprise"
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Hello,

Fixes #6339 . Looks as though the Tier, which is equivalent to the Name, has to be passed alongside the Name to take effect in the sku.

Tested:
- Creation with sku_name "Enterprise" and re-apply (no detection of "Basic" as reported, and verified through UI)
- Creation with sku_name "Basic", update to "Enterprise", and re-apply (Upgrades to Enterprise and stays Enterprise, verified through UI)

References:
https://docs.microsoft.com/en-us/azure/machine-learning/how-to-create-workspace-template

And from the API model:
```
// Sku sku of the resource                                                      
type Sku struct {                                                               
  // Name - Name of the sku                                                     
  Name *string `json:"name,omitempty"`                                          
  // Tier - Tier of the sku like Basic or Enterprise                            
  Tier *string `json:"tier,omitempty"`                                          
}
```