### PR TITLE
AuthorizationRules -> authorizationRules

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_authorization_rule_resource.go
@@ -119,7 +119,7 @@ func resourceArmEventHubNamespaceAuthorizationRuleRead(d *schema.ResourceData, m
 		return err
 	}
 
-	name := id.Path["AuthorizationRules"] // this is different then eventhub where its authorizationRules
+	name := id.Path["authorizationRules"]
 	resourceGroup := id.ResourceGroup
 	namespaceName := id.Path["namespaces"]
 
@@ -168,7 +168,7 @@ func resourceArmEventHubNamespaceAuthorizationRuleDelete(d *schema.ResourceData,
 		return err
 	}
 
-	name := id.Path["AuthorizationRules"] // this is different then eventhub where its authorizationRules
+	name := id.Path["authorizationRules"] 
 	resourceGroup := id.ResourceGroup
 	namespaceName := id.Path["namespaces"]
 


### PR DESCRIPTION
According to the latest API version for Microsoft.EventHub namespaces/authorizationRules templates, the correct path for authorization rules is `authorizationRules` since API version 2017-04-01.
See https://docs.microsoft.com/en-us/azure/templates/Microsoft.EventHub/namespaces/authorizationrules

Currently deployment fails when getting the authorization rule after creating a new authorization rule or fetching old one.