### PR TITLE
Fix test name typo in resource_arm_mssql_database_test.go

### DIFF
--- a/azurerm/internal/services/mssql/tests/resource_arm_mssql_database_test.go
+++ b/azurerm/internal/services/mssql/tests/resource_arm_mssql_database_test.go
@@ -327,7 +327,7 @@ func TestAccAzureRMMsSqlDatabase_threatDetectionPolicy(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMSqlDatabase_withBlobAuditingPolices(t *testing.T) {
+func TestAccAzureRMMsSqlDatabase_withBlobAuditingPolices(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
 
 	resource.ParallelTest(t, resource.TestCase{


### PR DESCRIPTION
Change test name TestAccAzureRMSqlDatabase_withBlobAuditingPolices to TestAccAzureRMMsSqlDatabase_withBlobAuditingPolices in resource_arm_mssql_database_test.go