### PR TITLE
Add doc/test for `O+C` && `ConfigModeAttr` attr

### DIFF
--- a/azurerm/internal/services/network/resource_arm_virtual_network.go
+++ b/azurerm/internal/services/network/resource_arm_virtual_network.go
@@ -99,9 +99,10 @@ func resourceArmVirtualNetwork() *schema.Resource {
 			},
 
 			"subnet": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -191,6 +191,8 @@ A `site_config` block supports the following:
 
 * `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.
 
+-> **NOTE** User has to explicitly set `ip_restriction` to empty slice (`[]`) to remove it.
+
 * `java_version` - (Optional) The version of Java to use. If specified `java_container` and `java_container_version` must also be specified. Possible values are `1.7`, `1.8` and `11` and their specific versions - except for Java 11 (e.g. `1.7.0_80`, `1.8.0_181`, `11`)
 
 * `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JAVA`, `JETTY`, and `TOMCAT`.

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -198,6 +198,8 @@ The following arguments are supported:
 
 * `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.
 
+-> **NOTE** User has to explicitly set `ip_restriction` to empty slice (`[]`) to remove it.
+
 * `java_container` - (Optional) The Java Container to use. If specified `java_version` and `java_container_version` must also be specified. Possible values are `JETTY` and `TOMCAT`.
 
 * `java_container_version` - (Optional) The version of the Java Container to use. If specified `java_version` and `java_container` must also be specified.

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -167,6 +167,8 @@ The following arguments are supported:
 
 * `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.
 
+-> **NOTE** User has to explicitly set `ip_restriction` to empty slice (`[]`) to remove it.
+
 ---
 
 A `cors` block supports the following:

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `access_policy` - (Optional) [A list](/docs/configuration/attr-as-blocks.html) of up to 16 objects describing access policies, as described below.
 
-~> **NOTE:** It's possible to define Key Vault Access Policies both within [the `azurerm_key_vault` resource](key_vault.html) via the `access_policy` block and by using [the `azurerm_key_vault_access_policy` resource](key_vault_access_policy.html). However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
+-> **NOTE** Since `access_policy` can be configured both inline and via the separate `azurerm_key_vault_access_policy` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
 
 * `enabled_for_deployment` - (Optional) Boolean flag to specify whether Azure Virtual Machines are permitted to retrieve certificates stored as secrets from the key vault. Defaults to `false`.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -295,9 +295,15 @@ A `load_balancer_profile` block supports the following:
 
 * `managed_outbound_ip_count` - (Optional) Count of desired managed outbound IPs for the cluster load balancer. Must be in the range of [1, 100].
 
+-> **NOTE** User has to explicitly set `managed_outbound_ip_count` to empty slice (`[]`) to remove it.
+
 * `outbound_ip_prefix_ids` - (Optional) The ID of the outbound Public IP Address Prefixes which should be used for the cluster load balancer.
 
+-> **NOTE** User has to explicitly set `outbound_ip_prefix_ids` to empty slice (`[]`) to remove it.
+
 * `outbound_ip_address_ids` - (Optional) The ID of the Public IP Addresses which should be used for outbound communication for the cluster load balancer.
+
+-> **NOTE** User has to explicitly set `outbound_ip_address_ids` to empty slice (`[]`) to remove it.
 
 ---
 

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -58,6 +58,8 @@ The following arguments are supported:
 
 * `security_rule` - (Optional) [List of objects](/docs/configuration/attr-as-blocks.html) representing security rules, as defined below.
 
+-> **NOTE** Since `security_rule` can be configured both inline and via the separate `azurerm_network_security_rule` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -11,6 +11,11 @@ description: |-
 
 Manages a Route Table
 
+~> **NOTE on Route Tables and Routes:** Terraform currently
+provides both a standalone [Route resource](route.html), and allows for Routes to be defined in-line within the [Route Table resource](route_table.html).
+At this time you cannot use a Route Table with in-line Routes in conjunction with any Route resources. Doing so will cause a conflict of Route configurations and will overwrite Routes.
+
+
 ## Example Usage
 
 ```hcl
@@ -48,6 +53,8 @@ The following arguments are supported:
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
 * `route` - (Optional) [List of objects](/docs/configuration/attr-as-blocks.html) representing routes. Each object accepts the arguments documented below.
