### PR TITLE
Documentation: Fixed data source managed_disk example

### DIFF
--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -19,7 +19,7 @@ data "azurerm_managed_disk" "existing" {
 }
 
 output "id" {
-  value = azurerm_managed_disk.existing.id
+  value = data.azurerm_managed_disk.existing.id
 }
 ```
 


### PR DESCRIPTION
Reasoning for docs update:
The example contains a bug, the output does not reference the previously defined resource due to missing `data.` prefix.

Relevant Terraform version:
affects current version of azurerm provider.