### PR TITLE
New Resource `r/azurerm_servicebus_namespace_virtual_network_rule`

### DIFF
--- a/azurerm/helpers/azure/servicebus.go
+++ b/azurerm/helpers/azure/servicebus.go
@@ -40,6 +40,13 @@ func ValidateServiceBusTopicName() schema.SchemaValidateFunc {
 	)
 }
 
+func ValidateServiceBusVirtualNetworkRuleName() schema.SchemaValidateFunc {
+	return validation.StringMatch(
+		regexp.MustCompile("^[a-zA-Z][-._a-zA-Z0-9]{0,62}[_a-zA-Z0-9]$"),
+		"The name can contain only letters, numbers, periods, hyphens and underscores. The name must start with a letter, and it must end with a letter, number or underscore and be between 2 and 64 characters long.",
+	)
+}
+
 func ValidateServiceBusAuthorizationRuleName() schema.SchemaValidateFunc {
 	return validation.StringMatch(
 		regexp.MustCompile("^[a-zA-Z0-9][-._a-zA-Z0-9]{0,48}([a-zA-Z0-9])?$"),

--- a/azurerm/internal/services/servicebus/registration.go
+++ b/azurerm/internal/services/servicebus/registration.go
@@ -31,13 +31,14 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_servicebus_namespace_authorization_rule": resourceArmServiceBusNamespaceAuthorizationRule(),
-		"azurerm_servicebus_namespace":                    resourceArmServiceBusNamespace(),
-		"azurerm_servicebus_queue_authorization_rule":     resourceArmServiceBusQueueAuthorizationRule(),
-		"azurerm_servicebus_queue":                        resourceArmServiceBusQueue(),
-		"azurerm_servicebus_subscription_rule":            resourceArmServiceBusSubscriptionRule(),
-		"azurerm_servicebus_subscription":                 resourceArmServiceBusSubscription(),
-		"azurerm_servicebus_topic_authorization_rule":     resourceArmServiceBusTopicAuthorizationRule(),
-		"azurerm_servicebus_topic":                        resourceArmServiceBusTopic(),
+		"azurerm_servicebus_namespace_authorization_rule":   resourceArmServiceBusNamespaceAuthorizationRule(),
+		"azurerm_servicebus_namespace_virtual_network_rule": resourceArmServiceBusNamespaceVirtualNetworkRule(),
+		"azurerm_servicebus_namespace":                      resourceArmServiceBusNamespace(),
+		"azurerm_servicebus_queue_authorization_rule":       resourceArmServiceBusQueueAuthorizationRule(),
+		"azurerm_servicebus_queue":                          resourceArmServiceBusQueue(),
+		"azurerm_servicebus_subscription_rule":              resourceArmServiceBusSubscriptionRule(),
+		"azurerm_servicebus_subscription":                   resourceArmServiceBusSubscription(),
+		"azurerm_servicebus_topic_authorization_rule":       resourceArmServiceBusTopicAuthorizationRule(),
+		"azurerm_servicebus_topic":                          resourceArmServiceBusTopic(),
 	}
 }

