### PR TITLE
Fix load-balancer example with new syntax for v2.0

### DIFF
--- a/examples/virtual-machines/virtual_machine/2-vms-loadbalancer-lbrules/main.tf
+++ b/examples/virtual-machines/virtual_machine/2-vms-loadbalancer-lbrules/main.tf
@@ -109,10 +109,17 @@ resource "azurerm_network_interface" "nic" {
     name                                    = "ipconfig${count.index}"
     subnet_id                               = "${azurerm_subnet.subnet.id}"
     private_ip_address_allocation           = "Dynamic"
-    load_balancer_backend_address_pools_ids = ["${azurerm_lb_backend_address_pool.backend_pool.id}"]
-    load_balancer_inbound_nat_rules_ids     = ["${element(azurerm_lb_nat_rule.tcp.*.id, count.index)}"]
   }
 }
+
+
+resource "azurerm_network_interface_nat_rule_association" "natrule" {
+  network_interface_id  = "element(azurerm_network_interface.nic.*.id, count.index)"
+  ip_configuration_name = "ipconfig${count.index}"
+  nat_rule_id           = "element(azurerm_lb_nat_rule.tcp.*.id, count.index)"
+  count                 = 2
+}
+
 
 resource "azurerm_virtual_machine" "vm" {
   name                  = "vm${count.index}"


### PR DESCRIPTION
The load_balancer_backend_address_pools_ids is deprecated in Azure provider 2.X so the example fails. Here is a quick fix.

I've kept the old element() style indexing to be consistent.