### PR TITLE
Update azurerm_subnet_nat_gateway_association document example usage.

### DIFF
--- a/website/docs/r/subnet_nat_gateway_association.html.markdown
+++ b/website/docs/r/subnet_nat_gateway_association.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_subnet" "example" {
   name                 = "example-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_nat_gateway" "example" {


### PR DESCRIPTION
Replace azurerm_subnet resource argument address_prefix by address_prefixes.

According [azurerm_subnet address_prefix description](https://www.terraform.io/docs/providers/azurerm/r/subnet.html#address_prefix), maybe it's better use address_prefixes in azurerm_subnet document example usage.