### PR TITLE
Spot Priority support for AKS

### DIFF
--- a/azurerm/helpers/validate/virtual_machine_scale_set.go
+++ b/azurerm/helpers/validate/virtual_machine_scale_set.go
@@ -1,0 +1,26 @@
+package validate
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// MaxBidPrice validates `max_bid_price` against the following rules:
+// * must be either -1 or positive number
+// * must have up to 5 digits after the radix point
+func MaxBidPrice(value interface{}, key string) (warns []string, errors []error) {
+	v := value.(float64)
+
+	if v < -1 || v > -1 && v <= 0 {
+		errors = append(errors, fmt.Errorf("%q must be between 0 (exclusive) and `math.MaxFloat64` (inclusive) or -1 (special value), got %f", key, v))
+	}
+
+	strV := fmt.Sprintf("%.5f", v)
+	parsedFloat, _ := strconv.ParseFloat(strV, 64)
+
+	if parsedFloat != v {
+		errors = append(errors, fmt.Errorf("%q can only include up to 5 digits after the radix point, got %g", key, v))
+	}
+
+	return
+}

--- a/azurerm/helpers/validate/virtual_machine_scale_set_test.go
+++ b/azurerm/helpers/validate/virtual_machine_scale_set_test.go
@@ -1,0 +1,116 @@
+package validate
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+const (
+	FieldName = "max_bid_price"
+)
+
+func TestMaxBidPrice(t *testing.T) {
+	type args struct {
+		value interface{}
+		key   string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErrors []error
+	}{
+		{
+			name: fmt.Sprintf("%q = 0.055", FieldName),
+			args: args{
+				value: interface{}(float64(0.055)),
+				key:   FieldName,
+			},
+			wantErrors: nil,
+		},
+		{
+			name: fmt.Sprintf("%q = 0.00001", FieldName),
+			args: args{
+				value: interface{}(float64(0.00001)),
+				key:   FieldName,
+			},
+			wantErrors: nil,
+		},
+		{
+			name: fmt.Sprintf("%q = 1002.3333", FieldName),
+			args: args{
+				value: interface{}(float64(1002.3333)),
+				key:   FieldName,
+			},
+			wantErrors: nil,
+		},
+		{
+			name: fmt.Sprintf("%q = 0.00007", FieldName),
+			args: args{
+				value: interface{}(float64(0.00007)),
+				key:   FieldName,
+			},
+			wantErrors: nil,
+		},
+		{
+			name: fmt.Sprintf("%q = -2", FieldName),
+			args: args{
+				value: interface{}(float64(-2.0)),
+				key:   FieldName,
+			},
+			wantErrors: []error{
+				fmt.Errorf("%q must be between 0 (exclusive) and `math.MaxFloat64` (inclusive) or -1 (special value), got %f",
+					FieldName, float64(-2.0)),
+			},
+		},
+		{
+			name: fmt.Sprintf("%q = 0.000009", FieldName),
+			args: args{
+				value: interface{}(float64(0.000009)),
+				key:   FieldName,
+			},
+			wantErrors: []error{
+				fmt.Errorf("%q can only include up to 5 digits after the radix point, got %g",
+					FieldName, float64(0.000009)),
+			},
+		},
+		{
+			name: fmt.Sprintf("%q = 0.000000001", FieldName),
+			args: args{
+				value: interface{}(float64(0.000000001)),
+				key:   FieldName,
+			},
+			wantErrors: []error{
+				fmt.Errorf("%q can only include up to 5 digits after the radix point, got %g",
+					FieldName, float64(0.000000001)),
+			},
+		},
+		{
+			name: fmt.Sprintf("%q = -2.000000001", FieldName),
+			args: args{
+				value: interface{}(float64(-2.000000001)),
+				key:   FieldName,
+			},
+			wantErrors: []error{
+				fmt.Errorf("%q must be between 0 (exclusive) and `math.MaxFloat64` (inclusive) or -1 (special value), got %f",
+					FieldName, float64(-2.000000001)),
+				fmt.Errorf("%q can only include up to 5 digits after the radix point, got %g",
+					FieldName, float64(-2.000000001)),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWarns, gotErrors := MaxBidPrice(tt.args.value, tt.args.key)
+
+			if !reflect.DeepEqual(gotErrors, tt.wantErrors) {
+				t.Errorf("SpotPrice() gotErrors = %v, want %v", gotErrors, tt.wantErrors)
+			}
+
+			// MaxBidPrice doesn't emit warnings
+			if !reflect.DeepEqual(gotWarns, []string(nil)) {
+				t.Errorf("SpotPrice() gotWarns = %v, want %v", gotWarns, []string(nil))
+			}
+		})
+	}
+}

