### PR TITLE
fix perfomance issue of keyvault

### DIFF
--- a/azurerm/helpers/azure/key_vault.go
+++ b/azurerm/helpers/azure/key_vault.go
@@ -3,89 +3,41 @@ package azure
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func GetKeyVaultBaseUrlFromID(ctx context.Context, client *keyvault.VaultsClient, keyVaultId string) (string, error) {
-	if keyVaultId == "" {
-		return "", fmt.Errorf("keyVaultId is empty")
+func GetKeyVaultNameFromBaseUrl(keyVaultUrl string) (string, error) {
+	groups := regexp.MustCompile(`^https://(.+)\.vault\.azure\.net/?$`).FindStringSubmatch(keyVaultUrl)
+	if len(groups) != 2 {
+		return "", fmt.Errorf("parsing keyVaultUrl: %q, expected group: 2", keyVaultUrl)
 	}
 
-	id, err := ParseAzureResourceID(keyVaultId)
-	if err != nil {
-		return "", err
-	}
-	resourceGroup := id.ResourceGroup
-
-	vaultName, ok := id.Path["vaults"]
-	if !ok {
-		return "", fmt.Errorf("resource id does not contain `vaults`: %q", keyVaultId)
-	}
-
-	resp, err := client.Get(ctx, resourceGroup, vaultName)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return "", fmt.Errorf("Error unable to find KeyVault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
-		}
-		return "", fmt.Errorf("Error making Read request on KeyVault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
-	}
-
-	if resp.Properties == nil || resp.Properties.VaultURI == nil {
-		return "", fmt.Errorf("vault (%s) response properties or VaultURI is nil", keyVaultId)
-	}
-
-	return *resp.Properties.VaultURI, nil
+	return groups[1], nil
 }
 
-func GetKeyVaultIDFromBaseUrl(ctx context.Context, client *keyvault.VaultsClient, keyVaultUrl string) (*string, error) {
-	list, err := client.ListComplete(ctx, utils.Int32(1000))
+func GetKeyVaultIDFromBaseUrl(ctx context.Context, client *resources.Client, keyVaultUrl string) (*string, error) {
+	name, err := GetKeyVaultNameFromBaseUrl(keyVaultUrl)
 	if err != nil {
-		return nil, fmt.Errorf("Error GetKeyVaultId unable to list Key Vaults %v", err)
+		return nil, err
 	}
 
-	for list.NotDone() {
-		v := list.Value()
-
-		if v.ID == nil {
-			return nil, fmt.Errorf("v.ID was nil")
-		}
-
-		vid, err := ParseAzureResourceID(*v.ID)
-		if err != nil {
-			return nil, fmt.Errorf("Error parsing ID for Key Vault URI %q: %s", *v.ID, err)
-		}
-		resourceGroup := vid.ResourceGroup
-		name := vid.Path["vaults"]
-
-		// resp does not appear to contain the vault properties, so lets fetch them
-		get, err := client.Get(ctx, resourceGroup, name)
-		if err != nil {
-			if utils.ResponseWasNotFound(get.Response) {
-				if e := list.NextWithContext(ctx); e != nil {
-					return nil, fmt.Errorf("Error getting next vault on KeyVault url %q : %+v", keyVaultUrl, err)
-				}
-				continue
-			}
-			return nil, fmt.Errorf("Error making Read request on KeyVault %q (Resource Group %q): %+v", name, resourceGroup, err)
-		}
-
-		if get.ID == nil || get.Properties == nil || get.Properties.VaultURI == nil {
-			return nil, fmt.Errorf("KeyVault %q (Resource Group %q) has nil ID, properties or vault URI", name, resourceGroup)
-		}
-
-		if keyVaultUrl == *get.Properties.VaultURI {
-			return get.ID, nil
-		}
-
-		if e := list.NextWithContext(ctx); e != nil {
-			return nil, fmt.Errorf("Error getting next vault on KeyVault url %q : %+v", keyVaultUrl, err)
-		}
+	filter := fmt.Sprintf("name eq '%s'", name)
+	keyVaults, err := client.List(ctx, filter, "", nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing key vaults: %+v", err)
+	}
+	values := keyVaults.Values()
+	if len(values) == 0 {
+		return nil, fmt.Errorf("no key Vault found with Url: %q", keyVaultUrl)
+	} else if len(values) > 1 {
+		return nil, fmt.Errorf("more than one key Vault found with Url: %q", keyVaultUrl)
 	}
 
-	// we haven't found it, but Data Sources and Resources need to handle this error separately
-	return nil, nil
+	return values[0].ID, nil
 }
 
 func KeyVaultExists(ctx context.Context, client *keyvault.VaultsClient, keyVaultId string) (bool, error) {

--- a/azurerm/helpers/azure/key_vault.go
+++ b/azurerm/helpers/azure/key_vault.go
@@ -28,7 +28,7 @@ func GetKeyVaultIDFromBaseUrl(ctx context.Context, client *resources.Client, key
 	filter := fmt.Sprintf("name eq '%s'", name)
 	keyVaults, err := client.List(ctx, filter, "", nil)
 	if err != nil {
-		return nil, fmt.Errorf("listing key vaults: %+v", err)
+		return nil, nil
 	}
 	values := keyVaults.Values()
 	if len(values) == 0 {

--- a/azurerm/helpers/azure/key_vault.go
+++ b/azurerm/helpers/azure/key_vault.go
@@ -28,11 +28,11 @@ func GetKeyVaultIDFromBaseUrl(ctx context.Context, client *resources.Client, key
 	filter := fmt.Sprintf("name eq '%s'", name)
 	keyVaults, err := client.List(ctx, filter, "", nil)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("listing key vault with name %q: %+v", name, err)
 	}
 	values := keyVaults.Values()
 	if len(values) == 0 {
-		return nil, fmt.Errorf("no key Vault found with Url: %q", keyVaultUrl)
+		return nil, nil
 	} else if len(values) > 1 {
 		return nil, fmt.Errorf("more than one key Vault found with Url: %q", keyVaultUrl)
 	}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -27,7 +27,7 @@ import (
 
 // todo refactor and find a home for this wayward func
 func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client).KeyVault.VaultsClient
+	client := meta.(*clients.Client).Resource.ResourcesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -449,6 +449,7 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 
 func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -458,7 +459,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
@@ -517,6 +518,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 
 func resourceArmKeyVaultCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -526,7 +528,7 @@ func resourceArmKeyVaultCertificateDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}

--- a/azurerm/internal/services/keyvault/key_vault_key_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource.go
@@ -260,6 +260,7 @@ func resourceArmKeyVaultKeyCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 	vaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -269,7 +270,7 @@ func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
@@ -319,6 +320,7 @@ func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error {
 	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -328,7 +330,7 @@ func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
@@ -402,6 +404,7 @@ func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceArmKeyVaultKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -411,7 +414,7 @@ func resourceArmKeyVaultKeyDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
-
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -16,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -180,6 +179,7 @@ func resourceArmKeyVaultSecretCreate(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) error {
 	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -190,7 +190,7 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
@@ -268,6 +268,7 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 
 func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) error {
 	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -277,7 +278,7 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
@@ -334,6 +335,7 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceArmKeyVaultSecretDelete(d *schema.ResourceData, meta interface{}) error {
 	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -343,7 +345,7 @@ func resourceArmKeyVaultSecretDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}

--- a/azurerm/internal/services/keyvault/parse/key_vault_id.go
+++ b/azurerm/internal/services/keyvault/parse/key_vault_id.go
@@ -1,6 +1,8 @@
 package parse
 
 import (
+	"fmt"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
@@ -28,4 +30,8 @@ func KeyVaultID(input string) (*KeyVaultId, error) {
 	}
 
 	return &account, nil
+}
+
+func (id *KeyVaultId) BaseUrl() string {
+	return fmt.Sprintf("https://%s.vault.azure.net/", id.Name)
 }

--- a/azurerm/internal/services/keyvault/tests/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_certificate_resource_test.go
@@ -5,12 +5,12 @@ import (
 	"log"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -249,23 +249,22 @@ func testCheckAzureRMKeyVaultCertificateDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
+		kvID, err := parse.KeyVaultID(keyVaultId)
 		if err != nil {
-			// deleted, this is fine.
-			return nil
+			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
 
-		ok, err := azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		ok, err := azure.KeyVaultExists(ctx, vaultClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, kvID.BaseUrl(), err)
 		}
 		if !ok {
-			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, kvID.BaseUrl())
 			return nil
 		}
 
 		// get the latest version
-		resp, err := client.GetCertificate(ctx, vaultBaseUrl, name, "")
+		resp, err := client.GetCertificate(ctx, kvID.BaseUrl(), name, "")
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return nil
@@ -293,24 +292,24 @@ func testCheckAzureRMKeyVaultCertificateExists(resourceName string) resource.Tes
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
+		kvID, err := parse.KeyVaultID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
 
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		ok, err = azure.KeyVaultExists(ctx, vaultClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, kvID.BaseUrl(), err)
 		}
 		if !ok {
-			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, kvID.BaseUrl())
 			return nil
 		}
 
-		resp, err := client.GetCertificate(ctx, vaultBaseUrl, name, "")
+		resp, err := client.GetCertificate(ctx, kvID.BaseUrl(), name, "")
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Key Vault Certificate %q (resource group: %q) does not exist", name, vaultBaseUrl)
+				return fmt.Errorf("Bad: Key Vault Certificate %q (resource group: %q) does not exist", name, kvID.BaseUrl())
 			}
 
 			return fmt.Errorf("Bad: Get on keyVault certificate: %+v", err)
@@ -333,21 +332,21 @@ func testCheckAzureRMKeyVaultCertificateDisappears(resourceName string) resource
 		}
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
+		kvID, err := parse.KeyVaultID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
 
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		ok, err = azure.KeyVaultExists(ctx, vaultClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+			return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", keyVaultId, name, kvID.BaseUrl(), err)
 		}
 		if !ok {
-			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, kvID.BaseUrl())
 			return nil
 		}
 
-		resp, err := client.DeleteCertificate(ctx, vaultBaseUrl, name)
+		resp, err := client.DeleteCertificate(ctx, kvID.BaseUrl(), name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return nil

--- a/azurerm/internal/services/keyvault/tests/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_certificate_resource_test.go
@@ -249,7 +249,7 @@ func testCheckAzureRMKeyVaultCertificateDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			// deleted, this is fine.
 			return nil
@@ -293,7 +293,7 @@ func testCheckAzureRMKeyVaultCertificateExists(resourceName string) resource.Tes
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
@@ -333,7 +333,7 @@ func testCheckAzureRMKeyVaultCertificateDisappears(resourceName string) resource
 		}
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}

--- a/azurerm/internal/services/keyvault/tests/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_key_resource_test.go
@@ -5,12 +5,12 @@ import (
 	"log"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -270,23 +270,22 @@ func testCheckAzureRMKeyVaultKeyDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
+		kvID, err := parse.KeyVaultID(keyVaultId)
 		if err != nil {
-			// key vault's been deleted
-			return nil
+			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
 
-		ok, err := azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		ok, err := azure.KeyVaultExists(ctx, vaultClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+			return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", keyVaultId, name, kvID.BaseUrl(), err)
 		}
 		if !ok {
-			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, kvID.BaseUrl())
 			return nil
 		}
 
 		// get the latest version
-		resp, err := client.GetKey(ctx, vaultBaseUrl, name, "")
+		resp, err := client.GetKey(ctx, kvID.BaseUrl(), name, "")
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return nil
@@ -313,24 +312,24 @@ func testCheckAzureRMKeyVaultKeyExists(resourceName string) resource.TestCheckFu
 		}
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
+		kvID, err := parse.KeyVaultID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
 
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		ok, err = azure.KeyVaultExists(ctx, vaultClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+			return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", keyVaultId, name, kvID.BaseUrl(), err)
 		}
 		if !ok {
-			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, kvID.BaseUrl())
 			return nil
 		}
 
-		resp, err := client.GetKey(ctx, vaultBaseUrl, name, "")
+		resp, err := client.GetKey(ctx, kvID.BaseUrl(), name, "")
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: Key Vault Key %q (resource group: %q) does not exist", name, vaultBaseUrl)
+				return fmt.Errorf("Bad: Key Vault Key %q (resource group: %q) does not exist", name, kvID.BaseUrl())
 			}
 
 			return fmt.Errorf("Bad: Get on keyVaultManagementClient: %+v", err)
