### PR TITLE
Update NAT Gateway documentation

### DIFF
--- a/website/docs/d/nat_gateway.html.markdown
+++ b/website/docs/d/nat_gateway.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Use this data source to access information about an existing NAT Gateway.
 
--> **NOTE:** The Azure NAT Gateway service is currently in private preview. Your subscription must be on the NAT Gateway private preview whitelist for this resource to be provisioned correctly. If you attempt to provision this resource and receive an `InvalidResourceType` error may mean that your subscription is not part of the NAT Gateway private preview or you are using a region which does not yet support the NAT Gateway private preview service. The NAT Gateway private preview service is currently available in a limited set of regions. Private preview resources may have multiple breaking changes over their lifecycle until they GA. You can opt into the Private Preview by contacting your Microsoft Representative.
-
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -9,8 +9,6 @@ description: |-
 
 Manages a Azure NAT Gateway.
 
--> **NOTE:** The Azure NAT Gateway service is currently in private preview. Your subscription must be on the NAT Gateway private preview whitelist for this resource to be provisioned correctly. If you attempt to provision this resource and receive an `InvalidResourceType` error may mean that your subscription is not part of the NAT Gateway private preview or you are using a region which does not yet support the NAT Gateway private preview service. The NAT Gateway private preview service is currently available in a limited set of regions. Private preview resources may have multiple breaking changes over their lifecycle until they GA. You can opt into the Private Preview by contacting your Microsoft Representative.
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Hi all,

I just drop the note out of the documentation, because the NAT Gateway was public available since 03/12/2020.

See the official publication [virtual-network-nat-now-generally-available](https://azure.microsoft.com/en-us/updates/virtual-network-nat-now-generally-available/)

Kind regards  