### PR TITLE
Fix incorrect rendering of h2 after stray codeblock

### DIFF
--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -101,7 +101,7 @@ An `unique_key` block supports the following:
 The following attributes are exported:
 
 * `id` - The ID of the CosmosDB Gremlin Graph.
-``
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:


### PR DESCRIPTION
Removes a stray codeblock in the `azurerm_cosmosdb_gremlin_graph` documentation that prevented the correct rendering of the next subsequent H2.

<img width="894" alt="Screenshot 2020-06-13 at 17 16 44" src="https://user-images.githubusercontent.com/2278911/84580148-e9109100-ad99-11ea-8034-8ded042ce216.png">
