### PR TITLE
Fix duplicate provider configuration in storage tests

### DIFF
--- a/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
@@ -316,6 +316,7 @@ func testAccAzureRMStorageContainer_basicAzureADAuth(data acceptance.TestData) s
 	return fmt.Sprintf(`
 provider "azurerm" {
   storage_use_azuread = true
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
@@ -313,14 +313,34 @@ resource "azurerm_storage_container" "test" {
 }
 
 func testAccAzureRMStorageContainer_basicAzureADAuth(data acceptance.TestData) string {
-	template := testAccAzureRMStorageContainer_basic(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   storage_use_azuread = true
 }
 
-%s
-`, template)
+resource "azurerm_resource_group" "test" {
+	name     = "acctestRG-%d"
+	location = "%s"
+  }
+  
+  resource "azurerm_storage_account" "test" {
+	name                     = "acctestacc%s"
+	resource_group_name      = azurerm_resource_group.test.name
+	location                 = azurerm_resource_group.test.location
+	account_tier             = "Standard"
+	account_replication_type = "LRS"
+  
+	tags = {
+	  environment = "staging"
+	}
+  }
+
+  resource "azurerm_storage_container" "test" {
+	name                  = "vhds"
+	storage_account_name  = azurerm_storage_account.test.name
+	container_access_type = "private"
+  }
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func testAccAzureRMStorageContainer_requiresImport(data acceptance.TestData) string {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_container_test.go
@@ -319,27 +319,27 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-	name     = "acctestRG-%d"
-	location = "%s"
-  }
-  
-  resource "azurerm_storage_account" "test" {
-	name                     = "acctestacc%s"
-	resource_group_name      = azurerm_resource_group.test.name
-	location                 = azurerm_resource_group.test.location
-	account_tier             = "Standard"
-	account_replication_type = "LRS"
-  
-	tags = {
-	  environment = "staging"
-	}
-  }
+  name     = "acctestRG-%d"
+  location = "%s"
+}
 
-  resource "azurerm_storage_container" "test" {
-	name                  = "vhds"
-	storage_account_name  = azurerm_storage_account.test.name
-	container_access_type = "private"
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
   }
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
@@ -229,6 +229,7 @@ func testAccAzureRMStorageQueue_basicAzureADAuth(data acceptance.TestData) strin
 	return fmt.Sprintf(`
 provider "azurerm" {
   storage_use_azuread = true
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
@@ -232,26 +232,26 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-	name     = "acctestRG-%d"
-	location = "%s"
-  }
+  name     = "acctestRG-%d"
+  location = "%s"
+}
   
-  resource "azurerm_storage_account" "test" {
-	name                     = "acctestacc%s"
-	resource_group_name      = azurerm_resource_group.test.name
-	location                 = azurerm_resource_group.test.location
-	account_tier             = "Standard"
-	account_replication_type = "LRS"
-  
-	tags = {
-	  environment = "staging"
-	}
-  }
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 
-	resource "azurerm_storage_queue" "test" {
-	name                 = "mysamplequeue-%d"
-	storage_account_name = azurerm_storage_account.test.name
-	}
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_queue" "test" {
+  name                 = "mysamplequeue-%d"
+  storage_account_name = azurerm_storage_account.test.name
+}
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
@@ -226,14 +226,33 @@ resource "azurerm_storage_queue" "test" {
 }
 
 func testAccAzureRMStorageQueue_basicAzureADAuth(data acceptance.TestData) string {
-	template := testAccAzureRMStorageQueue_basic(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   storage_use_azuread = true
 }
 
-%s
-`, template)
+resource "azurerm_resource_group" "test" {
+	name     = "acctestRG-%d"
+	location = "%s"
+  }
+  
+  resource "azurerm_storage_account" "test" {
+	name                     = "acctestacc%s"
+	resource_group_name      = azurerm_resource_group.test.name
+	location                 = azurerm_resource_group.test.location
+	account_tier             = "Standard"
+	account_replication_type = "LRS"
+  
+	tags = {
+	  environment = "staging"
+	}
+  }
+
+	resource "azurerm_storage_queue" "test" {
+	name                 = "mysamplequeue-%d"
+	storage_account_name = azurerm_storage_account.test.name
+	}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 
 func testAccAzureRMStorageQueue_requiresImport(data acceptance.TestData) string {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_queue_test.go
@@ -235,7 +235,7 @@ resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
 }
-  
+
 resource "azurerm_storage_account" "test" {
   name                     = "acctestacc%s"
   resource_group_name      = azurerm_resource_group.test.name


### PR DESCRIPTION
Remove duplicate provider configuration to make test pass.
For test:
`TestAccAzureRMStorageContainer_basicAzureADAuth`
`TestAccAzureRMStorageQueue_basicAzureADAuth`

![image](https://user-images.githubusercontent.com/20538091/80932572-a5b62080-8df2-11ea-96dc-f6a8ec137eca.png)
