### PR TITLE
azurerm_logic_app_action_http: add `run_after`

### DIFF
--- a/azurerm/internal/services/logic/logic_apps.go
+++ b/azurerm/internal/services/logic/logic_apps.go
@@ -16,6 +16,32 @@ import (
 )
 
 // NOTE: this file is not a recommended way of developing Terraform resources; this exists to work around the fact that this API is dynamic (by it's nature)
+func flattenLogicAppActionRunAfter(input map[string]interface{}) []interface{} {
+	if len(input) == 0 {
+		return nil
+	}
+	output := []interface{}{}
+	for k, v := range input {
+		output = append(output, map[string]interface{}{
+			"action_name":   k,
+			"action_result": v.([]interface{})[0],
+		})
+	}
+
+	return output
+}
+func expandLogicAppActionRunAfter(input []interface{}) map[string]interface{} {
+	if len(input) == 0 {
+		return nil
+	}
+	output := map[string]interface{}{}
+	for _, v := range input {
+		b := v.(map[string]interface{})
+		output[b["action_name"].(string)] = []string{b["action_result"].(string)}
+	}
+
+	return output
+}
 
 func resourceLogicAppActionUpdate(d *schema.ResourceData, meta interface{}, logicAppId string, name string, vals map[string]interface{}, resourceName string) error {
 	return resourceLogicAppComponentUpdate(d, meta, "Action", "actions", logicAppId, name, vals, resourceName)

--- a/website/docs/r/logic_app_action_http.html.markdown
+++ b/website/docs/r/logic_app_action_http.html.markdown
@@ -50,6 +50,16 @@ The following arguments are supported:
 
 * `headers` - (Optional) Specifies a Map of Key-Value Pairs that should be sent to the `uri` when this HTTP Action is triggered.
 
+* `run_after` - (Optional) Specifies the place of the HTTP Action in the Logic App Workflow. If not specified, the HTTP Action is right after the Trigger. A `run_after` block is as defined below.
+
+---
+
+A `run_after` block supports the following:
+
+* `action_name` - (Required) Specifies the name of the precedent HTTP Action.
+
+* `action_result` - (Required) Specifies the expected result of the precedent HTTP Action, only after which the current HTTP Action will be triggered.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Fixes terraform-providers/terraform-provider-azurerm#7069

## Test Result

```bash
💤 😡 127 via 🦉 v1.14.3 make testacc TEST=./azurerm/internal/services/logic/tests TESTARGS="-run='TestAccAzureRMLogicAppActionHttp_runAfter'"                       
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/logic/tests -v -run='TestAccAzureRMLogicAppActionHttp_runAfter' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLogicAppActionHttp_runAfter
=== PAUSE TestAccAzureRMLogicAppActionHttp_runAfter
=== CONT  TestAccAzureRMLogicAppActionHttp_runAfter
--- PASS: TestAccAzureRMLogicAppActionHttp_runAfter (184.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/logic/tests 184.291s
```