### PR TITLE
`azurerm_storage_account` - Enable migration of `account_kind` from `Storage` to `StorageV2`

### DIFF
--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
@@ -377,7 +377,7 @@ func TestAccAzureRMStorageAccount_storageV1ToV2Update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMStorageAccount_storageToV2(data),
+				Config: testAccAzureRMStorageAccount_storageToV2Prep(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "account_kind", "Storage"),
@@ -1156,7 +1156,7 @@ resource "azurerm_storage_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func testAccAzureRMStorageAccount_storageToV2(data acceptance.TestData) string {
+func testAccAzureRMStorageAccount_storageToV2Prep(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
@@ -368,6 +368,33 @@ func TestAccAzureRMStorageAccount_storageV2WithUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageAccount_storageV1ToV2Update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageAccount_storageToV2(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "account_kind", "Storage"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMStorageAccount_storageToV2Update(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "account_kind", "StorageV2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMStorageAccount_NonStandardCasing(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 
@@ -1121,6 +1148,60 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   access_tier              = "Cool"
+
+  tags = {
+    environment = "production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMStorageAccount_storageToV2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "Storage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMStorageAccount_storageToV2Update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "StorageV2"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 
   tags = {
     environment = "production"

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -86,6 +86,8 @@ The following arguments are supported:
 
 * `account_kind` - (Optional) Defines the Kind of account. Valid options are `BlobStorage`, `BlockBlobStorage`, `FileStorage`, `Storage` and `StorageV2`. Changing this forces a new resource to be created. Defaults to `StorageV2`.
 
+-> **NOTE:** Changing the `account_kind` value from `Storage` to `StorageV2` will not trigger a force new on the storage account, it will only upgrade the existing storage account from `Storage` to `StorageV2` keeping the existing storage account in place.
+
 * `account_tier` - (Required) Defines the Tier to use for this storage account. Valid options are `Standard` and `Premium`. For `FileStorage` accounts only `Premium` is valid. Changing this forces a new resource to be created.
 
 * `account_replication_type` - (Required) Defines the type of replication to use for this storage account. Valid options are `LRS`, `GRS`, `RAGRS` and `ZRS`.


### PR DESCRIPTION
Hi all,

With the update it's now possible to change the `account_kind` from `Storage`to `StorageV2` without dropping. (Migration is possible now)
For all other changes on the `account_kind` attribute a `ForceNew` will be triggered like before.

The migration was a valid path to change the `account_kind` without dropping it.
See also the comments in the [azure-sdk-for-go](https://github.com/Azure/azure-sdk-for-go/blob/7da5bb2d5ffd1a370c899d15fac9b59f4332c5bd/services/storage/mgmt/2019-06-01/storage/models.go#L1360) 


Here the output of `terraform apply`
```bash
Terraform will perform the following actions:

 # azurerm_storage_account.storage will be updated in-place
 ~ resource "azurerm_storage_account" "storage" {
      ~ account_kind                   = "Storage" -> "StorageV2"
...
Plan: 0 to add, 1 to change, 0 to destroy.
```


If you change the type back or to something else:
```bash
Terraform will perform the following actions:

  # azurerm_storage_account.storage must be replaced
-/+ resource "azurerm_storage_account" "storage" {
      ~ account_kind                     = "StorageV2" -> "Storage" # forces replacement
...
Plan: 1 to add, 0 to change, 1 to destroy.
```

Kind regards
Tobi 

Fixes #5758