### PR TITLE
[BUG] azurerm_redis_cache backup requires connection string

### DIFF
--- a/azurerm/internal/services/redis/resource_arm_redis_cache.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_cache.go
@@ -674,7 +674,7 @@ func expandRedisConfiguration(d *schema.ResourceData) (map[string]*string, error
 	if v, ok := d.GetOk("redis_configuration.0.rdb_backup_enabled"); ok {
 		backupEnabled := v.(bool)
 		if backupEnabled == true {
-			if v, ok := d.GetOk("redis_configuration.0.rdb_storage_connection_string"); !ok || v.(string) != "" {
+			if connStr, connOk := d.GetOk("redis_configuration.0.rdb_storage_connection_string"); !connOk || connStr.(string) == "" {
 				return nil, fmt.Errorf("The rdb_storage_connection_string property must be set when rdb_backup_enabled is true")
 			}
 		}

--- a/azurerm/internal/services/redis/resource_arm_redis_cache.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_cache.go
@@ -672,6 +672,12 @@ func expandRedisConfiguration(d *schema.ResourceData) (map[string]*string, error
 
 	// RDB Backup
 	if v, ok := d.GetOk("redis_configuration.0.rdb_backup_enabled"); ok {
+		backupEnabled := v.(bool)
+		if backupEnabled == true {
+			if v, ok := d.GetOk("redis_configuration.0.rdb_storage_connection_string"); !ok || v.(string) != "" {
+				return nil, fmt.Errorf("The rdb_storage_connection_string property must be set when rdb_backup_enabled is true")
+			}
+		}
 		delta := strconv.FormatBool(v.(bool))
 		output["rdb-backup-enabled"] = utils.String(delta)
 	}

--- a/azurerm/internal/services/redis/resource_arm_redis_cache.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_cache.go
@@ -672,8 +672,7 @@ func expandRedisConfiguration(d *schema.ResourceData) (map[string]*string, error
 
 	// RDB Backup
 	if v, ok := d.GetOk("redis_configuration.0.rdb_backup_enabled"); ok {
-		backupEnabled := v.(bool)
-		if backupEnabled == true {
+		if v.(bool) {
 			if connStr, connOk := d.GetOk("redis_configuration.0.rdb_storage_connection_string"); !connOk || connStr.(string) == "" {
 				return nil, fmt.Errorf("The rdb_storage_connection_string property must be set when rdb_backup_enabled is true")
 			}

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -92,6 +92,9 @@ A `redis_configuration` block supports the following:
 * `maxfragmentationmemory_reserved` - (Optional) Value in megabytes reserved to accommodate for memory fragmentation. Defaults are shown below.
 
 * `rdb_backup_enabled` - (Optional) Is Backup Enabled? Only supported on Premium SKU's.
+
+-> **NOTE:** If `rdb_backup_enabled` set to `true`, `rdb_storage_connection_string` must also be set.
+
 * `rdb_backup_frequency` - (Optional) The Backup Frequency in Minutes. Only supported on Premium SKU's. Possible values are: `15`, `30`, `60`, `360`, `720` and `1440`.
 * `rdb_backup_max_snapshot_count` - (Optional) The maximum number of snapshots to create as a backup. Only supported for Premium SKU's.
 * `rdb_storage_connection_string` - (Optional) The Connection String to the Storage Account. Only supported for Premium SKU's. In the format: `DefaultEndpointsProtocol=https;BlobEndpoint=${azurerm_storage_account.example.primary_blob_endpoint};AccountName=${azurerm_storage_account.example.name};AccountKey=${azurerm_storage_account.example.primary_access_key}`.


### PR DESCRIPTION
When creating a redis-cache resource, the rdb-storage-connection-string in the redis_configuration is required is rdb_backup_enabled is true.

Currently, an error is thrown during the create:

`redis.Client#Create: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidRequestBody" Message="The value of the parameter 'properties.redisConfiguration.rdb-storage-connection-string' is invalid."`

This change updates the error to:

`Error: Error parsing Redis Configuration: The rdb_storage_connection_string property must be set when rdb_backup_enabled is true
on <PATH>/main.tf line 23`

It also updates the docs.
