### PR TITLE
acctest: dynamically updating the build directory

### DIFF
--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -27,21 +27,24 @@ fun BuildSteps.ConfigureGoEnv() {
     })
 }
 
+fun servicePath(providerName: String, packageName: String) : String {
+    return "./%s/internal/services/%s".format(providerName, packageName)
+}
+
 fun BuildSteps.RunAcceptanceTests(providerName : String, packageName: String) {
-    var servicePath = "./%s/internal/services/%s".format(providerName, packageName)
-    hiddenVariable("SERVICE_PATH", servicePath, "The path at which to run - automatically updated")
-    var withTestsDirectoryPath = "##teamcity[setParameter name='SERVICE_PATH' value='%s/tests']".format(servicePath)
+    var packagePath = servicePath(providerName, packageName)
+    var withTestsDirectoryPath = "##teamcity[setParameter name='SERVICE_PATH' value='%s/tests']".format(packagePath)
 
     // some packages use a ./tests folder, others don't - conditionally append that if needed
     step(ScriptBuildStep {
         name          = "Determine Working Directory for this Package"
-        scriptContent = "if [ -d \"%s/tests\" ]; then echo \"%s\"; fi".format(servicePath, withTestsDirectoryPath)
+        scriptContent = "if [ -d \"%s/tests\" ]; then echo \"%s\"; fi".format(packagePath, withTestsDirectoryPath)
     })
 
     if (useTeamCityGoTest) {
         step(ScriptBuildStep {
             name = "Run Tests"
-            scriptContent = "go test -v \"$servicePath\" -timeout=\"%TIMEOUT%h\" -test.parallel=\"%PARALLELISM%\" -run=\"%TEST_PREFIX%\" -json"
+            scriptContent = "go test -v \"%SERVICE_PATH%\" -timeout=\"%TIMEOUT%h\" -test.parallel=\"%PARALLELISM%\" -run=\"%TEST_PREFIX%\" -json"
         })
     } else {
         step(ScriptBuildStep {
@@ -96,6 +99,10 @@ fun ParametrizedWithType.TerraformAcceptanceTestsFlag() {
 
 fun ParametrizedWithType.TerraformShouldPanicForSchemaErrors() {
     hiddenVariable("env.TF_SCHEMA_PANIC_ON_ERROR", "1", "Panic if unknown/unmatched fields are set into the state")
+}
+
+fun ParametrizedWithType.WorkingDirectory(providerName: String, packageName: String) {
+    text("SERVICE_PATH", servicePath(providerName, packageName), "", "The path at which to run - automatically updated", ParameterDisplay.HIDDEN)
 }
 
 fun ParametrizedWithType.hiddenVariable(name: String, value: String, description: String) {

--- a/.teamcity/components/build_components.kt
+++ b/.teamcity/components/build_components.kt
@@ -5,8 +5,11 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.schedule
 
 // NOTE: in time this could be pulled out into a separate Kotlin package
 
-// unfortunately TeamCity's Go Test Json parser appears to be broken
-// as such for the moment let's use the old method with a feature-flag
+// The native Go test runner (which TeamCity shells out to) will fail
+// the entire test suite when a single test panics, which isn't ideal.
+//
+// Until that changes, we'll continue to use `teamcity-go-test` to run
+// each test individually
 const val useTeamCityGoTest = false
 
 fun BuildFeatures.Golang() {
@@ -25,7 +28,15 @@ fun BuildSteps.ConfigureGoEnv() {
 }
 
 fun BuildSteps.RunAcceptanceTests(providerName : String, packageName: String) {
-    var servicePath = "./%s/internal/services/%s/tests".format(providerName, packageName)
+    var servicePath = "./%s/internal/services/%s".format(providerName, packageName)
+    hiddenVariable("SERVICE_PATH", servicePath, "The path at which to run - automatically updated")
+    var withTestsDirectoryPath = "##teamcity[setParameter name='SERVICE_PATH' value='%s/tests']".format(servicePath)
+
+    // some packages use a ./tests folder, others don't - conditionally append that if needed
+    step(ScriptBuildStep {
+        name          = "Determine Working Directory for this Package"
+        scriptContent = "if [ -d \"%s/tests\" ]; then echo \"%s\"; fi".format(servicePath, withTestsDirectoryPath)
+    })
 
     if (useTeamCityGoTest) {
         step(ScriptBuildStep {
@@ -36,14 +47,14 @@ fun BuildSteps.RunAcceptanceTests(providerName : String, packageName: String) {
         step(ScriptBuildStep {
             name = "Compile Test Binary"
             scriptContent = "go test -c -o test-binary"
-            workingDir = servicePath
+            workingDir = "%SERVICE_PATH%"
         })
 
         step(ScriptBuildStep {
             // ./test-binary -test.list=TestAccAzureRMResourceGroup_ | teamcity-go-test -test ./test-binary -timeout 1s
             name = "Run via jen20/teamcity-go-test"
             scriptContent = "./test-binary -test.list=\"%TEST_PREFIX%\" | teamcity-go-test -test ./test-binary -parallelism \"%PARALLELISM%\" -timeout \"%TIMEOUT%h\""
-            workingDir = servicePath
+            workingDir = "%SERVICE_PATH%"
         })
     }
 }

--- a/.teamcity/components/build_config_service.kt
+++ b/.teamcity/components/build_config_service.kt
@@ -35,6 +35,7 @@ class serviceDetails(name: String, displayName: String, environment: String) {
                 TerraformAcceptanceTestsFlag()
                 TerraformShouldPanicForSchemaErrors()
                 ReadOnlySettings()
+                WorkingDirectory(providerName, packageName)
             }
 
             triggers {


### PR DESCRIPTION
Some service packages contain a ./tests directory, others don't.

This PR should allow us to dynamically detect where we're running and run those tests