### PR TITLE
azurerm_express_route_circuit_peering  - support  customer_asn & routing_registry_name #1084

### DIFF
--- a/azurerm/internal/services/network/resource_arm_express_route_circuit_peering.go
+++ b/azurerm/internal/services/network/resource_arm_express_route_circuit_peering.go
@@ -95,6 +95,16 @@ func resourceArmExpressRouteCircuitPeering() *schema.Resource {
 							Required: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"customer_asn": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
+						"routing_registry_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "NONE",
+						},
 					},
 				},
 			},
@@ -276,12 +286,17 @@ func expandExpressRouteCircuitPeeringMicrosoftConfig(input []interface{}) *netwo
 
 	prefixes := make([]string, 0)
 	inputPrefixes := peering["advertised_public_prefixes"].([]interface{})
+	inputCustomerASN := int32(peering["customer_asn"].(int))
+	inputRoutingRegistryName := peering["routing_registry_name"].(string)
+
 	for _, v := range inputPrefixes {
 		prefixes = append(prefixes, v.(string))
 	}
 
 	return &network.ExpressRouteCircuitPeeringConfig{
 		AdvertisedPublicPrefixes: &prefixes,
+		CustomerASN:              &inputCustomerASN,
+		RoutingRegistryName:      &inputRoutingRegistryName,
 	}
 }
 
@@ -292,10 +307,15 @@ func flattenExpressRouteCircuitPeeringMicrosoftConfig(input *network.ExpressRout
 
 	config := make(map[string]interface{})
 	prefixes := make([]string, 0)
+	if customerASN := input.CustomerASN; customerASN != nil {
+		config["customer_asn"] = *customerASN
+	}
+	if routingRegistryName := input.RoutingRegistryName; routingRegistryName != nil {
+		config["routing_registry_name"] = *routingRegistryName
+	}
 	if ps := input.AdvertisedPublicPrefixes; ps != nil {
 		prefixes = *ps
 	}
-
 	config["advertised_public_prefixes"] = prefixes
 
 	return []interface{}{config}

--- a/azurerm/internal/services/network/tests/resource_arm_express_route_circuit_peering_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_express_route_circuit_peering_test.go
@@ -73,6 +73,29 @@ func testAccAzureRMExpressRouteCircuitPeering_microsoftPeering(t *testing.T) {
 	})
 }
 
+func testAccAzureRMExpressRouteCircuitPeering_microsoftPeeringCustomerRouting(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_express_route_circuit_peering", "test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMExpressRouteCircuitPeeringDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMExpressRouteCircuitPeering_msPeeringCustomerRouting(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMExpressRouteCircuitPeeringExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "peering_type", "MicrosoftPeering"),
+					resource.TestCheckResourceAttr(data.ResourceName, "microsoft_peering_config.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "microsoft_peering_config.0.customer_asn", "64511"),
+					resource.TestCheckResourceAttr(data.ResourceName, "microsoft_peering_config.0.routing_registry_name", "ARIN"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testAccAzureRMExpressRouteCircuitPeering_azurePrivatePeeringWithCircuitUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_express_route_circuit_peering", "test")
 
@@ -261,6 +284,55 @@ resource "azurerm_express_route_circuit_peering" "test" {
 
   microsoft_peering_config {
     advertised_public_prefixes = ["123.1.0.0/24"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMExpressRouteCircuitPeering_msPeeringCustomerRouting(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_express_route_circuit" "test" {
+  name                  = "acctest-erc-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  service_provider_name = "Equinix"
+  peering_location      = "Silicon Valley"
+  bandwidth_in_mbps     = 50
+
+  sku {
+    tier   = "Premium"
+    family = "MeteredData"
+  }
+
+  tags = {
+    Environment = "production"
+    Purpose     = "AcceptanceTests"
+  }
+}
+
+resource "azurerm_express_route_circuit_peering" "test" {
+  peering_type                  = "MicrosoftPeering"
+  express_route_circuit_name    = azurerm_express_route_circuit.test.name
+  resource_group_name           = azurerm_resource_group.test.name
+  peer_asn                      = 100
+  primary_peer_address_prefix   = "192.168.1.0/30"
+  secondary_peer_address_prefix = "192.168.2.0/30"
+  vlan_id                       = 300
+
+  microsoft_peering_config {
+    advertised_public_prefixes = ["123.1.0.0/24"]
+    // https://tools.ietf.org/html/rfc5398
+    customer_asn          = 64511
+    routing_registry_name = "ARIN"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/azurerm/internal/services/network/tests/resource_arm_express_route_circuit_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_express_route_circuit_test.go
@@ -34,7 +34,8 @@ func TestAccAzureRMExpressRouteCircuit(t *testing.T) {
 			"requiresImport":                testAccAzureRMExpressRouteCircuitPeering_requiresImport,
 		},
 		"MicrosoftPeering": {
-			"microsoftPeering": testAccAzureRMExpressRouteCircuitPeering_microsoftPeering,
+			"microsoftPeering":                testAccAzureRMExpressRouteCircuitPeering_microsoftPeering,
+			"microsoftPeeringCustomerRouting": testAccAzureRMExpressRouteCircuitPeering_microsoftPeeringCustomerRouting,
 		},
 		"authorization": {
 			"basic":          testAccAzureRMExpressRouteCircuitAuthorization_basic,

--- a/website/docs/r/express_route_circuit_peering.html.markdown
+++ b/website/docs/r/express_route_circuit_peering.html.markdown
@@ -78,6 +78,8 @@ The following arguments are supported:
 A `microsoft_peering_config` block contains:
 
 * `advertised_public_prefixes` - (Required) A list of Advertised Public Prefixes
+* `customer_asn` - (Optional) The CustomerASN of the peering
+* `routing_registry_name` - (Optional) The RoutingRegistryName of the configuration
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixing issue #1084 Microsoft Peering is missing customer_asn and routing_registry_name
- Test included
- Website updated

(fixes #1084)