### PR TITLE
 Remove ineffective tags from RecoveryServices.Backup

### DIFF
--- a/azurerm/internal/services/recoveryservices/data_source_backup_policy_vm.go
+++ b/azurerm/internal/services/recoveryservices/data_source_backup_policy_vm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -34,6 +35,8 @@ func dataSourceArmBackupPolicyVm() *schema.Resource {
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"tags": tags.SchemaDataSource(),
 		},
 	}
 }
@@ -61,5 +64,5 @@ func dataSourceArmBackupPolicyVmRead(d *schema.ResourceData, meta interface{}) e
 	id := strings.Replace(*protectionPolicy.ID, "Subscriptions", "subscriptions", 1)
 	d.SetId(id)
 
-	return nil
+	return tags.FlattenAndSet(d, protectionPolicy.Tags)
 }

--- a/azurerm/internal/services/recoveryservices/data_source_backup_policy_vm.go
+++ b/azurerm/internal/services/recoveryservices/data_source_backup_policy_vm.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -35,8 +34,6 @@ func dataSourceArmBackupPolicyVm() *schema.Resource {
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
-
-			"tags": tags.SchemaDataSource(),
 		},
 	}
 }
@@ -64,5 +61,5 @@ func dataSourceArmBackupPolicyVmRead(d *schema.ResourceData, meta interface{}) e
 	id := strings.Replace(*protectionPolicy.ID, "Subscriptions", "subscriptions", 1)
 	d.SetId(id)
 
-	return tags.FlattenAndSet(d, protectionPolicy.Tags)
+	return nil
 }

--- a/azurerm/internal/services/recoveryservices/data_source_backup_policy_vm.go
+++ b/azurerm/internal/services/recoveryservices/data_source_backup_policy_vm.go
@@ -34,6 +34,15 @@ func dataSourceArmBackupPolicyVm() *schema.Resource {
 			},
 
 			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Deprecated: "The Service API doesn't support `tags`. See more details from https://github.com/Azure/azure-rest-api-specs/issues/9251.",
+			},
 		},
 	}
 }

--- a/azurerm/internal/services/recoveryservices/resource_arm_backup_policy_vm.go
+++ b/azurerm/internal/services/recoveryservices/resource_arm_backup_policy_vm.go
@@ -19,6 +19,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -244,6 +245,16 @@ func resourceArmBackupProtectionPolicyVM() *schema.Resource {
 						},
 					},
 				},
+			},
+
+			"tags": {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				ValidateFunc: tags.Validate,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Deprecated: "The Service API doesn't support `tags`. See more details from https://github.com/Azure/azure-rest-api-specs/issues/9251.",
 			},
 		},
 

--- a/azurerm/internal/services/recoveryservices/resource_arm_backup_policy_vm.go
+++ b/azurerm/internal/services/recoveryservices/resource_arm_backup_policy_vm.go
@@ -19,7 +19,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -246,8 +245,6 @@ func resourceArmBackupProtectionPolicyVM() *schema.Resource {
 					},
 				},
 			},
-
-			"tags": tags.Schema(),
 		},
 
 		// if daily, we need daily retention
