### PR TITLE
azurerm_key_vault_certificate: fixed 'Unknown' issuer not working Issue #5589

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -442,6 +442,13 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 			return nil, "", fmt.Errorf("Error issuing read request in keyVaultCertificateCreationRefreshFunc for Certificate %q in Vault %q: %s", name, keyVaultBaseUrl, err)
 		}
 
+		if res.Policy != nil &&
+			res.Policy.IssuerParameters != nil &&
+			res.Policy.IssuerParameters.Name != nil &&
+			strings.EqualFold(*(res.Policy.IssuerParameters.Name), "unknown") {
+			return res, "Ready", nil
+		}
+
 		if res.Sid == nil || *res.Sid == "" {
 			return nil, "Provisioning", nil
 		}


### PR DESCRIPTION
The 'Unknown' issuer certificate workflow does not create a "ready to use" but pending certificate which needs to get signed. Until then it will not have a SID which is the reason why the current code times out waiting for a SID to become available (Refer to https://github.com/terraform-providers/terraform-provider-azurerm/blob/master/azurerm/internal/services/keyvault/key_vault_certificate_resource.go#L445). 

In this workflow, the user needs to manually download a certificate signing request (CSR file) from the portal and get it signed by an external CA (upload the CSR there and so on). Because of this the azurerm resource for an unknown issuer is finished with its work as soon as the certificate exists which is the case when the go client receives http status code 200. (Refer to https://github.com/Azure/azure-sdk-for-go/blob/master/services/keyvault/2016-10-01/keyvault/client.go#L1303 )

All possible issuers are:

- self: For self signed certificates (this works and is well tested)
- < CA Alias configured in Azure >: CA configured in Azure with user's CA account name and password. Azure can then automatically request signing and renewing certificates
- Unknown: Users need to take care that certificates get signed externally