### PR TITLE
Update VM name and VMSS name validation rule - now names can end with upper case letters

### DIFF
--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -35,7 +35,7 @@ func ValidateVmName(i interface{}, k string) (warnings []string, errors []error)
 		errors = append(errors, fmt.Errorf("%q must begin with an alphanumeric character", k))
 	}
 
-	if matched := regexp.MustCompile(`[a-zA-Z0-9_]$`).Match([]byte(v)); !matched {
+	if matched := regexp.MustCompile(`\w$`).Match([]byte(v)); !matched {
 		errors = append(errors, fmt.Errorf("%q must end with an alphanumeric character or underscore", k))
 	}
 

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -35,7 +35,7 @@ func ValidateVmName(i interface{}, k string) (warnings []string, errors []error)
 		errors = append(errors, fmt.Errorf("%q must begin with an alphanumeric character", k))
 	}
 
-	if matched := regexp.MustCompile(`[a-z0-9_]$`).Match([]byte(v)); !matched {
+	if matched := regexp.MustCompile(`[a-zA-Z0-9_]$`).Match([]byte(v)); !matched {
 		errors = append(errors, fmt.Errorf("%q must end with an alphanumeric character or underscore", k))
 	}
 

--- a/azurerm/internal/services/compute/validation_test.go
+++ b/azurerm/internal/services/compute/validation_test.go
@@ -72,6 +72,16 @@ func TestValidateVmName(t *testing.T) {
 			input:    "12345",
 			expected: false,
 		},
+		{
+			// can start with upper case letter
+			input:    "Test",
+			expected: true,
+		},
+		{
+			// can end with upper case letter
+			input:    "TEST",
+			expected: true,
+		},
 	}
 
 	for _, v := range testData {


### PR DESCRIPTION
Fixes #6920 