### PR TITLE
Support for Gateway-required VNet integration for `app_service` and `function_app`

### DIFF
--- a/azurerm/internal/services/network/virtual_network_gateway.go
+++ b/azurerm/internal/services/network/virtual_network_gateway.go
@@ -1,0 +1,44 @@
+package network
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func getProfilePackageResult(client network.VirtualNetworkGatewaysClient, future network.VirtualNetworkGatewaysGetVpnProfilePackageURLFuture) (str string, err error) {
+	var done bool
+	done, err = future.DoneWithContext(context.Background(), client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "network.VirtualNetworkGatewaysGetVpnProfilePackageURLFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("network.VirtualNetworkGatewaysGetVpnProfilePackageURLFuture")
+		return
+	}
+	sender := autorest.DecorateSender(client, autorest.DoRetryForStatusCodes(client.RetryAttempts, client.RetryDuration, autorest.StatusCodesForRetry...))
+	var s network.String
+	if s.Response.Response, err = future.GetResult(sender); err == nil && s.Response.Response.StatusCode != http.StatusNoContent {
+		str, err = getvpnprofilepackageResponder(client, s.Response.Response)
+		if err != nil {
+			err = autorest.NewErrorWithError(err, "network.VirtualNetworkGatewaysGetVpnProfilePackageURLFuture", "Result", s.Response.Response, "Failure responding to request")
+		}
+	}
+	return
+}
+
+func getvpnprofilepackageResponder(client network.VirtualNetworkGatewaysClient, resp *http.Response) (result string, err error) {
+	byteArr := make([]byte, 1024)
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
+		autorest.ByUnmarshallingBytes(&byteArr),
+		autorest.ByClosing())
+	result = string(byteArr[1 : len(byteArr)-1])
+	return
+}

--- a/azurerm/internal/services/web/registration.go
+++ b/azurerm/internal/services/web/registration.go
@@ -33,17 +33,18 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_app_service_active_slot":                      resourceArmAppServiceActiveSlot(),
-		"azurerm_app_service_certificate":                      resourceArmAppServiceCertificate(),
-		"azurerm_app_service_certificate_order":                resourceArmAppServiceCertificateOrder(),
-		"azurerm_app_service_custom_hostname_binding":          resourceArmAppServiceCustomHostnameBinding(),
-		"azurerm_app_service_environment":                      resourceArmAppServiceEnvironment(),
-		"azurerm_app_service_plan":                             resourceArmAppServicePlan(),
-		"azurerm_app_service_slot":                             resourceArmAppServiceSlot(),
-		"azurerm_app_service_source_control_token":             resourceArmAppServiceSourceControlToken(),
-		"azurerm_app_service_virtual_network_swift_connection": resourceArmAppServiceVirtualNetworkSwiftConnection(),
-		"azurerm_app_service":                                  resourceArmAppService(),
-		"azurerm_function_app":                                 resourceArmFunctionApp(),
-		"azurerm_function_app_slot":                            resourceArmFunctionAppSlot(),
+		"azurerm_app_service_active_slot":                        resourceArmAppServiceActiveSlot(),
+		"azurerm_app_service_certificate":                        resourceArmAppServiceCertificate(),
+		"azurerm_app_service_certificate_order":                  resourceArmAppServiceCertificateOrder(),
+		"azurerm_app_service_custom_hostname_binding":            resourceArmAppServiceCustomHostnameBinding(),
+		"azurerm_app_service_environment":                        resourceArmAppServiceEnvironment(),
+		"azurerm_app_service_plan":                               resourceArmAppServicePlan(),
+		"azurerm_app_service_slot":                               resourceArmAppServiceSlot(),
+		"azurerm_app_service_source_control_token":               resourceArmAppServiceSourceControlToken(),
+		"azurerm_app_service_virtual_network_swift_connection":   resourceArmAppServiceVirtualNetworkSwiftConnection(),
+		"azurerm_app_service_virtual_network_gateway_connection": resourceArmAppServiceVirtualNetworkGatewayConnection(),
+		"azurerm_app_service":                                    resourceArmAppService(),
+		"azurerm_function_app":                                   resourceArmFunctionApp(),
+		"azurerm_function_app_slot":                              resourceArmFunctionAppSlot(),
 	}
 }