@@ -354,21 +353,21 @@ func testCheckAzureRMKeyVaultKeyDisappears(resourceName string) resource.TestChe
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
+		kvID, err := parse.KeyVaultID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
 
-		ok, err = azure.KeyVaultExists(ctx, acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient, keyVaultId)
+		ok, err = azure.KeyVaultExists(ctx, vaultClient, keyVaultId)
 		if err != nil {
-			return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", keyVaultId, name, vaultBaseUrl, err)
+			return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", keyVaultId, name, kvID.BaseUrl(), err)
 		}
 		if !ok {
-			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, vaultBaseUrl)
+			log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q ", name, keyVaultId, kvID.BaseUrl())
 			return nil
 		}
 
-		resp, err := client.DeleteKey(ctx, vaultBaseUrl, name)
+		resp, err := client.DeleteKey(ctx, kvID.BaseUrl(), name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return nil

--- a/azurerm/internal/services/keyvault/tests/key_vault_key_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_key_resource_test.go
@@ -270,7 +270,7 @@ func testCheckAzureRMKeyVaultKeyDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			// key vault's been deleted
 			return nil
@@ -313,7 +313,7 @@ func testCheckAzureRMKeyVaultKeyExists(resourceName string) resource.TestCheckFu
 		}
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
@@ -354,7 +354,7 @@ func testCheckAzureRMKeyVaultKeyDisappears(resourceName string) resource.TestChe
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}

