### PR TITLE
update doc: add specific role needed for creating this resource

### DIFF
--- a/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_filesystem.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Data Lake Gen2 File System within an Azure Storage Account.
 
-~> **NOTE:** This Resource requires using Azure Active Directory to connect to Azure Storage, which in turn requires the `Storage` specific roles - which are not granted by default.
+~> **NOTE:** This Resource requires using Azure Active Directory to connect to Azure Storage, which in turn requires the `Storage` specific roles (such as `Storage Blob Data Contributor` role) - which are not granted by default.
 
 ## Example Usage
 


### PR DESCRIPTION
fix #6659 

According to https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-databricks-account#prerequisites, creating a Data Lake Gen2 File System needs `Storage Blob Data Contributor` role. 
explicitly note it in the doc