### PR TITLE
Update `azurerm_policy_assignment` - `location` should be required when `identity` is assigned

### DIFF
--- a/azurerm/internal/services/policy/policy_assignment_resource.go
+++ b/azurerm/internal/services/policy/policy_assignment_resource.go
@@ -159,6 +159,9 @@ func resourceArmPolicyAssignmentCreateUpdate(d *schema.ResourceData, meta interf
 	}
 
 	if _, ok := d.GetOk("identity"); ok {
+		if v := d.Get("location").(string); v == "" {
+			return fmt.Errorf("`location` must be set when `identity` is assigned")
+		}
 		policyIdentity := expandAzureRmPolicyIdentity(d)
 		assignment.Identity = policyIdentity
 	}


### PR DESCRIPTION
Fixes #4950 

This PR enforce this logic in the code. Previously, this is only documented, but not enforced in the code.