### PR TITLE
azurerm_mariadb_server - fix incorrect example code

### DIFF
--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_mariadb_server" "example" {
     storage_mb            = 5120
     backup_retention_days = 7
     geo_redundant_backup  = "Disabled"
-    storage_autogrow      = "Disabled"
+    auto_grow             = "Disabled"
   }
 
   administrator_login          = "mariadbadmin"


### PR DESCRIPTION
There is no argument named `storage_autogrow`. It is `auto_grow` instead.

[Source code](https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/internal/services/mariadb/resource_arm_mariadb_server.go#L129-L137) showing `auto_grow` in the schema for the `azurerm_mariadb_server` resource.