@@ -289,7 +286,6 @@ func resourceArmBackupProtectionPolicyVMCreateUpdate(d *schema.ResourceData, met
 	policyName := d.Get("name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
-	t := d.Get("tags").(map[string]interface{})
 
 	log.Printf("[DEBUG] Creating/updating Azure Backup Protection Policy %s (resource group %q)", policyName, resourceGroup)
 
@@ -315,7 +311,6 @@ func resourceArmBackupProtectionPolicyVMCreateUpdate(d *schema.ResourceData, met
 	}
 
 	policy := backup.ProtectionPolicyResource{
-		Tags: tags.Expand(t),
 		Properties: &backup.AzureIaaSVMProtectionPolicy{
 			TimeZone:             utils.String(d.Get("timezone").(string)),
 			BackupManagementType: backup.BackupManagementTypeAzureIaasVM,
@@ -418,7 +413,7 @@ func resourceArmBackupProtectionPolicyVMRead(d *schema.ResourceData, meta interf
 		}
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceArmBackupProtectionPolicyVMDelete(d *schema.ResourceData, meta interface{}) error {

--- a/azurerm/internal/services/recoveryservices/resource_arm_backup_protected_vm.go
+++ b/azurerm/internal/services/recoveryservices/resource_arm_backup_protected_vm.go
@@ -14,7 +14,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -60,8 +59,6 @@ func resourceArmRecoveryServicesBackupProtectedVM() *schema.Resource {
 				Required:     true,
 				ValidateFunc: azure.ValidateResourceID,
 			},
-
-			"tags": tags.Schema(),
 		},
 	}
 }
@@ -72,7 +69,6 @@ func resourceArmRecoveryServicesBackupProtectedVMCreateUpdate(d *schema.Resource
 	defer cancel()
 
 	resourceGroup := d.Get("resource_group_name").(string)
-	t := d.Get("tags").(map[string]interface{})
 
 	vaultName := d.Get("recovery_vault_name").(string)
 	vmId := d.Get("source_vm_id").(string)
@@ -107,7 +103,6 @@ func resourceArmRecoveryServicesBackupProtectedVMCreateUpdate(d *schema.Resource
 	}
 
 	item := backup.ProtectedItemResource{
-		Tags: tags.Expand(t),
 		Properties: &backup.AzureIaaSComputeVMProtectedItem{
 			PolicyID:          &policyId,
 			ProtectedItemType: backup.ProtectedItemTypeMicrosoftClassicComputevirtualMachines,
@@ -173,7 +168,7 @@ func resourceArmRecoveryServicesBackupProtectedVMRead(d *schema.ResourceData, me
 		}
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceArmRecoveryServicesBackupProtectedVMDelete(d *schema.ResourceData, meta interface{}) error {

--- a/azurerm/internal/services/recoveryservices/resource_arm_backup_protected_vm.go
+++ b/azurerm/internal/services/recoveryservices/resource_arm_backup_protected_vm.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -58,6 +59,16 @@ func resourceArmRecoveryServicesBackupProtectedVM() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"tags": {
+				Type:         schema.TypeMap,
+				Optional:     true,
+				ValidateFunc: tags.Validate,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Deprecated: "The Service API doesn't support `tags`. See more details from https://github.com/Azure/azure-rest-api-specs/issues/9251.",
 			},
 		},
 	}

--- a/azurerm/internal/services/recoveryservices/tests/data_source_backup_policy_vm_test.go
+++ b/azurerm/internal/services/recoveryservices/tests/data_source_backup_policy_vm_test.go
@@ -22,7 +22,6 @@ func TestAccDataSourceAzureRMBackupPolicyVm_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(data.ResourceName, "name"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "recovery_vault_name"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "resource_group_name"),
-					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "0"),
 				),
 			},
 		},

--- a/website/docs/d/backup_policy_vm.markdown
+++ b/website/docs/d/backup_policy_vm.markdown
@@ -36,9 +36,6 @@ The following attributes are exported:
 
 * `id` - The ID of the Backup VM Protection Policy.
 
-* `tags` - A mapping of tags assigned to the resource.
-
-
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/d/backup_policy_vm.markdown
+++ b/website/docs/d/backup_policy_vm.markdown
@@ -36,6 +36,10 @@ The following attributes are exported:
 
 * `id` - The ID of the Backup VM Protection Policy.
 
+* `tags` - A mapping of tags assigned to the resource.
+
+~> **Note:** `tags` has been deprecated and will be removed since the Service API doesn't support it. See more details from https://github.com/Azure/azure-rest-api-specs/issues/9251.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/d/backup_policy_vm.markdown
+++ b/website/docs/d/backup_policy_vm.markdown
@@ -36,6 +36,8 @@ The following attributes are exported:
 
 * `id` - The ID of the Backup VM Protection Policy.
 
+* `tags` - A mapping of tags assigned to the resource.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/d/backup_policy_vm.markdown
+++ b/website/docs/d/backup_policy_vm.markdown
@@ -38,6 +38,7 @@ The following attributes are exported:
 
 * `tags` - A mapping of tags assigned to the resource.
 
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:

--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 
 * `retention_yearly` - (Optional) Configures the policy yearly retention as documented in the `retention_yearly` block below.
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
 
 The `backup` block supports:

--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -85,6 +85,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+~> **Note:** `tags` has been deprecated and will be removed since the Service API doesn't support it. See more details from https://github.com/Azure/azure-rest-api-specs/issues/9251.
+
 ---
 
 The `backup` block supports:

--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -83,8 +83,6 @@ The following arguments are supported:
 
 * `retention_yearly` - (Optional) Configures the policy yearly retention as documented in the `retention_yearly` block below.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
-
 ---
 
 The `backup` block supports:

--- a/website/docs/r/backup_protected_vm.markdown
+++ b/website/docs/r/backup_protected_vm.markdown
@@ -58,6 +58,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+~> **Note:** `tags` has been deprecated and will be removed since the Service API doesn't support it. See more details from https://github.com/Azure/azure-rest-api-specs/issues/9251.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/backup_protected_vm.markdown
+++ b/website/docs/r/backup_protected_vm.markdown
@@ -56,8 +56,6 @@ The following arguments are supported:
 
 * `backup_policy_id` - (Required) Specifies the id of the backup policy to use.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
-
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/backup_protected_vm.markdown
+++ b/website/docs/r/backup_protected_vm.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `backup_policy_id` - (Required) Specifies the id of the backup policy to use.
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
fixes terraform-providers/terraform-provider-azurerm#5729

After confirmed with service team, tags is ineffective. (Azure/azure-rest-api-specs#9251)