### PR TITLE
acctest: updating the build config definition to 2020.1

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -2,7 +2,7 @@ import AzureRM
 import ClientConfiguration
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
 
-version = "2019.2"
+version = "2020.1"
 
 var clientId = DslContext.getParameter("clientId", "")
 var clientSecret = DslContext.getParameter("clientSecret", "")


### PR DESCRIPTION
Recommended after upgrading to 2020.1

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running tests.ParallelismTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.121 sec
Running tests.ConfigurationTests
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.293 sec
Running tests.VcsTests
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec

Results :

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```