### PR TITLE
`azurerm_role_assignment` - add notes for different id format 

### DIFF
--- a/website/docs/r/role_assignment.html.markdown
+++ b/website/docs/r/role_assignment.html.markdown
@@ -168,3 +168,8 @@ Role Assignments can be imported using the `resource id`, e.g.
 ```shell
 terraform import azurerm_role_assignment.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000
 ```
+
+~> **NOTE:** The format of `resource id` could be different for different kinds of `scope`:
+
+- for scope `Subscription`, the id format is `/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000`
+- for scope `Resource Group`, the id format is `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000`


### PR DESCRIPTION
fix #7097 

when scope is `management group`, because there is a bug https://github.com/terraform-providers/terraform-provider-azurerm/pull/6787 related with the id, I didn't add notes about id format in this case