### PR TITLE
CDN Endpoint: make origin_host_header required 

### DIFF
--- a/azurerm/internal/services/cdn/resource_arm_cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/resource_arm_cdn_endpoint.go
@@ -58,8 +58,7 @@ func resourceArmCdnEndpoint() *schema.Resource {
 
 			"origin_host_header": {
 				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Required: true,
 			},
 
 			"is_http_allowed": {

--- a/azurerm/internal/services/cdn/tests/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/internal/services/cdn/tests/resource_arm_cdn_endpoint_test.go
@@ -455,6 +455,8 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
+  origin_host_header = "www.example.com"
+
   origin {
     name       = "acceptanceTestCdnOrigin1"
     host_name  = "www.example.com"
@@ -475,6 +477,8 @@ resource "azurerm_cdn_endpoint" "import" {
   profile_name        = azurerm_cdn_endpoint.test.profile_name
   location            = azurerm_cdn_endpoint.test.location
   resource_group_name = azurerm_cdn_endpoint.test.resource_group_name
+
+  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
@@ -550,6 +554,8 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
+  origin_host_header = "www.example.com"
+
   origin {
     name       = "acceptanceTestCdnOrigin2"
     host_name  = "www.example.com"
@@ -588,6 +594,8 @@ resource "azurerm_cdn_endpoint" "test" {
   profile_name        = azurerm_cdn_profile.test.name
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+
+  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin2"
@@ -630,6 +638,8 @@ resource "azurerm_cdn_endpoint" "test" {
   is_https_allowed    = true
   origin_path         = "/origin-path"
   probe_path          = "/origin-path/probe"
+
+  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
@@ -679,6 +689,8 @@ resource "azurerm_cdn_endpoint" "test" {
   is_http_allowed     = false
   is_https_allowed    = true
   optimization_type   = "GeneralWebDelivery"
+
+  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
@@ -768,6 +780,8 @@ resource "azurerm_cdn_endpoint" "test" {
   resource_group_name = azurerm_resource_group.test.name
   is_http_allowed     = %s
   is_https_allowed    = %s
+
+  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -31,6 +31,8 @@ resource "azurerm_cdn_endpoint" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
+  origin_host_header = "www.example.com"
+
   origin {
     name      = "example"
     host_name = "www.example.com"
@@ -66,7 +68,7 @@ The following arguments are supported:
 
 * `origin` - (Required) The set of origins of the CDN endpoint. When multiple origins exist, the first origin will be used as primary and rest will be used as failover options. Each `origin` block supports fields documented below.
 
-* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
+* `origin_host_header` - (Required) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
 
 * `origin_path` - (Optional) The path used at for origin requests.
 


### PR DESCRIPTION
When omitting this property the API is always the following error:

```
Error: Error waiting for CDN Endpoint "example" (Profile "example-cdn" / Resource Group "test-rg") to finish creating: Code="BadRequest" Message="{\"ErrorMessage\":\"Errors found in Model: OriginHostHeader must match the regex '(^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9_\\\\-]*[a-zA-Z0-9])\\\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\\\-]*[A-Za-z0-9])$)|((?:[:0-9A-Fa-f]+))'.\"}"
```

Didn't want to do local validation with the above mentioned regex but to simply make this value required instead of optional.