### PR TITLE
`azurerm_iothub_dps` - fix crash when path isn't cased correctly 

### DIFF
--- a/azurerm/internal/services/iothub/resource_arm_iothub_dps.go
+++ b/azurerm/internal/services/iothub/resource_arm_iothub_dps.go
@@ -219,6 +219,10 @@ func resourceArmIotHubDPSRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	resourceGroup := id.ResourceGroup
 	name := id.Path["provisioningServices"]
+	// the name path can use the ProvisioningServices in older iterations
+	if name == "" {
+		name = id.Path["ProvisioningServices"]
+	}
 
 	resp, err := client.Get(ctx, name, resourceGroup)
 	if err != nil {


### PR DESCRIPTION
Fixes #5945 when importing from an older iothub dps