### PR TITLE
`azurerm_databricks_workspace`: Add workspace_id and url

### DIFF
--- a/azurerm/internal/services/databricks/databricks_workspace_resource.go
+++ b/azurerm/internal/services/databricks/databricks_workspace_resource.go
@@ -111,6 +111,16 @@ func resourceArmDatabricksWorkspace() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"workspace_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -231,6 +241,8 @@ func resourceArmDatabricksWorkspaceRead(d *schema.ResourceData, meta interface{}
 		d.Set("managed_resource_group_id", props.ManagedResourceGroupID)
 		d.Set("managed_resource_group_name", managedResourceGroupID.ResourceGroup)
 		d.Set("custom_parameters", flattenWorkspaceCustomParameters(props.Parameters))
+		d.Set("workspace_url", props.WorkspaceURL)
+		d.Set("workspace_id", props.WorkspaceID)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/databricks/tests/databricks_workspace_resource_test.go
+++ b/azurerm/internal/services/databricks/tests/databricks_workspace_resource_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -95,7 +96,7 @@ func TestAccAzureRMDatabricksWorkspace_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDatabricksWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_id"),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_url"),
+					resource.TestMatchResourceAttr(data.ResourceName, "workspace_url", regexp.MustCompile("azuredatabricks.net")),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_id"),
 				),
 			},

--- a/azurerm/internal/services/databricks/tests/databricks_workspace_resource_test.go
+++ b/azurerm/internal/services/databricks/tests/databricks_workspace_resource_test.go
@@ -95,6 +95,8 @@ func TestAccAzureRMDatabricksWorkspace_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDatabricksWorkspaceExists(data.ResourceName),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "managed_resource_group_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_url"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "workspace_id"),
 				),
 			},
 			data.ImportStep(),

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -68,9 +68,13 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The ID of the Databricks Workspace.
+* `id` - The ID of the Databricks Workspace in the Azure management plane.
 
 * `managed_resource_group_id` - The ID of the Managed Resource Group created by the Databricks Workspace.
+
+* `workspace_url` - The workspace URL which is of the format 'adb-{workspaceId}.{random}.azuredatabricks.net'
+
+* `workspace_id` - The unique identifier of the databricks workspace in Databricks control plane.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixes #6732

Add `workspace_id` and `workspace_url` as computed attributes.

Move to individual URLs: https://docs.microsoft.com/en-us/azure/databricks/release-notes/product/2020/april#unique-urls-for-each-azure-databricks-workspace
REST Doc: https://docs.microsoft.com/en-us/rest/api/databricks/workspaces/get#workspace

Just running some tests now. 