### PR TITLE
Fix test name conflict in resource_arm_hpc_cache_test.go

### DIFF
--- a/azurerm/internal/services/storage/tests/resource_arm_hpc_cache_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_hpc_cache_test.go
@@ -32,7 +32,7 @@ func TestAccAzureRMHPCCache_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMStreamAnalyticsJob_requiresImport(t *testing.T) {
+func TestAccAzureRMHPCCache_requiresImport(t *testing.T) {
 	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
 		return


### PR DESCRIPTION
The test `TestAccAzureRMStreamAnalyticsJob_requiresImport` in **resource_arm_hpc_cache_test.go** should be `TestAccAzureRMHPCCache_requiresImport`.