### PR TITLE
`azurerm_cosmosdb_account` modifying `geo_location` no longer triggers a recreation of the resource

### DIFF
--- a/azurerm/helpers/azure/location.go
+++ b/azurerm/helpers/azure/location.go
@@ -17,6 +17,10 @@ func SchemaLocationForDataSource() *schema.Schema {
 	return location.SchemaComputed()
 }
 
+func SchemaLocationWithoutForceNew() *schema.Schema {
+	return location.SchemaWithoutForceNew()
+}
+
 // azure.NormalizeLocation is a function which normalises human-readable region/location
 // names (e.g. "West US") to the values used and returned by the Azure API (e.g. "westus").
 // In state we track the API internal version as it is easier to go from the human form

--- a/azurerm/internal/location/schema.go
+++ b/azurerm/internal/location/schema.go
@@ -36,6 +36,18 @@ func SchemaComputed() *schema.Schema {
 	}
 }
 
+// Schema returns the Schema which should be used for Location fields
+// where these are Required and can be changed
+func SchemaWithoutForceNew() *schema.Schema {
+	return &schema.Schema{
+		Type:             schema.TypeString,
+		Required:         true,
+		ValidateFunc:     EnhancedValidate,
+		StateFunc:        StateFunc,
+		DiffSuppressFunc: DiffSuppressFunc,
+	}
+}
+
 func DiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
 	return Normalize(old) == Normalize(new)
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -151,7 +151,7 @@ func resourceArmCosmosDbAccount() *schema.Resource {
 							Computed: true,
 						},
 
-						"location": azure.SchemaLocation(),
+						"location": azure.SchemaLocationWithoutForceNew(),
 
 						"failover_priority": {
 							Type:         schema.TypeInt,


### PR DESCRIPTION
Fixes #3532 