### PR TITLE
Support custom image IDs in DTL VMs

### DIFF
--- a/azurerm/helpers/azure/devtest.go
+++ b/azurerm/helpers/azure/devtest.go
@@ -86,7 +86,7 @@ func ExpandDevTestLabVirtualMachineGalleryImageReference(input []interface{}, os
 func SchemaDevTestVirtualMachineGalleryImageReference() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
-		Required: true,
+		Optional: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/azurerm/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/devtestlabs/dev_test_linux_virtual_machine_resource.go
@@ -118,6 +118,12 @@ func resourceArmDevTestLinuxVirtualMachine() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"custom_image_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"gallery_image_reference": azure.SchemaDevTestVirtualMachineGalleryImageReference(),
 
 			"inbound_nat_rule": azure.SchemaDevTestVirtualMachineInboundNatRule(),
@@ -180,8 +186,16 @@ func resourceArmDevTestLinuxVirtualMachineCreateUpdate(d *schema.ResourceData, m
 	storageType := d.Get("storage_type").(string)
 	username := d.Get("username").(string)
 
-	galleryImageReferenceRaw := d.Get("gallery_image_reference").([]interface{})
-	galleryImageReference := azure.ExpandDevTestLabVirtualMachineGalleryImageReference(galleryImageReferenceRaw, "Linux")
+	customImageId, existsCustomImageId := d.GetOk("custom_image_id")
+	galleryImageReferenceRaw, existsGalleryImageReferenceRaw := d.GetOk("gallery_image_reference")
+	galleryImageReference := azure.ExpandDevTestLabVirtualMachineGalleryImageReference(galleryImageReferenceRaw.([]interface{}), "Linux")
+	if existsCustomImageId == existsGalleryImageReferenceRaw {
+		return fmt.Errorf("Either `custom_image_id` or `gallery_image_reference` shall be specified")
+	}
+	var customImageIdRef *string = nil
+	if customImageId != "" {
+		customImageIdRef = utils.String(customImageId.(string))
+	}
 
 	natRulesRaw := d.Get("inbound_nat_rule").(*schema.Set)
 	natRules := azure.ExpandDevTestLabVirtualMachineNatRules(natRulesRaw)
@@ -204,6 +218,7 @@ func resourceArmDevTestLinuxVirtualMachineCreateUpdate(d *schema.ResourceData, m
 			AllowClaim:                 utils.Bool(allowClaim),
 			IsAuthenticationWithSSHKey: utils.Bool(authenticateViaSsh),
 			DisallowPublicIPAddress:    utils.Bool(disallowPublicIPAddress),
+			CustomImageID:              customImageIdRef,
 			GalleryImageReference:      galleryImageReference,
 			LabSubnetName:              utils.String(labSubnetName),
 			LabVirtualNetworkID:        utils.String(labVirtualNetworkId),

--- a/website/docs/r/dev_test_linux_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_linux_virtual_machine.html.markdown
@@ -75,7 +75,11 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Dev Test Lab exists. Changing this forces a new resource to be created.
 
-* `gallery_image_reference` - (Required) A `gallery_image_reference` block as defined below.
+* `gallery_image_reference` - A `gallery_image_reference` block as defined below.
+
+* `custom_image_id` - Specifies the ID of a custom image that should be used to create the Virtual Machine.
+
+-> **NOTE:** One of either `gallery_image_reference` or `custom_image_id` must be specified.
 
 * `lab_subnet_name` - (Required) The name of a Subnet within the Dev Test Virtual Network where this machine should exist. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dev_test_windows_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_windows_virtual_machine.html.markdown
@@ -75,7 +75,11 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Dev Test Lab exists. Changing this forces a new resource to be created.
 
-* `gallery_image_reference` - (Required) A `gallery_image_reference` block as defined below.
+* `gallery_image_reference` - A `gallery_image_reference` block as defined below.
+
+* `custom_image_id` - Specifies the ID of a custom image that should be used to create the Virtual Machine.
+
+-> **NOTE:** One of either `gallery_image_reference` or `custom_image_id` must be specified.
 
 * `lab_subnet_name` - (Required) The name of a Subnet within the Dev Test Virtual Network where this machine should exist. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This PR aims to solve the issue such that it is not possible to create VMs based on custom images in DevTest Labs but only using normal VMs. This because the `custom_image_id` parameter is not exposed by the Terraform resource but is included in the Azure SDK.
In order to do that I implemented the possibility to specify a `custom_image_id` argument for the resource types `azurerm_dev_test_linux_virtual_machine` and `azurerm_dev_test_linux_virtual_machine`.

This allows to specify a DTL VM as follows:
```
resource "azurerm_dev_test_linux_virtual_machine" "example" {
  name                   = "example-vm03"
  lab_name               = azurerm_dev_test_lab.example.name
  resource_group_name    = azurerm_resource_group.example.name
  location               = azurerm_resource_group.example.location
  size                   = "Standard_DS2"
  username               = "exampleuser99"
  ssh_key                = file("~/.ssh/id_rsa.pub")
  lab_virtual_network_id = azurerm_dev_test_virtual_network.example.id
  lab_subnet_name        = azurerm_dev_test_virtual_network.example.subnet[0].name
  storage_type           = "Premium"
  notes                  = "Some notes about this Virtual Machine."

  custom_image_id        = "/subscriptions/{subscription_id}/resourcegroups/{resource_group}/providers/microsoft.devtestlab/labs/{dtl_name}/customimages/{image_name}"
}

```
Where the `custom_image_id` is the same that would be used in an ARM template.
