### PR TITLE
Fix case on AuthorizationRules to match Azure API

### DIFF
--- a/website/docs/r/eventhub_namespace_authorization_rule.html.markdown
+++ b/website/docs/r/eventhub_namespace_authorization_rule.html.markdown
@@ -93,5 +93,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 EventHub Namespace Authorization Rules can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_eventhub_namespace_authorization_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/authorizationRules/rule1
+terraform import azurerm_eventhub_namespace_authorization_rule.rule1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/AuthorizationRules/rule1
 ```


### PR DESCRIPTION
The resource ID for authorization rule specifies the rule name parameter `authorizationRules` with the first letter capitalized: `AuthorizationRules`.

When trying to import an authorization rule using the resource ID shown in the docs, you'll get the following error:
```
Error: Error making Read request on Azure EventHub Authorization Rule : eventhub.NamespacesClient#GetAuthorizationRule: Invalid input: autorest/validation: validation failed: parameter=authorizationRuleName constraint=MinLength value="" details: value length must be greater than or equal to 1
```