### PR TITLE
`azurerm_key_vault` allow case-insensitive `sku_name`

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -18,6 +18,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/set"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
@@ -72,7 +73,8 @@ func resourceArmKeyVault() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(keyvault.Standard),
 					string(keyvault.Premium),
-				}, false),
+				}, true),
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"tenant_id": {


### PR DESCRIPTION
KeyVault API (2016-10-01) allows case-insensitive `Sku.name`, so we need
to loosen the constraint also in terraform, which should not be a
breaking change.

(fixes: terraform-providers/terraform-provider-azurerm#7254)