### PR TITLE
app_service_environment: add field `resource_group_name`

### DIFF
--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -35,7 +35,7 @@ func SchemaResourceGroupNameForDataSource() *schema.Schema {
 	}
 }
 
-func SchemaResourceGroupNameOC() *schema.Schema {
+func SchemaResourceGroupNameOptionalComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,
 		ForceNew:     true,

--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -35,6 +35,16 @@ func SchemaResourceGroupNameForDataSource() *schema.Schema {
 	}
 }
 
+func SchemaResourceGroupNameOC() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		ForceNew:     true,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validateResourceGroupName,
+	}
+}
+
 func validateResourceGroupName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
 

--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -86,8 +86,8 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 				}, false),
 			},
 
-			// TODO: Make it "Required" in next major release
-			"resource_group_name": azure.SchemaResourceGroupNameOC(),
+			// TODO in 3.0 Make it "Required"
+			"resource_group_name": azure.SchemaResourceGroupNameOptionalComputed(),
 
 			"tags": tags.ForceNewSchema(),
 

--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -86,15 +86,13 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 				}, false),
 			},
 
+			// TODO: Make it "Required" in next major release
+			"resource_group_name": azure.SchemaResourceGroupNameOC(),
+
 			"tags": tags.ForceNewSchema(),
 
 			// Computed
 			"location": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"resource_group_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -118,10 +116,19 @@ func resourceArmAppServiceEnvironmentCreate(d *schema.ResourceData, meta interfa
 		return err
 	}
 
+	// TODO: Remove the implicit behavior in new major version.
+	// Discrepancy of resource group between ASE and Subnet is allowed. While for the sake of
+	// compatibility, we still allow user to use the resource group of Subnet to be the one for
+	// ASE implicitly. While allow user to explicitly specify the resource group, which takes higher
+	// precedence.
 	resourceGroup := subnet.ResourceGroup
-	vnet, err := networksClient.Get(ctx, resourceGroup, subnet.VirtualNetworkName, "")
+	if v, ok := d.GetOk("resource_group_name"); ok {
+		resourceGroup = v.(string)
+	}
+
+	vnet, err := networksClient.Get(ctx, subnet.ResourceGroup, subnet.VirtualNetworkName, "")
 	if err != nil {
-		return fmt.Errorf("Error retrieving Virtual Network %q (Resource Group %q): %+v", subnet.VirtualNetworkName, resourceGroup, err)
+		return fmt.Errorf("Error retrieving Virtual Network %q (Resource Group %q): %+v", subnet.VirtualNetworkName, subnet.ResourceGroup, err)
 	}
 
 	// the App Service Environment has to be in the same location as the Virtual Network
@@ -129,7 +136,7 @@ func resourceArmAppServiceEnvironmentCreate(d *schema.ResourceData, meta interfa
 	if loc := vnet.Location; loc != nil {
 		location = azure.NormalizeLocation(*loc)
 	} else {
-		return fmt.Errorf("Error determining Location from Virtual Network %q (Resource Group %q): `location` was nil", subnet.VirtualNetworkName, resourceGroup)
+		return fmt.Errorf("Error determining Location from Virtual Network %q (Resource Group %q): `location` was nil", subnet.VirtualNetworkName, subnet.ResourceGroup)
 	}
 
 	existing, err := client.Get(ctx, resourceGroup, name)

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -61,11 +61,13 @@ resource "azurerm_app_service_environment" "example" {
 
 * `front_end_scale_factor` - (Optional) Scale factor for front end instances. Possible values are between `5` and `15`. Defaults to `15`.
 
+* `resource_group_name` - (Optional) The name of the Resource Group where the App Service Environment exists. Defaults to the Resource Group of the Subnet (specified by `subnet_id`).
+
+* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created. 
+
 ## Attribute Reference
 
 * `id` - The ID of the App Service Environment.
-
-* `resource_group_name` - The name of the Resource Group where the App Service Environment exists.
 
 * `location` - The location where the App Service Environment exists.
 


### PR DESCRIPTION
This PR allows user to explicitly specify the resource group for app_service_environment, instead of implicitly using the one from Subnet.
In order to keep compatibility, the newly added `resource_group_name` is set as `Optional`+`Computed`, which should be changed to `Required` when a major version of provider bumps.

Fix /terraform-providers/terraform-provider-azurerm#6699.