### PR TITLE
azurerm_network_interface: expose internal_domain_name_suffix

### DIFF
--- a/azurerm/internal/services/network/resource_arm_network_interface.go
+++ b/azurerm/internal/services/network/resource_arm_network_interface.go
@@ -140,6 +140,11 @@ func resourceArmNetworkInterface() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			"internal_domain_name_suffix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 
 			// Computed
@@ -425,12 +430,17 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 		appliedDNSServers := make([]string, 0)
 		dnsServers := make([]string, 0)
 		internalDnsNameLabel := ""
+		internalDomainNameSuffix := ""
 		if dnsSettings := props.DNSSettings; dnsSettings != nil {
 			appliedDNSServers = flattenNetworkInterfaceDnsServers(dnsSettings.AppliedDNSServers)
 			dnsServers = flattenNetworkInterfaceDnsServers(dnsSettings.DNSServers)
 
 			if dnsSettings.InternalDNSNameLabel != nil {
 				internalDnsNameLabel = *dnsSettings.InternalDNSNameLabel
+			}
+
+			if dnsSettings.InternalDomainNameSuffix != nil {
+				internalDomainNameSuffix = *dnsSettings.InternalDomainNameSuffix
 			}
 		}
 
@@ -450,6 +460,7 @@ func resourceArmNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("enable_ip_forwarding", resp.EnableIPForwarding)
 		d.Set("enable_accelerated_networking", resp.EnableAcceleratedNetworking)
 		d.Set("internal_dns_name_label", internalDnsNameLabel)
+		d.Set("internal_domain_name_suffix", internalDomainNameSuffix)
 		d.Set("mac_address", props.MacAddress)
 		d.Set("private_ip_address", primaryPrivateIPAddress)
 		d.Set("virtual_machine_id", virtualMachineId)

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -112,6 +112,8 @@ The following attributes are exported:
 
 * `id` - The ID of the Network Interface.
 
+* `internal_domain_name_suffix` - Even if `internal_dns_name_label` is not specified, a DNS entry is created for the primary NIC of the VM. This DNS name can be constructed by concatenating the VM name with the value of `internal_domain_name_suffix`.
+
 * `mac_address` - The Media Access Control (MAC) Address of the Network Interface.
 
 * `private_ip_address` - The first private IP address of the network interface.


### PR DESCRIPTION
After a network interface has been created in a subnet, Azure assigns it
an internal domain name and exposes this as a property.

The suffix looks something like this:

tcjzv0sul21rwyt5qe31ylgpgo.ax.internal.cloudapp.net

Servers can reach each other internally at, for example:

server0.tcjzv0sul21rwyt5qe31ylgpgo.ax.internal.cloudapp.net

This change exposes the azure provided internal_domain_name_suffix in terraform.

This is useful, for example, when creating a self-signed server certificate to be used internally, if you do want the common name to match the hostname that the other server connects on.