### PR TITLE
Enable Keyvault soft delete recovery to be attempted when Read permissions are not allowed at Subscription

### DIFF
--- a/azurerm/internal/services/keyvault/resource_arm_key_vault.go
+++ b/azurerm/internal/services/keyvault/resource_arm_key_vault.go
@@ -215,10 +215,9 @@ func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// before creating check to see if the key vault exists in the soft delete state
 	softDeletedKeyVault, err := client.GetDeleted(ctx, name, location)
-	deniedAtSubscription := utils.ResponseWasForbidden(softDeletedKeyVault.Response)
 	if err != nil {
-		// If Terraform lacks permission to read at the Subscription don't assume 404
-		if !(utils.ResponseWasNotFound(softDeletedKeyVault.Response) || deniedAtSubscription) {
+		// If Terraform lacks permission to read at the Subscription we'll get 409, not 404
+		if !utils.ResponseWasNotFound(softDeletedKeyVault.Response) && !utils.ResponseWasForbidden(softDeletedKeyVault.Response) {
 			return fmt.Errorf("Error checking for the presence of an existing Soft-Deleted Key Vault %q (Location %q): %+v", name, location, err)
 		}
 	}
@@ -226,7 +225,7 @@ func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 	// if so, does the user want us to recover it?
 
 	recoverSoftDeletedKeyVault := false
-	if !(utils.ResponseWasNotFound(softDeletedKeyVault.Response) || deniedAtSubscription) {
+	if !utils.ResponseWasNotFound(softDeletedKeyVault.Response) && !utils.ResponseWasForbidden(softDeletedKeyVault.Response) {
 		if !meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedKeyVaults {
 			// this exists but the users opted out so they must import this it out-of-band
 			return fmt.Errorf(optedOutOfRecoveringSoftDeletedKeyVaultErrorFmt(name, location))

--- a/azurerm/internal/services/keyvault/resource_arm_key_vault.go
+++ b/azurerm/internal/services/keyvault/resource_arm_key_vault.go
@@ -215,15 +215,18 @@ func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// before creating check to see if the key vault exists in the soft delete state
 	softDeletedKeyVault, err := client.GetDeleted(ctx, name, location)
+	deniedAtSubscription := utils.ResponseWasForbidden(softDeletedKeyVault.Response)
 	if err != nil {
-		if !utils.ResponseWasNotFound(softDeletedKeyVault.Response) {
+		// If Terraform lacks permission to read at the Subscription don't assume 404
+		if !(utils.ResponseWasNotFound(softDeletedKeyVault.Response) || deniedAtSubscription) {
 			return fmt.Errorf("Error checking for the presence of an existing Soft-Deleted Key Vault %q (Location %q): %+v", name, location, err)
 		}
 	}
 
 	// if so, does the user want us to recover it?
+
 	recoverSoftDeletedKeyVault := false
-	if !utils.ResponseWasNotFound(softDeletedKeyVault.Response) {
+	if !(utils.ResponseWasNotFound(softDeletedKeyVault.Response) || deniedAtSubscription) {
 		if !meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedKeyVaults {
 			// this exists but the users opted out so they must import this it out-of-band
 			return fmt.Errorf(optedOutOfRecoveringSoftDeletedKeyVaultErrorFmt(name, location))

--- a/azurerm/utils/response.go
+++ b/azurerm/utils/response.go
@@ -11,6 +11,10 @@ func ResponseWasNotFound(resp autorest.Response) bool {
 	return ResponseWasStatusCode(resp, http.StatusNotFound)
 }
 
+func ResponseWasForbidden(resp autorest.Response) bool {
+	return ResponseWasStatusCode(resp, http.StatusForbidden)
+}
+
 func ResponseErrorIsRetryable(err error) bool {
 	if arerr, ok := err.(autorest.DetailedError); ok {
 		err = arerr.Original


### PR DESCRIPTION
This change permits Terraform to attempt to recover a soft-deleted keyvault when the Principal it is is being run with lacks read permissions for keyvaults at the Subscription level and `recover_soft_deleted_key_vaults` is set to `true`.

fixes #6059 