--- a/azurerm/internal/services/web/resource_arm_app_service_virtual_network_gateway_connection.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_virtual_network_gateway_connection.go
@@ -1,0 +1,206 @@
+package web
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
+
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2019-08-01/web"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmAppServiceVirtualNetworkGatewayConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmAppServiceVirtualNetworkGatewayConnectionCreateUpdate,
+		Read:   resourceArmAppServiceVirtualNetworkGatewayConnectionRead,
+		Update: resourceArmAppServiceVirtualNetworkGatewayConnectionCreateUpdate,
+		Delete: resourceArmAppServiceVirtualNetworkGatewayConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"app_service_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+			"vnet_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+			"vpn_gateway_package_uri": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				DiffSuppressFunc: func(_, old, _ string, _ *schema.ResourceData) bool {
+					return old != ""
+				},
+			},
+		},
+	}
+}
+
+func resourceArmAppServiceVirtualNetworkGatewayConnectionCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Get("app_service_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+	}
+	vnetIDRaw := d.Get("vnet_id").(string)
+	vnetID, err := azure.ParseAzureResourceID(vnetIDRaw)
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+	}
+	packageURI := d.Get("vpn_gateway_package_uri").(string)
+
+	resourceGroup := id.ResourceGroup
+	name := id.Path["sites"]
+	virtualNetworkName := vnetID.Path["virtualNetworks"]
+
+	locks.ByName(virtualNetworkName, network.VirtualNetworkResourceName)
+	defer locks.UnlockByName(virtualNetworkName, network.VirtualNetworkResourceName)
+
+	exists, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(exists.Response) {
+			return fmt.Errorf("Error retrieving existing App Service %q (Resource Group %q): App Service not found in resource group", name, resourceGroup)
+		}
+		return fmt.Errorf("Error retrieving existing App Service %q (Resource Group %q): %s", name, resourceGroup, err)
+	}
+
+	vnetInfo := web.VnetInfo{
+		VnetInfoProperties: &web.VnetInfoProperties{
+			VnetResourceID: utils.String(vnetIDRaw),
+		},
+	}
+	if _, err = client.CreateOrUpdateVnetConnection(ctx, resourceGroup, name, virtualNetworkName, vnetInfo); err != nil {
+		return fmt.Errorf("Error creating/updating App Service VNet association between %q (Resource Group %q) and Virtual Network %q: %s", name, resourceGroup, virtualNetworkName, err)
+	}
+
+	connectionEnvelope := web.VnetGateway{
+		VnetGatewayProperties: &web.VnetGatewayProperties{
+			VnetName:      utils.String(virtualNetworkName),
+			VpnPackageURI: utils.String(packageURI),
+		},
+	}
+	gatewayName := "primary"
+	if _, err = client.CreateOrUpdateVnetConnectionGateway(ctx, resourceGroup, name, virtualNetworkName, gatewayName, connectionEnvelope); err != nil {
+		return fmt.Errorf("Error creating/updating App Service VNet Gateway association between %q (Resource Group %q) and Virtual Network %q: %s", name, resourceGroup, virtualNetworkName, err)
+	}
+	read, err := client.GetVnetConnectionGateway(ctx, resourceGroup, name, virtualNetworkName, gatewayName)
+	if err != nil {
+		return fmt.Errorf("Error retrieving App Service VNet Gateway association between %q (Resource Group %q) and Virtual Network %q: %s", name, resourceGroup, virtualNetworkName, err)
+	}
+	d.SetId(*read.ID)
+
+	return resourceArmAppServiceVirtualNetworkGatewayConnectionRead(d, meta)
+}
+
+func resourceArmAppServiceVirtualNetworkGatewayConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+	}
+	virtualNetworkName := id.Path["virtualNetworkConnections"]
+	resourceGroup := id.ResourceGroup
+	name := id.Path["sites"]
+
+	appService, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(appService.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving existing App Service %q (Resource Group %q): %s", name, resourceGroup, err)
+	}
+	vnetConnection, err := client.GetVnetConnection(ctx, resourceGroup, name, virtualNetworkName)
+	if err != nil {
+		if utils.ResponseWasNotFound(vnetConnection.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving App Service VNet association for %q (Resource Group %q): %s", name, resourceGroup, err)
+	}
+	gatewayName := "primary"
+	vnetGateway, err := client.GetVnetConnectionGateway(ctx, resourceGroup, name, virtualNetworkName, gatewayName)
+	if err != nil {
+		if utils.ResponseWasNotFound(vnetGateway.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving App Service VNet Gateway association for %q (Resource Group %q): %s", name, resourceGroup, err)
+	}
+
+	d.Set("vnet_id", vnetConnection.VnetInfoProperties.VnetResourceID)
+	d.Set("app_service_id", appService.ID)
+	return nil
+}
+
+func resourceArmAppServiceVirtualNetworkGatewayConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Web.AppServicesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Get("app_service_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+	}
+	vnetID, err := azure.ParseAzureResourceID(d.Get("vnet_id").(string))
+	if err != nil {
+		return fmt.Errorf("Error parsing Azure Resource ID %q", vnetID)
+	}
+	resourceGroup := id.ResourceGroup
+	name := id.Path["sites"]
+	virtualNetworkName := vnetID.Path["virtualNetworks"]
+
+	locks.ByName(virtualNetworkName, network.VirtualNetworkResourceName)
+	defer locks.UnlockByName(virtualNetworkName, network.VirtualNetworkResourceName)
+
+	gatewayName := "primary"
+	read, err := client.GetVnetConnectionGateway(ctx, resourceGroup, name, virtualNetworkName, gatewayName)
+	if err != nil {
+		return fmt.Errorf("Error making read request on virtual network properties (App Service %q / Resource Group %q): %+v", name, resourceGroup, err)
+	}
+	if read.VnetGatewayProperties == nil {
+		return fmt.Errorf("Error retrieving virtual network properties (App Service %q / Resource Group %q): `properties` was nil", name, resourceGroup)
+	}
+	props := *read.VnetGatewayProperties
+	vnet := props.VnetName
+	if vnet == nil || *vnet == "" {
+		// assume deleted
+		return nil
+	}
+
+	resp, err := client.DeleteVnetConnection(ctx, resourceGroup, name, virtualNetworkName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("Error deleting virtual network properties (App Service %q / Resource Group %q): %+v", name, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_virtual_network_gateway_connection_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_virtual_network_gateway_connection_test.go
@@ -1,0 +1,491 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+// TODO: requires import
+
+func TestAccAzureRMAppServiceVirtualNetworkGatewayConnection_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_virtual_network_gateway_connection", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceVirtualNetworkGatewayConnection_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "vnet_id"),
+				),
+			},
+			data.ImportStep("vpn_gateway_package_uri"), //not returned as it is not exported, the initial import URL expired after one hour
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceVirtualNetworkGatewayConnection_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_virtual_network_gateway_connection", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceVirtualNetworkGatewayConnection_switch1(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionExists(data.ResourceName),
+					// resource.TestCheckResourceAttrSet(data.ResourceName, "subnet_id"),
+				),
+			},
+			{
+				Config: testAccAzureRMAppServiceVirtualNetworkGatewayConnection_switch2(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionExists(data.ResourceName),
+					// resource.TestCheckResourceAttrSet(data.ResourceName, "subnet_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMAppServiceVirtualNetworkGatewayConnection_disappears(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_virtual_network_gateway_connection", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceVirtualNetworkGatewayConnection_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionExists(data.ResourceName),
+					// resource.TestCheckResourceAttrSet(data.ResourceName, "subnet_id"),
+					testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionDisappears(data.ResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := rs.Primary.Attributes["id"]
+		parsedID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+		}
+		vnetID := rs.Primary.Attributes["vnet_id"]
+		parsedVnetID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource VNet ID %q", vnetID)
+		}
+		name := parsedID.Path["sites"]
+		resourceGroup := parsedID.ResourceGroup
+		virtualNetworkName := parsedVnetID.Path["virtualNetworkConnections"]
+		gatewayName := "primary"
+
+		resp, err := client.GetVnetConnectionGateway(ctx, resourceGroup, name, virtualNetworkName, gatewayName)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: App Service Virtual Network Association %q (Resource Group: %q) does not exist", name, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on appServicesClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := rs.Primary.Attributes["id"]
+		parsedID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+		}
+		vnetID := rs.Primary.Attributes["vnet_id"]
+		parsedVnetID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource VNet ID %q", vnetID)
+		}
+		name := parsedID.Path["sites"]
+		resourceGroup := parsedID.ResourceGroup
+		virtualNetworkName := parsedVnetID.Path["virtualNetworkConnections"]
+
+		resp, err := client.DeleteVnetConnection(ctx, resourceGroup, name, virtualNetworkName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp) {
+				return fmt.Errorf("Bad: Delete on appServicesClient: %+v", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMAppServiceVirtualNetworkGatewayConnectionDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServicesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_app_service_virtual_network_gateway_connection" {
+			continue
+		}
+
+		id := rs.Primary.Attributes["id"]
+		parsedID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource ID %q", id)
+		}
+		vnetID := rs.Primary.Attributes["vnet_id"]
+		parsedVnetID, err := azure.ParseAzureResourceID(id)
+		if err != nil {
+			return fmt.Errorf("Error parsing Azure Resource VNet ID %q", vnetID)
+		}
+		name := parsedID.Path["sites"]
+		resourceGroup := parsedID.ResourceGroup
+		virtualNetworkName := parsedVnetID.Path["virtualNetworks"]
+		gatewayName := "primary"
+
+		resp, err := client.GetVnetConnectionGateway(ctx, resourceGroup, name, virtualNetworkName, gatewayName)
+
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMAppServiceVirtualNetworkGatewayConnection_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appservice-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-VNET-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  lifecycle {
+    ignore_changes = [ddos_protection_plan]
+  }
+}
+
+resource "azurerm_subnet" "test1" {
+  name                 = "acctestSubnet1"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "acctestdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_subnet" "test2" {
+  name                 = "acctestSubnet2"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+
+  delegation {
+    name = "acctestdelegation"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctest-ASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctest-AS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+
+resource "azurerm_app_service_virtual_network_gateway_connection" "test" {
+  app_service_id          = azurerm_app_service.test.id
+  vnet_id                 = azurerm_virtual_network.test.id
+  vpn_gateway_package_uri = azurerm_virtual_network_gateway.test.vpn_client_configuration.0.vpn_profile_package_uri
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppServiceVirtualNetworkGatewayConnection_doubleGateway(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appservice-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test1" {
+  name                = "acctest-VNET1-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "%s"
+  resource_group_name = azurerm_resource_group.test.name
+  lifecycle {
+    ignore_changes = [ddos_protection_plan]
+  }
+}
+
+resource "azurerm_subnet" "test1" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test1.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctest-IP1-%d"
+  location            = azurerm_virtual_network.test1.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  allocation_method = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "test1" {
+  name                = "acctest-VNETGW1-%d"
+  location            = azurerm_virtual_network.test1.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+
+  active_active = false
+  enable_bgp    = false
+  sku           = "VpnGw1"
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.test1.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test1.id
+  }
+
+  vpn_client_configuration {
+    address_space = ["192.168.0.96/29"]
+
+    vpn_client_protocols = ["SSTP"]
+
+    root_certificate {
+      name = "DigiCert-Federated-ID-Root-CA"
+
+      public_cert_data = <<EOF
+	MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+	MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+	d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+	Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+	BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+	Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+	QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+	zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+	GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+	GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+	Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+	DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+	HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+	jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+	9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+	QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+	uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+	WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+	M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+	EOF
+
+    }
+  }
+}
+
+resource "azurerm_virtual_network" "test2" {
+	name                = "acctest-VNET2-%d"
+	address_space       = ["10.0.0.0/16"]
+	location            = "%s"
+	resource_group_name = azurerm_resource_group.test.name
+	lifecycle {
+	  ignore_changes = [ddos_protection_plan]
+	}
+  }
+  
+  resource "azurerm_subnet" "test2" {
+	name                 = "GatewaySubnet"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test2.name
+	address_prefixes     = ["10.0.1.0/24"]
+  }
+  
+  resource "azurerm_public_ip" "test2" {
+	name                = "acctest-IP2-%d"
+	location            = azurerm_virtual_network.test2.location
+	resource_group_name = azurerm_resource_group.test.name
+  
+	allocation_method = "Dynamic"
+  }
+  
+  resource "azurerm_virtual_network_gateway" "test2" {
+	name                = "acctest-VNETGW2-%d"
+	location            = azurerm_virtual_network.test2.location
+	resource_group_name = azurerm_resource_group.test.name
+  
+	type     = "Vpn"
+	vpn_type = "RouteBased"
+  
+	active_active = false
+	enable_bgp    = false
+	sku           = "VpnGw1"
+  
+	ip_configuration {
+	  name                          = "vnetGatewayConfig"
+	  public_ip_address_id          = azurerm_public_ip.test2.id
+	  private_ip_address_allocation = "Dynamic"
+	  subnet_id                     = azurerm_subnet.test2.id
+	}
+  
+	vpn_client_configuration {
+	  address_space = ["192.168.0.96/29"]
+  
+	  vpn_client_protocols = ["SSTP"]
+  
+	  root_certificate {
+		name = "DigiCert-Federated-ID-Root-CA"
+  
+		public_cert_data = <<EOF
+	  MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+	  MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+	  d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+	  Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+	  BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+	  Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+	  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+	  QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+	  zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+	  GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+	  GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+	  Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+	  DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+	  HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+	  jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+	  9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+	  QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+	  uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+	  WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+	  M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+	  EOF
+  
+	  }
+	}
+  }
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctest-ASP-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "test" {
+  name                = "acctest-AS-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  app_service_plan_id = azurerm_app_service_plan.test.id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.RandomInteger,
+		data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMAppServiceVirtualNetworkGatewayConnection_switch1(data acceptance.TestData) string {
+	template := testAccAzureRMAppServiceVirtualNetworkGatewayConnection_doubleGateway(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_virtual_network_gateway_connection" "test" {
+  app_service_id          = azurerm_app_service.test.id
+  vnet_id                 = azurerm_virtual_network.test1.id
+  vpn_gateway_package_uri = azurerm_virtual_network_gateway.test1.vpn_client_configuration.0.vpn_profile_package_uri
+}
+`, template)
+}
+
+func testAccAzureRMAppServiceVirtualNetworkGatewayConnection_switch2(data acceptance.TestData) string {
+	template := testAccAzureRMAppServiceVirtualNetworkGatewayConnection_doubleGateway(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_virtual_network_gateway_connection" "test" {
+  app_service_id          = azurerm_app_service.test.id
+  vnet_id                 = azurerm_virtual_network.test2.id
+  vpn_gateway_package_uri = azurerm_virtual_network_gateway.test2.vpn_client_configuration.0.vpn_profile_package_uri
+}
+`, template)
+}

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_virtual_network_swift_connection_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_virtual_network_swift_connection_test.go
@@ -189,41 +189,78 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_virtual_network" "test" {
   name                = "acctest-VNET-%d"
   address_space       = ["10.0.0.0/16"]
-  location            = azurerm_resource_group.test.location
+  location            = "%s"
   resource_group_name = azurerm_resource_group.test.name
   lifecycle {
     ignore_changes = [ddos_protection_plan]
   }
 }
 
-resource "azurerm_subnet" "test1" {
-  name                 = "acctestSubnet1"
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.1.0/24"
-
-  delegation {
-    name = "acctestdelegation"
-
-    service_delegation {
-      name    = "Microsoft.Web/serverFarms"
-      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
-    }
-  }
+  address_prefixes     = ["10.0.1.0/24"]
 }
 
-resource "azurerm_subnet" "test2" {
-  name                 = "acctestSubnet2"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.2.0/24"
+resource "azurerm_public_ip" "test" {
+  name                = "acctest-IP-%d"
+  location            = azurerm_virtual_network.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
-  delegation {
-    name = "acctestdelegation"
+  allocation_method = "Dynamic"
+}
 
-    service_delegation {
-      name    = "Microsoft.Web/serverFarms"
-      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctest-VNETGW-%d"
+  location            = azurerm_virtual_network.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+
+  active_active = false
+  enable_bgp    = false
+  sku           = "VpnGw1"
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  vpn_client_configuration {
+    address_space = ["192.168.0.96/29"]
+
+    vpn_client_protocols = ["SSTP"]
+
+    root_certificate {
+      name = "DigiCert-Federated-ID-Root-CA"
+
+      public_cert_data = <<EOF
+	MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+	MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+	d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+	Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+	BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+	Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+	QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+	zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+	GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+	GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+	Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+	DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+	HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+	jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+	9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+	QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+	uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+	WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+	M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+	EOF
+
     }
   }
 }
@@ -245,7 +282,7 @@ resource "azurerm_app_service" "test" {
   resource_group_name = azurerm_resource_group.test.name
   app_service_plan_id = azurerm_app_service_plan.test.id
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func testAccAzureRMAppServiceVirtualNetworkSwiftConnection_basic(data acceptance.TestData) string {

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -796,6 +796,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/app_service_virtual_network_gateway_connection.html">azurerm_app_service_virtual_network_gateway_connection</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/app_service_virtual_network_swift_connection.html">azurerm_app_service_virtual_network_swift_connection</a>
                 </li>
 

--- a/website/docs/r/app_service_virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/app_service_virtual_network_gateway_connection.html.markdown
@@ -1,0 +1,158 @@
+---
+subcategory: "App Service (Web Apps)"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_app_service_virtual_network_gateway_connection"
+description: |-
+  Manages a Gateway-requiring Virtual Network Connection.
+---
+
+# azurerm_app_service_virtual_network_gateway_connection
+
+Manages a Gateway-requiring Virtual Network Connection.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "accexample-VNET-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "North Europe"
+  resource_group_name = azurerm_resource_group.example.name
+  lifecycle {
+    ignore_changes = [ddos_protection_plan]
+  }
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "example" {
+  name                = "example"
+  location            = azurerm_virtual_network.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  allocation_method = "Dynamic"
+}
+
+resource "azurerm_virtual_network_gateway" "example" {
+  name                = "example"
+  location            = azurerm_virtual_network.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  type     = "Vpn"
+  vpn_type = "RouteBased"
+
+  active_active = false
+  enable_bgp    = false
+  sku           = "VpnGw1"
+
+  ip_configuration {
+    name                          = "vnetGatewayConfig"
+    public_ip_address_id          = azurerm_public_ip.example.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.example.id
+  }
+
+  vpn_client_configuration {
+    address_space = ["192.168.0.96/29"]
+
+    vpn_client_protocols = ["SSTP"]
+
+    root_certificate {
+      name = "example"
+
+      public_cert_data = <<EOF
+	MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
+	MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+	d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
+	Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
+	BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
+	Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
+	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
+	QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
+	zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
+	GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
+	GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
+	Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
+	DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
+	HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
+	jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
+	9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
+	QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
+	uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
+	WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
+	M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
+	EOF
+
+    }
+  }
+}
+
+resource "azurerm_app_service_plan" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  sku {
+    tier = "Standard"
+    size = "S1"
+  }
+}
+
+resource "azurerm_app_service" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  app_service_plan_id = azurerm_app_service_plan.example.id
+}
+
+resource "azurerm_app_service_virtual_network_gateway_connection" "example" {
+  app_service_id          = azurerm_app_service.example.id
+  vnet_id                 = azurerm_virtual_network.example.id
+  vpn_gateway_package_uri = azurerm_virtual_network_gateway.example.vpn_client_configuration.0.vpn_profile_package_uri
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `app_service_id` - (Required) The ID of the App Service associated to the Virtual Network. Changing this forces a new Gateway-requiring Virtual Network Connection to be created.
+
+* `vnet_id` - (Required) The ID of the VNet. Changing this forces a new Gateway-requiring Virtual Network Connection to be created.
+
+* `vpn_gateway_package_uri` - (Required) The URI of the endpoint providing the configuration for the VPN connection. 
+
+~> Note: The URI is used and applied the first time, after that it is ignored until the resource is recreated.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Gateway-requiring Virtual Network Connection.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Gateway-requiring Virtual Network Connection.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Gateway-requiring Virtual Network Connection.
+* `update` - (Defaults to 30 minutes) Used when updating the Gateway-requiring Virtual Network Connection.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Gateway-requiring Virtual Network Connection.
+
+## Import
+
+Gateway-requiring Virtual Network Connections can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_app_service_virtual_network_gateway_connection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Web/sites/appservice1/virtualNetworkConnections/vnet1
+```


### PR DESCRIPTION
Fixes #1460

## Affected resources
- `azurerm_virtual_network_gateway` (extra output, `vpn_profile_package_uri`)
- `azurerm_app_service_virtual_network_gateway_connection` (new resource)

### Example
```hcl
resource "azurerm_resource_group" "example" {
  name     = "example"
  location = "West Europe"
}

resource "azurerm_virtual_network" "example" {
  name                = "accexample-VNET-%d"
  address_space       = ["10.0.0.0/16"]
  location            = "North Europe"
  resource_group_name = azurerm_resource_group.example.name

  lifecycle {
    ignore_changes = [ddos_protection_plan]
  }
}

resource "azurerm_subnet" "example" {
  name                 = "GatewaySubnet"
  resource_group_name  = azurerm_resource_group.example.name
  virtual_network_name = azurerm_virtual_network.example.name
  address_prefixes     = ["10.0.1.0/24"]
}

resource "azurerm_public_ip" "example" {
  name                = "example"
  location            = azurerm_virtual_network.example.location 
  resource_group_name = azurerm_resource_group.example.name

  allocation_method = "Dynamic"
}

resource "azurerm_virtual_network_gateway" "example" {
  name                = "example"
  location            = azurerm_virtual_network.example.location
  resource_group_name = azurerm_resource_group.example.name

  type     = "Vpn"
  vpn_type = "RouteBased"

  active_active = false
  enable_bgp    = false
  sku           = "VpnGw1"

  ip_configuration {
    name                          = "vnetGatewayConfig"
    public_ip_address_id          = azurerm_public_ip.example.id
    private_ip_address_allocation = "Dynamic"
    subnet_id                     = azurerm_subnet.example.id
  }

  vpn_client_configuration {
    address_space = ["192.168.0.96/29"]

    vpn_client_protocols = ["SSTP"]

    root_certificate {
      name = "example"
      public_cert_data = <<EOF
MIIDuzCCAqOgAwIBAgIQCHTZWCM+IlfFIRXIvyKSrjANBgkqhkiG9w0BAQsFADBn
MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
d3cuZGlnaWNlcnQuY29tMSYwJAYDVQQDEx1EaWdpQ2VydCBGZWRlcmF0ZWQgSUQg
Um9vdCBDQTAeFw0xMzAxMTUxMjAwMDBaFw0zMzAxMTUxMjAwMDBaMGcxCzAJBgNV
BAYTAlVTMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdp
Y2VydC5jb20xJjAkBgNVBAMTHURpZ2lDZXJ0IEZlZGVyYXRlZCBJRCBSb290IENB
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvAEB4pcCqnNNOWE6Ur5j
QPUH+1y1F9KdHTRSza6k5iDlXq1kGS1qAkuKtw9JsiNRrjltmFnzMZRBbX8Tlfl8
zAhBmb6dDduDGED01kBsTkgywYPxXVTKec0WxYEEF0oMn4wSYNl0lt2eJAKHXjNf
GTwiibdP8CUR2ghSM2sUTI8Nt1Omfc4SMHhGhYD64uJMbX98THQ/4LMGuYegou+d
GTiahfHtjn7AboSEknwAMJHCh5RlYZZ6B1O4QbKJ+34Q0eKgnI3X6Vc9u0zf6DH8
Dk+4zQDYRRTqTnVO3VT8jzqDlCRuNtq6YvryOWN74/dq8LQhUnXHvFyrsdMaE1X2
DwIDAQABo2MwYTAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNV
HQ4EFgQUGRdkFnbGt1EWjKwbUne+5OaZvRYwHwYDVR0jBBgwFoAUGRdkFnbGt1EW
jKwbUne+5OaZvRYwDQYJKoZIhvcNAQELBQADggEBAHcqsHkrjpESqfuVTRiptJfP
9JbdtWqRTmOf6uJi2c8YVqI6XlKXsD8C1dUUaaHKLUJzvKiazibVuBwMIT84AyqR
QELn3e0BtgEymEygMU569b01ZPxoFSnNXc7qDZBDef8WfqAV/sxkTi8L9BkmFYfL
uGLOhRJOFprPdoDIUBB+tmCl3oDcBy3vnUeOEioz8zAkprcb3GHwHAK+vHmmfgcn
WsfMLH4JCLa/tRYL+Rw/N3ybCkDp00s0WUZ+AoDywSl0Q/ZEnNY0MsFiw6LyIdbq
M/s/1JRtO3bDSzD9TazRVzn2oBqzSa8VgIo5C1nOnoAKJTlsClJKvIhnRlaLQqk=
      EOF
    }
  }
}
```

## Naming
As `azurerm_app_service_virtual_network_gateway_connection` is probably also applicable for `azurerm_function_app` I'm struggling with a good naming convention for the resource. This would also affect `azurerm_app_service_virtual_network_swift_connection`, as based on the issue and the documentation the possibility of using it with `azurerm_function_app` is unclear.

## Acceptance Tests
- 1/1 test is passing for the specific resource:
```bash
--- PASS: TestAccAzureRMAppServiceVirtualNetworkGatewayConnection_basic (2252.60s)
```
- all VNet Gateway tests should pass, as I touched it:
```bash

```