### PR TITLE
azurerm_app_service_environment - support for user_whitelisted_ip_ranges

### DIFF
--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	helpersValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	networkParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/parse"
 	networkValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/validate"
@@ -86,6 +87,15 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 				}, false),
 			},
 
+			"user_whitelisted_ip_ranges": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: helpersValidate.CIDR,
+				},
+			},
+
 			// TODO in 3.0 Make it "Required"
 			"resource_group_name": azure.SchemaResourceGroupNameOptionalComputed(),
 
@@ -109,6 +119,7 @@ func resourceArmAppServiceEnvironmentCreate(d *schema.ResourceData, meta interfa
 	name := d.Get("name").(string)
 	internalLoadBalancingMode := d.Get("internal_load_balancing_mode").(string)
 	t := d.Get("tags").(map[string]interface{})
+	userWhitelistedIPRangesRaw := d.Get("user_whitelisted_ip_ranges").(*schema.Set).List()
 
 	subnetId := d.Get("subnet_id").(string)
 	subnet, err := networkParse.SubnetID(subnetId)
@@ -166,6 +177,7 @@ func resourceArmAppServiceEnvironmentCreate(d *schema.ResourceData, meta interfa
 				ID:     utils.String(subnetId),
 				Subnet: utils.String(subnet.Name),
 			},
+			UserWhitelistedIPRanges: utils.ExpandStringSlice(userWhitelistedIPRangesRaw),
 
 			// the SDK is coded primarily for v1, which needs a non-null entry for workerpool, so we construct an empty slice for it
 			// TODO: remove this hack once https://github.com/Azure/azure-rest-api-specs/pull/8433 has been merged
@@ -222,6 +234,11 @@ func resourceArmAppServiceEnvironmentUpdate(d *schema.ResourceData, meta interfa
 		v := d.Get("pricing_tier").(string)
 		v = convertFromIsolatedSKU(v)
 		environment.AppServiceEnvironment.MultiSize = utils.String(v)
+	}
+
+	if d.HasChange("user_whitelisted_ip_ranges") {
+		v := d.Get("user_whitelisted_ip_ranges").(*schema.Set).List()
+		environment.UserWhitelistedIPRanges = utils.ExpandStringSlice(v)
 	}
 
 	if _, err := client.Update(ctx, id.ResourceGroup, id.Name, environment); err != nil {
@@ -282,6 +299,7 @@ func resourceArmAppServiceEnvironmentRead(d *schema.ResourceData, meta interface
 			pricingTier = convertToIsolatedSKU(*props.MultiSize)
 		}
 		d.Set("pricing_tier", pricingTier)
+		d.Set("user_whitelisted_ip_ranges", props.UserWhitelistedIPRanges)
 	}
 
 	return tags.FlattenAndSet(d, existing.Tags)

--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -88,7 +88,7 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 			},
 
 			"user_whitelisted_ip_ranges": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -41,11 +41,11 @@ resource "azurerm_subnet" "gateway" {
 }
 
 resource "azurerm_app_service_environment" "example" {
-  name                        = "example-ase"
-  subnet_id                   = azurerm_subnet.ase.id
-  pricing_tier                = "I2"
-  front_end_scale_factor      = 10
-  user_whitelisted_ip_ranges  = ["11.22.33.44/32", "55.66.77.0/24"]
+  name                       = "example-ase"
+  subnet_id                  = azurerm_subnet.ase.id
+  pricing_tier               = "I2"
+  front_end_scale_factor     = 10
+  user_whitelisted_ip_ranges = ["11.22.33.44/32", "55.66.77.0/24"]
 }
 
 ```

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -41,10 +41,11 @@ resource "azurerm_subnet" "gateway" {
 }
 
 resource "azurerm_app_service_environment" "example" {
-  name                   = "example-ase"
-  subnet_id              = azurerm_subnet.ase.id
-  pricing_tier           = "I2"
-  front_end_scale_factor = 10
+  name                        = "example-ase"
+  subnet_id                   = azurerm_subnet.ase.id
+  pricing_tier                = "I2"
+  front_end_scale_factor      = 10
+  user_whitelisted_ip_ranges  = ["11.22.33.44/32", "55.66.77.0/24"]
 }
 
 ```
@@ -62,6 +63,10 @@ resource "azurerm_app_service_environment" "example" {
 * `pricing_tier` - (Optional) Pricing tier for the front end instances. Possible values are `I1`, `I2` and `I3`. Defaults to `I1`.
 
 * `front_end_scale_factor` - (Optional) Scale factor for front end instances. Possible values are between `5` and `15`. Defaults to `15`.
+
+* `user_whitelisted_ip_ranges` - (Optional) User added IP ranges to whitelist on ASE db. Use the addresses you want to set as the explicit egress address ranges.  Use CIDR format.
+
+~> **NOTE:** `user_whitelisted_ip_ranges` The addresses that will be used for all outbound traffic from your App Service Environment to the internet to avoid asymmetric routing challenge. If you're routing the traffic on premises, these addresses are your NATs or gateway IPs. If you want to route the App Service Environment outbound traffic through an NVA, the egress address is the public IP of the NVA. Please visit [Create your ASE with the egress addresses](https://docs.microsoft.com/en-us/azure/app-service/environment/forced-tunnel-support#add-your-own-ips-to-the-ase-azure-sql-firewall)
 
 * `resource_group_name` - (Optional) The name of the Resource Group where the App Service Environment exists. Defaults to the Resource Group of the Subnet (specified by `subnet_id`).
 


### PR DESCRIPTION
Exposing new argument user_whitelisted_ip_ranges.
Capability: User added IP ranges to whitelist on ASE db. Use the addresses you want to set as the explicit egress address ranges.  Use CIDR format.

resource "azurerm_app_service_environment" "example" {
  name                          = "example-ase"
  subnet_id                     = azurerm_subnet.ase.id
  pricing_tier                  = "I2"
  front_end_scale_factor        = 10
  internal_load_balancing_mode  = "Web, Publishing"
  **user_whitelisted_ip_ranges    = ["11.22.33.44/32", "55.66.77.0/24"]**
}