### PR TITLE
app_service_environment resource - allow `Web, Publishing ` for the `internal_load_balancing_mode ` property

### DIFF
--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -23,6 +23,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+const (
+	InternalLoadBalancingModeWebPublishing web.InternalLoadBalancingMode = "Web, Publishing"
+)
+
 func resourceArmAppServiceEnvironment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmAppServiceEnvironmentCreate,
@@ -65,6 +69,7 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 					string(web.InternalLoadBalancingModeNone),
 					string(web.InternalLoadBalancingModePublishing),
 					string(web.InternalLoadBalancingModeWeb),
+					string(InternalLoadBalancingModeWebPublishing),
 				}, false),
 			},
 

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -41,10 +41,11 @@ resource "azurerm_subnet" "gateway" {
 }
 
 resource "azurerm_app_service_environment" "example" {
-  name                   = "example-ase"
-  subnet_id              = azurerm_subnet.ase.id
-  pricing_tier           = "I2"
-  front_end_scale_factor = 10
+  name                          = "example-ase"
+  subnet_id                     = azurerm_subnet.ase.id
+  pricing_tier                  = "I2"
+  front_end_scale_factor        = 10
+  internal_load_balancing_mode  = "Web, Publishing"
 }
 
 ```

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -41,11 +41,11 @@ resource "azurerm_subnet" "gateway" {
 }
 
 resource "azurerm_app_service_environment" "example" {
-  name                          = "example-ase"
-  subnet_id                     = azurerm_subnet.ase.id
-  pricing_tier                  = "I2"
-  front_end_scale_factor        = 10
-  internal_load_balancing_mode  = "Web, Publishing"
+  name                         = "example-ase"
+  subnet_id                    = azurerm_subnet.ase.id
+  pricing_tier                 = "I2"
+  front_end_scale_factor       = 10
+  internal_load_balancing_mode = "Web, Publishing"
 }
 
 ```

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -57,7 +57,9 @@ resource "azurerm_app_service_environment" "example" {
 
 ~> **NOTE** a /24 or larger CIDR is required. Once associated with an ASE this size cannot be changed.
 
-* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web` and `Publishing`. Defaults to `None`.
+* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web`, `Publishing` and combined value `"Web, Publishing"`. Defaults to `None`.
+
+~> **NOTE** You should prefer to select value either `None` or combined value `"Web, Publishing"` as the other values might become deprecated in the future.
 
 * `pricing_tier` - (Optional) Pricing tier for the front end instances. Possible values are `I1`, `I2` and `I3`. Defaults to `I1`.
 


### PR DESCRIPTION
Currently the resource app_service_environment supports only three modes for InternalLoadBalancingMode argument:

0. - None
1. - Web
2. - Publishing

But ASE supports one more ILB mode. It is combined value: "Web, Publishing"

0. - None = public VIP only
1. - Web = only ports 80/443 are mapped to ILB VIP
2. - Publishing = only FTP ports are mapped to ILB VIP
3. - Web, Publishing  = both ports 80/443 and FTP ports are mapped to an ILB VIP.

This fix is accepting additional ILB mode number 3 .

resource "azurerm_app_service_environment" "ase" {
  name = var.aseName
  resource_group_name =  var.resourceGroupName
  subnet_id = data.azurerm_subnet.aseSubnet.id
  pricing_tier = "I2"
  front_end_scale_factor = 10
  **internal_load_balancing_mode = "Web, Publishing"**
}

