### PR TITLE
Update permitted Python versions for App Service

### DIFF
--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -400,6 +400,7 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						"2.7",
+						"3.4",
 						"3.6",
 						"3.7",
 						"3.8",

--- a/azurerm/helpers/azure/app_service.go
+++ b/azurerm/helpers/azure/app_service.go
@@ -400,7 +400,9 @@ func SchemaAppServiceSiteConfig() *schema.Schema {
 					Optional: true,
 					ValidateFunc: validation.StringInSlice([]string{
 						"2.7",
-						"3.4",
+						"3.6",
+						"3.7",
+						"3.8",
 					}, false),
 				},
 

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_slot_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_slot_test.go
@@ -1175,7 +1175,7 @@ func TestAccAzureRMAppServiceSlot_windowsPython(t *testing.T) {
 				Config: testAccAzureRMAppServiceSlot_windowsPython(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceSlotExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.python_version", "3.4"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.python_version", "3.8"),
 				),
 			},
 		},
@@ -3287,7 +3287,7 @@ resource "azurerm_app_service_slot" "test" {
   app_service_name    = azurerm_app_service.test.name
 
   site_config {
-    python_version = "3.4"
+    python_version = "3.8"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_test.go
@@ -1190,7 +1190,7 @@ func TestAccAzureRMAppService_windowsPython(t *testing.T) {
 				Config: testAccAzureRMAppService_windowsPython(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMAppServiceExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.python_version", "3.4"),
+					resource.TestCheckResourceAttr(data.ResourceName, "site_config.0.python_version", "3.8"),
 				),
 			},
 			data.ImportStep(),
@@ -3467,7 +3467,7 @@ resource "azurerm_app_service" "test" {
   app_service_plan_id = azurerm_app_service_plan.test.id
 
   site_config {
-    python_version = "3.4"
+    python_version = "3.8"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -219,7 +219,7 @@ Additional examples of how to run Containers via the `azurerm_app_service` resou
 
 * `php_version` - (Optional) The version of PHP to use in this App Service. Possible values are `5.5`, `5.6`, `7.0`, `7.1`, `7.2`, and `7.3`.
 
-* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7` and `3.4`.
+* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7`, `3.6`, `3.7` and `3.8`.
 
 * `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -219,7 +219,7 @@ Additional examples of how to run Containers via the `azurerm_app_service` resou
 
 * `php_version` - (Optional) The version of PHP to use in this App Service. Possible values are `5.5`, `5.6`, `7.0`, `7.1`, `7.2`, and `7.3`.
 
-* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7`, `3.6`, `3.7` and `3.8`.
+* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7`, `3.4`, `3.6`, `3.7` and `3.8`.
 
 * `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -216,7 +216,7 @@ The following arguments are supported:
 
 * `php_version` - (Optional) The version of PHP to use in this App Service Slot. Possible values are `5.5`, `5.6`, `7.0`, `7.1`, `7.2`, and `7.3`.
 
-* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7`, `3.6`, `3.7` and `3.8`.
+* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7`, `3.4`, `3.6`, `3.7` and `3.8`.
 
 * `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -216,7 +216,7 @@ The following arguments are supported:
 
 * `php_version` - (Optional) The version of PHP to use in this App Service Slot. Possible values are `5.5`, `5.6`, `7.0`, `7.1`, `7.2`, and `7.3`.
 
-* `python_version` - (Optional) The version of Python to use in this App Service Slot. Possible values are `2.7` and `3.4`.
+* `python_version` - (Optional) The version of Python to use in this App Service. Possible values are `2.7`, `3.6`, `3.7` and `3.8`.
 
 * `remote_debugging_enabled` - (Optional) Is Remote Debugging Enabled? Defaults to `false`.
 


### PR DESCRIPTION
This updates the validation list for python_version to those currently supported by App Service. Fixes #7010 