### PR TITLE
`azurerm_public_ip_prefix`: Update `prefix_length` validation to accept all valid IPv4 address ranges

### DIFF
--- a/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
+++ b/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
@@ -104,11 +104,11 @@ func resourceArmPublicIpPrefixCreateUpdate(d *schema.ResourceData, meta interfac
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, publicIpPrefix)
 	if err != nil {
-		return fmt.Errorf("Error Creating/Updating Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("creating/Updating Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for completion of Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("waiting for completion of Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	read, err := client.Get(ctx, resGroup, name, "")
@@ -143,7 +143,7 @@ func resourceArmPublicIpPrefixRead(d *schema.ResourceData, meta interface{}) err
 			return nil
 		}
 
-		return fmt.Errorf("Error making Read request on Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("making Read request on Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	d.Set("name", resp.Name)
@@ -179,11 +179,11 @@ func resourceArmPublicIpPrefixDelete(d *schema.ResourceData, meta interface{}) e
 
 	future, err := client.Delete(ctx, resGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error deleting Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("deleting Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("Error waiting for deletion of Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
+		return fmt.Errorf("waiting for deletion of Public IP Prefix %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
+++ b/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
@@ -59,7 +59,7 @@ func resourceArmPublicIpPrefix() *schema.Resource {
 				Optional:     true,
 				Default:      28,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(0, 32),
+				ValidateFunc: validation.IntBetween(0, 31),
 			},
 
 			"ip_prefix": {

--- a/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
+++ b/azurerm/internal/services/network/resource_arm_public_ip_prefix.go
@@ -59,7 +59,7 @@ func resourceArmPublicIpPrefix() *schema.Resource {
 				Optional:     true,
 				Default:      28,
 				ForceNew:     true,
-				ValidateFunc: validation.IntBetween(28, 31),
+				ValidateFunc: validation.IntBetween(0, 32),
 			},
 
 			"ip_prefix": {

--- a/azurerm/internal/services/network/tests/resource_arm_public_ip_prefix_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_public_ip_prefix_test.go
@@ -140,6 +140,8 @@ func TestAccAzureRMPublicIpPrefix_prefixLength31(t *testing.T) {
 }
 
 func TestAccAzureRMPublicIpPrefix_prefixLength24(t *testing.T) {
+	// NOTE: This test will fail unless the subscription is updated
+	//        to accept a minimum PrefixLength of 24
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 
 	resource.ParallelTest(t, resource.TestCase{

--- a/azurerm/internal/services/network/tests/resource_arm_public_ip_prefix_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_public_ip_prefix_test.go
@@ -118,7 +118,7 @@ func TestAccAzureRMPublicIpPrefix_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMPublicIpPrefix_prefixLength(t *testing.T) {
+func TestAccAzureRMPublicIpPrefix_prefixLength31(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -127,11 +127,32 @@ func TestAccAzureRMPublicIpPrefix_prefixLength(t *testing.T) {
 		CheckDestroy: testCheckAzureRMPublicIPPrefixDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMPublicIPPrefix_prefixLength(data),
+				Config: testAccAzureRMPublicIPPrefix_prefixLength31(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMPublicIPPrefixExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "ip_prefix"),
 					resource.TestCheckResourceAttr(data.ResourceName, "prefix_length", "31"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMPublicIpPrefix_prefixLength24(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_public_ip_prefix", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMPublicIPPrefixDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMPublicIPPrefix_prefixLength24(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPublicIPPrefixExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ip_prefix"),
+					resource.TestCheckResourceAttr(data.ResourceName, "prefix_length", "24"),
 				),
 			},
 			data.ImportStep(),
@@ -254,7 +275,7 @@ resource "azurerm_public_ip_prefix" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMPublicIPPrefix_prefixLength(data acceptance.TestData) string {
+func testAccAzureRMPublicIPPrefix_prefixLength31(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -271,6 +292,27 @@ resource "azurerm_public_ip_prefix" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   prefix_length = 31
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMPublicIPPrefix_prefixLength24(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_public_ip_prefix" "test" {
+  name                = "acctestpublicipprefix-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  prefix_length = 24
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 -> **Note**: Public IP Prefix can only be created with Standard SKUs at this time.
 
-* `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 0 (4,294,967,296 addresses) and 32 (1 address). Defaults to `28`(16 addresses). Changing this forces a new resource to be created.
+* `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 0 (4,294,967,296 addresses) and 31 (2 addresses). Defaults to `28`(16 addresses). Changing this forces a new resource to be created.
 
 -> **Please Note**: There may be Public IP address limits on the subscription . [More information available here](https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits?toc=%2fazure%2fvirtual-network%2ftoc.json#publicip-address)
 

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 -> **Note**: Public IP Prefix can only be created with Standard SKUs at this time.
 
-* `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 28 (16 addresses) and 31 (2 addresses). Changing this forces a new resource to be created.
+* `prefix_length` - (Optional) Specifies the number of bits of the prefix. The value can be set between 0 (4,294,967,296 addresses) and 32 (1 address). Defaults to `28`(16 addresses). Changing this forces a new resource to be created.
 
 -> **Please Note**: There may be Public IP address limits on the subscription . [More information available here](https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits?toc=%2fazure%2fvirtual-network%2ftoc.json#publicip-address)
 


### PR DESCRIPTION
[Feb 11, 2020](https://github.com/terraform-providers/terraform-provider-azurerm/pull/5693) there was a change to the resource to restrict the range to be between 28 and 31 due to the product documentation which states that by default [/28](https://docs.microsoft.com/en-us/azure/virtual-network/public-ip-address-prefix#benefits) is the maximum limit, however also in the documentation it states that you should contact customer support to [change the default limit of /28](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=/azure/virtual-network/toc.json#publicip-address).

Since there is no way for terraform to know the approved range for a given subscription I have opened up the validation to check that the passed value is between `0` and `31`, which should cover all possible IPv4 scenarios.  
