### PR TITLE
`azurerm_frontdoor` - Expose the `header_frontdoor_id` attribute

### DIFF
--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -51,7 +51,7 @@ func resourceArmFrontDoor() *schema.Resource {
 				Computed: true,
 			},
 
-			"frontdoor_id": {
+			"header_frontdoor_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -710,7 +710,7 @@ func resourceArmFrontDoorRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		d.Set("cname", properties.Cname)
-		d.Set("frontdoor_id", properties.FrontdoorID)
+		d.Set("header_frontdoor_id", properties.FrontdoorID)
 		d.Set("load_balancer_enabled", properties.EnabledState == frontdoor.EnabledStateEnabled)
 		d.Set("friendly_name", properties.FriendlyName)
 

--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -51,6 +51,11 @@ func resourceArmFrontDoor() *schema.Resource {
 				Computed: true,
 			},
 
+			"frontdoor_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"friendly_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -705,6 +710,7 @@ func resourceArmFrontDoorRead(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		d.Set("cname", properties.Cname)
+		d.Set("frontdoor_id", properties.FrontdoorID)
 		d.Set("load_balancer_enabled", properties.EnabledState == frontdoor.EnabledStateEnabled)
 		d.Set("friendly_name", properties.FriendlyName)
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -294,7 +294,7 @@ The following attributes are exported:
 
 * `cname` - The host that each frontendEndpoint must CNAME to.
 
-* `frontdoor_id` - The ID of the Front Door which can be used to filter on the incoming header `X-Azure-FDID` attribute which is sent by the Front Door to your backend.
+* `header_frontdoor_id` - The unique ID of the Front Door which is embedded into the incoming headers `X-Azure-FDID` attribute and maybe used to filter traffic sent by the Front Door to your backend.
 
 * `id` - The ID of the FrontDoor.
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -294,11 +294,11 @@ The following attributes are exported:
 
 * `cname` - The host that each frontendEndpoint must CNAME to.
 
+* `frontdoor_id` - The ID of the Front Door which can be used to filter on the incoming header `X-Azure-FDID` attribute which is sent by the Front Door to your backend.
+
 * `id` - The ID of the FrontDoor.
 
 ## Timeouts
-
-
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 


### PR DESCRIPTION
Fixes #6741 