### PR TITLE
`azurerm_automation_account` DS set its own ID

### DIFF
--- a/azurerm/internal/services/automation/tests/automation_account_data_source_test.go
+++ b/azurerm/internal/services/automation/tests/automation_account_data_source_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -20,6 +21,8 @@ func TestAccDataSourceAutomationAccount(t *testing.T) {
 				Config: testAccDataSourceAutomationAccount_complete(resourceGroupName, data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "resource_group_name", resourceGroupName),
+					resource.TestMatchResourceAttr(data.ResourceName, "id",
+						regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft.Automation/automationAccounts/[^/]+$`)),
 				),
 			},
 		},

--- a/azurerm/internal/services/automation/tests/automation_account_data_source_test.go
+++ b/azurerm/internal/services/automation/tests/automation_account_data_source_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceAutomationAccount(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "resource_group_name", resourceGroupName),
 					resource.TestMatchResourceAttr(data.ResourceName, "id",
-						regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft.Automation/automationAccounts/[^/]+$`)),
+						regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\.Automation/automationAccounts/[^/]+$`)),
 				),
 			},
 		},


### PR DESCRIPTION
Previously, it uses the automation account agent registration info's ID
as its ID, which causes other resources which refers to that ID will fail
to parse the resource ID (as it doesn't apply to resource ID format).

Nevertheless, we shall change to use the ID of the resource
`azurerm_automation_account` as the DS's ID.

Fixes: terraform-providers/terraform-provider-azurerm#6746

## Test Result

```bash
💤 😡 2 via 🦉 v1.14.2 make testacc TEST=./azurerm/internal/services/automation/tests TESTARGS="-run TestAccDataSourceAutomationAccount"
==> Checking that code complies with gofmt requirements...                                                                                   
==> Checking that Custom Timeouts are used...                                                                                                
TF_ACC=1 go test ./azurerm/internal/services/automation/tests -v -run TestAccDataSourceAutomationAccount -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceAutomationAccount                                                                                                 
=== PAUSE TestAccDataSourceAutomationAccount                                                                                                 
=== CONT  TestAccDataSourceAutomationAccount                                                                                                 
--- PASS: TestAccDataSourceAutomationAccount (183.86s)                                                                                       
PASS                                                                                                                                         
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/automation/tests    183.878s     
```