--- a/azurerm/internal/services/keyvault/tests/key_vault_secret_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_secret_resource_test.go
@@ -189,7 +189,7 @@ func testCheckAzureRMKeyVaultSecretDestroy(s *terraform.State) error {
 
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			// key vault's been deleted
 			return nil
@@ -232,7 +232,7 @@ func testCheckAzureRMKeyVaultSecretExists(resourceName string) resource.TestChec
 		}
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}
@@ -272,7 +272,7 @@ func testCheckAzureRMKeyVaultSecretDisappears(resourceName string) resource.Test
 		}
 		name := rs.Primary.Attributes["name"]
 		keyVaultId := rs.Primary.Attributes["key_vault_id"]
-		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+		vaultBaseUrl, err := azure.GetKeyVaultBaseUrlFromID(keyVaultId)
 		if err != nil {
 			return fmt.Errorf("Error looking up Secret %q vault url from id %q: %+v", name, keyVaultId, err)
 		}

--- a/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
@@ -104,12 +104,7 @@ func resourceArmStorageAccountCustomerManagedKeyCreateUpdate(d *schema.ResourceD
 		}
 	}
 
-	keyVaultIdRaw := d.Get("key_vault_id").(string)
-	keyVaultId, err := keyVaultParse.KeyVaultID(keyVaultIdRaw)
-	if err != nil {
-		return err
-	}
-
+	keyVaultId, _ := keyVaultParse.KeyVaultID(d.Get("key_vault_id").(string))
 	keyVault, err := vaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Key Vault %q (Resource Group %q): %+v", keyVaultId.Name, keyVaultId.ResourceGroup, err)
