### PR TITLE
`azurerm_web_application_firewall_policy` - Add support for `GeoMatch` operator in request filter

### DIFF
--- a/azurerm/internal/services/network/web_application_firewall_policy_resource.go
+++ b/azurerm/internal/services/network/web_application_firewall_policy_resource.go
@@ -106,6 +106,7 @@ func resourceArmWebApplicationFirewallPolicy() *schema.Resource {
 										Required: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											string(network.WebApplicationFirewallOperatorIPMatch),
+											string(network.WebApplicationFirewallOperatorGeoMatch),
 											string(network.WebApplicationFirewallOperatorEqual),
 											string(network.WebApplicationFirewallOperatorContains),
 											string(network.WebApplicationFirewallOperatorLessThan),


### PR DESCRIPTION
This fixes the missing GeoMatch operator for custom rules.