### PR TITLE
Add Virtual Machine Scale Set Data Source

### DIFF
--- a/azurerm/internal/services/compute/registration.go
+++ b/azurerm/internal/services/compute/registration.go
@@ -35,6 +35,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 		"azurerm_shared_image":              dataSourceArmSharedImage(),
 		"azurerm_snapshot":                  dataSourceArmSnapshot(),
 		"azurerm_virtual_machine":           dataSourceArmVirtualMachine(),
+		"azurerm_virtual_machine_scale_set": dataSourceArmVirtualMachineScaleSet(),
 	}
 }
 

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_resource_test.go
@@ -91,7 +91,7 @@ resource "azurerm_subnet" "test" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/tests/virtual_machine_scale_set_data_source_test.go
+++ b/azurerm/internal/services/compute/tests/virtual_machine_scale_set_data_source_test.go
@@ -1,0 +1,72 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine_scale_set", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { acceptance.PreCheck(t) },
+		Providers: acceptance.SupportedProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.0.type", "SystemAssigned"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.0.principal_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine_scale_set", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.0.type", "SystemAssigned"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "identity.0.principal_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux(data acceptance.TestData) string {
+	template := testAccAzureRMLinuxVirtualMachineScaleSet_identitySystemAssigned(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_virtual_machine_scale_set" "test" {
+  name                = azurerm_linux_virtual_machine_scale_set.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func testAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows(data acceptance.TestData) string {
+	template := testAccAzureRMWindowsVirtualMachineScaleSet_identitySystemAssigned(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_virtual_machine_scale_set" "test" {
+  name                = azurerm_windows_virtual_machine_scale_set.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}

--- a/azurerm/internal/services/compute/tests/virtual_machine_scale_set_data_source_test.go
+++ b/azurerm/internal/services/compute/tests/virtual_machine_scale_set_data_source_test.go
@@ -47,6 +47,24 @@ func TestAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAzureRMVirtualMachineScaleSet_orchestrated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_virtual_machine_scale_set", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAzureRMVirtualMachineScaleSet_orchestrated(data),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(data.ResourceName, "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux(data acceptance.TestData) string {
 	template := testAccAzureRMLinuxVirtualMachineScaleSet_identitySystemAssigned(data)
 	return fmt.Sprintf(`
@@ -66,6 +84,18 @@ func testAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows(data acceptance
 
 data "azurerm_virtual_machine_scale_set" "test" {
   name                = azurerm_windows_virtual_machine_scale_set.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func testAccDataSourceAzureRMVirtualMachineScaleSet_orchestrated(data acceptance.TestData) string {
+	template := testAccAzureRMWindowsVirtualMachine_orchestratedZonal(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_virtual_machine_scale_set" "test" {
+  name                = azurerm_orchestrated_virtual_machine_scale_set.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
 `, template)

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_resource_test.go
@@ -95,7 +95,7 @@ resource "azurerm_subnet" "test" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 `, name, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -1,0 +1,87 @@
+package compute
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func dataSourceArmVirtualMachineScaleSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmVirtualMachineScaleSetRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameForDataSource(),
+
+			"location": azure.SchemaLocationForDataSource(),
+
+			"identity": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"identity_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
+						"principal_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.VMScaleSetClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	resGroup := d.Get("resource_group_name").(string)
+	name := d.Get("name").(string)
+
+	resp, err := client.Get(ctx, resGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Error: Virtual Machine Scale Set %q (Resource Group %q) was not found", name, resGroup)
+		}
+
+		return fmt.Errorf("Error making Read request on Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	if err := d.Set("identity", FlattenVirtualMachineScaleSetIdentity(resp.Identity)); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -77,6 +77,9 @@ func dataSourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error making Read request on Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("Error reading Virtual Machine Scale Set %q (Resource Group %q): ID is empty or nil", name, resourceGroup)
+	}
 	d.SetId(*resp.ID)
 
 	if err := d.Set("identity", FlattenVirtualMachineScaleSetIdentity(resp.Identity)); err != nil {

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -78,7 +78,7 @@ func dataSourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interf
 	}
 
 	if resp.ID == nil || *resp.ID == "" {
-		return fmt.Errorf("Error reading Virtual Machine Scale Set %q (Resource Group %q): ID is empty or nil", name, resourceGroup)
+		return fmt.Errorf("Error reading Virtual Machine Scale Set %q (Resource Group %q): ID is empty or nil", name, resGroup)
 	}
 	d.SetId(*resp.ID)
 

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -602,6 +602,10 @@
                 </li>
 
                 <li>
+                    <a href="/docs/providers/azurerm/d/virtual_machine_scale_set.html">azurerm_virtual_machine_scale_set</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/virtual_network.html">azurerm_virtual_network</a>
                 </li>
 

--- a/website/docs/d/virtual_machine_scale_set.html.markdown
+++ b/website/docs/d/virtual_machine_scale_set.html.markdown
@@ -47,7 +47,7 @@ A `identity` block exports the following:
 
 * `principal_id` - The ID of the System Managed Service Principal assigned to the Virtual Machine Scale Set.
 
-* `type` - The identity types of the Managed Identity assigned to the Virtual Machine Scale Set.
+* `type` - The identity type of the Managed Identity assigned to the Virtual Machine Scale Set.
 
 ## Timeouts
 

--- a/website/docs/d/virtual_machine_scale_set.html.markdown
+++ b/website/docs/d/virtual_machine_scale_set.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about an existing Virtual Machine Sca
 
 ```hcl
 data "azurerm_virtual_machine_scale_set" "example" {
-  name = "existing"
+  name                = "existing"
   resource_group_name = "existing"
 }
 

--- a/website/docs/d/virtual_machine_scale_set.html.markdown
+++ b/website/docs/d/virtual_machine_scale_set.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_virtual_machine_scale_set"
+description: |-
+  Gets information about an existing Virtual Machine Scale Set.
+---
+
+# Data Source: azurerm_virtual_machine_scale_set
+
+Use this data source to access information about an existing Virtual Machine Scale Set.
+
+## Example Usage
+
+```hcl
+data "azurerm_virtual_machine_scale_set" "example" {
+  name = "existing"
+  resource_group_name = "existing"
+}
+
+output "id" {
+  value = data.azurerm_virtual_machine_scale_set.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Virtual Machine Scale Set.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Virtual Machine Scale Set exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Virtual Machine Scale Set.
+
+* `identity` - A `identity` block as defined below.
+
+---
+
+A `identity` block exports the following:
+
+* `identity_ids` -  The list of User Managed Identity ID's which are assigned to the Virtual Machine Scale Set.
+
+* `principal_id` - The ID of the System Managed Service Principal assigned to the Virtual Machine Scale Set.
+
+* `type` - The identity types of the Managed Identity assigned to the Virtual Machine Scale Set.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Machine Scale Set.


### PR DESCRIPTION
Exports the scale set ID as well as an identity block

```=== RUN   TestAccDataSourceAzureRMVirtualMachine_basicLinux
=== PAUSE TestAccDataSourceAzureRMVirtualMachine_basicLinux
=== RUN   TestAccDataSourceAzureRMVirtualMachine_basicWindows
=== PAUSE TestAccDataSourceAzureRMVirtualMachine_basicWindows
=== RUN   TestAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux
=== PAUSE TestAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux
=== RUN   TestAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows
=== PAUSE TestAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows
=== CONT  TestAccDataSourceAzureRMVirtualMachine_basicLinux
=== CONT  TestAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows
=== CONT  TestAccDataSourceAzureRMVirtualMachine_basicWindows
=== CONT  TestAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux
--- PASS: TestAccDataSourceAzureRMVirtualMachine_basicWindows (358.42s)
--- PASS: TestAccDataSourceAzureRMVirtualMachine_basicLinux (452.13s)
--- PASS: TestAccDataSourceAzureRMVirtualMachineScaleSet_basicLinux (507.31s)
--- PASS: TestAccDataSourceAzureRMVirtualMachineScaleSet_basicWindows (546.94s)
PASS
```

Fixes #7142