### PR TITLE
`azurerm_resources` - does not return all matched resources sometimes

### DIFF
--- a/azurerm/internal/services/resource/data_source_resources.go
+++ b/azurerm/internal/services/resource/data_source_resources.go
@@ -126,7 +126,8 @@ func dataSourceArmResourcesRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map[string]interface{}) (result []map[string]interface{}) {
+func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map[string]interface{}) []map[string]interface{} {
+	var result []map[string]interface{}
 	for _, res := range inputs {
 		if res.ID == nil {
 			continue
@@ -187,5 +188,5 @@ func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map
 			log.Printf("[DEBUG] azurerm_resources - resources %q (id: %q) skipped as a required tag is not set or has the wrong value.", *res.Name, *res.ID)
 		}
 	}
-	return
+	return result
 }

--- a/azurerm/internal/services/resource/data_source_resources.go
+++ b/azurerm/internal/services/resource/data_source_resources.go
@@ -104,6 +104,7 @@ func dataSourceArmResourcesRead(d *schema.ResourceData, meta interface{}) error 
 		filter += v
 	}
 
+	// Use List instead of listComplete because of bug in SDK: https://github.com/Azure/azure-sdk-for-go/issues/9510
 	resources := make([]map[string]interface{}, 0)
 	resourcesResp, err := client.List(ctx, filter, "", nil)
 	if err != nil {

--- a/azurerm/internal/services/resource/data_source_resources.go
+++ b/azurerm/internal/services/resource/data_source_resources.go
@@ -113,7 +113,7 @@ func dataSourceArmResourcesRead(d *schema.ResourceData, meta interface{}) error 
 	resources = append(resources, filterResource(resourcesResp.Values(), requiredTags)...)
 	for resourcesResp.Response().NextLink != nil && *resourcesResp.Response().NextLink != "" {
 		if err := resourcesResp.NextWithContext(ctx); err != nil {
-			return fmt.Errorf("loading Resource List: %s: %+v", err)
+			return fmt.Errorf("loading Resource List: %+v", err)
 		}
 		resources = append(resources, filterResource(resourcesResp.Values(), requiredTags)...)
 	}


### PR DESCRIPTION
CX team is using terraform data source data "azurerm_resources" to retrieve resources and are using those values to perform some automated deployments.
 
Sometimes, the output of the azurerm_resources presents with no values in first iteration and a nextLink. this [doc](https://www.terraform.io/docs/providers/azurerm/d/resources.html) says that the expected output is of type "resources"  
 
I don't see a way to access the nextLink property in terraform (as far as I researched) the problem with nextLink is that since the first value is null, it is throwing error stating index not available
 
28:    managed_relay_name      = data.azurerm_resources.databricks_managed_relay.resources.name data.azurerm_resources.databricks_managed_relay.resources is empty list of object
The given key does not identify an element in this collection value.

fixes #7035 