### PR TITLE
Apim example

### DIFF
--- a/examples/api-management/README.md
+++ b/examples/api-management/README.md
@@ -1,0 +1,3 @@
+## Example: API Management
+
+This example provisions an API Management service, containing an API based on a provided Open API spec, a Group, and a Product that is associated with both.

--- a/examples/api-management/main.tf
+++ b/examples/api-management/main.tf
@@ -1,0 +1,78 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+resource "azurerm_api_management" "apim_service" {
+  name                = "${var.prefix}-apim-service"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+  publisher_name      = "Example Publisher"
+  publisher_email     = "publisher@example.com"
+  sku_name            = "Developer_1"
+  tags = {
+    Environment = "Example"
+  }
+  policy {
+    xml_content = <<XML
+    <policies>
+      <inbound />
+      <backend />
+      <outbound />
+      <on-error />
+    </policies>
+XML
+  }
+}
+
+resource "azurerm_api_management_api" "api" {
+  name                = "${var.prefix}-api"
+  resource_group_name = azurerm_resource_group.rg.name
+  api_management_name = azurerm_api_management.apim_service.name
+  revision            = "1"
+  display_name        = "${var.prefix}-api"
+  path                = "example"
+  protocols           = ["https", "http"]
+  description         = "An example API"
+  import {
+    content_format = var.open_api_spec_content_format
+    content_value  = var.open_api_spec_content_value
+  }
+}
+
+resource "azurerm_api_management_product" "product" {
+  product_id            = "${var.prefix}-product"
+  resource_group_name   = azurerm_resource_group.rg.name
+  api_management_name   = azurerm_api_management.apim_service.name
+  display_name          = "${var.prefix}-product"
+  subscription_required = true
+  approval_required     = false
+  published             = true
+  description           = "An example Product"
+}
+
+resource "azurerm_api_management_group" "group" {
+  name                = "${var.prefix}-group"
+  resource_group_name = azurerm_resource_group.rg.name
+  api_management_name = azurerm_api_management.apim_service.name
+  display_name        = "${var.prefix}-group"
+  description         = "An example group"
+}
+
+resource "azurerm_api_management_product_api" "product_api" {
+  resource_group_name = azurerm_resource_group.rg.name
+  api_management_name = azurerm_api_management.apim_service.name
+  product_id          = azurerm_api_management_product.product.product_id
+  api_name            = azurerm_api_management_api.api.name
+}
+
+resource "azurerm_api_management_product_group" "product_group" {
+  resource_group_name = azurerm_resource_group.rg.name
+  api_management_name = azurerm_api_management.apim_service.name
+  product_id          = azurerm_api_management_product.product.product_id
+  group_name          = azurerm_api_management_group.group.name
+}

--- a/examples/api-management/outputs.tf
+++ b/examples/api-management/outputs.tf
@@ -1,0 +1,45 @@
+output "service_id" {
+  description = "The ID of the API Management Service created"
+  value       = azurerm_api_management.apim_service.id
+}
+
+output "gateway_url" {
+  description = "The URL of the Gateway for the API Management Service"
+  value       = azurerm_api_management.apim_service.gateway_url
+}
+
+output "service_public_ip_addresses" {
+  description = "The Public IP addresses of the API Management Service"
+  value       = azurerm_api_management.apim_service.public_ip_addresses
+}
+
+output "api_outputs" {
+  description = "The IDs, state, and version outputs of the APIs created"
+  value = {
+      id             = azurerm_api_management_api.api.id
+      is_current     = azurerm_api_management_api.api.is_current
+      is_online      = azurerm_api_management_api.api.is_online
+      version        = azurerm_api_management_api.api.version
+      version_set_id = azurerm_api_management_api.api.version_set_id
+    }
+}
+
+output "group_id" {
+  description = "The ID of the API Management Group created"
+  value = azurerm_api_management_group.group.id
+}
+
+output "product_ids" {
+  description = "The ID of the Product created"
+  value = azurerm_api_management_product.product.id
+}
+
+output "product_api_ids" {
+  description = "The ID of the Product/API association created"
+  value       = azurerm_api_management_product_api.product_api.id
+}
+
+output "product_group_ids" {
+  description = "The ID of the Product/Group association created"
+  value       = azurerm_api_management_product_group.product_group.id
+}

--- a/examples/api-management/variables.tf
+++ b/examples/api-management/variables.tf
@@ -1,0 +1,15 @@
+variable "prefix" {
+  description = "The prefix which should be used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created."
+}
+
+variable "open_api_spec_content_format" {
+    description = "The format of the content from which the API Definition should be imported. Possible values are: swagger-json, swagger-link-json, wadl-link-json, wadl-xml, wsdl and wsdl-link."
+}
+
+variable "open_api_spec_content_value" {
+    description = "The Content from which the API Definition should be imported. When a content_format of *-link-* is specified this must be a URL, otherwise this must be defined inline."
+}


### PR DESCRIPTION
I've added an example for API Management that allows the user to create a new APIM service that contains an API, Group, and Product. I've added outputs as well, though many of the other examples do not include them. 