@@ -129,11 +124,6 @@ func resourceArmStorageAccountCustomerManagedKeyCreateUpdate(d *schema.ResourceD
 		return fmt.Errorf("Key Vault %q (Resource Group %q) must be configured for both Purge Protection and Soft Delete", keyVaultId.Name, keyVaultId.ResourceGroup)
 	}
 
-	keyVaultBaseURL, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultsClient, keyVaultIdRaw)
-	if err != nil {
-		return fmt.Errorf("Error looking up Key Vault URI from Key Vault %q (Resource Group %q): %+v", keyVaultId.Name, keyVaultId.ResourceGroup, err)
-	}
-
 	keyName := d.Get("key_name").(string)
 	keyVersion := d.Get("key_version").(string)
 	props := storage.AccountUpdateParameters{
@@ -151,7 +141,7 @@ func resourceArmStorageAccountCustomerManagedKeyCreateUpdate(d *schema.ResourceD
 				KeyVaultProperties: &storage.KeyVaultProperties{
 					KeyName:     utils.String(keyName),
 					KeyVersion:  utils.String(keyVersion),
-					KeyVaultURI: utils.String(keyVaultBaseURL),
+					KeyVaultURI: utils.String(keyVaultId.BaseUrl()),
 				},
 			},
 		},

