### PR TITLE
acctests: fixing a missing `%`

### DIFF
--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -42,7 +42,7 @@ fun BuildSteps.RunAcceptanceTests(providerName : String, packageName: String) {
         step(ScriptBuildStep {
             // ./test-binary -test.list=TestAccAzureRMResourceGroup_ | teamcity-go-test -test ./test-binary -timeout 1s
             name = "Run via jen20/teamcity-go-test"
-            scriptContent = "./test-binary -test.list=\"%TEST_PREFIX%\" | teamcity-go-test -test ./test-binary -parallelism \"%PARALLELISM%\" -timeout \"TIMEOUT%h\""
+            scriptContent = "./test-binary -test.list=\"%TEST_PREFIX%\" | teamcity-go-test -test ./test-binary -parallelism \"%PARALLELISM%\" -timeout \"%TIMEOUT%h\""
             workingDir = servicePath
         })
     }


### PR DESCRIPTION
As it stands this runs without substitution