### PR TITLE
`azurerm_automation_runbook` - add support for create runbook as draft and then publish

### DIFF
--- a/azurerm/internal/services/automation/automation_runbook_resource.go
+++ b/azurerm/internal/services/automation/automation_runbook_resource.go
@@ -306,7 +306,7 @@ func resourceArmAutomationRunbookDelete(d *schema.ResourceData, meta interface{}
 }
 
 func expandContentLink(inputs []interface{}) *automation.ContentLink {
-	if len(inputs) == 0 {
+	if len(inputs) == 0 || inputs[0] == nil {
 		return nil
 	}
 

--- a/azurerm/internal/services/automation/automation_runbook_resource.go
+++ b/azurerm/internal/services/automation/automation_runbook_resource.go
@@ -87,15 +87,18 @@ func resourceArmAutomationRunbook() *schema.Resource {
 			},
 
 			"content": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"content", "publish_content_link"},
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
 			"publish_content_link": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				AtLeastOneOf: []string{"content", "publish_content_link"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"uri": {
@@ -166,19 +169,23 @@ func resourceArmAutomationRunbookCreateUpdate(d *schema.ResourceData, meta inter
 	logVerbose := d.Get("log_verbose").(bool)
 	description := d.Get("description").(string)
 
-	contentLink := expandContentLink(d)
-
 	parameters := automation.RunbookCreateOrUpdateParameters{
 		RunbookCreateOrUpdateProperties: &automation.RunbookCreateOrUpdateProperties{
-			LogVerbose:         &logVerbose,
-			LogProgress:        &logProgress,
-			RunbookType:        runbookType,
-			Description:        &description,
-			PublishContentLink: &contentLink,
+			LogVerbose:  &logVerbose,
+			LogProgress: &logProgress,
+			RunbookType: runbookType,
+			Description: &description,
 		},
 
 		Location: &location,
 		Tags:     tags.Expand(t),
+	}
+
+	contentLink := expandContentLink(d.Get("publish_content_link").([]interface{}))
+	if contentLink != nil {
+		parameters.RunbookCreateOrUpdateProperties.PublishContentLink = contentLink
+	} else {
+		parameters.RunbookCreateOrUpdateProperties.Draft = &automation.RunbookDraft{}
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, resGroup, accName, name, parameters); err != nil {
@@ -298,12 +305,14 @@ func resourceArmAutomationRunbookDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func expandContentLink(d *schema.ResourceData) automation.ContentLink {
-	inputs := d.Get("publish_content_link").([]interface{})
+func expandContentLink(inputs []interface{}) *automation.ContentLink {
+	if len(inputs) == 0 {
+		return nil
+	}
+
 	input := inputs[0].(map[string]interface{})
 	uri := input["uri"].(string)
 	version := input["version"].(string)
-
 	hashes := input["hash"].([]interface{})
 
 	if len(hashes) > 0 {
@@ -311,7 +320,7 @@ func expandContentLink(d *schema.ResourceData) automation.ContentLink {
 		hashValue := hash["value"].(string)
 		hashAlgorithm := hash["algorithm"].(string)
 
-		return automation.ContentLink{
+		return &automation.ContentLink{
 			URI:     &uri,
 			Version: &version,
 			ContentHash: &automation.ContentHash{
@@ -321,7 +330,7 @@ func expandContentLink(d *schema.ResourceData) automation.ContentLink {
 		}
 	}
 
-	return automation.ContentLink{
+	return &automation.ContentLink{
 		URI:     &uri,
 		Version: &version,
 	}

--- a/azurerm/internal/services/automation/tests/automation_runbook_resource_test.go
+++ b/azurerm/internal/services/automation/tests/automation_runbook_resource_test.go
@@ -23,7 +23,6 @@ func TestAccAzureRMAutomationRunbook_PSWorkflow(t *testing.T) {
 				Config: testAccAzureRMAutomationRunbook_PSWorkflow(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAutomationRunbookExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "runbook_type", "PowerShellWorkflow"),
 				),
 			},
 			data.ImportStep("publish_content_link"),
@@ -184,11 +183,12 @@ resource "azurerm_automation_runbook" "test" {
   log_verbose  = "true"
   log_progress = "true"
   description  = "This is a test runbook for terraform acceptance test"
-  runbook_type = "PowerShellWorkflow"
+  runbook_type = "PowerShell"
 
-  publish_content_link {
-    uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
-  }
+  content = <<CONTENT
+# Some test content
+# for Terraform acceptance test
+CONTENT
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -207,11 +207,12 @@ resource "azurerm_automation_runbook" "import" {
   log_verbose  = "true"
   log_progress = "true"
   description  = "This is a test runbook for terraform acceptance test"
-  runbook_type = "PowerShellWorkflow"
+  runbook_type = "PowerShell"
 
-  publish_content_link {
-    uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
-  }
+  content = <<CONTENT
+# Some test content
+# for Terraform acceptance test
+CONTENT
 }
 `, template)
 }

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -76,10 +76,6 @@ resource "azurerm_automation_runbook" "example" {
   description             = "This is an example runbook"
   runbook_type            = "PowerShell"
 
-  publish_content_link {
-    uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
-  }
-
   content = data.local_file.example.content
 }
 ```
@@ -102,15 +98,13 @@ The following arguments are supported:
 
 * `log_verbose` - (Required) Verbose log option.
 
-* `publish_content_link` - (Required) The published runbook content link.
+* `publish_content_link` - (Optional) The published runbook content link.
 
 * `description` - (Optional) A description for this credential.
 
 * `content` - (Optional) The desired content of the runbook.
 
 ~> **NOTE** The Azure API requires a `publish_content_link` to be supplied even when specifying your own `content`.
-
-~> **NOTE** Setting `content` to an empty string will revert the runbook to the `publish_content_link`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
according to https://github.com/Azure/azure-rest-api-specs/blob/master/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/examples/createRunbookAsDraft.json, we could create runbook with no `publish_content_link`

this PR add supports for it. This is also the same experience with the portal

Additionally, I think exposing `publish_content_link` is a little confusing for users, and it tends to reports wield error. I wonder Could we make it deprecated and removed in next version ? 

relevant issues:
#6588 
#4403 
#3086


![image](https://user-images.githubusercontent.com/2786738/81287668-c05bf400-9095-11ea-8abe-4300f8d54d4e.png)
