### PR TITLE
calling_web_hook could be empty for `azurerm_bot_channel_ms_teams`

### DIFF
--- a/azurerm/internal/services/bot/tests/bot_channel_ms_teams_resource_test.go
+++ b/azurerm/internal/services/bot/tests/bot_channel_ms_teams_resource_test.go
@@ -130,8 +130,6 @@ resource "azurerm_bot_channel_ms_teams" "test" {
   bot_name            = azurerm_bot_channels_registration.test.name
   location            = azurerm_bot_channels_registration.test.location
   resource_group_name = azurerm_resource_group.test.name
-  calling_web_hook    = "https://example.com/"
-  enable_calling      = true
 }
 `, template)
 }
@@ -145,8 +143,8 @@ resource "azurerm_bot_channel_ms_teams" "test" {
   bot_name            = azurerm_bot_channels_registration.test.name
   location            = azurerm_bot_channels_registration.test.location
   resource_group_name = azurerm_resource_group.test.name
-  calling_web_hook    = "https://example2.com/"
-  enable_calling      = false
+  calling_web_hook    = "https://example.com/"
+  enable_calling      = true
 }
 `, template)
 }

--- a/website/docs/r/bot_channel_ms_teams.markdown
+++ b/website/docs/r/bot_channel_ms_teams.markdown
@@ -34,8 +34,6 @@ resource "azurerm_bot_channel_ms_teams" "example" {
   bot_name            = azurerm_bot_channels_registration.example.name
   location            = azurerm_bot_channels_registration.example.location
   resource_group_name = azurerm_resource_group.example.name
-  calling_web_hook    = "https://example2.com/"
-  enable_calling      = false
 }
 ```
 


### PR DESCRIPTION
fix #5450

- when callingWebHook is empty, make the field be nil. In this way, the backend service will not validate this field

After fix this bug, I encountered another bug:
`calling_web_hook` could not be updated to empty because the update is a patch rest api, It will omit the empty parameter,  the field `calling_web_hook` will remain the last value.
I have submitted an issue in the rest-api-spec:
https://github.com/Azure/azure-rest-api-specs/issues/9809

to avoid diff in terraform, I added `comuted: true`