### PR TITLE
app_service_environment resource is missing description for existing argument internal_load_balancing_mode

### DIFF
--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -57,6 +57,8 @@ resource "azurerm_app_service_environment" "example" {
 
 ~> **NOTE** a /24 or larger CIDR is required. Once associated with an ASE this size cannot be changed.
 
+* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web` and `Publishing`. Defaults to `None`.
+
 * `pricing_tier` - (Optional) Pricing tier for the front end instances. Possible values are `I1`, `I2` and `I3`. Defaults to `I1`.
 
 * `front_end_scale_factor` - (Optional) Scale factor for front end instances. Possible values are between `5` and `15`. Defaults to `15`.


### PR DESCRIPTION
Documentation for app_service_environment resource is missing description for existing argument internal_load_balancing_mode. So, just updated documentation. Should be easy to merge.