### PR TITLE
Update doc for network profile of aks

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -267,7 +267,7 @@ A `network_profile` block supports the following:
 
 * `network_policy` - (Optional) Sets up network policy to be used with Azure CNI. [Network policy allows us to control the traffic flow between pods](https://docs.microsoft.com/en-us/azure/aks/use-network-policies). Currently supported values are `calico` and `azure`. Changing this forces a new resource to be created.
 
-~> **NOTE:** When `network_plugin` is set to `kubenet` the `network_policy` field can only be set to `calico`, otherwise it has to be set to `azure`.
+~> **NOTE:** When `network_policy` is set to `azure`, the `network_plugin` field can only be set to `azure`.
 
 * `dns_service_ip` - (Optional) IP address within the Kubernetes service address range that will be used by cluster service discovery (kube-dns). This is required when `network_plugin` is set to `azure`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
fixes terraform-providers/terraform-provider-azurerm#5298

It only supports below scenarios:
network_plugin = azure,     network_policy = azure/calico
network_plugin = kubenet, network_policy = calico