### PR TITLE
`azurerm_linux_virtual_machine_scale_set` - fixes crash with `boot_diagnositics` 

### DIFF
--- a/azurerm/internal/services/compute/shared_schema.go
+++ b/azurerm/internal/services/compute/shared_schema.go
@@ -113,7 +113,7 @@ func bootDiagnosticsSchema() *schema.Schema {
 }
 
 func expandBootDiagnostics(input []interface{}) *compute.DiagnosticsProfile {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return &compute.DiagnosticsProfile{
 			BootDiagnostics: &compute.BootDiagnostics{
 				Enabled:    utils.Bool(false),


### PR DESCRIPTION
Fixes #6488