### PR TITLE
`resource_arm_application_gateway` - Fix crash in `backend_address_pool.x.fqdns`

### DIFF
--- a/azurerm/internal/services/network/resource_arm_application_gateway.go
+++ b/azurerm/internal/services/network/resource_arm_application_gateway.go
@@ -1829,9 +1829,11 @@ func expandApplicationGatewayBackendAddressPools(d *schema.ResourceData) *[]netw
 		backendAddresses := make([]network.ApplicationGatewayBackendAddress, 0)
 
 		for _, ip := range v["fqdns"].([]interface{}) {
-			backendAddresses = append(backendAddresses, network.ApplicationGatewayBackendAddress{
-				Fqdn: utils.String(ip.(string)),
-			})
+			if ip != nil {
+				backendAddresses = append(backendAddresses, network.ApplicationGatewayBackendAddress{
+					Fqdn: utils.String(ip.(string)),
+				})
+			}
 		}
 		for _, ip := range v["ip_addresses"].([]interface{}) {
 			backendAddresses = append(backendAddresses, network.ApplicationGatewayBackendAddress{

--- a/azurerm/internal/services/network/resource_arm_application_gateway.go
+++ b/azurerm/internal/services/network/resource_arm_application_gateway.go
@@ -116,7 +116,7 @@ func resourceArmApplicationGateway() *schema.Resource {
 							Optional: true,
 							MinItems: 1,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
+								Type:         schema.TypeString,
 								ValidateFunc: validation.NoZeroValues,
 							},
 						},
@@ -1830,11 +1830,9 @@ func expandApplicationGatewayBackendAddressPools(d *schema.ResourceData) *[]netw
 		backendAddresses := make([]network.ApplicationGatewayBackendAddress, 0)
 
 		for _, ip := range v["fqdns"].([]interface{}) {
-			if ip != nil {
-				backendAddresses = append(backendAddresses, network.ApplicationGatewayBackendAddress{
-					Fqdn: utils.String(ip.(string)),
-				})
-			}
+			backendAddresses = append(backendAddresses, network.ApplicationGatewayBackendAddress{
+				Fqdn: utils.String(ip.(string)),
+			})
 		}
 		for _, ip := range v["ip_addresses"].([]interface{}) {
 			backendAddresses = append(backendAddresses, network.ApplicationGatewayBackendAddress{

--- a/azurerm/internal/services/network/resource_arm_application_gateway.go
+++ b/azurerm/internal/services/network/resource_arm_application_gateway.go
@@ -117,6 +117,7 @@ func resourceArmApplicationGateway() *schema.Resource {
 							MinItems: 1,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
+								ValidateFunc: validation.NoZeroValues,
 							},
 						},
 


### PR DESCRIPTION
Empty values aren't allowed and cause crashes so we'll prevent that with some extra validation 

Fixes #6528 