--- a/azurerm/internal/services/servicebus/resource_arm_servicebus_namespace_virtual_network_rule.go
+++ b/azurerm/internal/services/servicebus/resource_arm_servicebus_namespace_virtual_network_rule.go
@@ -1,0 +1,203 @@
+package servicebus
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/servicebus/mgmt/2018-01-01-preview/servicebus"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmServiceBusNamespaceVirtualNetworkRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmServiceBusNamespaceVirtualNetworkRuleCreateUpdate,
+		Read:   resourceArmServiceBusNamespaceVirtualNetworkRuleRead,
+		Update: resourceArmServiceBusNamespaceVirtualNetworkRuleCreateUpdate,
+		Delete: resourceArmServiceBusNamespaceVirtualNetworkRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateServiceBusVirtualNetworkRuleName(),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"namespace_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateServiceBusNamespaceName(),
+			},
+
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceArmServiceBusNamespaceVirtualNetworkRuleCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ServiceBus.NamespacesClientPreview
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	namespaceName := d.Get("namespace_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	virtualNetworkSubnetId := d.Get("subnet_id").(string)
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.GetVirtualNetworkRule(ctx, resourceGroup, namespaceName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing ServiceBus Namespace Virtual Network Rule %q (ServiceBus Namespace: %q, Resource Group: %q): %+v", name, namespaceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_servicebus_namespace_virtual_network_rule", *existing.ID)
+		}
+	}
+
+	parameters := servicebus.VirtualNetworkRule{
+		VirtualNetworkRuleProperties: &servicebus.VirtualNetworkRuleProperties{
+			VirtualNetworkSubnetID: utils.String(virtualNetworkSubnetId),
+		},
+	}
+
+	if _, err := client.CreateOrUpdateVirtualNetworkRule(ctx, resourceGroup, namespaceName, name, parameters); err != nil {
+		return fmt.Errorf("Error creating ServiceBus Namespace Virtual Network Rule %q (ServiceBus Namespace: %q, Resource Group: %q): %+v", name, namespaceName, resourceGroup, err)
+	}
+
+	resp, err := client.GetVirtualNetworkRule(ctx, resourceGroup, namespaceName, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving ServiceBus Namespace Virtual Network Rule %q (ServiceBus Namespace: %q, Resource Group: %q): %+v", name, namespaceName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmServiceBusNamespaceVirtualNetworkRuleRead(d, meta)
+}
+
+func resourceArmServiceBusNamespaceVirtualNetworkRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ServiceBus.NamespacesClientPreview
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	namespaceName := id.Path["namespaces"]
+	name := id.Path["virtualnetworkrules"]
+
+	resp, err := client.GetVirtualNetworkRule(ctx, resourceGroup, namespaceName, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Error reading ServiceBus Namespace Virtual Network Rule %q - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error reading ServiceBus Namespace Virtual Network Rule: %q (ServiceBus Namespace: %q, Resource Group: %q): %+v", name, namespaceName, resourceGroup, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("namespace_name", namespaceName)
+
+	if props := resp.VirtualNetworkRuleProperties; props != nil {
+		d.Set("subnet_id", props.VirtualNetworkSubnetID)
+	}
+
+	return nil
+}
+
+func resourceArmServiceBusNamespaceVirtualNetworkRuleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ServiceBus.NamespacesClientPreview
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	namespaceName := id.Path["namespaces"]
+	name := id.Path["virtualnetworkrules"]
+
+	if _, err = client.DeleteVirtualNetworkRule(ctx, resourceGroup, namespaceName, name); err != nil {
+		return fmt.Errorf("Error issuing Azure ARM delete request of ServiceBus Namespace Virtual Network Rule %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	return nil
+}
+
+/*
+	This function checks the format of the ServiceBus Namespace Virtual Network Rule Name to make sure that
+	it does not contain any potentially invalid values.
+*/
+func ValidateServiceBusNamespaceVirtualNetworkRuleName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	// Cannot be empty
+	if len(value) == 0 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be an empty string: %q", k, value))
+	}
+
+	// Cannot be more than 128 characters
+	if len(value) > 128 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 128 characters: %q", k, value))
+	}
+
+	// Must only contain alphanumeric characters or hyphens
+	if !regexp.MustCompile(`^[A-Za-z0-9-]*$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q can only contain alphanumeric characters and hyphens: %q",
+			k, value))
+	}
+
+	// Cannot end in a hyphen
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen: %q", k, value))
+	}
+
+	// Cannot start with a number or hyphen
+	if regexp.MustCompile(`^[0-9-]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot start with a number or hyphen: %q", k, value))
+	}
+
+	// There are multiple returns in the case that there is more than one invalid
+	// case applied to the name.
+	return warnings, errors
+}

