### PR TITLE
`azurerm_app_service` `ip_restriction` - add default for `priority`

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -325,7 +325,7 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 							"priority": {
 								Type:         schema.TypeInt,
 								Optional:     true,
-								Computed:     true,
+								Default:      65000,
 								ValidateFunc: validation.IntBetween(1, 2147483647),
 							},
 							"action": {

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -538,7 +538,7 @@ func TestAccAzureRMAppService_completeIpRestriction(t *testing.T) {
 				Config: testAccAzureRMAppService_manyCompleteIpRestrictions(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.#", "3"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.ip_address", "10.10.10.10/32"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.name", "test-restriction"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.0.priority", "123"),
@@ -547,6 +547,10 @@ func TestAccAzureRMAppService_completeIpRestriction(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.1.name", "test-restriction-2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.1.priority", "1234"),
 					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.1.action", "Deny"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.2.ip_address", "30.30.30.0/24"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.2.name", "test-restriction-3"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.2.priority", "65000"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.ip_restriction.2.action", "Deny"),
 				),
 			},
 			data.ImportStep(),
@@ -2736,6 +2740,12 @@ resource "azurerm_app_service" "test" {
       name       = "test-restriction-2"
       priority   = 1234
       action     = "Deny"
+    }
+
+    ip_restriction {
+	  ip_address = "30.30.30.0/24"
+	  name       = "test-restriction-3"
+	  action     = "Deny"
     }
   }
 }

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -2743,9 +2743,9 @@ resource "azurerm_app_service" "test" {
     }
 
     ip_restriction {
-	  ip_address = "30.30.30.0/24"
-	  name       = "test-restriction-3"
-	  action     = "Deny"
+      ip_address = "30.30.30.0/24"
+      name       = "test-restriction-3"
+      action     = "Deny"
     }
   }
 }


### PR DESCRIPTION
Fixes: #6876

As noted in the issue, an apply will fail with the `Priority must be specified in an all or nothing manner` error if multiple ip restrictions are created and some have priority specified while others do not. This PR addresses that error by setting a default `priority` value of `65000` (this is what Azure defaults to) instead of trying to compute the value. 

```
=== RUN   TestAccAzureRMAppService_completeIpRestriction
=== PAUSE TestAccAzureRMAppService_completeIpRestriction
=== CONT  TestAccAzureRMAppService_completeIpRestriction
--- PASS: TestAccAzureRMAppService_completeIpRestriction (196.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/web/tests   196.940s
```