### PR TITLE
acctests: boosting the default concurrency to 20

### DIFF
--- a/.teamcity/components/build_azure.kt
+++ b/.teamcity/components/build_azure.kt
@@ -1,6 +1,11 @@
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParametrizedWithType
 
-class ClientConfiguration(var clientId: String, var clientSecret: String, val subscriptionId : String, val tenantId : String) {
+class ClientConfiguration(var clientId: String,
+                          var clientSecret: String,
+                          val subscriptionId : String,
+                          val tenantId : String,
+                          val altClientId: String,
+                          val altClientSecret: String) {
 }
 
 class LocationConfiguration(var primary : String, var secondary : String, var ternary : String, var rotate : Boolean) {
@@ -8,7 +13,9 @@ class LocationConfiguration(var primary : String, var secondary : String, var te
 
 fun ParametrizedWithType.ConfigureAzureSpecificTestParameters(environment: String, config: ClientConfiguration, locationsForEnv: LocationConfiguration) {
     hiddenPasswordVariable("env.ARM_CLIENT_ID", config.clientId, "The ID of the Service Principal used for Testing")
+    hiddenPasswordVariable("env.ARM_CLIENT_ID_ALT", config.altClientId, "The ID of the Alternate Service Principal used for Testing")
     hiddenPasswordVariable("env.ARM_CLIENT_SECRET", config.clientSecret, "The Client Secret of the Service Principal used for Testing")
+    hiddenPasswordVariable("env.ARM_CLIENT_SECRET_ALT", config.altClientSecret, "The Client Secret of the Alternate Service Principal used for Testing")
     hiddenVariable("env.ARM_ENVIRONMENT", environment, "The Azure Environment in which the tests are running")
     hiddenVariable("env.ARM_PROVIDER_DYNAMIC_TEST", "%b".format(locationsForEnv.rotate), "Should tests rotate between the supported regions?")
     hiddenPasswordVariable("env.ARM_SUBSCRIPTION_ID", config.subscriptionId, "The ID of the Azure Subscription used for Testing")

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -34,7 +34,7 @@ fun BuildSteps.RunAcceptanceTests(providerName : String, packageName: String) {
     } else {
         step(ScriptBuildStep {
             name = "Install tombuildsstuff/teamcity-go-test-json"
-            scriptContent = "wget https://github.com/tombuildsstuff/teamcity-go-test-json/releases/download/v0.1.0/teamcity-go-test-json_linux_amd64 && chmod +x teamcity-go-test-json_linux_amd64"
+            scriptContent = "wget https://github.com/tombuildsstuff/teamcity-go-test-json/releases/download/v0.2.0/teamcity-go-test-json_linux_amd64 && chmod +x teamcity-go-test-json_linux_amd64"
         })
 
         var servicePath = "./%s/internal/services/%s/...".format(providerName, packageName)

--- a/.teamcity/components/project.kt
+++ b/.teamcity/components/project.kt
@@ -22,6 +22,7 @@ fun buildConfigurationsForServices(services: Map<String, String>, providerName :
     var locationsForEnv = locations.get(environment)!!
 
     services.forEach { (serviceName, displayName) ->
+        // TODO: overriding locations
         var defaultTestConfig = testConfiguration(defaultParallelism, defaultStartHour)
         var testConfig = serviceTestConfigurationOverrides.getOrDefault(serviceName, defaultTestConfig)
         var runNightly = runNightly.getOrDefault(environment, false)

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -2,7 +2,7 @@
 var defaultStartHour = 0
 
 // specifies the default level of parallelism per-service-package
-var defaultParallelism = 10
+var defaultParallelism = 20
 
 var locations = mapOf(
         "public" to LocationConfiguration("westeurope", "eastus2", "francecentral", false),
@@ -16,20 +16,11 @@ var runNightly = mapOf(
 
 // specifies a list of services which should be run with a custom test configuration
 var serviceTestConfigurationOverrides = mapOf(
-        // The API Management tests take ~45m each
-        "apimanagement" to testConfiguration(10, defaultStartHour),
-
-        // Compute is a large package
-        "compute" to testConfiguration(10, defaultStartHour),
-
         // The AKS API has a low rate limit
         "containers" to testConfiguration(5, defaultStartHour),
 
         // Data Lake has a low quota
         "datalake" to testConfiguration(2, defaultStartHour),
-
-        // Network is a large package
-        "network" to testConfiguration(10, defaultStartHour),
 
         // SignalR only allows provisioning one "Free" instance at a time,
         // which is used in multiple tests

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -9,7 +9,9 @@ var clientSecret = DslContext.getParameter("clientSecret", "")
 var subscriptionId = DslContext.getParameter("subscriptionId", "")
 var tenantId = DslContext.getParameter("tenantId", "")
 var environment = DslContext.getParameter("environment", "public")
+var clientIdAlt = DslContext.getParameter("clientIdAlt", "")
+var clientSecretAlt = DslContext.getParameter("clientSecretAlt", "")
 
-var clientConfig = ClientConfiguration(clientId, clientSecret, subscriptionId, tenantId)
+var clientConfig = ClientConfiguration(clientId, clientSecret, subscriptionId, tenantId, clientIdAlt, clientSecretAlt)
 
 project(AzureRM(environment, clientConfig))

--- a/.teamcity/tests/helpers.kt
+++ b/.teamcity/tests/helpers.kt
@@ -3,5 +3,5 @@ package tests
 import ClientConfiguration
 
 fun TestConfiguration() : ClientConfiguration {
-    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId")
+    return ClientConfiguration("clientId", "clientSecret", "subscriptionId", "tenantId", "altClientId", "altClientSecret")
 }


### PR DESCRIPTION
Also hooks up `ARM_CLIENT_ID_ALT` and `ARM_CLIENT_SECRET_ALT` used in a couple of the tests and fixes an issue with test output