### PR TITLE
Revert "CDN Endpoint: make origin_host_header required "

### DIFF
--- a/azurerm/internal/services/cdn/resource_arm_cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/resource_arm_cdn_endpoint.go
@@ -58,7 +58,8 @@ func resourceArmCdnEndpoint() *schema.Resource {
 
 			"origin_host_header": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 
 			"is_http_allowed": {

--- a/azurerm/internal/services/cdn/tests/resource_arm_cdn_endpoint_test.go
+++ b/azurerm/internal/services/cdn/tests/resource_arm_cdn_endpoint_test.go
@@ -449,8 +449,6 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
-
   origin {
     name       = "acceptanceTestCdnOrigin1"
     host_name  = "www.example.com"
@@ -471,8 +469,6 @@ resource "azurerm_cdn_endpoint" "import" {
   profile_name        = azurerm_cdn_endpoint.test.profile_name
   location            = azurerm_cdn_endpoint.test.location
   resource_group_name = azurerm_cdn_endpoint.test.resource_group_name
-
-  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
@@ -548,8 +544,6 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
-
   origin {
     name       = "acceptanceTestCdnOrigin2"
     host_name  = "www.example.com"
@@ -588,8 +582,6 @@ resource "azurerm_cdn_endpoint" "test" {
   profile_name        = azurerm_cdn_profile.test.name
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-
-  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin2"
@@ -632,8 +624,6 @@ resource "azurerm_cdn_endpoint" "test" {
   is_https_allowed    = true
   origin_path         = "/origin-path"
   probe_path          = "/origin-path/probe"
-
-  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
@@ -683,8 +673,6 @@ resource "azurerm_cdn_endpoint" "test" {
   is_http_allowed     = false
   is_https_allowed    = true
   optimization_type   = "GeneralWebDelivery"
-
-  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
@@ -774,8 +762,6 @@ resource "azurerm_cdn_endpoint" "test" {
   resource_group_name = azurerm_resource_group.test.name
   is_http_allowed     = %s
   is_https_allowed    = %s
-
-  origin_host_header = "www.example.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -31,8 +31,6 @@ resource "azurerm_cdn_endpoint" "example" {
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
-  origin_host_header = "www.example.com"
-
   origin {
     name      = "example"
     host_name = "www.example.com"
@@ -68,7 +66,7 @@ The following arguments are supported:
 
 * `origin` - (Required) The set of origins of the CDN endpoint. When multiple origins exist, the first origin will be used as primary and rest will be used as failover options. Each `origin` block supports fields documented below.
 
-* `origin_host_header` - (Required) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
+* `origin_host_header` - (Optional) The host header CDN provider will send along with content requests to origins. Defaults to the host name of the origin.
 
 * `origin_path` - (Optional) The path used at for origin requests.
 


### PR DESCRIPTION
Reverts terraform-providers/terraform-provider-azurerm#6550 because it's a breaking change 