### PR TITLE
azurerm_marketplace_agreement: fix obtaining the "publisher" from resource path

### DIFF
--- a/azurerm/internal/services/compute/marketplace_agreement_resource.go
+++ b/azurerm/internal/services/compute/marketplace_agreement_resource.go
@@ -133,7 +133,7 @@ func resourceArmMarketplaceAgreementRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	publisher := id.Path["agreements"]
+	publisher := id.Path["publishers"]
 	offer := id.Path["offers"]
 	plan := id.Path["plans"]
 
@@ -174,7 +174,7 @@ func resourceArmMarketplaceAgreementDelete(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	publisher := id.Path["agreements"]
+	publisher := id.Path["publishers"]
 	offer := id.Path["offers"]
 	plan := id.Path["plans"]
 


### PR DESCRIPTION
Fixes #7301

Here is an example of a resource path:
`/subscriptions/<FIXME_TENANT>/providers/Microsoft.MarketplaceOrdering/offerTypes/VirtualMachine/publishers/kali-linux/offers/kali-linux/plans/kali/agreements/current`

The `publisher` value is obtained through `publishers`

Note: first contribution here! :)
Note: sorry I didn't update the associated test as I'm afraid I don't know enough this project to do it properly, and I don't know Go