### PR TITLE
Deprecation of `azurerm.kubernetes_cluster.private_link_enabled` for `enable_private_cluster`

### DIFF
--- a/azurerm/internal/services/containers/data_source_kubernetes_cluster.go
+++ b/azurerm/internal/services/containers/data_source_kubernetes_cluster.go
@@ -215,11 +215,11 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 				Type:          schema.TypeBool,
 				Computed:      true,
 				Optional:      true,
-				ConflictsWith: []string{"enable_private_cluster"},
-				Deprecated:    "Deprecated in favor of `enable_private_cluster`", // TODO -- remove this in next major version
+				ConflictsWith: []string{"private_cluster_enabled"},
+				Deprecated:    "Deprecated in favor of `private_cluster_enabled`", // TODO -- remove this in next major version
 			},
 
-			"enable_private_cluster": {
+			"private_cluster_enabled": {
 				Type:          schema.TypeBool,
 				Optional:      true,
 				Computed:      true, // TODO -- remove this when deprecation resolves
@@ -503,7 +503,7 @@ func dataSourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}
 			}
 
 			d.Set("private_link_enabled", accessProfile.EnablePrivateCluster)
-			d.Set("enable_private_cluster", accessProfile.EnablePrivateCluster)
+			d.Set("private_cluster_enabled", accessProfile.EnablePrivateCluster)
 		}
 
 		addonProfiles := flattenKubernetesClusterDataSourceAddonProfiles(props.AddonProfiles)

--- a/azurerm/internal/services/containers/data_source_kubernetes_cluster.go
+++ b/azurerm/internal/services/containers/data_source_kubernetes_cluster.go
@@ -212,8 +212,18 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 			},
 
 			"private_link_enabled": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:          schema.TypeBool,
+				Computed:      true,
+				Optional:      true,
+				ConflictsWith: []string{"enable_private_cluster"},
+				Deprecated:    "Deprecated in favor of `enable_private_cluster`", // TODO -- remove this in next major version
+			},
+
+			"enable_private_cluster": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true, // TODO -- remove this when deprecation resolves
+				ConflictsWith: []string{"private_link_enabled"},
 			},
 
 			"private_fqdn": {
@@ -493,6 +503,7 @@ func dataSourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}
 			}
 
 			d.Set("private_link_enabled", accessProfile.EnablePrivateCluster)
+			d.Set("enable_private_cluster", accessProfile.EnablePrivateCluster)
 		}
 
 		addonProfiles := flattenKubernetesClusterDataSourceAddonProfiles(props.AddonProfiles)

--- a/azurerm/internal/services/containers/resource_arm_kubernetes_cluster.go
+++ b/azurerm/internal/services/containers/resource_arm_kubernetes_cluster.go
@@ -302,11 +302,11 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ConflictsWith: []string{"enable_private_cluster"},
-				Deprecated:    "Deprecated in favor of `enable_private_cluster`", // TODO -- remove this in next major version
+				ConflictsWith: []string{"private_cluster_enabled"},
+				Deprecated:    "Deprecated in favor of `private_cluster_enabled`", // TODO -- remove this in next major version
 			},
 
