### PR TITLE
`azurerm_redis_cache` - correctly build connection strings when SSL is disabled

### DIFF
--- a/azurerm/internal/services/redis/data_source_redis_cache.go
+++ b/azurerm/internal/services/redis/data_source_redis_cache.go
@@ -289,8 +289,9 @@ func dataSourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("secondary_access_key", keys.SecondaryKey)
 
 	if props != nil {
-		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.PrimaryKey, *props.EnableNonSslPort))
-		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.SecondaryKey, *props.EnableNonSslPort))
+		enableSslPort := !*props.EnableNonSslPort
+		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.PrimaryKey, enableSslPort))
+		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keys.SecondaryKey, enableSslPort))
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/redis/resource_arm_redis_cache.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_cache.go
@@ -570,8 +570,9 @@ func resourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("secondary_access_key", keysResp.SecondaryKey)
 
 	if props != nil {
-		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.PrimaryKey, *props.EnableNonSslPort))
-		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.SecondaryKey, *props.EnableNonSslPort))
+		enableSslPort := !*props.EnableNonSslPort
+		d.Set("primary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.PrimaryKey, enableSslPort))
+		d.Set("secondary_connection_string", getRedisConnectionString(*props.HostName, *props.SslPort, *keysResp.SecondaryKey, enableSslPort))
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)


### PR DESCRIPTION
Fixes #6279