### PR TITLE
ID not set when retrieving data factory fix #4827

### DIFF
--- a/azurerm/internal/services/datafactory/data_source_data_factory.go
+++ b/azurerm/internal/services/datafactory/data_source_data_factory.go
@@ -141,9 +141,11 @@ func dataSourceArmDataFactoryRead(d *schema.ResourceData, meta interface{}) erro
 
 		return fmt.Errorf("Error retrieving Data Factory %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("API returns a nil/empty id on Data Factory %q (resource group %q): %+v", name, resourceGroup, err)
+	}
+	d.SetId(*resp.ID)
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", resourceGroup)
 	if location := resp.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}

--- a/azurerm/internal/services/datafactory/tests/data_source_data_factory_test.go
+++ b/azurerm/internal/services/datafactory/tests/data_source_data_factory_test.go
@@ -37,3 +37,38 @@ data "azurerm_data_factory" "test" {
 }
 `, config)
 }
+
+func TestAccAzureRMDataFactoryDataSource_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataFactoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataFactoryDataSource_identity(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataFactoryExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.#"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.0.type"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.0.principal_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.0.tenant_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAzureRMDataFactoryDataSource_identity(data acceptance.TestData) string {
+	config := testAccAzureRMDataFactory_identity(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_data_factory" "test" {
+  name                = azurerm_data_factory.test.name
+  resource_group_name = azurerm_data_factory.test.resource_group_name
+}
+`, config)
+}


### PR DESCRIPTION
The data source for data factory id was not set during Read.  Set the ID
added a better acctest to validate.

Fixes #4827