### PR TITLE
WIP: Enable Customer Managed Key retrieval in other subscription

### DIFF
--- a/azurerm/internal/acceptance/client_data.go
+++ b/azurerm/internal/acceptance/client_data.go
@@ -22,6 +22,9 @@ type ClientData struct {
 	// SubscriptionID is the UUID of the Azure Subscription where tests are being run
 	SubscriptionID string
 
+	// SubscriptionIDAlt is the UUID of an Azure Subscription for "non-local" resource testing requirements. e.g. KeyVaults
+	SubscriptionIDAlt string
+
 	// TenantID is the UUID of the Azure Tenant where tests are being run
 	TenantID string
 
@@ -45,6 +48,7 @@ func (td TestData) Client() ClientData {
 		},
 		IsServicePrincipal: true,
 		SubscriptionID:     os.Getenv("ARM_SUBSCRIPTION_ID"),
+		SubscriptionIDAlt:  os.Getenv("ARM_SUBSCRIPTION_ID_ALT"),
 		TenantID:           os.Getenv("ARM_TENANT_ID"),
 	}
 }

--- a/azurerm/internal/services/keyvault/client/client.go
+++ b/azurerm/internal/services/keyvault/client/client.go
@@ -9,6 +9,8 @@ import (
 type Client struct {
 	VaultsClient     *keyvault.VaultsClient
 	ManagementClient *keyvaultmgmt.BaseClient
+
+	options *common.ClientOptions
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -21,5 +23,12 @@ func NewClient(o *common.ClientOptions) *Client {
 	return &Client{
 		VaultsClient:     &VaultsClient,
 		ManagementClient: &ManagementClient,
+		options:          o,
 	}
+}
+
+func (client Client) KeyVaultClientForSubscription(subscriptionId string) *keyvault.VaultsClient {
+	vaultsClient := keyvault.NewVaultsClientWithBaseURI(client.options.ResourceManagerEndpoint, subscriptionId)
+	client.options.ConfigureClient(&vaultsClient.Client, client.options.ResourceManagerAuthorizer)
+	return &vaultsClient
 }

--- a/azurerm/internal/services/keyvault/parse/key_vault_id.go
+++ b/azurerm/internal/services/keyvault/parse/key_vault_id.go
@@ -7,6 +7,7 @@ import (
 type KeyVaultId struct {
 	Name          string
 	ResourceGroup string
+	Subscription  string
 }
 
 func KeyVaultID(input string) (*KeyVaultId, error) {
@@ -16,6 +17,7 @@ func KeyVaultID(input string) (*KeyVaultId, error) {
 	}
 
 	account := KeyVaultId{
+		Subscription:  id.SubscriptionID,
 		ResourceGroup: id.ResourceGroup,
 	}
 

--- a/azurerm/internal/services/keyvault/parse/key_vault_id_test.go
+++ b/azurerm/internal/services/keyvault/parse/key_vault_id_test.go
@@ -41,6 +41,7 @@ func TestKeyVaultID(t *testing.T) {
 			Expected: &KeyVaultId{
 				Name:          "vault1",
 				ResourceGroup: "resGroup1",
+				Subscription:  "00000000-0000-0000-0000-0000000000000",
 			},
 		},
 		{

--- a/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
@@ -110,6 +110,11 @@ func resourceArmStorageAccountCustomerManagedKeyCreateUpdate(d *schema.ResourceD
 		return err
 	}
 
+	// KeyVault may be in another subscription - e.g. Shared Services pattern
+	if keyVaultId.Subscription != vaultsClient.SubscriptionID {
+		vaultsClient.SubscriptionID = keyVaultId.Subscription
+	}
+
 	keyVault, err := vaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Key Vault %q (Resource Group %q): %+v", keyVaultId.Name, keyVaultId.ResourceGroup, err)

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_customer_managed_key_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_customer_managed_key_test.go
@@ -87,6 +87,25 @@ func TestAccAzureRMStorageAccountCustomerManagedKey_updateKey(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageAccountCustomerMangedKey_remoteKeyVault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account_customer_managed_key", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageAccountCustomerMangedKey_remoteKeyVault(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountCustomerManagedKeyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMStorageAccountExistsWithDefaultSettings(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -275,4 +294,106 @@ resource "azurerm_storage_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func testAccAzureRMStorageAccountCustomerMangedKey_remoteKeyVault(data acceptance.TestData) string {
+	clientData := data.Client()
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+provider "azurerm" {
+  alias           = "alt"
+  subscription_id = "%s"
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "remotetest" {
+  provider = azurerm.alt
+
+  name     = "acctestRG-alt-%d"
+  location = "%s"
+}
+
+resource "azurerm_key_vault" "remotetest" {
+  provider = azurerm.alt
+
+  name                     = "acctestkv%s"
+  location                 = azurerm_resource_group.remotetest.location
+  resource_group_name      = azurerm_resource_group.remotetest.name
+  tenant_id                = "%s"
+  sku_name                 = "standard"
+}
+
+resource "azurerm_key_vault_access_policy" "storage" {
+  provider = azurerm.alt
+
+  key_vault_id = azurerm_key_vault.remotetest.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_storage_account.test.identity.0.principal_id
+
+  key_permissions    = ["get", "create", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_access_policy" "client" {
+  provider = azurerm.alt
+
+  key_vault_id = azurerm_key_vault.remotetest.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions    = ["get", "create", "delete", "list", "restore", "recover", "unwrapkey", "wrapkey", "purge", "encrypt", "decrypt", "sign", "verify"]
+  secret_permissions = ["get"]
+}
+
+resource "azurerm_key_vault_key" "first" {
+  provider = azurerm.alt
+
+  name         = "first"
+  key_vault_id = azurerm_key_vault.remotetest.id
+  key_type     = "RSA"
+  key_size     = 2048
+  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+
+  depends_on = [
+    azurerm_key_vault_access_policy.client,
+    azurerm_key_vault_access_policy.storage,
+  ]
+}
+
+resource "azurerm_resource_group" "test" {
+  provider = azurerm
+
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  provider = azurerm
+
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_storage_account_customer_managed_key" "test" {
+  provider = azurerm
+
+  storage_account_id = azurerm_storage_account.test.id
+  key_vault_id       = azurerm_key_vault.remotetest.id
+  key_name           = azurerm_key_vault_key.first.name
+  key_version        = azurerm_key_vault_key.first.version
+}
+
+`, clientData.SubscriptionIDAlt, data.RandomInteger, data.Locations.Primary, data.RandomString, clientData.TenantID, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_customer_managed_key_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_customer_managed_key_test.go
@@ -321,11 +321,11 @@ resource "azurerm_resource_group" "remotetest" {
 resource "azurerm_key_vault" "remotetest" {
   provider = azurerm.alt
 
-  name                     = "acctestkv%s"
-  location                 = azurerm_resource_group.remotetest.location
-  resource_group_name      = azurerm_resource_group.remotetest.name
-  tenant_id                = "%s"
-  sku_name                 = "standard"
+  name                = "acctestkv%s"
+  location            = azurerm_resource_group.remotetest.location
+  resource_group_name = azurerm_resource_group.remotetest.name
+  tenant_id           = "%s"
+  sku_name            = "standard"
 }
 
 resource "azurerm_key_vault_access_policy" "storage" {


### PR DESCRIPTION
Enable retrieval of Customer Managed Keys from a KeyVault in another subscription.

Note: WIP Status due to Acceptance Test environment changes needed to create appropriate tests.

Fixes #6298 