### PR TITLE
azurerm_redis_cache: support new maxmemory policies `allkeys-lfu' & 'volatile-lfu`

### DIFF
--- a/azurerm/internal/services/redis/resource_arm_redis_cache.go
+++ b/azurerm/internal/services/redis/resource_arm_redis_cache.go
@@ -900,10 +900,12 @@ func validateRedisMaxMemoryPolicy(v interface{}, _ string) (warnings []string, e
 		"allkeys-random":  true,
 		"volatile-random": true,
 		"volatile-ttl":    true,
+		"allkeys-lfu":     true,
+		"volatile-lfu":    true,
 	}
 
 	if !families[value] {
-		errors = append(errors, fmt.Errorf("Redis Max Memory Policy can only be 'noeviction' / 'allkeys-lru' / 'volatile-lru' / 'allkeys-random' / 'volatile-random' / 'volatile-ttl'"))
+		errors = append(errors, fmt.Errorf("Redis Max Memory Policy can only be 'noeviction' / 'allkeys-lru' / 'volatile-lru' / 'allkeys-random' / 'volatile-random' / 'volatile-ttl' / 'allkeys-lfu' / 'volatile-lfu'"))
 	}
 
 	return warnings, errors

--- a/azurerm/internal/services/redis/validation_test.go
+++ b/azurerm/internal/services/redis/validation_test.go
@@ -57,6 +57,8 @@ func TestAccAzureRMRedisCacheMaxMemoryPolicy_validation(t *testing.T) {
 		{Value: "allkeys-random", ErrCount: 0},
 		{Value: "volatile-random", ErrCount: 0},
 		{Value: "volatile-ttl", ErrCount: 0},
+		{Value: "allkeys-lfu", ErrCount: 0},
+		{Value: "volatile-lfu", ErrCount: 0},
 		{Value: "something-else", ErrCount: 1},
 	}
 


### PR DESCRIPTION
Fixes #7030