### PR TITLE
`azurerm_log_analytics_workspace` - Support `rentention_in_days` for Free Tier

### DIFF
--- a/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -69,7 +69,7 @@ func resourceArmLogAnalyticsWorkspace() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(30, 730),
+				ValidateFunc: validation.Any(validation.IntBetween(30, 730), validation.IntInSlice([]int{7})),
 			},
 
 			"workspace_id": {

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 ~> **NOTE:** A new pricing model took effect on `2018-04-03`, which requires the SKU `PerGB2018`. If you're provisioned resources before this date you have the option of remaining with the previous Pricing SKU and using the other SKU's defined above. More information about [the Pricing SKU's is available at the following URI](http://aka.ms/PricingTierWarning).
 
-* `retention_in_days` - (Optional) The workspace data retention in days. Possible values range between 30 and 730.
+* `retention_in_days` - (Optional) The workspace data retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Fixes terraform-providers/terraform-provider-azurerm#6764

## Test Result

```bash
💤 via 🦉 v1.14.2 make testacc TEST=./azurerm/internal/services/loganalytics/tests TESTARGS="-run TestAccAzureRMLogAnalyticsWorkspace_freeTier"
==> Checking that code complies with gofmt requirements...                                                                                   
==> Checking that Custom Timeouts are used...                                                                                                
TF_ACC=1 go test ./azurerm/internal/services/loganalytics/tests -v -run TestAccAzureRMLogAnalyticsWorkspace_freeTier -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLogAnalyticsWorkspace_freeTier                                                                                       
=== PAUSE TestAccAzureRMLogAnalyticsWorkspace_freeTier                                                                                       
=== CONT  TestAccAzureRMLogAnalyticsWorkspace_freeTier                                                                                       
--- PASS: TestAccAzureRMLogAnalyticsWorkspace_freeTier (248.29s)                                                                             
PASS                                                                                                                                         
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/tests  248.309s  
```