### PR TITLE
virtual hub connection resource mispell attributes

### DIFF
--- a/azurerm/internal/services/network/resource_arm_virtual_hub_connection.go
+++ b/azurerm/internal/services/network/resource_arm_virtual_hub_connection.go
@@ -55,13 +55,13 @@ func resourceArmVirtualHubConnection() *schema.Resource {
 				ValidateFunc: azure.ValidateResourceID,
 			},
 
-			"hub_to_vitual_network_traffic_allowed": {
+			"hub_to_virtual_network_traffic_allowed": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"vitual_network_to_hub_gateways_traffic_allowed": {
+			"virtual_network_to_hub_gateways_traffic_allowed": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
@@ -123,8 +123,8 @@ func resourceArmVirtualHubConnectionCreate(d *schema.ResourceData, meta interfac
 			RemoteVirtualNetwork: &network.SubResource{
 				ID: utils.String(d.Get("remote_virtual_network_id").(string)),
 			},
-			AllowHubToRemoteVnetTransit:         utils.Bool(d.Get("hub_to_vitual_network_traffic_allowed").(bool)),
-			AllowRemoteVnetToUseHubVnetGateways: utils.Bool(d.Get("vitual_network_to_hub_gateways_traffic_allowed").(bool)),
+			AllowHubToRemoteVnetTransit:         utils.Bool(d.Get("hub_to_virtual_network_traffic_allowed").(bool)),
+			AllowRemoteVnetToUseHubVnetGateways: utils.Bool(d.Get("virtual_network_to_hub_gateways_traffic_allowed").(bool)),
 			EnableInternetSecurity:              utils.Bool(d.Get("internet_security_enabled").(bool)),
 		},
 	}
@@ -198,8 +198,8 @@ func resourceArmVirtualHubConnectionRead(d *schema.ResourceData, meta interface{
 	d.Set("virtual_hub_id", virtualHub.ID)
 
 	if props := connection.HubVirtualNetworkConnectionProperties; props != nil {
-		d.Set("hub_to_vitual_network_traffic_allowed", props.AllowHubToRemoteVnetTransit)
-		d.Set("vitual_network_to_hub_gateways_traffic_allowed", props.AllowRemoteVnetToUseHubVnetGateways)
+		d.Set("hub_to_virtual_network_traffic_allowed", props.AllowHubToRemoteVnetTransit)
+		d.Set("virtual_network_to_hub_gateways_traffic_allowed", props.AllowRemoteVnetToUseHubVnetGateways)
 		d.Set("internet_security_enabled", props.EnableInternetSecurity)
 		remoteVirtualNetworkId := ""
 		if props.RemoteVirtualNetwork != nil && props.RemoteVirtualNetwork.ID != nil {

--- a/azurerm/internal/services/network/tests/resource_arm_virtual_hub_connection_test.go
+++ b/azurerm/internal/services/network/tests/resource_arm_virtual_hub_connection_test.go
@@ -252,21 +252,21 @@ resource "azurerm_subnet_network_security_group_association" "test2" {
 }
 
 resource "azurerm_virtual_hub_connection" "test" {
-  name                                           = "acctestvhubconn-%d"
-  virtual_hub_id                                 = azurerm_virtual_hub.test.id
-  remote_virtual_network_id                      = azurerm_virtual_network.test.id
-  hub_to_vitual_network_traffic_allowed          = true
-  vitual_network_to_hub_gateways_traffic_allowed = false
-  internet_security_enabled                      = false
+  name                                            = "acctestvhubconn-%d"
+  virtual_hub_id                                  = azurerm_virtual_hub.test.id
+  remote_virtual_network_id                       = azurerm_virtual_network.test.id
+  hub_to_virtual_network_traffic_allowed          = true
+  virtual_network_to_hub_gateways_traffic_allowed = false
+  internet_security_enabled                       = false
 }
 
 resource "azurerm_virtual_hub_connection" "test2" {
-  name                                           = "acctestvhubconn2-%d"
-  virtual_hub_id                                 = azurerm_virtual_hub.test.id
-  remote_virtual_network_id                      = azurerm_virtual_network.test2.id
-  hub_to_vitual_network_traffic_allowed          = false
-  vitual_network_to_hub_gateways_traffic_allowed = false
-  internet_security_enabled                      = true
+  name                                            = "acctestvhubconn2-%d"
+  virtual_hub_id                                  = azurerm_virtual_hub.test.id
+  remote_virtual_network_id                       = azurerm_virtual_network.test2.id
+  hub_to_virtual_network_traffic_allowed          = false
+  virtual_network_to_hub_gateways_traffic_allowed = false
+  internet_security_enabled                       = true
 }
 `, template, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/virtual_hub_connection.html.markdown
+++ b/website/docs/r/virtual_hub_connection.html.markdown
@@ -58,9 +58,9 @@ The following arguments are supported:
 
 ---
 
-* `hub_to_vitual_network_traffic_allowed` - (Optional) Is the Virtual Hub traffic allowed to transit via the Remote Virtual Network? Changing this forces a new resource to be created.
+* `hub_to_virtual_network_traffic_allowed` - (Optional) Is the Virtual Hub traffic allowed to transit via the Remote Virtual Network? Changing this forces a new resource to be created.
 
-* `vitual_network_to_hub_gateways_traffic_allowed` - (Optional) Is Remote Virtual Network traffic allowed to transit the Hub's Virtual Network Gateway's? Changing this forces a new resource to be created.
+* `virtual_network_to_hub_gateways_traffic_allowed` - (Optional) Is Remote Virtual Network traffic allowed to transit the Hub's Virtual Network Gateway's? Changing this forces a new resource to be created.
 
 * `internet_security_enabled` - (Optional) Should Internet Security be enabled to secure internet traffic? Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Fix two attributes' misspelled names, which fixes #6663  

## Test

```bash
💤 via 🦉 v1.14.2 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMVirtualHubConnection_'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMVirtualHubConnection_' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMVirtualHubConnection_basic
=== PAUSE TestAccAzureRMVirtualHubConnection_basic
=== RUN   TestAccAzureRMVirtualHubConnection_requiresImport
=== PAUSE TestAccAzureRMVirtualHubConnection_requiresImport
=== RUN   TestAccAzureRMVirtualHubConnection_complete
=== PAUSE TestAccAzureRMVirtualHubConnection_complete
=== RUN   TestAccAzureRMVirtualHubConnection_update
=== PAUSE TestAccAzureRMVirtualHubConnection_update
=== CONT  TestAccAzureRMVirtualHubConnection_basic
=== CONT  TestAccAzureRMVirtualHubConnection_update
=== CONT  TestAccAzureRMVirtualHubConnection_complete
=== CONT  TestAccAzureRMVirtualHubConnection_requiresImport
--- PASS: TestAccAzureRMVirtualHubConnection_basic (743.29s)
--- PASS: TestAccAzureRMVirtualHubConnection_requiresImport (798.29s)
--- PASS: TestAccAzureRMVirtualHubConnection_complete (1708.36s)
--- PASS: TestAccAzureRMVirtualHubConnection_update (1709.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       1709.347s
```