--- a/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_namespace_virtual_network_rule_test.go
+++ b/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_namespace_virtual_network_rule_test.go
@@ -1,0 +1,176 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMServiceBusNamespaceVirtualNetworkRule_create(t *testing.T) {
+	testAccAzureRMServiceBusNamespaceVirtualNetworkRule(t)
+}
+
+func testAccAzureRMServiceBusNamespaceVirtualNetworkRule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace_virtual_network_rule", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMServiceBusNamespaceVirtualNetworkRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMServiceBusNamespaceVirtualNetworkRule_base(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusNamespaceVirtualNetworkRuleExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "namespace_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "resource_group_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "subnet_id"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMServiceBusNamespaceVirtualNetworkRule_requiresImport(t *testing.T) {
+	if !features.ShouldResourcesBeImported() {
+		t.Skip("Skipping since resources aren't required to be imported")
+		return
+	}
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace_virtual_network_rule", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMServiceBusNamespaceVirtualNetworkRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMServiceBusNamespaceVirtualNetworkRule_base(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusNamespaceVirtualNetworkRuleExists(data.ResourceName)),
+			},
+			{
+				Config:      testAccAzureRMServiceBusNamespaceVirtualNetworkRule_requiresImport(data),
+				ExpectError: acceptance.RequiresImportError("azurerm_servicebus_namespace_virtual_network_rule"),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMServiceBusNamespaceVirtualNetworkRuleDestroy(s *terraform.State) error {
+	conn := acceptance.AzureProvider.Meta().(*clients.Client).ServiceBus.NamespacesClientPreview
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_servicebus_namespace_virtual_network_rule" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		namespaceName := rs.Primary.Attributes["namespace_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.GetVirtualNetworkRule(ctx, resourceGroup, namespaceName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func testCheckAzureRMServiceBusNamespaceVirtualNetworkRuleExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acceptance.AzureProvider.Meta().(*clients.Client).ServiceBus.NamespacesClientPreview
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		namespaceName := rs.Primary.Attributes["namespace_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for ServiceBus Namespace: %s", name)
+		}
+
+		resp, err := conn.GetVirtualNetworkRule(ctx, resourceGroup, namespaceName, name)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: ServiceBus Namespace Virtual Network Rule %q (namespace %s / resource group: %s) does not exist", name, namespaceName, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on ServiceBus Namespace: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMServiceBusNamespaceVirtualNetworkRule_base(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvnet%[1]d"
+  address_space       = ["10.7.29.0/29"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.7.29.0/29"
+  service_endpoints    = ["Microsoft.ServiceBus"]
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+  name                = "acctest-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Premium"
+  capacity            = "1"
+}
+
+resource "azurerm_servicebus_namespace_virtual_network_rule" "test" {
+  name                = "acctest-%[1]d"
+  namespace_name      = azurerm_servicebus_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  subnet_id           = azurerm_subnet.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAccAzureRMServiceBusNamespaceVirtualNetworkRule_requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_servicebus_namespace_virtual_network_rule" "import" {
+  name                = azurerm_servicebus_namespace_virtual_network_rule.test.name
+  namespace_name      = azurerm_servicebus_namespace_virtual_network_rule.test.namespace_name
+  resource_group_name = azurerm_servicebus_namespace_virtual_network_rule.test.resource_group_name
+  subnet_id           = azurerm_servicebus_namespace_virtual_network_rule.test.subnet_id
+}
+`, testAccAzureRMServiceBusNamespaceVirtualNetworkRule_base(data))
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1788,6 +1788,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/servicebus_namespace_virtual_network_rule.html">azurerm_servicebus_namespace_virtual_network_rule</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/servicebus_queue.html">azurerm_servicebus_queue</a>
                 </li>
 

--- a/website/docs/r/servicebus_namespace_virtual_network_rule.html.markdown
+++ b/website/docs/r/servicebus_namespace_virtual_network_rule.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "Messaging"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_servicebus_namespace_virtual_network_rule"
+description: |-
+  Manages a ServiceBus Namespace Virtual Network Rule within a ServiceBus.
+---
+
+# azurerm_servicebus_namespace_virtual_network_rule
+
+Manages a ServiceBus Namespace Virtual Network Rule within a ServiceBus.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "terraform-servicebus"
+  location = "West US"
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "example-vnet"
+  address_space       = ["10.7.29.0/29"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "example-subnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefix       = "10.7.29.0/29"
+  service_endpoints    = ["Microsoft.ServiceBus"]
+}
+
+resource "azurerm_servicebus_namespace" "servicebus" {
+  name                = "tfex_sevicebus_namespace"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "Premium"
+
+  tags = {
+    source = "terraform"
+  }
+}
+
+resource "azurerm_servicebus_namespace_virtual_network_rule" "example" {
+  name                = "servicebus-namespace-vnet-rule"
+  namespace_name      = azurerm_servicebus_namespace.servicebus.name
+  resource_group_name = azurerm_resource_group.example.name
+  subnet_id           = azurerm_subnet.subnet.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name of the ServiceBus Namespace Virtual Network Rule resource. Changing this forces a new resource to be created.
+
+~> **NOTE:** `name` must be between 2-64 characters long and must satisfy all of the requirements below:
+1. Contains only alphanumeric, underscores and hyphen characters
+2. Cannot start with an underscore or hyphen
+3. Cannot end with a hyphen
+
+* `namespace_name` - (Required) Specifies the name of the ServiceBus Namespace. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which the ServiceBus Namespace exists. Changing this forces a new resource to be created.
+
+* `subnet_id` - (Required) The ID of the subnet that the ServiceBus Namespace will be connected to.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ServiceBus Namespace ID.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the ServiceBus Namespace Virtual Network Rule.
+* `update` - (Defaults to 30 minutes) Used when updating the ServiceBus Namespace Virtual Network Rule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the ServiceBus Namespace Virtual Network Rule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the ServiceBus Namespace Virtual Network Rule.
+
+## Import
+
+ServiceBus Namespace virtual network rules can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_servicebus_namespace_virtual_network_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ServiceBus/namespaces/namespace1/virtualnetworkrules/rule1
+```


### PR DESCRIPTION
Fixes #2255

@tombuildsstuff I changed the resource name to `azurerm_servicebus_namespace_virtual_network_rule` compared to the proposed name of `azurerm_servicebus_subscription_virtual_network_rule`, as it seems a child resource of `azurerm_servicebus_namespace` at this moment.

```
--- PASS: TestAccAzureRMServiceBusNamespaceVirtualNetworkRule_requiresImport (560.76s)
--- PASS: TestAccAzureRMServiceBusNamespaceVirtualNetworkRule_create (816.97s)
```