### PR TITLE
policy_assignment - allow scopes without `subscription/<id>`

### DIFF
--- a/azurerm/internal/services/policy/parse/definition.go
+++ b/azurerm/internal/services/policy/parse/definition.go
@@ -12,8 +12,10 @@ type PolicyDefinitionId struct {
 
 // TODO: This parsing function is currently suppressing every case difference due to github issue: https://github.com/Azure/azure-rest-api-specs/issues/8353
 func PolicyDefinitionID(input string) (*PolicyDefinitionId, error) {
-	// in general, the id of a definition should be:
+	// in general, the id of a definition should be (for custom policy definition):
 	// {scope}/providers/Microsoft.Authorization/policyDefinitions/{name}
+	// and for built-in policy-definition:
+	// /providers/Microsoft.Authorization/policyDefinitions/{name}
 	regex := regexp.MustCompile(`/providers/[Mm]icrosoft\.[Aa]uthorization/policy[Dd]efinitions/`)
 	if !regex.MatchString(input) {
 		return nil, fmt.Errorf("unable to parse Policy Definition ID %q", input)
@@ -29,6 +31,12 @@ func PolicyDefinitionID(input string) (*PolicyDefinitionId, error) {
 	name := segments[1]
 	if name == "" {
 		return nil, fmt.Errorf("unable to parse Policy Definition ID %q: definition name is empty", input)
+	}
+
+	if scope == "" {
+		return &PolicyDefinitionId{
+			Name: name,
+		}, nil
 	}
 
 	scopeId, err := PolicyScopeID(scope)

--- a/azurerm/internal/services/policy/parse/definition_test.go
+++ b/azurerm/internal/services/policy/parse/definition_test.go
@@ -18,6 +18,13 @@ func TestValidatePolicyDefinitionID(t *testing.T) {
 			Error: true,
 		},
 		{
+			Name:  "built-in policy definition ID",
+			Input: "/providers/Microsoft.Authorization/policyDefinitions/00000000-0000-0000-0000-000000000000",
+			Expected: &PolicyDefinitionId{
+				Name: "00000000-0000-0000-0000-000000000000",
+			},
+		},
+		{
 			Name:  "regular policy definition",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/def1",
 			Expected: &PolicyDefinitionId{

--- a/azurerm/internal/services/policy/tests/resource_arm_policy_assignment_test.go
+++ b/azurerm/internal/services/policy/tests/resource_arm_policy_assignment_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 )
 
-func TestAccAzureRMPolicyAssignment_basic(t *testing.T) {
+func TestAccAzureRMPolicyAssignment_basicCustom(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_policy_assignment", "test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -20,7 +20,25 @@ func TestAccAzureRMPolicyAssignment_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMPolicyAssignmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAzureRMPolicyAssignment_basic(data),
+				Config: testAzureRMPolicyAssignment_basicCustom(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPolicyAssignmentExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMPolicyAssignment_basicBuiltin(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_policy_assignment", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMPolicyAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMPolicyAssignment_basicBuiltin(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPolicyAssignmentExists(data.ResourceName),
 				),
@@ -43,7 +61,7 @@ func TestAccAzureRMPolicyAssignment_requiresImport(t *testing.T) {
 		CheckDestroy: testCheckAzureRMPolicyAssignmentDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAzureRMPolicyAssignment_basic(data),
+				Config: testAzureRMPolicyAssignment_basicCustom(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPolicyAssignmentExists(data.ResourceName),
 				),
@@ -155,24 +173,24 @@ func testCheckAzureRMPolicyAssignmentDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAzureRMPolicyAssignment_basic(data acceptance.TestData) string {
+func testAzureRMPolicyAssignment_basicCustom(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
 resource "azurerm_policy_definition" "test" {
-  name         = "acctestpol-%d"
+  name         = "acctestpol-%[1]d"
   policy_type  = "Custom"
   mode         = "All"
-  display_name = "acctestpol-%d"
+  display_name = "acctestpol-%[1]d"
 
   policy_rule = <<POLICY_RULE
 	{
     "if": {
       "not": {
         "field": "location",
-        "equals": "%s"
+        "equals": "%[2]s"
       }
     },
     "then": {
@@ -184,20 +202,50 @@ POLICY_RULE
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_policy_assignment" "test" {
-  name                 = "acctestpa-%d"
+  name                 = "acctestpa-%[1]d"
   scope                = azurerm_resource_group.test.id
   policy_definition_id = azurerm_policy_definition.test.id
 }
-`, data.RandomInteger, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAzureRMPolicyAssignment_basicBuiltin(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_policy_definition" "test" {
+  display_name = "Allowed locations"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_policy_assignment" "test" {
+  name                 = "acctestpa-%[1]d"
+  scope                = azurerm_resource_group.test.id
+  policy_definition_id = data.azurerm_policy_definition.test.id
+  parameters           = <<PARAMETERS
+{
+  "listOfAllowedLocations": {
+    "value": [ "%[2]s" ]
+  }
+}
+PARAMETERS
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func testAzureRMPolicyAssignment_requiresImport(data acceptance.TestData) string {
-	template := testAzureRMPolicyAssignment_basic(data)
+	template := testAzureRMPolicyAssignment_basicCustom(data)
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
Fixes #6523 