### PR TITLE
Fix: Managed Disk changes cause stopping regardless of current state

### DIFF
--- a/azurerm/internal/services/compute/resource_arm_managed_disk.go
+++ b/azurerm/internal/services/compute/resource_arm_managed_disk.go
@@ -407,7 +407,7 @@ func resourceArmManagedDiskUpdate(d *schema.ResourceData, meta interface{}) erro
 
 				// could also be the provisioning state which we're not bothered with here
 				state := strings.ToLower(*status.Code)
-				if !strings.HasPrefix(state, "PowerState/") {
+				if !strings.HasPrefix(state, "powerstate/") {
 					continue
 				}
 


### PR DESCRIPTION
Because of a typo this code path with always continue and never get to a point when current VM state is evaluated. This causes stop/deallocate being triggered even if the VM is already in stopped state.

This can cause races when more than one disk is being modified for the same VM.