### PR TITLE
[azurerm_private_link_service] Nil check additional properties

### DIFF
--- a/azurerm/internal/services/network/data_source_private_link_service.go
+++ b/azurerm/internal/services/network/data_source_private_link_service.go
@@ -122,17 +122,13 @@ func dataSourceArmPrivateLinkServiceRead(d *schema.ResourceData, meta interface{
 		d.Set("enable_proxy_protocol", props.EnableProxyProtocol)
 
 		if autoApproval := props.AutoApproval; autoApproval != nil {
-			if autoApproval.Subscriptions != nil {
-				if err := d.Set("auto_approval_subscription_ids", utils.FlattenStringSlice(autoApproval.Subscriptions)); err != nil {
-					return fmt.Errorf("Error setting `auto_approval_subscription_ids`: %+v", err)
-				}
+			if err := d.Set("auto_approval_subscription_ids", utils.FlattenStringSlice(autoApproval.Subscriptions)); err != nil {
+				return fmt.Errorf("Error setting `auto_approval_subscription_ids`: %+v", err)
 			}
 		}
 		if visibility := props.Visibility; visibility != nil {
-			if visibility.Subscriptions != nil {
-				if err := d.Set("visibility_subscription_ids", utils.FlattenStringSlice(visibility.Subscriptions)); err != nil {
-					return fmt.Errorf("Error setting `visibility_subscription_ids`: %+v", err)
-				}
+			if err := d.Set("visibility_subscription_ids", utils.FlattenStringSlice(visibility.Subscriptions)); err != nil {
+				return fmt.Errorf("Error setting `visibility_subscription_ids`: %+v", err)
 			}
 		}
 

--- a/azurerm/internal/services/network/data_source_private_link_service.go
+++ b/azurerm/internal/services/network/data_source_private_link_service.go
@@ -121,14 +121,18 @@ func dataSourceArmPrivateLinkServiceRead(d *schema.ResourceData, meta interface{
 		d.Set("alias", props.Alias)
 		d.Set("enable_proxy_protocol", props.EnableProxyProtocol)
 
-		if props.AutoApproval.Subscriptions != nil {
-			if err := d.Set("auto_approval_subscription_ids", utils.FlattenStringSlice(props.AutoApproval.Subscriptions)); err != nil {
-				return fmt.Errorf("Error setting `auto_approval_subscription_ids`: %+v", err)
+		if autoApproval := props.AutoApproval; autoApproval != nil {
+			if autoApproval.Subscriptions != nil {
+				if err := d.Set("auto_approval_subscription_ids", utils.FlattenStringSlice(autoApproval.Subscriptions)); err != nil {
+					return fmt.Errorf("Error setting `auto_approval_subscription_ids`: %+v", err)
+				}
 			}
 		}
-		if props.Visibility.Subscriptions != nil {
-			if err := d.Set("visibility_subscription_ids", utils.FlattenStringSlice(props.Visibility.Subscriptions)); err != nil {
-				return fmt.Errorf("Error setting `visibility_subscription_ids`: %+v", err)
+		if visibility := props.Visibility; visibility != nil {
+			if visibility.Subscriptions != nil {
+				if err := d.Set("visibility_subscription_ids", utils.FlattenStringSlice(visibility.Subscriptions)); err != nil {
+					return fmt.Errorf("Error setting `visibility_subscription_ids`: %+v", err)
+				}
 			}
 		}
 


### PR DESCRIPTION
We noticed the API doesn't always return these properties which was causing a crash