### PR TITLE
use name instead of id

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -80,7 +80,7 @@ resource "azurerm_function_app" "example" {
   location                   = azurerm_resource_group.example.location
   resource_group_name        = azurerm_resource_group.example.name
   app_service_plan_id        = azurerm_app_service_plan.example.id
-  storage_account_name       = azurerm_storage_account.test.id
+  storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 }
 ```


### PR DESCRIPTION
With `id` it doesn't work since it is validating it (max 24 chars and no special chars...)