### PR TITLE
`azurerm_hdinsight_cluster` deprecate `min_instance_count`

### DIFF
--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -665,10 +665,13 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 	}
 
 	if definition.CanSpecifyInstanceCount {
+		// TODO 3.0: remove this property
 		result["min_instance_count"] = &schema.Schema{
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ForceNew:     true,
+			Computed:     true,
+			Deprecated:   "this has been deprecated from the API and will be removed in version 3.0 of the provider",
 			ValidateFunc: validation.IntBetween(definition.MinInstanceCount, definition.MaxInstanceCount),
 		}
 		result["target_instance_count"] = &schema.Schema{

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_hbase_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_hbase_cluster_resource_test.go
@@ -382,7 +382,6 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
       dynamic "worker_node" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
-          min_instance_count    = lookup(worker_node.value, "min_instance_count", null)
           password              = lookup(worker_node.value, "password", null)
           ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_interactive_query_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_interactive_query_cluster_resource_test.go
@@ -384,7 +384,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
       dynamic "worker_node" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
-          min_instance_count    = lookup(worker_node.value, "min_instance_count", null)
           password              = lookup(worker_node.value, "password", null)
           ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_kafka_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_kafka_cluster_resource_test.go
@@ -389,7 +389,6 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
       dynamic "worker_node" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
-          min_instance_count       = lookup(worker_node.value, "min_instance_count", null)
           number_of_disks_per_node = worker_node.value.number_of_disks_per_node
           password                 = lookup(worker_node.value, "password", null)
           ssh_keys                 = lookup(worker_node.value, "ssh_keys", null)

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_ml_services_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_ml_services_cluster_resource_test.go
@@ -334,7 +334,6 @@ resource "azurerm_hdinsight_ml_services_cluster" "import" {
       dynamic "worker_node" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
-          min_instance_count    = lookup(worker_node.value, "min_instance_count", null)
           password              = lookup(worker_node.value, "password", null)
           ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_rserver_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_rserver_cluster_resource_test.go
@@ -334,7 +334,6 @@ resource "azurerm_hdinsight_rserver_cluster" "import" {
       dynamic "worker_node" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
-          min_instance_count    = lookup(worker_node.value, "min_instance_count", null)
           password              = lookup(worker_node.value, "password", null)
           ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_spark_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_spark_cluster_resource_test.go
@@ -384,7 +384,6 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
       dynamic "worker_node" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
-          min_instance_count    = lookup(worker_node.value, "min_instance_count", null)
           password              = lookup(worker_node.value, "password", null)
           ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_storm_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_storm_cluster_resource_test.go
@@ -304,7 +304,6 @@ resource "azurerm_hdinsight_storm_cluster" "import" {
       dynamic "worker_node" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
-          min_instance_count    = lookup(worker_node.value, "min_instance_count", null)
           password              = lookup(worker_node.value, "password", null)
           ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -200,7 +200,7 @@ A `worker_node` block supports the following:
 
 * `vm_size` - (Required) The Size of the Virtual Machine which should be used as the Worker Nodes. Changing this forces a new resource to be created.
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -196,7 +196,7 @@ A `worker_node` block supports the following:
 
 * `vm_size` - (Required) The Size of the Virtual Machine which should be used as the Worker Nodes. Changing this forces a new resource to be created.
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -199,7 +199,7 @@ A `worker_node` block supports the following:
 
 -> **NOTE:** High memory instances must be specified for the Head Node (Azure suggests a `Standard_D14_V2`).
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -199,7 +199,7 @@ A `worker_node` block supports the following:
 
 * `vm_size` - (Required) The Size of the Virtual Machine which should be used as the Worker Nodes. Changing this forces a new resource to be created.
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_ml_services_cluster.html.markdown
+++ b/website/docs/r/hdinsight_ml_services_cluster.html.markdown
@@ -197,7 +197,7 @@ A `worker_node` block supports the following:
 
 * `vm_size` - (Required) The Size of the Virtual Machine which should be used as the Worker Nodes. Changing this forces a new resource to be created.
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_rserver_cluster.html.markdown
+++ b/website/docs/r/hdinsight_rserver_cluster.html.markdown
@@ -195,7 +195,7 @@ A `worker_node` block supports the following:
 
 * `vm_size` - (Required) The Size of the Virtual Machine which should be used as the Worker Nodes. Changing this forces a new resource to be created.
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -196,7 +196,7 @@ A `worker_node` block supports the following:
 
 * `vm_size` - (Required) The Size of the Virtual Machine which should be used as the Worker Nodes. Changing this forces a new resource to be created.
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_storm_cluster.html.markdown
+++ b/website/docs/r/hdinsight_storm_cluster.html.markdown
@@ -182,7 +182,7 @@ A `worker_node` block supports the following:
 
 * `vm_size` - (Required) The Size of the Virtual Machine which should be used as the Worker Nodes. Changing this forces a new resource to be created.
 
-* `min_instance_count` - (Optional) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
+* `min_instance_count` - (Optional / **Deprecated** ) The minimum number of instances which should be run for the Worker Nodes. Changing this forces a new resource to be created.
 
 * `password` - (Optional) The Password associated with the local administrator for the Worker Nodes. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This address part of terraform-providers/terraform-provider-azurerm#7067.

`min_instance_count` has no effect during resource creation for
hdinsight cluster resource set. Besides, it actually cause plan skew if
user specified it to a non-zero value.

## Test Result

```bash
💤 via 🦉 v1.14.4 make testacc TEST=./azurerm/internal/services/hdinsight/tests TESTARGS="-run='TestAccAzureRMHDInsightKafkaCluster_basic|TestAccAzureRMHDInsightHadoopCluster_basic'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/hdinsight/tests -v -run='TestAccAzureRMHDInsightKafkaCluster_basic|TestAccAzureRMHDInsightHadoopCluster_basic' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMHDInsightHadoopCluster_basic
=== PAUSE TestAccAzureRMHDInsightHadoopCluster_basic
=== RUN   TestAccAzureRMHDInsightKafkaCluster_basic
=== PAUSE TestAccAzureRMHDInsightKafkaCluster_basic
=== CONT  TestAccAzureRMHDInsightHadoopCluster_basic
=== CONT  TestAccAzureRMHDInsightKafkaCluster_basic
--- PASS: TestAccAzureRMHDInsightKafkaCluster_basic (1154.21s)
--- PASS: TestAccAzureRMHDInsightHadoopCluster_basic (1169.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/hdinsight/tests     1169.741s
```