### PR TITLE
azurerm_eventhub_namespace_authorization_rule  - lock so multiple resource updates won't clash

### DIFF
--- a/azurerm/internal/services/eventhub/resource_arm_eventhub.go
+++ b/azurerm/internal/services/eventhub/resource_arm_eventhub.go
@@ -18,6 +18,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+var eventHubResourceName = "azurerm_eventhub"
+
 func resourceArmEventHub() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmEventHubCreateUpdate,

--- a/azurerm/internal/services/eventhub/resource_arm_eventhub_authorization_rule.go
+++ b/azurerm/internal/services/eventhub/resource_arm_eventhub_authorization_rule.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -88,11 +89,11 @@ func resourceArmEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, me
 		}
 	}
 
-	azureRMLockByName(eventHubName, eventHubResourceName)
-	defer azureRMUnlockByName(eventHubName, eventHubResourceName)
+	locks.ByName(eventHubName, eventHubResourceName)
+	defer locks.UnlockByName(eventHubName, eventHubResourceName)
 
-	azureRMLockByName(namespaceName, eventHubNamespaceResourceName)
-	defer azureRMUnlockByName(namespaceName, eventHubNamespaceResourceName)
+	locks.ByName(namespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
 
 	parameters := eventhub.AuthorizationRule{
 		Name: &name,
@@ -183,12 +184,11 @@ func resourceArmEventHubAuthorizationRuleDelete(d *schema.ResourceData, meta int
 	namespaceName := id.Path["namespaces"]
 	eventHubName := id.Path["eventhubs"]
 
-	azureRMLockByName(eventHubName, eventHubResourceName)
-	defer azureRMUnlockByName(eventHubName, eventHubResourceName)
+	locks.ByName(eventHubName, eventHubResourceName)
+	defer locks.UnlockByName(eventHubName, eventHubResourceName)
 
-	azureRMLockByName(namespaceName, eventHubNamespaceResourceName)
-	defer azureRMUnlockByName(namespaceName, eventHubNamespaceResourceName)
-
+	locks.ByName(namespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
 
 	resp, err := eventhubClient.DeleteAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
 

--- a/azurerm/internal/services/eventhub/resource_arm_eventhub_authorization_rule.go
+++ b/azurerm/internal/services/eventhub/resource_arm_eventhub_authorization_rule.go
@@ -88,6 +88,12 @@ func resourceArmEventHubAuthorizationRuleCreateUpdate(d *schema.ResourceData, me
 		}
 	}
 
+	azureRMLockByName(eventHubName, eventHubResourceName)
+	defer azureRMUnlockByName(eventHubName, eventHubResourceName)
+
+	azureRMLockByName(namespaceName, eventHubNamespaceResourceName)
+	defer azureRMUnlockByName(namespaceName, eventHubNamespaceResourceName)
+
 	parameters := eventhub.AuthorizationRule{
 		Name: &name,
 		AuthorizationRuleProperties: &eventhub.AuthorizationRuleProperties{
@@ -176,6 +182,13 @@ func resourceArmEventHubAuthorizationRuleDelete(d *schema.ResourceData, meta int
 	resourceGroup := id.ResourceGroup
 	namespaceName := id.Path["namespaces"]
 	eventHubName := id.Path["eventhubs"]
+
+	azureRMLockByName(eventHubName, eventHubResourceName)
+	defer azureRMUnlockByName(eventHubName, eventHubResourceName)
+
+	azureRMLockByName(namespaceName, eventHubNamespaceResourceName)
+	defer azureRMUnlockByName(namespaceName, eventHubNamespaceResourceName)
+
 
 	resp, err := eventhubClient.DeleteAuthorizationRule(ctx, resourceGroup, namespaceName, eventHubName, name)
 

--- a/azurerm/internal/services/eventhub/resource_arm_eventhub_namespace.go
+++ b/azurerm/internal/services/eventhub/resource_arm_eventhub_namespace.go
@@ -25,6 +25,7 @@ import (
 // Default Authorization Rule/Policy created by Azure, used to populate the
 // default connection strings and keys
 var eventHubNamespaceDefaultAuthorizationRule = "RootManageSharedAccessKey"
+var eventHubNamespaceResourceName = "azurerm_eventhub_namespace"
 
 func resourceArmEventHubNamespace() *schema.Resource {
 	return &schema.Resource{

--- a/azurerm/internal/services/eventhub/resource_arm_eventhub_namespace_authorization_rule.go
+++ b/azurerm/internal/services/eventhub/resource_arm_eventhub_namespace_authorization_rule.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -79,6 +80,9 @@ func resourceArmEventHubNamespaceAuthorizationRuleCreateUpdate(d *schema.Resourc
 			return tf.ImportAsExistsError("azurerm_eventhub_namespace_authorization_rule", *existing.ID)
 		}
 	}
+
+	locks.ByName(namespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
 
 	parameters := eventhub.AuthorizationRule{
 		Name: &name,
@@ -165,6 +169,9 @@ func resourceArmEventHubNamespaceAuthorizationRuleDelete(d *schema.ResourceData,
 	name := id.Path["AuthorizationRules"] // this is different then eventhub where its authorizationRules
 	resourceGroup := id.ResourceGroup
 	namespaceName := id.Path["namespaces"]
+
+	locks.ByName(namespaceName, eventHubNamespaceResourceName)
+	defer locks.UnlockByName(namespaceName, eventHubNamespaceResourceName)
 
 	resp, err := eventhubClient.DeleteAuthorizationRule(ctx, resourceGroup, namespaceName, name)
 

--- a/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
@@ -274,30 +274,30 @@ func testAzureRMEventHubAuthorizationRule_multi(data acceptance.TestData, listen
 %s
 
 resource "azurerm_eventhub_authorization_rule" "test1" {
-	name                  = "acctestruleone-%d"
-	eventhub_name         = azurerm_eventhub.test.name
-	namespace_name        = azurerm_eventhub_namespace.test.name
-	resource_group_name   = azurerm_resource_group.test.name
-	send                  = true
-	listen                = true
+  name                = "acctestruleone-%d"
+  eventhub_name       = azurerm_eventhub.test.name
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  send                = true
+  listen              = true
 }
 
 resource "azurerm_eventhub_authorization_rule" "test2" {
-	name                  = "acctestruletwo-%d"
-	eventhub_name         = azurerm_eventhub.test.name
-	namespace_name        = azurerm_eventhub_namespace.test.name
-	resource_group_name   = azurerm_resource_group.test.name
-	send                  = true
-	listen                = true
+  name                = "acctestruletwo-%d"
+  eventhub_name       = azurerm_eventhub.test.name
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  send                = true
+  listen              = true
 }
 
 resource "azurerm_eventhub_authorization_rule" "test3" {
-	name                  = "acctestrulethree-%d"
-	eventhub_name         = azurerm_eventhub.test.name
-	namespace_name        = azurerm_eventhub_namespace.test.name
-	resource_group_name   = azurerm_resource_group.test.name
-	send                  = true
-	listen                = true
+  name                = "acctestrulethree-%d"
+  eventhub_name       = azurerm_eventhub.test.name
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  send                = true
+  listen              = true
 }
 `, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
@@ -58,10 +58,10 @@ func testAccAzureRMEventHubAuthorizationRule(t *testing.T, listen, send, manage 
 	})
 }
 
-func TestAccAzureRMEventHubAuthorizationRule_multi(t *testing.T, listen, send, manage bool) {
-	data1 := acceptance.BuildTestData(t, "azurerm_eventhub_authorization_rule", "test1")
-	data2 := acceptance.BuildTestData(t, "azurerm_eventhub_authorization_rule", "test2")
-	data3 := acceptance.BuildTestData(t, "azurerm_eventhub_authorization_rule", "test3")
+func TestAccAzureRMEventHubAuthorizationRule_multi(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_authorization_rule", "test1")
+	resourceTwoName := "azurerm_eventhub_authorization_rule.test2"
+	resourceThreeName := "azurerm_eventhub_authorization_rule.test3"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -69,31 +69,39 @@ func TestAccAzureRMEventHubAuthorizationRule_multi(t *testing.T, listen, send, m
 		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAzureRMNotificationHubAuthorizationRule_multi(data, listen, send, manage),
+				Config: testAzureRMEventHubAuthorizationRule_multi(data, true, true, true),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMNotificationHubAuthorizationRuleExists(data1.ResourceName),
-					resource.TestCheckResourceAttr(data1.ResourceName, "manage", "false"),
-					resource.TestCheckResourceAttr(data1.ResourceName, "send", "true"),
-					resource.TestCheckResourceAttr(data1.ResourceName, "listen", "true"),
-					resource.TestCheckResourceAttrSet(data1.ResourceName, "primary_access_key"),
-					resource.TestCheckResourceAttrSet(data1.ResourceName, "secondary_access_key"),
-					testCheckAzureRMNotificationHubAuthorizationRuleExists(data2.ResourceName),
-					resource.TestCheckResourceAttr(data2.ResourceName, "manage", "false"),
-					resource.TestCheckResourceAttr(data2.ResourceName, "send", "true"),
-					resource.TestCheckResourceAttr(data2.ResourceName, "listen", "true"),
-					resource.TestCheckResourceAttrSet(data2.ResourceName, "primary_access_key"),
-					resource.TestCheckResourceAttrSet(data2.ResourceName, "secondary_access_key"),
-					testCheckAzureRMNotificationHubAuthorizationRuleExists(data3.ResourceName),
-					resource.TestCheckResourceAttr(data3.ResourceName, "manage", "false"),
-					resource.TestCheckResourceAttr(data3.ResourceName, "send", "true"),
-					resource.TestCheckResourceAttr(data3.ResourceName, "listen", "true"),
-					resource.TestCheckResourceAttrSet(data3.ResourceName, "primary_access_key"),
-					resource.TestCheckResourceAttrSet(data3.ResourceName, "secondary_access_key"),
+					testCheckAzureRMEventHubAuthorizationRuleExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "manage", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "send", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "secondary_connection_string"),
+					testCheckAzureRMEventHubAuthorizationRuleExists(resourceTwoName),
+					resource.TestCheckResourceAttr(resourceTwoName, "manage", "false"),
+					resource.TestCheckResourceAttr(resourceTwoName, "send", "true"),
+					resource.TestCheckResourceAttr(resourceTwoName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(resourceTwoName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(resourceTwoName, "secondary_connection_string"),
+					testCheckAzureRMEventHubAuthorizationRuleExists(resourceThreeName),
+					resource.TestCheckResourceAttr(resourceThreeName, "manage", "false"),
+					resource.TestCheckResourceAttr(resourceThreeName, "send", "true"),
+					resource.TestCheckResourceAttr(resourceThreeName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(resourceThreeName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(resourceThreeName, "secondary_connection_string"),
 				),
 			},
-			data1.ImportStep(),
-			data2.ImportStep(),
-			data3.ImportStep(),
+			data.ImportStep(),
+			{
+				ResourceName:      resourceTwoName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceThreeName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -260,36 +268,41 @@ resource "azurerm_eventhub_authorization_rule" "test" {
 `, data.RandomInteger, data.Locations.Primary, listen, send, manage)
 }
 
-func testAzureRMEventAuthorizationRule_multi(data acceptance.TestData, listen, send, manage bool) string {
+func testAzureRMEventHubAuthorizationRule_multi(data acceptance.TestData, listen, send, manage bool) string {
 	template := testAccAzureRMEventHubAuthorizationRule_base(data, listen, send, manage)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_eventhub_authorization_rule" "test1" {
-	name                  = "acctestruleone-%[2]d"
+	name                  = "acctestruleone-%d"
 	eventhub_name         = azurerm_eventhub.test.name
 	namespace_name        = azurerm_eventhub_namespace.test.name
 	resource_group_name   = azurerm_resource_group.test.name
 	send                  = true
 	listen                = true
+	manage                = true
 }
+
 resource "azurerm_eventhub_authorization_rule" "test2" {
-	name                  = "acctestruletwo-%[2]d"
+	name                  = "acctestruletwo-%d"
 	eventhub_name         = azurerm_eventhub.test.name
 	namespace_name        = azurerm_eventhub_namespace.test.name
 	resource_group_name   = azurerm_resource_group.test.name
 	send                  = true
 	listen                = true
+	manage                = true
 }
+
 resource "azurerm_eventhub_authorization_rule" "test3" {
-	name                  = "acctestrulethree-%[2]d"
+	name                  = "acctestrulethree-%d"
 	eventhub_name         = azurerm_eventhub.test.name
 	namespace_name        = azurerm_eventhub_namespace.test.name
 	resource_group_name   = azurerm_resource_group.test.name
 	send                  = true
 	listen                = true
+	manage                = true
 }
-`, template, data.RandomInteger)
+`, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func testAccAzureRMEventHubAuthorizationRule_requiresImport(data acceptance.TestData, listen, send, manage bool) string {

--- a/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
@@ -58,6 +58,46 @@ func testAccAzureRMEventHubAuthorizationRule(t *testing.T, listen, send, manage 
 	})
 }
 
+func TestAccAzureRMEventHubAuthorizationRule_multi(t *testing.T, listen, send, manage bool) {
+	data1 := acceptance.BuildTestData(t, "azurerm_eventhub_authorization_rule", "test1")
+	data2 := acceptance.BuildTestData(t, "azurerm_eventhub_authorization_rule", "test2")
+	data3 := acceptance.BuildTestData(t, "azurerm_eventhub_authorization_rule", "test3")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMNotificationHubAuthorizationRule_multi(data, listen, send, manage),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNotificationHubAuthorizationRuleExists(data1.ResourceName),
+					resource.TestCheckResourceAttr(data1.ResourceName, "manage", "false"),
+					resource.TestCheckResourceAttr(data1.ResourceName, "send", "true"),
+					resource.TestCheckResourceAttr(data1.ResourceName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(data1.ResourceName, "primary_access_key"),
+					resource.TestCheckResourceAttrSet(data1.ResourceName, "secondary_access_key"),
+					testCheckAzureRMNotificationHubAuthorizationRuleExists(data2.ResourceName),
+					resource.TestCheckResourceAttr(data2.ResourceName, "manage", "false"),
+					resource.TestCheckResourceAttr(data2.ResourceName, "send", "true"),
+					resource.TestCheckResourceAttr(data2.ResourceName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(data2.ResourceName, "primary_access_key"),
+					resource.TestCheckResourceAttrSet(data2.ResourceName, "secondary_access_key"),
+					testCheckAzureRMNotificationHubAuthorizationRuleExists(data3.ResourceName),
+					resource.TestCheckResourceAttr(data3.ResourceName, "manage", "false"),
+					resource.TestCheckResourceAttr(data3.ResourceName, "send", "true"),
+					resource.TestCheckResourceAttr(data3.ResourceName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(data3.ResourceName, "primary_access_key"),
+					resource.TestCheckResourceAttrSet(data3.ResourceName, "secondary_access_key"),
+				),
+			},
+			data1.ImportStep(),
+			data2.ImportStep(),
+			data3.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMEventHubAuthorizationRule_requiresImport(t *testing.T) {
 	if !features.ShouldResourcesBeImported() {
 		t.Skip("Skipping since resources aren't required to be imported")
@@ -218,6 +258,38 @@ resource "azurerm_eventhub_authorization_rule" "test" {
   manage = %[5]t
 }
 `, data.RandomInteger, data.Locations.Primary, listen, send, manage)
+}
+
+func testAzureRMEventAuthorizationRule_multi(data acceptance.TestData, listen, send, manage bool) string {
+	template := testAccAzureRMEventHubAuthorizationRule_base(data, listen, send, manage)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_eventhub_authorization_rule" "test1" {
+	name                  = "acctestruleone-%[2]d"
+	eventhub_name         = azurerm_eventhub.test.name
+	namespace_name        = azurerm_eventhub_namespace.test.name
+	resource_group_name   = azurerm_resource_group.test.name
+	send                  = true
+	listen                = true
+}
+resource "azurerm_eventhub_authorization_rule" "test2" {
+	name                  = "acctestruletwo-%[2]d"
+	eventhub_name         = azurerm_eventhub.test.name
+	namespace_name        = azurerm_eventhub_namespace.test.name
+	resource_group_name   = azurerm_resource_group.test.name
+	send                  = true
+	listen                = true
+}
+resource "azurerm_eventhub_authorization_rule" "test3" {
+	name                  = "acctestrulethree-%[2]d"
+	eventhub_name         = azurerm_eventhub.test.name
+	namespace_name        = azurerm_eventhub_namespace.test.name
+	resource_group_name   = azurerm_resource_group.test.name
+	send                  = true
+	listen                = true
+}
+`, template, data.RandomInteger)
 }
 
 func testAccAzureRMEventHubAuthorizationRule_requiresImport(data acceptance.TestData, listen, send, manage bool) string {

--- a/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
+++ b/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_authorization_rule_test.go
@@ -280,7 +280,6 @@ resource "azurerm_eventhub_authorization_rule" "test1" {
 	resource_group_name   = azurerm_resource_group.test.name
 	send                  = true
 	listen                = true
-	manage                = true
 }
 
 resource "azurerm_eventhub_authorization_rule" "test2" {
@@ -290,7 +289,6 @@ resource "azurerm_eventhub_authorization_rule" "test2" {
 	resource_group_name   = azurerm_resource_group.test.name
 	send                  = true
 	listen                = true
-	manage                = true
 }
 
 resource "azurerm_eventhub_authorization_rule" "test3" {
@@ -300,7 +298,6 @@ resource "azurerm_eventhub_authorization_rule" "test3" {
 	resource_group_name   = azurerm_resource_group.test.name
 	send                  = true
 	listen                = true
-	manage                = true
 }
 `, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_namespace_authorization_rule_test.go
+++ b/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_namespace_authorization_rule_test.go
@@ -277,33 +277,33 @@ func testAzureRMEventHubNamespaceAuthorizationRule_multi(data acceptance.TestDat
 %s
 
 resource "azurerm_eventhub_namespace_authorization_rule" "test1" {
-	name                  = "acctestruleone-%d"
-	namespace_name        = azurerm_eventhub_namespace.test.name
-	resource_group_name   = azurerm_resource_group.test.name
-  
-	send                  = true
-	listen                = true
-	manage                = false
+  name                = "acctestruleone-%d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  send   = true
+  listen = true
+  manage = false
 }
 
 resource "azurerm_eventhub_namespace_authorization_rule" "test2" {
-	name                  = "acctestruletwo-%d"
-	namespace_name        = azurerm_eventhub_namespace.test.name
-	resource_group_name   = azurerm_resource_group.test.name
-	
-	send                  = true
-	listen                = true
-	manage                = false
+  name                = "acctestruletwo-%d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  send   = true
+  listen = true
+  manage = false
 }
 
 resource "azurerm_eventhub_namespace_authorization_rule" "test3" {
-	name                  = "acctestrulethree-%d"
-	namespace_name        = azurerm_eventhub_namespace.test.name
-	resource_group_name   = azurerm_resource_group.test.name
-  
-	send                  = true
-	listen                = true
-	manage                = false
+  name                = "acctestrulethree-%d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  send   = true
+  listen = true
+  manage = false
 }
 `, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_namespace_authorization_rule_test.go
+++ b/azurerm/internal/services/eventhub/tests/resource_arm_eventhub_namespace_authorization_rule_test.go
@@ -121,6 +121,54 @@ func TestAccAzureRMEventHubNamespaceAuthorizationRule_rightsUpdate(t *testing.T)
 	})
 }
 
+func TestAccAzureRMEventHubNamespaceAuthorizationRule_multi(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace_authorization_rule", "test1")
+	resourceTwoName := "azurerm_eventhub_namespace_authorization_rule.test2"
+	resourceThreeName := "azurerm_eventhub_namespace_authorization_rule.test3"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMEventHubNamespaceAuthorizationRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMEventHubNamespaceAuthorizationRule_multi(data, true, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMEventHubNamespaceAuthorizationRuleExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "manage", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "send", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "secondary_connection_string"),
+					testCheckAzureRMEventHubNamespaceAuthorizationRuleExists(resourceTwoName),
+					resource.TestCheckResourceAttr(resourceTwoName, "manage", "false"),
+					resource.TestCheckResourceAttr(resourceTwoName, "send", "true"),
+					resource.TestCheckResourceAttr(resourceTwoName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(resourceTwoName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(resourceTwoName, "secondary_connection_string"),
+					testCheckAzureRMEventHubNamespaceAuthorizationRuleExists(resourceThreeName),
+					resource.TestCheckResourceAttr(resourceThreeName, "manage", "false"),
+					resource.TestCheckResourceAttr(resourceThreeName, "send", "true"),
+					resource.TestCheckResourceAttr(resourceThreeName, "listen", "true"),
+					resource.TestCheckResourceAttrSet(resourceThreeName, "primary_connection_string"),
+					resource.TestCheckResourceAttrSet(resourceThreeName, "secondary_connection_string"),
+				),
+			},
+			data.ImportStep(),
+			{
+				ResourceName:      resourceTwoName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      resourceThreeName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testCheckAzureRMEventHubNamespaceAuthorizationRuleDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Eventhub.NamespacesClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -221,4 +269,41 @@ resource "azurerm_eventhub_namespace_authorization_rule" "import" {
   manage              = azurerm_eventhub_namespace_authorization_rule.test.manage
 }
 `, template)
+}
+
+func testAzureRMEventHubNamespaceAuthorizationRule_multi(data acceptance.TestData, listen, send, manage bool) string {
+	template := testAccAzureRMEventHubNamespaceAuthorizationRule_base(data, listen, send, manage)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_eventhub_namespace_authorization_rule" "test1" {
+	name                  = "acctestruleone-%d"
+	namespace_name        = azurerm_eventhub_namespace.test.name
+	resource_group_name   = azurerm_resource_group.test.name
+  
+	send                  = true
+	listen                = true
+	manage                = false
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "test2" {
+	name                  = "acctestruletwo-%d"
+	namespace_name        = azurerm_eventhub_namespace.test.name
+	resource_group_name   = azurerm_resource_group.test.name
+	
+	send                  = true
+	listen                = true
+	manage                = false
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "test3" {
+	name                  = "acctestrulethree-%d"
+	namespace_name        = azurerm_eventhub_namespace.test.name
+	resource_group_name   = azurerm_resource_group.test.name
+  
+	send                  = true
+	listen                = true
+	manage                = false
+}
+`, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
Fixes #4893 