### PR TITLE
azuerm_function_app - correctly set kind when os_type is `linux`

### DIFF
--- a/azurerm/internal/services/web/resource_arm_function_app.go
+++ b/azurerm/internal/services/web/resource_arm_function_app.go
@@ -448,7 +448,7 @@ func resourceArmFunctionAppUpdate(d *schema.ResourceData, meta interface{}) erro
 	kind := "functionapp"
 	if osTypeRaw, ok := d.GetOk("os_type"); ok {
 		osType := osTypeRaw.(string)
-		if osType == "Linux" {
+		if osType == "linux" {
 			kind = "functionapp,linux"
 		}
 	}


### PR DESCRIPTION
There is a typo in the code where osType is "Linux" instead of "linux". The format does not match with checks and other parts of the code such as in row 354.

Current behaviour causes the function app to be generated as Windows despite the value of os_type.  This fixes #6931 for example.