### PR TITLE
fix issue: spring cloud app without deployment will cause error status and broken experience

### DIFF
--- a/azurerm/internal/services/appplatform/client/client.go
+++ b/azurerm/internal/services/appplatform/client/client.go
@@ -6,19 +6,24 @@ import (
 )
 
 type Client struct {
-	ServicesClient *appplatform.ServicesClient
-	AppsClient     *appplatform.AppsClient
+	AppsClient        *appplatform.AppsClient
+	DeploymentsClient *appplatform.DeploymentsClient
+	ServicesClient    *appplatform.ServicesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
 	appsClient := appplatform.NewAppsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&appsClient.Client, o.ResourceManagerAuthorizer)
 
+	deploymentsClient := appplatform.NewDeploymentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&deploymentsClient.Client, o.ResourceManagerAuthorizer)
+
 	servicesClient := appplatform.NewServicesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&servicesClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		AppsClient:     &appsClient,
-		ServicesClient: &servicesClient,
+		AppsClient:        &appsClient,
+		DeploymentsClient: &deploymentsClient,
+		ServicesClient:    &servicesClient,
 	}
 }


### PR DESCRIPTION
In the service api design, single app without deployment will cause wield status and bad experience for user. 

![image](https://user-images.githubusercontent.com/2786738/83849942-c56a9c80-a742-11ea-8296-3c6c91189116.png)

To avoid such problem, we could create spring cloud app with a default deployment.