+
+-> **NOTE** Since `route` can be configured both inline and via the separate `azurerm_route` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
 
 * `disable_bgp_route_propagation` - (Optional) Boolean flag which controls propagation of routes learned by BGP on that route table. True means disable.
 

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -74,9 +74,15 @@ The following arguments are supported:
 
 * `bypass` - (Optional)  Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of `Logging`, `Metrics`, `AzureServices`, or `None`.
 
+-> **NOTE** User has to explicitly set `bypass` to empty slice (`[]`) to remove it.
+
 * `ip_rules` - (Optional) List of public IP or IP ranges in CIDR Format. Only IPV4 addresses are allowed. Private IP address ranges (as defined in [RFC 1918](https://tools.ietf.org/html/rfc1918#section-3)) are not allowed.
 
+-> **NOTE** User has to explicitly set `ip_rules` to empty slice (`[]`) to remove it.
+
 * `virtual_network_subnet_ids` - (Optional) A list of virtual network subnet ids to to secure the storage account.
+
+-> **NOTE** User has to explicitly set `virtual_network_subnet_ids` to empty slice (`[]`) to remove it.
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -93,6 +93,8 @@ The following arguments are supported:
 * `subnet` - (Optional) Can be specified multiple times to define multiple
     subnets. Each `subnet` block supports fields documented below.
 
+-> **NOTE** Since `subnet` can be configured both inline and via the separate `azurerm_subnet` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
Add document to guide user how to clean up the `O+C` && `ConfigModeAttr`
attributes. Also add test to check the ability to clean up them by
explicitly empty it for some resources.

- virtual_network: code + doc + test
- key_vault: doc + test
- network_security_group: doc + test
- app_service: doc (as test already available)
- app_service_slot: doc (as test already available)
- route_table: doc (as test already available)
- function_app: doc
- kubernetes_cluster: doc
- storage_account_network_rules: doc

The resources listed above are from the output of mixture of below
commands:

```bash
$ gogrep -r -x '{$*_,  Optional: true, Computed: true, ConfigMode:
schema.SchemaConfigModeAttr, $*_, Elem: $_, $*_}' ./...
$ gogrep -r -x '{$*_, ConfigMode: schema.SchemaConfigModeAttr, Optional:
true, Computed: true, $*_, Elem: $_, $*_}' ./...
```

There might be some more potential resources, actually, the nested blocks
with `O+C` are likely needed to add the `ConfigModeAttr` to be able to
clean up (except for the case `MinItems` is specified). I'll keep those
untouched for now.

## Test Result (for the one I modified)

```bash
💤 😡 2 via 🦉 v1.14.2 make testacc TEST=./azurerm/internal/services/keyvault/tests TESTARGS="-run='TestAccAzureRMKeyVault_deletePolicy'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/keyvault/tests -v -run='TestAccAzureRMKeyVault_deletePolicy' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMKeyVault_deletePolicy
=== PAUSE TestAccAzureRMKeyVault_deletePolicy
=== CONT  TestAccAzureRMKeyVault_deletePolicy
--- PASS: TestAccAzureRMKeyVault_deletePolicy (322.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/tests      322.338s

💤 😡 2 via 🦉 v1.14.2 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMNetworkSecurityGroup_deleteRule'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMNetworkSecurityGroup_deleteRule' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMNetworkSecurityGroup_deleteRule
=== PAUSE TestAccAzureRMNetworkSecurityGroup_deleteRule
=== CONT  TestAccAzureRMNetworkSecurityGroup_deleteRule
--- PASS: TestAccAzureRMNetworkSecurityGroup_deleteRule (160.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       160.168s

💤 😡 2 via 🦉 v1.14.2 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMVirtualNetwork_deleteSubnet'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMVirtualNetwork_deleteSubnet' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMVirtualNetwork_deleteSubnet
=== PAUSE TestAccAzureRMVirtualNetwork_deleteSubnet
=== CONT  TestAccAzureRMVirtualNetwork_deleteSubnet
--- PASS: TestAccAzureRMVirtualNetwork_deleteSubnet (339.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests339.790s
```

## Reference

terraform-providers/terraform-provider-azurerm#6623