### PR TITLE
Update Azure Policy Apply Example

### DIFF
--- a/website/docs/r/policy_assignment.html.markdown
+++ b/website/docs/r/policy_assignment.html.markdown
@@ -63,7 +63,7 @@ resource "azurerm_policy_assignment" "example" {
 
   parameters = <<PARAMETERS
 {
-  "allowedLocations": {
+  "listOfAllowedLocations": {
     "value": [ "West Europe" ]
   }
 }


### PR DESCRIPTION
Azure schema changed and JSON needs to use `listOfAllowedLocations` instead of `allowedLocations`. Otherwise you get this error:

```
Error: policy.AssignmentsClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="MissingPolicyParameter" Message="The policy assignment 'allowed_locations' is missing the parameter(s) 'listOfAllowedLocations' as defined in the policy definition 'e56962a6-4747-49cd-b67b-bf8b01975c4c'."
```
That policy definition refers to a built-in Azure Policy - see https://docs.microsoft.com/en-us/azure/governance/policy/samples/built-in-policies#general