### PR TITLE
`SchemaResourceGroupNameForDataSource` Add `ValidateFunc`

### DIFF
--- a/azurerm/helpers/azure/resource_group.go
+++ b/azurerm/helpers/azure/resource_group.go
@@ -30,8 +30,9 @@ func SchemaResourceGroupNameDiffSuppress() *schema.Schema {
 
 func SchemaResourceGroupNameForDataSource() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeString,
-		Required: true,
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validateResourceGroupName,
 	}
 }
 


### PR DESCRIPTION
This could avoid user input illegal resource group name, which might cause issues like #6691.

Fixes #6691