### PR TITLE
tool: adding a check for gradually deprecated functions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -82,6 +82,7 @@ test-docker:
 	docker run --rm -v $$(pwd):/go/src/github.com/terraform-providers/terraform-provider-azurerm -w /go/src/github.com/terraform-providers/terraform-provider-azurerm golang:1.13 make test
 
 test: fmtcheck
+	@TEST=$(TEST) ./scripts/run-gradually-deprecated.sh
 	@TEST=$(TEST) ./scripts/run-test.sh
 
 test-compile:

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+function checkForConditionalRun {
+  if [ "$TRAVIS" == "ci" ];
+  then
+    echo "Checking if this should be conditionally run.."
+    result=$(git diff --name-only origin/master | grep azurerm/)
+    if [ "$result" = "" ];
+    then
+      echo "No changes committed to ./azurerm - nothing to lint - exiting"
+      exit 0
+    fi
+  fi
+}
+
+function runDeprecatedFunctions {
+  echo "==> Checking for use of gradually deprecated functions..."
+  result=$(git diff --name-only origin/master | grep azurerm/)
+  if [ "$result" = "" ];
+  then
+    # No changes committed to ./azurerm - so nothing to check
+    exit 0
+  fi
+
+  # require resources to be imported is now hard-coded on - but only checking for additions
+  result=$(git diff origin/master | grep + | grep -R "features\.ShouldResourcesBeImported")
+  if [ "$result" = "" ];
+  then
+    echo "The Feature Flag for 'ShouldResourcesBeImported' will be deprecated in the future"
+    echo "and shouldn't be used in new resources - please remove new usages of the"
+    echo "'ShouldResourcesBeImported' function from these changes - since this is now enabled"
+    echo "by default."
+    echo ""
+    echo "In the future this function will be marked as Deprecated - however it's not for"
+    echo "the moment to not conflict with open Pull Requests."
+  fi
+}
+
+function main {
+  checkForConditionalRun
+  runDeprecatedFunctions
+}
+
+main


### PR DESCRIPTION
Go's linter immediately flags usages of functions which are marked as Deprecated - which makes sense when there's 10 usages, but less so when there's hundreds of usages and you want to remove things gradually.

This PR introduces a check for functions which will be deprecated in the future, since they're no longer required - namely the feature flag "RequireResourcesToBeImported" which is now enabled by default.

Over time we'll work through the existing codebase and remove usages of this function - but we intentionally don't want to do this in a single sweep as to not break open PR's (since this defaulted to "enabled" there's not much harm in this code kicking around for a while)