-			"enable_private_cluster": {
+			"private_cluster_enabled": {
 				Type:          schema.TypeBool,
 				Optional:      true,
 				ForceNew:      true,
@@ -574,7 +574,7 @@ func resourceArmKubernetesClusterCreate(d *schema.ResourceData, meta interface{}
 	if v, ok := d.GetOk("private_link_enabled"); ok {
 		enablePrivateCluster = v.(bool)
 	}
-	if v, ok := d.GetOk("enable_private_cluster"); ok {
+	if v, ok := d.GetOk("private_cluster_enabled"); ok {
 		enablePrivateCluster = v.(bool)
 	}
 
@@ -765,7 +765,7 @@ func resourceArmKubernetesClusterUpdate(d *schema.ResourceData, meta interface{}
 		if v, ok := d.GetOk("private_link_enabled"); ok {
 			enablePrivateCluster = v.(bool)
 		}
-		if v, ok := d.GetOk("enable_private_cluster"); ok {
+		if v, ok := d.GetOk("private_cluster_enabled"); ok {
 			enablePrivateCluster = v.(bool)
 		}
 		existing.ManagedClusterProperties.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
@@ -930,7 +930,7 @@ func resourceArmKubernetesClusterRead(d *schema.ResourceData, meta interface{}) 
 			}
 
 			d.Set("private_link_enabled", accessProfile.EnablePrivateCluster)
-			d.Set("enable_private_cluster", accessProfile.EnablePrivateCluster)
+			d.Set("private_cluster_enabled", accessProfile.EnablePrivateCluster)
 		}
 
 		addonProfiles := flattenKubernetesAddOnProfiles(props.AddonProfiles)

--- a/azurerm/internal/services/containers/tests/data_source_kubernetes_cluster_test.go
+++ b/azurerm/internal/services/containers/tests/data_source_kubernetes_cluster_test.go
@@ -60,7 +60,7 @@ func testAccDataSourceAzureRMKubernetesCluster_privateCluster(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "private_fqdn"),
-					resource.TestCheckResourceAttr(data.ResourceName, "enable_private_cluster", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_cluster_enabled", "true"),
 				),
 			},
 			data.ImportStep("service_principal.0.client_secret"),

--- a/azurerm/internal/services/containers/tests/data_source_kubernetes_cluster_test.go
+++ b/azurerm/internal/services/containers/tests/data_source_kubernetes_cluster_test.go
@@ -42,12 +42,12 @@ func testAccDataSourceAzureRMKubernetesCluster_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceAzureRMKubernetesCluster_privateLink(t *testing.T) {
+func TestAccDataSourceAzureRMKubernetesCluster_privateCluster(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
-	testAccDataSourceAzureRMKubernetesCluster_privateLink(t)
+	testAccDataSourceAzureRMKubernetesCluster_privateCluster(t)
 }
 
-func testAccDataSourceAzureRMKubernetesCluster_privateLink(t *testing.T) {
+func testAccDataSourceAzureRMKubernetesCluster_privateCluster(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 
 	resource.Test(t, resource.TestCase{
@@ -56,11 +56,11 @@ func testAccDataSourceAzureRMKubernetesCluster_privateLink(t *testing.T) {
 		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMKubernetesCluster_privateLinkConfig(data, true),
+				Config: testAccAzureRMKubernetesCluster_privateClusterConfig(data, true),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "private_fqdn"),
-					resource.TestCheckResourceAttr(data.ResourceName, "private_link_enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_private_cluster", "true"),
 				),
 			},
 			data.ImportStep("service_principal.0.client_secret"),

--- a/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_network_test.go
+++ b/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_network_test.go
@@ -348,7 +348,7 @@ func testAccAzureRMKubernetesCluster_privateClusterOn(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "private_fqdn"),
-					resource.TestCheckResourceAttr(data.ResourceName, "enable_private_cluster", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_cluster_enabled", "true"),
 				),
 			},
 			data.ImportStep(),
@@ -373,7 +373,7 @@ func testAccAzureRMKubernetesCluster_privateClusterOff(t *testing.T) {
 				Config: testAccAzureRMKubernetesCluster_privateClusterConfig(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "enable_private_cluster", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "private_cluster_enabled", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -1026,11 +1026,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                   = "acctestaks%d"
-  location               = azurerm_resource_group.test.location
-  resource_group_name    = azurerm_resource_group.test.name
-  dns_prefix             = "acctestaks%d"
-  enable_private_cluster = %t
+  name                    = "acctestaks%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  dns_prefix              = "acctestaks%d"
+  private_cluster_enabled = %t
 
   linux_profile {
     admin_username = "acctestuser%d"

--- a/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_network_test.go
+++ b/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_network_test.go
@@ -330,12 +330,12 @@ func testAccAzureRMKubernetesCluster_outboundTypeUserDefinedRouting(t *testing.T
 	})
 }
 
-func TestAccAzureRMKubernetesCluster_privateLinkOn(t *testing.T) {
+func TestAccAzureRMKubernetesCluster_privateClusterOn(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
-	testAccAzureRMKubernetesCluster_privateLinkOn(t)
+	testAccAzureRMKubernetesCluster_privateClusterOn(t)
 }
 
-func testAccAzureRMKubernetesCluster_privateLinkOn(t *testing.T) {
+func testAccAzureRMKubernetesCluster_privateClusterOn(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -344,11 +344,11 @@ func testAccAzureRMKubernetesCluster_privateLinkOn(t *testing.T) {
 		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMKubernetesCluster_privateLinkConfig(data, true),
+				Config: testAccAzureRMKubernetesCluster_privateClusterConfig(data, true),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "private_fqdn"),
-					resource.TestCheckResourceAttr(data.ResourceName, "private_link_enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_private_cluster", "true"),
 				),
 			},
 			data.ImportStep(),
@@ -356,12 +356,12 @@ func testAccAzureRMKubernetesCluster_privateLinkOn(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMKubernetesCluster_privateLinkOff(t *testing.T) {
+func TestAccAzureRMKubernetesCluster_privateClusterOff(t *testing.T) {
 	checkIfShouldRunTestsIndividually(t)
-	testAccAzureRMKubernetesCluster_privateLinkOff(t)
+	testAccAzureRMKubernetesCluster_privateClusterOff(t)
 }
 
-func testAccAzureRMKubernetesCluster_privateLinkOff(t *testing.T) {
+func testAccAzureRMKubernetesCluster_privateClusterOff(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -370,10 +370,10 @@ func testAccAzureRMKubernetesCluster_privateLinkOff(t *testing.T) {
 		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMKubernetesCluster_privateLinkConfig(data, false),
+				Config: testAccAzureRMKubernetesCluster_privateClusterConfig(data, false),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "private_link_enabled", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_private_cluster", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -1014,7 +1014,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func testAccAzureRMKubernetesCluster_privateLinkConfig(data acceptance.TestData, enablePrivateLink bool) string {
+func testAccAzureRMKubernetesCluster_privateClusterConfig(data acceptance.TestData, enablePrivateCluster bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1026,11 +1026,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_kubernetes_cluster" "test" {
-  name                 = "acctestaks%d"
-  location             = azurerm_resource_group.test.location
-  resource_group_name  = azurerm_resource_group.test.name
-  dns_prefix           = "acctestaks%d"
-  private_link_enabled = %t
+  name                   = "acctestaks%d"
+  location               = azurerm_resource_group.test.location
+  resource_group_name    = azurerm_resource_group.test.name
+  dns_prefix             = "acctestaks%d"
+  enable_private_cluster = %t
 
   linux_profile {
     admin_username = "acctestuser%d"
@@ -1055,7 +1055,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     load_balancer_sku = "standard"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enablePrivateLink, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, enablePrivateCluster, data.RandomInteger)
 }
 
 func testAccAzureRMKubernetesCluster_standardLoadBalancerConfig(data acceptance.TestData) string {

--- a/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_test.go
+++ b/azurerm/internal/services/containers/tests/resource_arm_kubernetes_cluster_test.go
@@ -91,8 +91,8 @@ func TestAccAzureRMKubernetes_all(t *testing.T) {
 			"windowsProfile":                 testAccAzureRMKubernetesCluster_windowsProfile,
 			"outboundTypeLoadBalancer":       testAccAzureRMKubernetesCluster_outboundTypeLoadBalancer,
 			"outboundTypeUserDefinedRouting": testAccAzureRMKubernetesCluster_outboundTypeUserDefinedRouting,
-			"privateLinkOn":                  testAccAzureRMKubernetesCluster_privateLinkOn,
-			"privateLinkOff":                 testAccAzureRMKubernetesCluster_privateLinkOff,
+			"privateClusterOn":               testAccAzureRMKubernetesCluster_privateClusterOn,
+			"privateClusterOff":              testAccAzureRMKubernetesCluster_privateClusterOff,
 		},
 		"scaling": {
 			"addAgent":                         testAccAzureRMKubernetesCluster_addAgent,
@@ -127,7 +127,7 @@ func TestAccAzureRMKubernetes_all(t *testing.T) {
 			"nodeLabels":                                  testAccDataSourceAzureRMKubernetesCluster_nodeLabels,
 			"nodeTaints":                                  testAccDataSourceAzureRMKubernetesCluster_nodeTaints,
 			"enableNodePublicIP":                          testAccDataSourceAzureRMKubernetesCluster_enableNodePublicIP,
-			"privateLink":                                 testAccDataSourceAzureRMKubernetesCluster_privateLink,
+			"privateCluster":                              testAccDataSourceAzureRMKubernetesCluster_privateCluster,
 		},
 	}
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -62,9 +62,7 @@ The following attributes are exported:
 
 * `kubernetes_version` - The version of Kubernetes used on the managed Kubernetes Cluster.
 
-* `private_link_enabled` - Does this Kubernetes Cluster have the Kubernetes API exposed via Private Link?                           
-
--> **NOTE:** At this time Private Link is in Public Preview
+* `enable_private_cluster` - If the cluster has the Kubernetes API only exposed on internal IP addresses.                           
 
 * `location` - The Azure Region in which the managed Kubernetes Cluster exists.
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -62,7 +62,7 @@ The following attributes are exported:
 
 * `kubernetes_version` - The version of Kubernetes used on the managed Kubernetes Cluster.
 
-* `enable_private_cluster` - If the cluster has the Kubernetes API only exposed on internal IP addresses.                           
+* `private_cluster_enabled` - If the cluster has the Kubernetes API only exposed on internal IP addresses.                           
 
 * `location` - The Azure Region in which the managed Kubernetes Cluster exists.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -100,7 +100,7 @@ In addition, one of either `identity` or `service_principal` must be specified.
 
 -> **NOTE:** Azure requires that a new, non-existent Resource Group is used, as otherwise the provisioning of the Kubernetes Service will fail.
 
-* `enable_private_cluster` Should this Kubernetes Cluster have it's API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to `false`. Changing this forces a new resource to be created.
+* `private_cluster_enabled` Should this Kubernetes Cluster have it's API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `role_based_access_control` - (Optional) A `role_based_access_control` block. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -100,9 +100,7 @@ In addition, one of either `identity` or `service_principal` must be specified.
 
 -> **NOTE:** Azure requires that a new, non-existent Resource Group is used, as otherwise the provisioning of the Kubernetes Service will fail.
 
-* `private_link_enabled` Should this Kubernetes Cluster have Private Link Enabled? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to `false`. Changing this forces a new resource to be created.
-
--> **NOTE:**  At this time Private Link is in Public Preview. For an example of how to enable a Preview feature, please visit [Private Azure Kubernetes Service cluster](https://docs.microsoft.com/en-gb/azure/aks/private-clusters)
+* `enable_private_cluster` Should this Kubernetes Cluster have it's API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `role_based_access_control` - (Optional) A `role_based_access_control` block. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Fixes #6416 

Motivation in the issue.