### PR TITLE
Workaround for strange response code in recovery services network mappings API. Fixes issue #6026

### DIFF
--- a/azurerm/internal/services/recoveryservices/resource_arm_site_recovery_network_mapping.go
+++ b/azurerm/internal/services/recoveryservices/resource_arm_site_recovery_network_mapping.go
@@ -2,6 +2,7 @@ package recoveryservices
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-01-10/siterecovery"
@@ -106,8 +107,9 @@ func resourceArmSiteRecoveryNetworkMappingCreate(d *schema.ResourceData, meta in
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, fabricName, sourceNetworkName, name)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
+			if !utils.ResponseWasNotFound(existing.Response) &&
+				!utils.ResponseWasStatusCode(existing.Response, http.StatusBadRequest) { // API incorrectly returns 400 instead of 404
+				return fmt.Errorf("hej Error checking for presence of existing site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
 			}
 		}
 

--- a/azurerm/internal/services/recoveryservices/resource_arm_site_recovery_network_mapping.go
+++ b/azurerm/internal/services/recoveryservices/resource_arm_site_recovery_network_mapping.go
@@ -108,8 +108,10 @@ func resourceArmSiteRecoveryNetworkMappingCreate(d *schema.ResourceData, meta in
 		existing, err := client.Get(ctx, fabricName, sourceNetworkName, name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) &&
-				!utils.ResponseWasStatusCode(existing.Response, http.StatusBadRequest) { // API incorrectly returns 400 instead of 404
-				return fmt.Errorf("hej Error checking for presence of existing site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
+				// todo this workaround can be removed when this bug is fixed
+				// https://github.com/Azure/azure-sdk-for-go/issues/8705
+				!utils.ResponseWasStatusCode(existing.Response, http.StatusBadRequest) {
+				return fmt.Errorf("Error checking for presence of existing site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
 			}
 		}
 

--- a/azurerm/internal/services/recoveryservices/tests/resource_arm_site_recovery_network_mapping_test.go
+++ b/azurerm/internal/services/recoveryservices/tests/resource_arm_site_recovery_network_mapping_test.go
@@ -112,7 +112,7 @@ func testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceName string) resou
 		if err != nil {
 			return err
 		}
-		networkName := id.Path["virtualNetworks"]
+		networkName := id.Path["virtualnetworks"]
 
 		client := acceptance.AzureProvider.Meta().(*clients.Client).RecoveryServices.NetworkMappingClient(resourceGroupName, vaultName)
 
@@ -120,7 +120,7 @@ func testCheckAzureRMSiteRecoveryNetworkMappingExists(resourceName string) resou
 		resp, err := client.Get(ctx, fabricName, networkName, mappingName)
 		if err != nil {
 			if resp.Response.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("Bad: networkMapping %q (network %q) does not exist", mappingName, networkName)
+				return fmt.Errorf("Bad: networkMapping %q (network %q, %q) does not exist", mappingName, networkName, networkId)
 			}
 
 			return fmt.Errorf("Bad: Get on networkMappingClient: %+v", err)


### PR DESCRIPTION
Issue #6026 seems to be caused by the Azure API returning 400 instead of 404 when there are no network-mapping with the name that we ask for. This pull requests adds a workaround for that.

(Is there a way for me to report a bug on the API?)