### PR TITLE
`azurerm_monitor_scheduled_query_rules_alert` honor absent `custom_webhook_payload`

### DIFF
--- a/azurerm/internal/services/monitor/common_monitor.go
+++ b/azurerm/internal/services/monitor/common_monitor.go
@@ -16,7 +16,11 @@ func flattenAzureRmScheduledQueryRulesAlertAction(input *insights.AzNsActionGrou
 			v["action_group"] = *input.ActionGroup
 		}
 		v["email_subject"] = input.EmailSubject
-		v["custom_webhook_payload"] = input.CustomWebhookPayload
+		p := ""
+		if input.CustomWebhookPayload != nil {
+			p = *input.CustomWebhookPayload
+		}
+		v["custom_webhook_payload"] = p
 	}
 	return []interface{}{v}
 }

--- a/azurerm/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
@@ -75,7 +75,6 @@ func resourceArmMonitorScheduledQueryRulesAlert() *schema.Resource {
 						"custom_webhook_payload": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Default:      "{}",
 							ValidateFunc: validation.StringIsJSON,
 						},
 						"email_subject": {
@@ -418,7 +417,9 @@ func expandMonitorScheduledQueryRulesAlertAction(input []interface{}) *insights.
 		actionGroups := v["action_group"].(*schema.Set).List()
 		result.ActionGroup = utils.ExpandStringSlice(actionGroups)
 		result.EmailSubject = utils.String(v["email_subject"].(string))
-		result.CustomWebhookPayload = utils.String(v["custom_webhook_payload"].(string))
+		if p := v["custom_webhook_payload"].(string); p != "" {
+			result.CustomWebhookPayload = utils.String(p)
+		}
 	}
 
 	return &result

--- a/azurerm/internal/services/monitor/tests/monitor_scheduled_query_rules_alert_resource_test.go
+++ b/azurerm/internal/services/monitor/tests/monitor_scheduled_query_rules_alert_resource_test.go
@@ -109,6 +109,7 @@ resource "azurerm_application_insights" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   application_type    = "web"
+  retention_in_days   = 90
 }
 
 resource "azurerm_monitor_action_group" "test" {
@@ -156,6 +157,7 @@ resource "azurerm_application_insights" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   application_type    = "web"
+  retention_in_days   = 90
 }
 
 resource "azurerm_monitor_action_group" "test" {
@@ -208,6 +210,7 @@ resource "azurerm_application_insights" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   application_type    = "web"
+  retention_in_days   = 90
 }
 
 resource "azurerm_monitor_action_group" "test" {
@@ -263,6 +266,7 @@ resource "azurerm_application_insights" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   application_type    = "web"
+  retention_in_days   = 90
 }
 
 resource "azurerm_log_analytics_workspace" "test" {

--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -155,7 +155,7 @@ The following arguments are supported:
 * `action_group` - (Required) List of action group reference resource IDs.
 * `custom_webhook_payload` - (Optional) Custom payload to be sent for all webhook payloads in alerting action.
 
--> **NOTE** When `custom_webhook_payload` is not specified, there will be no webhook sent. If you wants to send a empty webhook payload, please assign `{}` to it.
+-> **NOTE** When `custom_webhook_payload` is not specified, there will be no webhook sent. To send an empty webhook payload, you can set `custom_webhook_payload = "{}"`.
 
 * `email_subject` - (Optional) Custom subject override for all email ids in Azure action group.
 

--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -154,6 +154,9 @@ The following arguments are supported:
 
 * `action_group` - (Required) List of action group reference resource IDs.
 * `custom_webhook_payload` - (Optional) Custom payload to be sent for all webhook payloads in alerting action.
+
+-> **NOTE** When `custom_webhook_payload` is not specified, there will be no webhook sent. If you wants to send a empty webhook payload, please assign `{}` to it.
+
 * `email_subject` - (Optional) Custom subject override for all email ids in Azure action group.
 
 ---


### PR DESCRIPTION
Rather than setting a default value for `custom_webhook_payload`, we
shall honor absence of it, in which case the backend service will just
stop sending the webhook payload, and which is usually what user expected
(instead of sending an empty message).

This is kind of a **breaking change**, though.

Fixes: terraform-providers/terraform-provider-azurerm#6718

## Test Result

```bash
💤 via 🦉 v1.14.2 make testacc TEST=./azurerm/internal/services/monitor/tests TESTARGS="-run TestAccAzureRMMonitorScheduledQueryRules_AlertingAction"                                                                                                                                     
==> Checking that code complies with gofmt requirements...                                                                                   
==> Checking that Custom Timeouts are used...                                                                                                
TF_ACC=1 go test ./azurerm/internal/services/monitor/tests -v -run TestAccAzureRMMonitorScheduledQueryRules_AlertingAction -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"                                              
=== RUN   TestAccAzureRMMonitorScheduledQueryRules_AlertingActionBasic                                                                       
=== PAUSE TestAccAzureRMMonitorScheduledQueryRules_AlertingActionBasic                                                                       
=== RUN   TestAccAzureRMMonitorScheduledQueryRules_AlertingActionUpdate                   
=== PAUSE TestAccAzureRMMonitorScheduledQueryRules_AlertingActionUpdate                                                                      
=== RUN   TestAccAzureRMMonitorScheduledQueryRules_AlertingActionComplete                                                                    
=== PAUSE TestAccAzureRMMonitorScheduledQueryRules_AlertingActionComplete                                                                    
=== RUN   TestAccAzureRMMonitorScheduledQueryRules_AlertingActionCrossResource                                                               
=== PAUSE TestAccAzureRMMonitorScheduledQueryRules_AlertingActionCrossResource
=== CONT  TestAccAzureRMMonitorScheduledQueryRules_AlertingActionBasic                               
=== CONT  TestAccAzureRMMonitorScheduledQueryRules_AlertingActionCrossResource                                  
=== CONT  TestAccAzureRMMonitorScheduledQueryRules_AlertingActionComplete                                                                    
=== CONT  TestAccAzureRMMonitorScheduledQueryRules_AlertingActionUpdate                                                                      
--- PASS: TestAccAzureRMMonitorScheduledQueryRules_AlertingActionBasic (142.24s)
--- PASS: TestAccAzureRMMonitorScheduledQueryRules_AlertingActionCrossResource (142.20s)                                                                                                                                                                                                  
--- PASS: TestAccAzureRMMonitorScheduledQueryRules_AlertingActionComplete (156.42s)                                                          
--- PASS: TestAccAzureRMMonitorScheduledQueryRules_AlertingActionUpdate (224.51s)                                                            
PASS                                                                                                                                                                                                                                                                                      
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/monitor/tests       224.624s
```