### PR TITLE
azurerm_network_interface: change case in import

### DIFF
--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -140,5 +140,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Network Interfaces can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_network_interface.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1
+terraform import azurerm_network_interface.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/networkInterfaces/nic1
 ```


### PR DESCRIPTION
The `microsoft.network` part of this resource id is in lowercase meanwhile it is written `Microsoft.Network` in other resources.
This inconsistency can sometimes be a source of conflicts.