### PR TITLE
`azurerm_application_insights` - `retention_in_days` defaults to 90

### DIFF
--- a/azurerm/internal/services/applicationinsights/application_insights_resource.go
+++ b/azurerm/internal/services/applicationinsights/application_insights_resource.go
@@ -64,6 +64,7 @@ func resourceArmApplicationInsights() *schema.Resource {
 			"retention_in_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Default:  90,
 				ValidateFunc: validation.IntInSlice([]int{
 					30,
 					60,

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `daily_data_cap_notifications_disabled` - (Optional) Specifies if a notification email will be send when the daily data volume cap is met.
 
-* `retention_in_days` - (Optional) Specifies the retention period in days. Possible values are `30`, `60`, `90`, `120`, `180`, `270`, `365`, `550` or `730`.
+* `retention_in_days` - (Optional) Specifies the retention period in days. Possible values are `30`, `60`, `90`, `120`, `180`, `270`, `365`, `550` or `730`. Defaults to `90`.
 
 * `sampling_percentage` - (Optional) Specifies the percentage of the data produced by the monitored application that is sampled for Application Insights telemetry.
 


### PR DESCRIPTION
The current resource is not idempotent, it seems Azure now sets this to 90 by default

```hcl
resource "azurerm_application_insights" "test" {
  name                = "test"
  location            = "uksouth"
  resource_group_name = "test"
  application_type    = "web"
}
```

```
> terraform apply

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # azurerm_application_insights.test will be created
  + resource "azurerm_application_insights" "test" {
      + app_id                                = (known after apply)
      + application_type                      = "web"
      + daily_data_cap_in_gb                  = (known after apply)
      + daily_data_cap_notifications_disabled = (known after apply)
      + id                                    = (known after apply)
      + instrumentation_key                   = (sensitive value)
      + location                              = "uksouth"
      + name                                  = "test"
      + resource_group_name                   = "test"
      + sampling_percentage                   = 100
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

azurerm_application_insights.test: Creating...
azurerm_application_insights.test: Still creating... [10s elapsed]
azurerm_application_insights.test: Still creating... [20s elapsed]
azurerm_application_insights.test: Creation complete after 28s [id=/subscriptions/xxx/resourceGroups/test/providers/microsoft.insights/components/test]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

> terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_application_insights.test: Refreshing state... [id=/subscriptions/xxx/resourceGroups/test/providers/microsoft.insights/components/test]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azurerm_application_insights.test will be updated in-place
  ~ resource "azurerm_application_insights" "test" {
        app_id                                = "b0dac594-ed19-42c2-8a68-647b27345921"
        application_type                      = "web"
        daily_data_cap_in_gb                  = 100
        daily_data_cap_notifications_disabled = false
        id                                    = "/subscriptions/xxx/resourceGroups/test/providers/microsoft.insights/components/test"
        instrumentation_key                   = (sensitive value)
        location                              = "uksouth"
        name                                  = "test"
        resource_group_name                   = "test"
      - retention_in_days                     = 90 -> null
        sampling_percentage                   = 100
        tags                                  = {}
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```