### PR TITLE
Support create option for scale set data disks

### DIFF
--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -730,6 +730,16 @@ func VirtualMachineScaleSetDataDiskSchema() *schema.Schema {
 					}, false),
 				},
 
+				"create_option": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(compute.DiskCreateOptionTypesEmpty),
+						string(compute.DiskCreateOptionTypesFromImage),
+					}, false),
+					Default: string(compute.DiskCreateOptionTypesEmpty),
+				},
+
 				"disk_encryption_set_id": {
 					Type:     schema.TypeString,
 					Optional: true,
@@ -787,9 +797,7 @@ func ExpandVirtualMachineScaleSetDataDisk(input []interface{}) *[]compute.Virtua
 				StorageAccountType: compute.StorageAccountTypes(raw["storage_account_type"].(string)),
 			},
 			WriteAcceleratorEnabled: utils.Bool(raw["write_accelerator_enabled"].(bool)),
-
-			// AFAIK this is required to be Empty
-			CreateOption: compute.DiskCreateOptionTypesEmpty,
+			CreateOption:            compute.DiskCreateOptionTypes(raw["create_option"].(string)),
 		}
 
 		if id := raw["disk_encryption_set_id"].(string); id != "" {
@@ -838,6 +846,7 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleS
 
 		output = append(output, map[string]interface{}{
 			"caching":                   string(v.Caching),
+			"create_option":             string(v.CreateOption),
 			"lun":                       lun,
 			"disk_encryption_set_id":    diskEncryptionSetId,
 			"disk_size_gb":              diskSizeGb,

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -246,6 +246,8 @@ A `data_disk` block supports the following:
 
 * `caching` - (Required) The type of Caching which should be used for this Data Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
+* `create_option` - (Optional) The create option which should be used for this Data Disk. Possible values are `Empty` and `FromImage`. Defaults to `Empty`. (`FromImage` should only be used if the source image includes data disks).
+
 * `disk_size_gb` - (Required) The size of the Data Disk which should be created.
 
 * `lun` - (Required) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine.

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -238,6 +238,8 @@ A `data_disk` block supports the following:
 
 * `caching` - (Required) The type of Caching which should be used for this Data Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
+* `create_option` - (Optional) The create option which should be used for this Data Disk. Possible values are `Empty` and `FromImage`. Defaults to `Empty`. (`FromImage` should only be used if the source image includes data disks).
+
 * `disk_size_gb` - (Required) The size of the Data Disk which should be created.
 
 * `lun` - (Required) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine.


### PR DESCRIPTION
If you use a custom image that includes data disks you need to specify them as `FromImage`

Example:
```hcl
  # This comes from the source image
  data_disk {
    storage_account_type = "Standard_LRS"
    caching              = "ReadWrite"
    lun                  = 0
    disk_size_gb         = 10
    create_option        = "FromImage"
  }

  # This is an additional disk
  data_disk {
    storage_account_type = "Premium_LRS"
    caching              = "ReadWrite"
    lun                  = 1
    disk_size_gb         = 50
    create_option        = "Empty"
  }
```