### PR TITLE
update import doc for "azurerm_network_interface_security_group_association"

### DIFF
--- a/website/docs/r/network_interface_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_security_group_association.html.markdown
@@ -85,7 +85,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Associations between Network Interfaces and Network Security Group can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_network_interface_security_group_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/networkSecurityGroups/group1
+terraform import azurerm_network_interface_security_group_association.association1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/networkSecurityGroups/group1"
 ```
 
 -> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}|{networkSecurityGroupId}`.

--- a/website/docs/r/network_interface_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_security_group_association.html.markdown
@@ -85,7 +85,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Associations between Network Interfaces and Network Security Group can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_network_interface_security_group_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1/ipConfigurations/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/networkSecurityGroups/group1
+terraform import azurerm_network_interface_security_group_association.association1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/example|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/networkSecurityGroups/group1
 ```
 
--> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}/|{networkSecurityGroupId}`.
+-> **NOTE:** This ID is specific to Terraform - and is of the format `{networkInterfaceId}|{networkSecurityGroupId}`.


### PR DESCRIPTION
fix #6638

fix problems:
1. the format of networkinterfaceid is wrong
2. no need to escape between \`  \`
3. would better add quote for the resource id because "|" has special meanings in many kinds of shell
