### PR TITLE
Fix deprecated interpolation syntax in docs

### DIFF
--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -21,8 +21,8 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_virtual_network" "example" {
   name                = "example-vnet1"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   address_space       = ["10.0.0.0/16"]
 }
 

--- a/website/docs/r/automation_certificate.html.markdown
+++ b/website/docs/r/automation_certificate.html.markdown
@@ -28,8 +28,8 @@ resource "azurerm_automation_account" "example" {
 
 resource "azurerm_automation_certificate" "example" {
   name                    = "certificate1"
-  resource_group_name     = "${azurerm_resource_group.example.name}"
-  automation_account_name = "${azurerm_automation_account.example.name}"
+  resource_group_name     = azurerm_resource_group.example.name
+  automation_account_name = azurerm_automation_account.example.name
 
   description = "This is an example certificate"
   base64      = base64encode(file("certificate.pfx"))

--- a/website/docs/r/backup_policy_file_share.markdown
+++ b/website/docs/r/backup_policy_file_share.markdown
@@ -22,15 +22,15 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_recovery_services_vault" "vault" {
   name                = "tfex-recovery-vault"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
   sku                 = "Standard"
 }
 
 resource "azurerm_backup_policy_file_share" "policy" {
   name                = "tfex-recovery-vault-policy"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  recovery_vault_name = "${azurerm_recovery_services_vault.vault.name}"
+  resource_group_name = azurerm_resource_group.rg.name
+  recovery_vault_name = azurerm_recovery_services_vault.vault.name
 
   timezone = "UTC"
 

--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -20,15 +20,15 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_recovery_services_vault" "example" {
   name                = "tfex-recovery-vault"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 
 resource "azurerm_backup_policy_vm" "example" {
   name                = "tfex-recovery-vault-policy"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  recovery_vault_name = "${azurerm_recovery_services_vault.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
+  recovery_vault_name = azurerm_recovery_services_vault.example.name
 
   timezone = "UTC"
 

--- a/website/docs/r/backup_protected_file_share.markdown
+++ b/website/docs/r/backup_protected_file_share.markdown
@@ -24,34 +24,34 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_recovery_services_vault" "vault" {
   name                = "tfex-recovery-vault"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
   sku                 = "Standard"
 }
 
 resource "azurerm_storage_account" "sa" {
   name                     = "examplesa"
-  location                 = "${azurerm_resource_group.rg.location}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
+  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = azurerm_resource_group.rg.name
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_share" "example" {
   name                 = "example-share"
-  storage_account_name = "${azurerm_storage_account.sa.name}"
+  storage_account_name = azurerm_storage_account.sa.name
 }
 
 resource "azurerm_backup_container_storage_account" "protection-container" {
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  recovery_vault_name = "${azurerm_recovery_services_vault.vault.name}"
-  storage_account_id  = "${azurerm_storage_account.sa.id}"
+  resource_group_name = azurerm_resource_group.rg.name
+  recovery_vault_name = azurerm_recovery_services_vault.vault.name
+  storage_account_id  = azurerm_storage_account.sa.id
 }
 
 resource "azurerm_backup_policy_file_share" "example" {
   name                = "tfex-recovery-vault-policy"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
-  recovery_vault_name = "${azurerm_recovery_services_vault.vault.name}"
+  resource_group_name = azurerm_resource_group.rg.name
+  recovery_vault_name = azurerm_recovery_services_vault.vault.name
 
   backup {
     frequency = "Daily"
@@ -64,11 +64,11 @@ resource "azurerm_backup_policy_file_share" "example" {
 }
 
 resource "azurerm_backup_protected_file_share" "share1" {
-  resource_group_name       = "${azurerm_resource_group.rg.name}"
-  recovery_vault_name       = "${azurerm_recovery_services_vault.vault.name}"
-  source_storage_account_id = "${azurerm_backup_container_storage_account.protection-container.storage_account_id}"
-  source_file_share_name    = "${azurerm_storage_share.example.name}"
-  backup_policy_id          = "${azurerm_backup_policy_file_share.example.id}"
+  resource_group_name       = azurerm_resource_group.rg.name
+  recovery_vault_name       = azurerm_recovery_services_vault.vault.name
+  source_storage_account_id = azurerm_backup_container_storage_account.protection-container.storage_account_id
+  source_file_share_name    = azurerm_storage_share.example.name
+  backup_policy_id          = azurerm_backup_policy_file_share.example.id
 }
 ```
 

--- a/website/docs/r/backup_protected_vm.markdown
+++ b/website/docs/r/backup_protected_vm.markdown
@@ -20,15 +20,15 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_recovery_services_vault" "example" {
   name                = "tfex-recovery-vault"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "Standard"
 }
 
 resource "azurerm_backup_policy_vm" "example" {
   name                = "tfex-recovery-vault-policy"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  recovery_vault_name = "${azurerm_recovery_services_vault.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
+  recovery_vault_name = azurerm_recovery_services_vault.example.name
 
   backup {
     frequency = "Daily"
@@ -37,10 +37,10 @@ resource "azurerm_backup_policy_vm" "example" {
 }
 
 resource "azurerm_backup_protected_vm" "vm1" {
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  recovery_vault_name = "${azurerm_recovery_services_vault.example.name}"
-  source_vm_id        = "${azurerm_virtual_machine.example.id}"
-  backup_policy_id    = "${azurerm_backup_policy_vm.example.id}"
+  resource_group_name = azurerm_resource_group.example.name
+  recovery_vault_name = azurerm_recovery_services_vault.example.name
+  source_vm_id        = azurerm_virtual_machine.example.id
+  backup_policy_id    = azurerm_backup_policy_vm.example.id
 }
 ```
 

--- a/website/docs/r/bot_channel_directline.markdown
+++ b/website/docs/r/bot_channel_directline.markdown
@@ -23,15 +23,15 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_bot_channels_registration" "example" {
   name                = "example"
   location            = "global"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
   microsoft_app_id    = "${data.azurerm_client_config.current.service_principal_application_id}"
 }
 
 resource "azurerm_bot_channel_directline" "example" {
-  bot_name            = "${azurerm_bot_channels_registration.example.name}"
-  location            = "${azurerm_bot_channels_registration.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  bot_name            = azurerm_bot_channels_registration.example.name
+  location            = azurerm_bot_channels_registration.example.location
+  resource_group_name = azurerm_resource_group.example.name
 
   site {
     name    = "default"

--- a/website/docs/r/bot_channel_email.markdown
+++ b/website/docs/r/bot_channel_email.markdown
@@ -25,15 +25,15 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_bot_channels_registration" "example" {
   name                = "example"
   location            = "global"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
   microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_channel_Email" "example" {
-  bot_name              = "${azurerm_bot_channels_registration.example.name}"
-  location              = "${azurerm_bot_channels_registration.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  bot_name              = azurerm_bot_channels_registration.example.name
+  location              = azurerm_bot_channels_registration.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   client_id             = "exampleId"
   client_secret         = "exampleSecret"
   verification_token    = "exampleVerificationToken"

--- a/website/docs/r/bot_channel_ms_teams.markdown
+++ b/website/docs/r/bot_channel_ms_teams.markdown
@@ -25,15 +25,15 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_bot_channels_registration" "example" {
   name                = "example"
   location            = "global"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
   microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_channel_ms_teams" "example" {
-  bot_name            = "${azurerm_bot_channels_registration.example.name}"
-  location            = "${azurerm_bot_channels_registration.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  bot_name            = azurerm_bot_channels_registration.example.name
+  location            = azurerm_bot_channels_registration.example.location
+  resource_group_name = azurerm_resource_group.example.name
   calling_web_hook    = "https://example2.com/"
   enable_calling      = false
 }

--- a/website/docs/r/bot_channel_slack.markdown
+++ b/website/docs/r/bot_channel_slack.markdown
@@ -25,15 +25,15 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_bot_channels_registration" "example" {
   name                = "example"
   location            = "global"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
   microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_channel_slack" "example" {
-  bot_name              = "${azurerm_bot_channels_registration.example.name}"
-  location              = "${azurerm_bot_channels_registration.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  bot_name              = azurerm_bot_channels_registration.example.name
+  location              = azurerm_bot_channels_registration.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   client_id             = "exampleId"
   client_secret         = "exampleSecret"
   verification_token    = "exampleVerificationToken"

--- a/website/docs/r/bot_channels_registration.markdown
+++ b/website/docs/r/bot_channels_registration.markdown
@@ -23,7 +23,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_bot_channels_registration" "example" {
   name                = "example"
   location            = "global"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
   microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }

--- a/website/docs/r/bot_connection.markdown
+++ b/website/docs/r/bot_connection.markdown
@@ -23,16 +23,16 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_bot_channels_registration" "example" {
   name                = "example"
   location            = "global"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
   microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }
 
 resource "azurerm_bot_connection" "example" {
   name                  = "example"
-  bot_name              = "${azurerm_bot_channels_registration.example.name}"
-  location              = "${azurerm_bot_channels_registration.example.location}"
-  resource_group_name   = "${azurerm_resource_group.example.name}"
+  bot_name              = azurerm_bot_channels_registration.example.name
+  location              = azurerm_bot_channels_registration.example.location
+  resource_group_name   = azurerm_resource_group.example.name
   service_provider_name = "box"
   client_id             = "exampleId"
   client_secret         = "exampleSecret"

--- a/website/docs/r/bot_web_app.markdown
+++ b/website/docs/r/bot_web_app.markdown
@@ -23,7 +23,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_bot_web_app" "example" {
   name                = "example"
   location            = "global"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "F0"
   microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
 }

--- a/website/docs/r/data_lake_store_file.html.markdown
+++ b/website/docs/r/data_lake_store_file.html.markdown
@@ -23,12 +23,12 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_data_lake_store" "example" {
   name                = "consumptiondatalake"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 }
 
 resource "azurerm_data_lake_store_file" "example" {
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
   local_file_path     = "/path/to/local/file"
   remote_file_path    = "/path/created/for/remote/file"
 }

--- a/website/docs/r/devspace_controller.html.markdown
+++ b/website/docs/r/devspace_controller.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_devspace_controller" "example" {
   sku_name = "S1"
 
   host_suffix                              = "suffix"
-  target_container_host_resource_id        = "${azurerm_kubernetes_cluster.example.id}"
+  target_container_host_resource_id        = azurerm_kubernetes_cluster.example.id
   target_container_host_credentials_base64 = "${base64encode(azurerm_kubernetes_cluster.example.kube_config_raw)}"
 
   tags = {

--- a/website/docs/r/iotcentral_application.html.markdown
+++ b/website/docs/r/iotcentral_application.html.markdown
@@ -20,8 +20,8 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_iotcentral_application" "example" {
   name                = "example-iotcentral-app"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
   sub_domain          = "example-iotcentral-app-subdomain"
 
   display_name = "example-iotcentral-app-display-name"

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -419,9 +419,9 @@ The `kube_admin_config` and `kube_config` blocks export the following:
 ```
 provider "kubernetes" {
   load_config_file       = "false"
-  host                   = "${azurerm_kubernetes_cluster.main.kube_config.0.host}"
-  username               = "${azurerm_kubernetes_cluster.main.kube_config.0.username}"
-  password               = "${azurerm_kubernetes_cluster.main.kube_config.0.password}"
+  host                   = azurerm_kubernetes_cluster.main.kube_config.0.host
+  username               = azurerm_kubernetes_cluster.main.kube_config.0.username
+  password               = azurerm_kubernetes_cluster.main.kube_config.0.password
   client_certificate     = "${base64decode(azurerm_kubernetes_cluster.main.kube_config.0.client_certificate)}"
   client_key             = "${base64decode(azurerm_kubernetes_cluster.main.kube_config.0.client_key)}"
   cluster_ca_certificate = "${base64decode(azurerm_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate)}"

--- a/website/docs/r/kusto_database.html.markdown
+++ b/website/docs/r/kusto_database.html.markdown
@@ -20,8 +20,8 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_kusto_cluster" "cluster" {
   name                = "kustocluster"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   sku {
     name     = "Standard_D13_v2"

--- a/website/docs/r/kusto_database_principal.html.markdown
+++ b/website/docs/r/kusto_database_principal.html.markdown
@@ -22,8 +22,8 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_kusto_cluster" "cluster" {
   name                = "kustocluster"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
 
   sku {
     name     = "Standard_D13_v2"

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -102,9 +102,9 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 
 resource "azurerm_monitor_autoscale_setting" "example" {
   name                = "myAutoscaleSetting"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
-  target_resource_id  = "${azurerm_virtual_machine_scale_set.example.id}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  target_resource_id  = azurerm_virtual_machine_scale_set.example.id
 
   profile {
     name = "Weekends"
@@ -118,7 +118,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = "${azurerm_virtual_machine_scale_set.example.id}"
+        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -138,7 +138,7 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     rule {
       metric_trigger {
         metric_name        = "Percentage CPU"
-        metric_resource_id = "${azurerm_virtual_machine_scale_set.example.id}"
+        metric_resource_id = azurerm_virtual_machine_scale_set.example.id
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -21,12 +21,12 @@ resource "azurerm_resource_group" "example" {
 
 data "azurerm_storage_account" "example" {
   name                = "examplestoracc"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 data "azurerm_key_vault" "example" {
   name                = "example-vault"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_monitor_diagnostic_setting" "example" {

--- a/website/docs/r/netapp_account.html.markdown
+++ b/website/docs/r/netapp_account.html.markdown
@@ -22,8 +22,8 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_netapp_account" "example" {
   name                = "example-netapp"
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 
   active_directory {
     username            = "aduser"

--- a/website/docs/r/powerbi_embedded.html.markdown
+++ b/website/docs/r/powerbi_embedded.html.markdown
@@ -20,8 +20,8 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_powerbi_embedded" "example" {
   name                = "example-powerbi"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku_name            = "A1"
   administrators      = ["azsdktest@microsoft.com"]
 }

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_private_dns_zone" "example" {
   name                = "mydomain.com"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "example" {

--- a/website/docs/r/recovery_services_vault.markdown
+++ b/website/docs/r/recovery_services_vault.markdown
@@ -20,8 +20,8 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_recovery_services_vault" "vault" {
   name                = "example_recovery_vault"
-  location            = "${azurerm_resource_group.rg.location}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
   sku                 = "Standard"
 
   soft_delete_enabled = true

--- a/website/docs/r/security_center_workspace.markdown
+++ b/website/docs/r/security_center_workspace.markdown
@@ -24,14 +24,14 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_log_analytics_workspace" "example" {
   name                = "tfex-security-workspace"
-  location            = "${azurerm_resource_group.example.location}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
   sku                 = "PerGB2018"
 }
 
 resource "azurerm_security_center_workspace" "example" {
   scope        = "/subscriptions/00000000-0000-0000-0000-000000000000"
-  workspace_id = "${azurerm_log_analytics_workspace.example.id}"
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 ```
 

--- a/website/docs/r/sql_active_directory_administrator.markdown
+++ b/website/docs/r/sql_active_directory_administrator.markdown
@@ -22,16 +22,16 @@ resource "azurerm_resource_group" "example" {
 
 resource "azurerm_sql_server" "example" {
   name                         = "mysqlserver"
-  resource_group_name          = "${azurerm_resource_group.example.name}"
-  location                     = "${azurerm_resource_group.example.location}"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
   version                      = "12.0"
   administrator_login          = "4dm1n157r470r"
   administrator_login_password = "4-v3ry-53cr37-p455w0rd"
 }
 
 resource "azurerm_sql_active_directory_administrator" "example" {
-  server_name         = "${azurerm_sql_server.example.name}"
-  resource_group_name = "${azurerm_resource_group.example.name}"
+  server_name         = azurerm_sql_server.example.name
+  resource_group_name = azurerm_resource_group.example.name
   login               = "sqladmin"
   tenant_id           = "${data.azurerm_client_config.current.tenant_id}"
   object_id           = "${data.azurerm_client_config.current.object_id}"

--- a/website/docs/r/user_assigned_identity.markdown
+++ b/website/docs/r/user_assigned_identity.markdown
@@ -19,8 +19,8 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_user_assigned_identity" "example" {
-  resource_group_name = "${azurerm_resource_group.example.name}"
-  location            = "${azurerm_resource_group.example.location}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
 
   name = "search-api"
 }


### PR DESCRIPTION

This should fix the deprecated interpolation across all the doc files.
If you rather have me breaking the PR up per service, let me know.