### PR TITLE
`azurerm_monitor_action_group` - Doc Fix`function_app_resource_id` 

### DIFF
--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -151,7 +151,7 @@ The following arguments are supported:
 `azure_function_receiver` supports the following:
 
 * `name` - (Required) The name of the Azure Function receiver.
-* `function_app_resouce_id` - (Required) The Azure resource ID of the function app.
+* `function_app_resource_id` - (Required) The Azure resource ID of the function app.
 * `function_name` - (Required) The function name in the function app.
 * `http_trigger_url` - (Required) The http trigger url where http request sent to.
 * `use_common_alert_schema` - (Optional) Enables or disables the common alert schema.


### PR DESCRIPTION
Fix monitor_action_group azure_function_receiver function_app_resource_id typo