### PR TITLE
azurerm_hdinsight_* - support for `tls_min_version `

### DIFF
--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -46,6 +46,19 @@ func SchemaHDInsightTier() *schema.Schema {
 	}
 }
 
+func SchemaHDInsightTls() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		ValidateFunc: validation.StringInSlice([]string{
+			"1.0",
+			"1.1",
+			"1.2",
+		}, false),
+	}
+}
+
 func SchemaHDInsightClusterVersion() *schema.Schema {
 	return &schema.Schema{
 		Type:             schema.TypeString,

--- a/azurerm/internal/services/hdinsight/data_source_hdinsight_cluster.go
+++ b/azurerm/internal/services/hdinsight/data_source_hdinsight_cluster.go
@@ -52,6 +52,11 @@ func dataSourceArmHDInsightSparkCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"tls_min_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"gateway": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -130,6 +135,7 @@ func dataSourceArmHDInsightClusterRead(d *schema.ResourceData, meta interface{})
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			d.Set("component_versions", flattenHDInsightsDataSourceComponentVersions(def.ComponentVersion))

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_hadoop_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_hadoop_cluster.go
@@ -74,6 +74,8 @@ func resourceArmHDInsightHadoopCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"component_version": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -178,6 +180,7 @@ func resourceArmHDInsightHadoopClusterCreate(d *schema.ResourceData, meta interf
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	componentVersionsRaw := d.Get("component_version").([]interface{})
 	componentVersions := expandHDInsightHadoopComponentVersion(componentVersionsRaw)
@@ -219,9 +222,10 @@ func resourceArmHDInsightHadoopClusterCreate(d *schema.ResourceData, meta interf
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:             utils.String("Hadoop"),
 				ComponentVersion: componentVersions,
@@ -326,6 +330,7 @@ func resourceArmHDInsightHadoopClusterRead(d *schema.ResourceData, meta interfac
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("component_version", flattenHDInsightHadoopComponentVersion(def.ComponentVersion)); err != nil {

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_hbase_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_hbase_cluster.go
@@ -69,6 +69,8 @@ func resourceArmHDInsightHBaseCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"component_version": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -131,6 +133,7 @@ func resourceArmHDInsightHBaseClusterCreate(d *schema.ResourceData, meta interfa
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	componentVersionsRaw := d.Get("component_version").([]interface{})
 	componentVersions := expandHDInsightHBaseComponentVersion(componentVersionsRaw)
@@ -172,9 +175,10 @@ func resourceArmHDInsightHBaseClusterCreate(d *schema.ResourceData, meta interfa
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:             utils.String("HBase"),
 				ComponentVersion: componentVersions,
@@ -253,6 +257,7 @@ func resourceArmHDInsightHBaseClusterRead(d *schema.ResourceData, meta interface
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("component_version", flattenHDInsightHBaseComponentVersion(def.ComponentVersion)); err != nil {

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_interactive_query_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_interactive_query_cluster.go
@@ -69,6 +69,8 @@ func resourceArmHDInsightInteractiveQueryCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"component_version": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -131,6 +133,7 @@ func resourceArmHDInsightInteractiveQueryClusterCreate(d *schema.ResourceData, m
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	componentVersionsRaw := d.Get("component_version").([]interface{})
 	componentVersions := expandHDInsightInteractiveQueryComponentVersion(componentVersionsRaw)
@@ -172,9 +175,10 @@ func resourceArmHDInsightInteractiveQueryClusterCreate(d *schema.ResourceData, m
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:             utils.String("INTERACTIVEHIVE"),
 				ComponentVersion: componentVersions,
@@ -253,6 +257,7 @@ func resourceArmHDInsightInteractiveQueryClusterRead(d *schema.ResourceData, met
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("component_version", flattenHDInsightInteractiveQueryComponentVersion(def.ComponentVersion)); err != nil {

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_kafka_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_kafka_cluster.go
@@ -70,6 +70,8 @@ func resourceArmHDInsightKafkaCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"component_version": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -132,6 +134,7 @@ func resourceArmHDInsightKafkaClusterCreate(d *schema.ResourceData, meta interfa
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	componentVersionsRaw := d.Get("component_version").([]interface{})
 	componentVersions := expandHDInsightKafkaComponentVersion(componentVersionsRaw)
@@ -173,9 +176,10 @@ func resourceArmHDInsightKafkaClusterCreate(d *schema.ResourceData, meta interfa
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:             utils.String("Kafka"),
 				ComponentVersion: componentVersions,
@@ -254,6 +258,7 @@ func resourceArmHDInsightKafkaClusterRead(d *schema.ResourceData, meta interface
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("component_version", flattenHDInsightKafkaComponentVersion(def.ComponentVersion)); err != nil {

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_ml_services_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_ml_services_cluster.go
@@ -80,6 +80,8 @@ func resourceArmHDInsightMLServicesCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"gateway": azure.SchemaHDInsightsGateway(),
 
 			"rstudio": {
@@ -148,6 +150,7 @@ func resourceArmHDInsightMLServicesClusterCreate(d *schema.ResourceData, meta in
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	gatewayRaw := d.Get("gateway").([]interface{})
 	rStudio := d.Get("rstudio").(bool)
@@ -187,9 +190,10 @@ func resourceArmHDInsightMLServicesClusterCreate(d *schema.ResourceData, meta in
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:           utils.String("MLServices"),
 				Configurations: gateway,
@@ -272,6 +276,7 @@ func resourceArmHDInsightMLServicesClusterRead(d *schema.ResourceData, meta inte
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("gateway", azure.FlattenHDInsightsConfigurations(configuration.Value)); err != nil {

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_rserver_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_rserver_cluster.go
@@ -80,6 +80,8 @@ func resourceArmHDInsightRServerCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"gateway": azure.SchemaHDInsightsGateway(),
 
 			"rstudio": {
@@ -148,6 +150,7 @@ func resourceArmHDInsightRServerClusterCreate(d *schema.ResourceData, meta inter
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	gatewayRaw := d.Get("gateway").([]interface{})
 	rStudio := d.Get("rstudio").(bool)
@@ -187,9 +190,10 @@ func resourceArmHDInsightRServerClusterCreate(d *schema.ResourceData, meta inter
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:           utils.String("RServer"),
 				Configurations: gateway,
@@ -272,6 +276,7 @@ func resourceArmHDInsightRServerClusterRead(d *schema.ResourceData, meta interfa
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("gateway", azure.FlattenHDInsightsConfigurations(configuration.Value)); err != nil {

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_spark_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_spark_cluster.go
@@ -69,6 +69,8 @@ func resourceArmHDInsightSparkCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"component_version": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -131,6 +133,7 @@ func resourceArmHDInsightSparkClusterCreate(d *schema.ResourceData, meta interfa
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	componentVersionsRaw := d.Get("component_version").([]interface{})
 	componentVersions := expandHDInsightSparkComponentVersion(componentVersionsRaw)
@@ -172,9 +175,10 @@ func resourceArmHDInsightSparkClusterCreate(d *schema.ResourceData, meta interfa
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:             utils.String("Spark"),
 				ComponentVersion: componentVersions,
@@ -253,6 +257,7 @@ func resourceArmHDInsightSparkClusterRead(d *schema.ResourceData, meta interface
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("component_version", flattenHDInsightSparkComponentVersion(def.ComponentVersion)); err != nil {

--- a/azurerm/internal/services/hdinsight/resource_arm_hdinsight_storm_cluster.go
+++ b/azurerm/internal/services/hdinsight/resource_arm_hdinsight_storm_cluster.go
@@ -70,6 +70,8 @@ func resourceArmHDInsightStormCluster() *schema.Resource {
 
 			"tier": azure.SchemaHDInsightTier(),
 
+			"tls_min_version": azure.SchemaHDInsightTls(),
+
 			"component_version": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -130,6 +132,7 @@ func resourceArmHDInsightStormClusterCreate(d *schema.ResourceData, meta interfa
 	clusterVersion := d.Get("cluster_version").(string)
 	t := d.Get("tags").(map[string]interface{})
 	tier := hdinsight.Tier(d.Get("tier").(string))
+	tls := d.Get("tls_min_version").(string)
 
 	componentVersionsRaw := d.Get("component_version").([]interface{})
 	componentVersions := expandHDInsightStormComponentVersion(componentVersionsRaw)
@@ -170,9 +173,10 @@ func resourceArmHDInsightStormClusterCreate(d *schema.ResourceData, meta interfa
 	params := hdinsight.ClusterCreateParametersExtended{
 		Location: utils.String(location),
 		Properties: &hdinsight.ClusterCreateProperties{
-			Tier:           tier,
-			OsType:         hdinsight.Linux,
-			ClusterVersion: utils.String(clusterVersion),
+			Tier:                   tier,
+			OsType:                 hdinsight.Linux,
+			ClusterVersion:         utils.String(clusterVersion),
+			MinSupportedTLSVersion: utils.String(tls),
 			ClusterDefinition: &hdinsight.ClusterDefinition{
 				Kind:             utils.String("Storm"),
 				ComponentVersion: componentVersions,
@@ -251,6 +255,7 @@ func resourceArmHDInsightStormClusterRead(d *schema.ResourceData, meta interface
 	if props := resp.Properties; props != nil {
 		d.Set("cluster_version", props.ClusterVersion)
 		d.Set("tier", string(props.Tier))
+		d.Set("tls_min_version", props.MinSupportedTLSVersion)
 
 		if def := props.ClusterDefinition; def != nil {
 			if err := d.Set("component_version", flattenHDInsightStormComponentVersion(def.ComponentVersion)); err != nil {

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_hadoop_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_hadoop_cluster_test.go
@@ -319,6 +319,32 @@ func TestAccAzureRMHDInsightHadoopCluster_gen2AndBlobStorage(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightHadoopCluster_tls(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightHadoopCluster_tls(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightHadoopCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightHadoopCluster_template(data)
 	return fmt.Sprintf(`
@@ -973,4 +999,57 @@ resource "azurerm_role_assignment" "test" {
 }
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMHDInsightHadoopCluster_tls(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightHadoopCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_hadoop_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+  component_version {
+    hadoop = "2.7"
+  }
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_v2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_v2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_interactive_query_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_interactive_query_cluster_test.go
@@ -205,6 +205,32 @@ func TestAccAzureRMHDInsightInteractiveQueryCluster_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightInteractiveQueryCluster_tls(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_interactive_query_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightInteractiveQueryCluster_tls(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightInteractiveQueryCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightInteractiveQueryCluster_template(data)
 	return fmt.Sprintf(`
@@ -719,4 +745,57 @@ resource "azurerm_role_assignment" "test" {
   principal_id         = "${azurerm_user_assigned_identity.test.principal_id}"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMHDInsightInteractiveQueryCluster_tls(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightInteractiveQueryCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_interactive_query_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+  component_version {
+    interactive_hive = "2.1"
+  }
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D13_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D14_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_kafka_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_kafka_cluster_test.go
@@ -208,6 +208,32 @@ func TestAccAzureRMHDInsightKafkaCluster_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightKafkaCluster_tls(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_kafka_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightKafkaCluster_tls(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightKafkaCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightKafkaCluster_template(data)
 	return fmt.Sprintf(`
@@ -729,4 +755,58 @@ resource "azurerm_role_assignment" "test" {
   principal_id         = "${azurerm_user_assigned_identity.test.principal_id}"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMHDInsightKafkaCluster_tls(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightKafkaCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_kafka_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+  component_version {
+    kafka = "1.1"
+  }
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size                  = "Standard_D3_V2"
+      username                 = "acctestusrvm"
+      password                 = "AccTestvdSC4daf986!"
+      target_instance_count    = 3
+      number_of_disks_per_node = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_ml_services_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_ml_services_cluster_test.go
@@ -198,6 +198,35 @@ func TestAccAzureRMHDInsightMLServicesCluster_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightMLServicesCluster_tls(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_ml_services_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightMLServicesCluster_tls(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "edge_ssh_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"roles.0.edge_node.0.password",
+				"roles.0.edge_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightMLServicesCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightMLServicesCluster_template(data)
 	return fmt.Sprintf(`
@@ -639,4 +668,60 @@ resource "azurerm_storage_container" "test" {
   container_access_type = "private"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMHDInsightMLServicesCluster_tls(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightMLServicesCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_ml_services_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+  rstudio             = true
+  tls_min_version     = "1.2"
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D3_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    edge_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_rserver_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_rserver_cluster_test.go
@@ -198,6 +198,35 @@ func TestAccAzureRMHDInsightRServerCluster_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightRServerCluster_tls(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_rserver_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightRServerCluster_tls(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "edge_ssh_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"roles.0.edge_node.0.password",
+				"roles.0.edge_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightRServerCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightRServerCluster_template(data)
 	return fmt.Sprintf(`
@@ -639,4 +668,60 @@ resource "azurerm_storage_container" "test" {
   container_access_type = "private"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMHDInsightRServerCluster_tls(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightRServerCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_rserver_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+  rstudio             = true
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D3_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    edge_node {
+      vm_size  = "Standard_D3_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_spark_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_spark_cluster_test.go
@@ -205,6 +205,32 @@ func TestAccAzureRMHDInsightSparkCluster_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightSparkCluster_tls(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_spark_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightSparkCluster_tls(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightSparkCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightSparkCluster_template(data)
 	return fmt.Sprintf(`
@@ -719,4 +745,57 @@ resource "azurerm_role_assignment" "test" {
   principal_id         = "${azurerm_user_assigned_identity.test.principal_id}"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMHDInsightSparkCluster_tls(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightSparkCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_spark_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+  component_version {
+    spark = "2.3"
+  }
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_A4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
+    }
+
+    zookeeper_node {
+      vm_size  = "Medium"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_storm_cluster_test.go
+++ b/azurerm/internal/services/hdinsight/tests/resource_arm_hdinsight_storm_cluster_test.go
@@ -180,6 +180,32 @@ func TestAccAzureRMHDInsightStormCluster_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightStormCluster_tls(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_storm_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightStormCluster_tls(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightStormCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightStormCluster_template(data)
 	return fmt.Sprintf(`
@@ -596,4 +622,57 @@ resource "azurerm_storage_container" "test" {
   container_access_type = "private"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMHDInsightStormCluster_tls(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightStormCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_storm_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+  tls_min_version     = "1.2"
+
+  component_version {
+    storm = "1.1"
+  }
+
+  gateway {
+    enabled  = true
+    username = "acctestusrgw"
+    password = "TerrAform123!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_A4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 3
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_A4_V2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/website/docs/d/hdinsight_cluster.html.markdown
+++ b/website/docs/d/hdinsight_cluster.html.markdown
@@ -50,6 +50,8 @@ output "https_endpoint" {
 
 * `ssh_endpoint` - The SSH Endpoint for this HDInsight Cluster.
 
+* `min_tls_version` - The minimal supported tls version. 
+
 * `tags` - A map of tags assigned to the HDInsight Cluster.
 
 ---

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -103,6 +103,10 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight Hadoop Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
+
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight Hadoop Cluster.

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -103,6 +103,10 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight HBase Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
+
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight HBase Cluster.

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -102,6 +102,9 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight Interactive Query Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight Interactive Query Cluster.

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -104,6 +104,10 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight Kafka Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
+
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight Kafka Cluster.

--- a/website/docs/r/hdinsight_ml_services_cluster.html.markdown
+++ b/website/docs/r/hdinsight_ml_services_cluster.html.markdown
@@ -104,6 +104,10 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight ML Services Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
+
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight ML Services Cluster.

--- a/website/docs/r/hdinsight_rserver_cluster.html.markdown
+++ b/website/docs/r/hdinsight_rserver_cluster.html.markdown
@@ -104,6 +104,10 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight RServer Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
+
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight RServer Cluster.

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -103,6 +103,10 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight Spark Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
+
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight Spark Cluster.

--- a/website/docs/r/hdinsight_storm_cluster.html.markdown
+++ b/website/docs/r/hdinsight_storm_cluster.html.markdown
@@ -101,6 +101,10 @@ The following arguments are supported:
 
 * `tier` - (Required) Specifies the Tier which should be used for this HDInsight Storm Cluster. Possible values are `Standard` or `Premium`. Changing this forces a new resource to be created.
 
+* `min_tls_version` - (Optional) The minimal supported TLS version. Possible values are 1.0, 1.1 or 1.2. Changing this forces a new resource to be created.
+
+~> **NOTE:** Starting on June 30, 2020, Azure HDInsight will enforce TLS 1.2 or later versions for all HTTPS connections. For more information, see [Azure HDInsight TLS 1.2 Enforcement](https://azure.microsoft.com/en-us/updates/azure-hdinsight-tls-12-enforcement/).
+
 ---
 
 * `tags` - (Optional) A map of Tags which should be assigned to this HDInsight Storm Cluster.


### PR DESCRIPTION
Added support for min tls version for azurerm_hdinsight_*_cluster resources.

Sample configuration:
```hcl
resource "azurerm_hdinsight_hadoop_cluster" "example" {
  name                = "example-hdicluster"
  resource_group_name = "${azurerm_resource_group.example.name}"
  location            = "${azurerm_resource_group.example.location}"
  cluster_version     = "3.6"
  tier                = "Standard"
  min_tls_version = "1.2" # possible values 1.0, 1.1, 1.2
.....
}
```

Tests:
```bash
make testacc TEST='./azurerm/internal/services/hdinsight/tests/' TESTARGS='-run=_tls  -parallel=1' TESTTIMEOUT='300m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/hdinsight/tests/ -v -run=_tls  -parallel=1 -timeout 300m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMHDInsightHadoopCluster_tls
=== PAUSE TestAccAzureRMHDInsightHadoopCluster_tls
=== RUN   TestAccAzureRMHDInsightHBaseCluster_tls
=== PAUSE TestAccAzureRMHDInsightHBaseCluster_tls
=== RUN   TestAccAzureRMHDInsightInteractiveQueryCluster_tls
=== PAUSE TestAccAzureRMHDInsightInteractiveQueryCluster_tls
=== RUN   TestAccAzureRMHDInsightKafkaCluster_tls
=== PAUSE TestAccAzureRMHDInsightKafkaCluster_tls
=== RUN   TestAccAzureRMHDInsightMLServicesCluster_tls
=== PAUSE TestAccAzureRMHDInsightMLServicesCluster_tls
=== RUN   TestAccAzureRMHDInsightRServerCluster_tls
=== PAUSE TestAccAzureRMHDInsightRServerCluster_tls
=== RUN   TestAccAzureRMHDInsightSparkCluster_tls
=== PAUSE TestAccAzureRMHDInsightSparkCluster_tls
=== RUN   TestAccAzureRMHDInsightStormCluster_tls
=== PAUSE TestAccAzureRMHDInsightStormCluster_tls
=== CONT  TestAccAzureRMHDInsightHadoopCluster_tls
--- PASS: TestAccAzureRMHDInsightHadoopCluster_tls (953.94s)
=== CONT  TestAccAzureRMHDInsightMLServicesCluster_tls
--- PASS: TestAccAzureRMHDInsightMLServicesCluster_tls (1269.72s)
=== CONT  TestAccAzureRMHDInsightStormCluster_tls
--- PASS: TestAccAzureRMHDInsightStormCluster_tls (1024.41s)
=== CONT  TestAccAzureRMHDInsightSparkCluster_tls
--- PASS: TestAccAzureRMHDInsightSparkCluster_tls (1082.57s)
=== CONT  TestAccAzureRMHDInsightRServerCluster_tls
--- PASS: TestAccAzureRMHDInsightRServerCluster_tls (729.02s)
=== CONT  TestAccAzureRMHDInsightInteractiveQueryCluster_tls
--- PASS: TestAccAzureRMHDInsightInteractiveQueryCluster_tls (1146.04s)
=== CONT  TestAccAzureRMHDInsightKafkaCluster_tls
--- PASS: TestAccAzureRMHDInsightKafkaCluster_tls (815.68s)
=== CONT  TestAccAzureRMHDInsightHBaseCluster_tls
--- PASS: TestAccAzureRMHDInsightHBaseCluster_tls (1097.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/hdinsight/tests     8119.836s
```

Fixes: #6372 