### PR TITLE
azurerm_hdinsight_*_cluster - fix broken updaten due to api not allowing cluster to be disabled

### DIFF
--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight"
@@ -94,9 +93,19 @@ func SchemaHDInsightsGateway() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
-					Type:     schema.TypeBool,
-					Required: true,
-					ForceNew: true,
+					Type:       schema.TypeBool,
+					Optional:   true,
+					ForceNew:   false,
+					Computed:   true,
+					Deprecated: "HDInsight doesn't support disabling gateway anymore",
+					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+						enabled := i.(bool)
+
+						if !enabled {
+							errors = append(errors, fmt.Errorf("Only true is supported, because HDInsight doesn't support disabling gateway anymore. Provided value %t", enabled))
+						}
+						return warnings, errors
+					},
 				},
 				// NOTE: these are Required since if these aren't present you get a `500 bad request`
 				"username": {
@@ -160,7 +169,7 @@ func ExpandHDInsightsConfigurations(input []interface{}) map[string]interface{} 
 	vs := input[0].(map[string]interface{})
 
 	// NOTE: Admin username must be different from SSH Username
-	enabled := vs["enabled"].(bool)
+	enabled := true
 	username := vs["username"].(string)
 	password := vs["password"].(string)
 
@@ -254,13 +263,7 @@ func ExpandHDInsightsAmbariMetastore(input []interface{}) map[string]interface{}
 }
 
 func FlattenHDInsightsConfigurations(input map[string]*string) []interface{} {
-	enabled := false
-	if v, exists := input["restAuthCredential.isEnabled"]; exists && v != nil {
-		e, err := strconv.ParseBool(*v)
-		if err == nil {
-			enabled = e
-		}
-	}
+	enabled := true
 
 	username := ""
 	if v, exists := input["restAuthCredential.username"]; exists && v != nil {

--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -116,7 +116,7 @@ func SchemaHDInsightsGateway() *schema.Schema {
 				"password": {
 					Type:      schema.TypeString,
 					Required:  true,
-					ForceNew:  true,
+					ForceNew:  false,
 					Sensitive: true,
 					// Azure returns the key as *****. We'll suppress that here.
 					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {

--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -92,10 +92,11 @@ func SchemaHDInsightsGateway() *schema.Schema {
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
+				// TODO 3.0: remove this attribute
 				"enabled": {
 					Type:       schema.TypeBool,
 					Optional:   true,
-                                        Default: true,
+					Default:    true,
 					Deprecated: "HDInsight doesn't support disabling gateway anymore",
 					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
 						enabled := i.(bool)

--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -95,8 +95,7 @@ func SchemaHDInsightsGateway() *schema.Schema {
 				"enabled": {
 					Type:       schema.TypeBool,
 					Optional:   true,
-					ForceNew:   false,
-					Computed:   true,
+                                        Default: true,
 					Deprecated: "HDInsight doesn't support disabling gateway anymore",
 					ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
 						enabled := i.(bool)
@@ -116,7 +115,6 @@ func SchemaHDInsightsGateway() *schema.Schema {
 				"password": {
 					Type:      schema.TypeString,
 					Required:  true,
-					ForceNew:  false,
 					Sensitive: true,
 					// Azure returns the key as *****. We'll suppress that here.
 					DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_hadoop_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_hadoop_cluster_resource_test.go
@@ -452,7 +452,6 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 
   gateway {
-    enabled  = true
     username = "acctestusrgw"
     password = "TerrAform123!"
   }

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_hadoop_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_hadoop_cluster_resource_test.go
@@ -435,6 +435,47 @@ func TestAccAzureRMHDInsightHadoopCluster_updateMetastore(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMHDInsightHadoopCluster_updateGateway(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hadoop_cluster", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMHDInsightClusterDestroy(data.ResourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMHDInsightHadoopCluster_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"storage_account"),
+			{
+				Config: testAccAzureRMHDInsightHadoopCluster_updateGateway(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMHDInsightClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "https_endpoint"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "ssh_endpoint"),
+				),
+			},
+			data.ImportStep("roles.0.head_node.0.password",
+				"roles.0.head_node.0.vm_size",
+				"roles.0.worker_node.0.password",
+				"roles.0.worker_node.0.vm_size",
+				"roles.0.zookeeper_node.0.password",
+				"roles.0.zookeeper_node.0.vm_size",
+				"storage_account"),
+		},
+	})
+}
+
 func testAccAzureRMHDInsightHadoopCluster_basic(data acceptance.TestData) string {
 	template := testAccAzureRMHDInsightHadoopCluster_template(data)
 	return fmt.Sprintf(`
@@ -1314,4 +1355,55 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMHDInsightHadoopCluster_updateGateway(data acceptance.TestData) string {
+	template := testAccAzureRMHDInsightHadoopCluster_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hdinsight_hadoop_cluster" "test" {
+  name                = "acctesthdi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_version     = "3.6"
+  tier                = "Standard"
+
+  component_version {
+    hadoop = "2.7"
+  }
+
+  gateway {
+    username = "acctestusrgw"
+    password = "TerrAformne3!"
+  }
+
+  storage_account {
+    storage_container_id = azurerm_storage_container.test.id
+    storage_account_key  = azurerm_storage_account.test.primary_access_key
+    is_default           = true
+  }
+
+  roles {
+    head_node {
+      vm_size  = "Standard_D3_v2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+
+    worker_node {
+      vm_size               = "Standard_D4_V2"
+      username              = "acctestusrvm"
+      password              = "AccTestvdSC4daf986!"
+      target_instance_count = 2
+    }
+
+    zookeeper_node {
+      vm_size  = "Standard_D3_v2"
+      username = "acctestusrvm"
+      password = "AccTestvdSC4daf986!"
+    }
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -123,9 +123,9 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -123,7 +123,7 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -121,9 +121,9 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -121,7 +121,7 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -119,9 +119,9 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -119,7 +119,7 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -122,9 +122,9 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -122,7 +122,7 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 

--- a/website/docs/r/hdinsight_ml_services_cluster.html.markdown
+++ b/website/docs/r/hdinsight_ml_services_cluster.html.markdown
@@ -116,7 +116,7 @@ The following arguments are supported:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 

--- a/website/docs/r/hdinsight_ml_services_cluster.html.markdown
+++ b/website/docs/r/hdinsight_ml_services_cluster.html.markdown
@@ -116,9 +116,9 @@ The following arguments are supported:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_rserver_cluster.html.markdown
+++ b/website/docs/r/hdinsight_rserver_cluster.html.markdown
@@ -116,7 +116,7 @@ The following arguments are supported:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 

--- a/website/docs/r/hdinsight_rserver_cluster.html.markdown
+++ b/website/docs/r/hdinsight_rserver_cluster.html.markdown
@@ -116,9 +116,9 @@ The following arguments are supported:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -121,9 +121,9 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -121,7 +121,7 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 

--- a/website/docs/r/hdinsight_storm_cluster.html.markdown
+++ b/website/docs/r/hdinsight_storm_cluster.html.markdown
@@ -119,9 +119,9 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Required) Is the Ambari portal enabled? Changing this forces a new resource to be created.
+* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
 
-* `password` - (Required) The password used for the Ambari Portal. Changing this forces a new resource to be created.
+* `password` - (Required) The password used for the Ambari Portal.
 
 -> **NOTE:** This password must be different from the one used for the `head_node`, `worker_node` and `zookeeper_node` roles.
 

--- a/website/docs/r/hdinsight_storm_cluster.html.markdown
+++ b/website/docs/r/hdinsight_storm_cluster.html.markdown
@@ -119,7 +119,7 @@ A `component_version` block supports the following:
 
 A `gateway` block supports the following:
 
-* `enabled` - (Optional) Is the Ambari portal enabled? Deprecated: HDInsight doesn't support disabling gateway anymore.
+* `enabled` - (Optional/ **Deprecated) Is the Ambari portal enabled? The HDInsight API doesn't support disabling gateway anymore.
 
 * `password` - (Required) The password used for the Ambari Portal.
 


### PR DESCRIPTION
Fixes issues like https://github.com/terraform-providers/terraform-provider-azurerm/issues/7067

HDInisght doesn't support disabling Gateway/Ambari for Linux clusters and only Linux clusters supported. 
Making gateway.enabled property always equal true.
Also using API call to update Gateway settings (changing password)


