### PR TITLE
GH-7227 Fix application_gateway subnet documentation

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -252,7 +252,7 @@ A `frontend_ip_configuration` block supports the following:
 
 * `name` - (Required) The name of the Frontend IP Configuration.
 
-* `subnet_id` - (Optional) The name or ID of the Subnet.
+* `subnet_id` - (Optional) The ID of the Subnet.
 
 * `private_ip_address` - (Optional) The Private IP Address to use for the Application Gateway.
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -252,7 +252,7 @@ A `frontend_ip_configuration` block supports the following:
 
 * `name` - (Required) The name of the Frontend IP Configuration.
 
-* `subnet_id` - (Required) The ID of the Subnet which the Application Gateway should be connected to.
+* `subnet_id` - (Optional) The name or ID of the Subnet.
 
 * `private_ip_address` - (Optional) The Private IP Address to use for the Application Gateway.
 
@@ -276,7 +276,7 @@ A `gateway_ip_configuration` block supports the following:
 
 * `name` - (Required) The Name of this Gateway IP Configuration.
 
-* `subnet_id` - (Required) The ID of a Subnet.
+* `subnet_id` - (Required) The ID of the Subnet which the Application Gateway should be connected to.
 
 ---
 


### PR DESCRIPTION
Align the documentation for the `application_gateway` `subnet_id`s with the following documentation:

- https://docs.microsoft.com/en-us/rest/api/application-gateway/applicationgateways/createorupdate#applicationgatewayipconfiguration
- https://docs.microsoft.com/en-us/rest/api/application-gateway/applicationgateways/createorupdate#frontendipconfiguration
- https://docs.microsoft.com/en-us/cli/azure/network/application-gateway/frontend-ip?view=azure-cli-latest#az-network-application-gateway-frontend-ip-create-optional-parameters
- https://docs.microsoft.com/en-us/cli/azure/network/application-gateway?view=azure-cli-latest#az-network-application-gateway-create-optional-parameters

Fixes #7227.