--- a/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
@@ -157,7 +157,7 @@ func resourceArmStorageAccountCustomerManagedKeyCreateUpdate(d *schema.ResourceD
 
 func resourceArmStorageAccountCustomerManagedKeyRead(d *schema.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage.AccountsClient
-	vaultsClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -206,7 +206,7 @@ func resourceArmStorageAccountCustomerManagedKeyRead(d *schema.ResourceData, met
 		return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): `properties.encryption.keyVaultProperties.keyVaultUri` was nil", storageAccountId.Name, storageAccountId.ResourceGroup)
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultsClient, keyVaultUri)
+	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, keyVaultUri)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Key Vault ID from the Base URI %q: %+v", keyVaultUri, err)
 	}

--- a/azurerm/internal/services/web/resource_arm_app_service_certificate.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_certificate.go
@@ -117,7 +117,7 @@ func resourceArmAppServiceCertificate() *schema.Resource {
 }
 
 func resourceArmAppServiceCertificateCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	vaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	resourcesClient := meta.(*clients.Client).Resource.ResourcesClient
 	client := meta.(*clients.Client).Web.CertificatesClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -173,7 +173,7 @@ func resourceArmAppServiceCertificateCreateUpdate(d *schema.ResourceData, meta i
 
 		keyVaultBaseUrl := parsedSecretId.KeyVaultBaseUrl
 
-		keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultClient, keyVaultBaseUrl)
+		keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, resourcesClient, keyVaultBaseUrl)
 		if err != nil {
 			return fmt.Errorf("Error retrieving the Resource ID for the Key Vault at URL %q: %s", keyVaultBaseUrl, err)
 		}


### PR DESCRIPTION
fix #6196

I think the root cause of this issue is every key/secret/certificate will list all key vaults, which causes the poor performance and Context Deadline Exceeded.

according to https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning

the key vault name is global unique, and 
```
An object identifier has the following general format:

https://{keyvault-name}.vault.azure.net/{object-type}/{object-name}/{object-version}
```
we could directly get baseURL from keyvault name and get keyvault name from baseURL.

AS for get keyvault id from name, I use resourcesClient instead of listing to improve the performance.

![image](https://user-images.githubusercontent.com/2786738/81641586-ed245880-9453-11ea-8054-88bec1071009.png)
![image](https://user-images.githubusercontent.com/2786738/81641613-ff05fb80-9453-11ea-8628-6b4bedeecc04.png)
