### PR TITLE
Fix typo in resource "azurerm_application_insights": application_type "Other" -> "other"

### DIFF
--- a/website/docs/r/api_management_logger.html.markdown
+++ b/website/docs/r/api_management_logger.html.markdown
@@ -23,7 +23,7 @@ resource "azurerm_application_insights" "example" {
   name                = "example-appinsights"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  application_type    = "Other"
+  application_type    = "other"
 }
 
 resource "azurerm_api_management" "example" {


### PR DESCRIPTION
As a reference, please see here: https://www.terraform.io/docs/providers/azurerm/r/application_insights.html#argument-reference