### PR TITLE
`azurerm_subnet`: Support for multiple prefixes with `address_prefixes` 

### DIFF
--- a/azurerm/internal/services/network/data_source_subnet.go
+++ b/azurerm/internal/services/network/data_source_subnet.go
@@ -40,6 +40,12 @@ func dataSourceArmSubnet() *schema.Resource {
 				Computed: true,
 			},
 
+			"address_prefixes": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
 			"network_security_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -95,6 +101,15 @@ func dataSourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 
 	if props := resp.SubnetPropertiesFormat; props != nil {
 		d.Set("address_prefix", props.AddressPrefix)
+		if props.AddressPrefixes == nil {
+			if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
+				d.Set("address_prefixes", []string{*props.AddressPrefix})
+			} else {
+				d.Set("address_prefixes", []string{})
+			}
+		} else {
+			d.Set("address_prefixes", utils.FlattenStringSlice(props.AddressPrefixes))
+		}
 
 		d.Set("enforce_private_link_endpoint_network_policies", flattenSubnetPrivateLinkNetworkPolicy(props.PrivateEndpointNetworkPolicies))
 		d.Set("enforce_private_link_service_network_policies", flattenSubnetPrivateLinkNetworkPolicy(props.PrivateLinkServiceNetworkPolicies))

--- a/azurerm/internal/services/network/resource_arm_virtual_network.go
+++ b/azurerm/internal/services/network/resource_arm_virtual_network.go
@@ -442,8 +442,9 @@ func resourceAzureSubnetHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(m["name"].(string))
-		buf.WriteString(m["address_prefix"].(string))
-
+		if v, ok := m["address_prefix"]; ok {
+			buf.WriteString(v.(string))
+		}
 		if v, ok := m["security_group"]; ok {
 			buf.WriteString(v.(string))
 		}

--- a/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_subnet_test.go
@@ -32,6 +32,25 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMSubnet_basic_addressPrefixes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMSubnet_basic_addressPrefixes(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMSubnet_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_subnet", "test")
 
@@ -434,6 +453,27 @@ resource "azurerm_subnet" "test" {
   enforce_private_link_service_network_policies = %t
 }
 `, template, enabled)
+}
+
+func testAccAzureRMSubnet_basic_addressPrefixes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-n-%d"
+  location = "%s"
+}
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16", "ace:cab:deca::/48"]
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefixes     = ["10.0.0.0/24", "ace:cab:deca:deed::/64"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func testAccAzureRMSubnet_requiresImport(data acceptance.TestData) string {

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -33,7 +33,8 @@ output "subnet_id" {
 ## Attributes Reference
 
 * `id` - The ID of the Subnet.
-* `address_prefix` - The address prefix used for the subnet.
+* `address_prefix` - (Deprecated) The address prefix used for the subnet.
+* `address_prefixes` - The address prefixes for the subnet.
 * `enforce_private_link_service_network_policies` - Enable or Disable network policies on private link service in the subnet.
 * `network_security_group_id` - The ID of the Network Security Group associated with the subnet.
 * `route_table_id` - The ID of the Route Table associated with this subnet.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_subnet" "example" {
   name                 = "testsubnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 
   delegation {
     name = "acctestdelegation"
@@ -57,7 +57,11 @@ The following arguments are supported:
 
 * `virtual_network_name` - (Required) The name of the virtual network to which to attach the subnet. Changing this forces a new resource to be created.
 
-* `address_prefix` - (Required) The address prefix to use for the subnet.
+* `address_prefix` - (Optional / **Deprecated in favour of `address_prefixes`**) The address prefix to use for the subnet.
+
+* `address_prefixes` - (Optional) The address prefixes to use for the subnet.
+
+-> **NOTE:** One of `address_prefix` or `address_prefixes` is required.
 
 ---
 
@@ -101,7 +105,8 @@ The following attributes are exported:
 * `name` - The name of the subnet.
 * `resource_group_name` - The name of the resource group in which the subnet is created in.
 * `virtual_network_name` - The name of the virtual network in which the subnet is created in
-* `address_prefix` - The address prefix for the subnet
+* `address_prefix` - (Deprecated) The address prefix for the subnet
+* `address_prefixes` - The address prefixes for the subnet
 
 ## Timeouts
 


### PR DESCRIPTION
**Splitting https://github.com/terraform-providers/terraform-provider-azurerm/pull/6148 into separate PR's**

The azure subnet resource supports addressPrefix when one prefix is available and addressPrefixes when two or or more are set (for instance, when configuring an ipv4 and ipv6 dual stack configuration for a network). Update azurerm_subnet to allow either address_prefix or address_prefixes as input, where the latter is a list of string. Check that at least one is set, and mark the older address_prefix as deprecated.

The data source for subnet is modified to always return address_prefixes to simplify retrieval (although this could be changed to always return the first address prefix as address_prefix).

Today, if two prefixes are specified via CLI or Azure UI the data source returns no address_prefix and it is not possible to create a new subnet with two prefixes via Terraform.

Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/5140