### PR TITLE
Add type PipelineReference in trigger resource

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_trigger_schedule_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_trigger_schedule_resource.go
@@ -166,6 +166,7 @@ func resourceArmDataFactoryTriggerScheduleCreateUpdate(d *schema.ResourceData, m
 
 	reference := &datafactory.PipelineReference{
 		ReferenceName: utils.String(d.Get("pipeline_name").(string)),
+		Type:          utils.String("PipelineReference"),
 	}
 
 	scheduleProps := &datafactory.ScheduleTrigger{


### PR DESCRIPTION
When the type is omitted, the trigger cannot be activated.

This fixes #6869 which has more details about the bug and why this PR is needed.