--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
@@ -169,7 +170,7 @@ func resourceLinuxVirtualMachine() *schema.Resource {
 				Type:         schema.TypeFloat,
 				Optional:     true,
 				Default:      -1,
-				ValidateFunc: validation.FloatAtLeast(-1.0),
+				ValidateFunc: validate.MaxBidPrice,
 			},
 
 			"plan": planSchema(),

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -159,9 +159,10 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 			},
 
 			"max_bid_price": {
-				Type:     schema.TypeFloat,
-				Optional: true,
-				Default:  -1,
+				Type:         schema.TypeFloat,
+				Optional:     true,
+				Default:      -1,
+				ValidateFunc: validate.MaxBidPrice,
 			},
 
 			"overprovision": {

--- a/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_data_source.go
@@ -209,6 +209,21 @@ func dataSourceArmKubernetesCluster() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+
+						"priority": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"eviction_policy": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"max_bid_price": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -882,6 +897,24 @@ func flattenKubernetesClusterDataSourceAgentPoolProfiles(input *[]containerservi
 
 		if profile.Tags != nil {
 			agentPoolProfile["tags"] = tags.Flatten(profile.Tags)
+		}
+
+		if profile.ScaleSetEvictionPolicy != "" {
+			agentPoolProfile["eviction_policy"] = string(profile.ScaleSetEvictionPolicy)
+		} else {
+			agentPoolProfile["eviction_policy"] = string(containerservice.Delete)
+		}
+
+		if profile.ScaleSetPriority != "" {
+			agentPoolProfile["priority"] = string(profile.ScaleSetPriority)
+		} else {
+			agentPoolProfile["priority"] = string(containerservice.Regular)
+		}
+
+		if profile.SpotMaxPrice != nil {
+			agentPoolProfile["max_bid_price"] = *profile.SpotMaxPrice
+		} else {
+			agentPoolProfile["max_bid_price"] = -1.0
 		}
 
 		agentPoolProfiles = append(agentPoolProfiles, agentPoolProfile)

--- a/azurerm/internal/services/containers/kubernetes_nodepool.go
+++ b/azurerm/internal/services/containers/kubernetes_nodepool.go
@@ -97,14 +97,15 @@ func SchemaDefaultNodePool() *schema.Schema {
 					Type:     schema.TypeMap,
 					ForceNew: true,
 					Optional: true,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-					},
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
 
 				"node_taints": {
 					Type:     schema.TypeList,
+					ForceNew: true,
 					Optional: true,
+					Computed: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 				},
 
@@ -134,24 +135,22 @@ func ConvertDefaultNodePoolToAgentPool(input *[]containerservice.ManagedClusterA
 	return containerservice.AgentPool{
 		Name: defaultCluster.Name,
 		ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
-			Count:                  defaultCluster.Count,
-			VMSize:                 defaultCluster.VMSize,
-			OsDiskSizeGB:           defaultCluster.OsDiskSizeGB,
-			VnetSubnetID:           defaultCluster.VnetSubnetID,
-			MaxPods:                defaultCluster.MaxPods,
-			OsType:                 defaultCluster.OsType,
-			MaxCount:               defaultCluster.MaxCount,
-			MinCount:               defaultCluster.MinCount,
-			EnableAutoScaling:      defaultCluster.EnableAutoScaling,
-			Type:                   defaultCluster.Type,
-			OrchestratorVersion:    defaultCluster.OrchestratorVersion,
-			AvailabilityZones:      defaultCluster.AvailabilityZones,
-			EnableNodePublicIP:     defaultCluster.EnableNodePublicIP,
-			ScaleSetPriority:       defaultCluster.ScaleSetPriority,
-			ScaleSetEvictionPolicy: defaultCluster.ScaleSetEvictionPolicy,
-			NodeLabels:             defaultCluster.NodeLabels,
-			NodeTaints:             defaultCluster.NodeTaints,
-			Tags:                   defaultCluster.Tags,
+			Count:               defaultCluster.Count,
+			VMSize:              defaultCluster.VMSize,
+			OsDiskSizeGB:        defaultCluster.OsDiskSizeGB,
+			VnetSubnetID:        defaultCluster.VnetSubnetID,
+			MaxPods:             defaultCluster.MaxPods,
+			OsType:              defaultCluster.OsType,
+			MaxCount:            defaultCluster.MaxCount,
+			MinCount:            defaultCluster.MinCount,
+			EnableAutoScaling:   defaultCluster.EnableAutoScaling,
+			Type:                defaultCluster.Type,
+			OrchestratorVersion: defaultCluster.OrchestratorVersion,
+			AvailabilityZones:   defaultCluster.AvailabilityZones,
+			EnableNodePublicIP:  defaultCluster.EnableNodePublicIP,
+			NodeLabels:          defaultCluster.NodeLabels,
+			NodeTaints:          defaultCluster.NodeTaints,
+			Tags:                defaultCluster.Tags,
 		},
 	}
 }
@@ -184,8 +183,6 @@ func ExpandDefaultNodePool(d *schema.ResourceData) (*[]containerservice.ManagedC
 
 		// // TODO: support these in time
 		// OrchestratorVersion:    nil,
-		// ScaleSetEvictionPolicy: "",
-		// ScaleSetPriority:       "",
 	}
 
 	availabilityZonesRaw := raw["availability_zones"].([]interface{})

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -84,6 +84,18 @@ The following arguments are supported:
 
 * `os_type` - (Optional) The Operating System which should be used for this Node Pool. Changing this forces a new resource to be created. Possible values are `Linux` and `Windows`. Defaults to `Linux`.
 
+* `priority` - (Optional) The Priority of this Node Pool. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this value forces a new resource to be created.
+
+-> **NOTE:** Support for Spot `priority` is currently in Preview on an opt-in basis. To use it, enable feature `spotpoolpreview` for `namespace Microsoft.ContainerService`. For an example of how to enable a Preview feature, please visit [Register spotpoolpreview preview feature](https://docs.microsoft.com/en-us/azure/aks/spot-node-pool#register-spotpoolpreview-preview-feature).
+
+* `eviction_policy` - (Optional) The Policy which should be used for this Node Pool. Possible values are `Delete` and `Deallocate`. Defaults to `Delete`. Changing this forces a new resource to be created.
+
+-> **NOTE:** This can only be configured when `priority` is set to `Spot`.
+
+* `max_bid_price` - (Optional) The maximum price you're willing to pay for each Virtual Machine in this Node Pool (US Dollars). It must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machines in the Node Pool will be evicted using the `eviction_policy`. Defaults to `-1`, which means that each Virtual Machine in the Scale Set should not be evicted for price reasons.
+
+-> **NOTE:** This can only be configured when `priority` is set to `Spot`.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ~> At this time there's a bug in the AKS API where Tags for a Node Pool are not stored in the correct case - you [may wish to use Terraform's `ignore_changes` functionality to ignore changes to the casing](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) until this is fixed in the AKS API.


### PR DESCRIPTION
* Support of Spot Priority for `azurerm_kubernetes_cluster_node_pool`
* `node_taints` and `node_labels` were marked as *computed* and they must force a pool recreation.

The initial work was started as #6231

Fixes #6086

Co-Authored-By: Alok Kumar <rajalokan@gmail.com>

### TODO
- [x] Add test coverage
- [x] Update documentation
- [x] Rename `spot_price` to `max_bid_price`
