### PR TITLE
`azurerm_policy_assignment` - added support for `enforcement_mode` 

### DIFF
--- a/azurerm/internal/services/policy/policy_assignment_resource.go
+++ b/azurerm/internal/services/policy/policy_assignment_resource.go
@@ -114,13 +114,9 @@ func resourceArmPolicyAssignment() *schema.Resource {
 			},
 
 			"enforcement_mode": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(policy.Default),
-					string(policy.DoNotEnforce),
-				}, false),
+				Default:  true,
 			},
 
 			"not_scopes": {
@@ -139,7 +135,7 @@ func resourceArmPolicyAssignmentCreateUpdate(d *schema.ResourceData, meta interf
 
 	name := d.Get("name").(string)
 	scope := d.Get("scope").(string)
-	enforcementMode := policy.EnforcementMode(d.Get("enforcement_mode").(string))
+	enforcementMode := convertEnforcementMode(utils.Bool(d.Get("enforcement_mode").(bool)))
 	policyDefinitionId := d.Get("policy_definition_id").(string)
 	displayName := d.Get("display_name").(string)
 
@@ -262,6 +258,7 @@ func resourceArmPolicyAssignmentRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("policy_definition_id", props.PolicyDefinitionID)
 		d.Set("description", props.Description)
 		d.Set("display_name", props.DisplayName)
+		d.Set("enforcement_mode", props.EnforcementMode)
 
 		if params := props.Parameters; params != nil {
 			json, err := flattenParameterValuesValueToString(params)
@@ -349,4 +346,12 @@ func expandAzureRmPolicyNotScopes(d *schema.ResourceData) *[]string {
 	}
 
 	return &notScopesRes
+}
+
+func convertEnforcementMode(mode *bool) policy.EnforcementMode {
+	if *mode {
+		return policy.Default
+	} else {
+		return policy.DoNotEnforce
+	}
 }

--- a/azurerm/internal/services/policy/policy_assignment_resource.go
+++ b/azurerm/internal/services/policy/policy_assignment_resource.go
@@ -113,6 +113,16 @@ func resourceArmPolicyAssignment() *schema.Resource {
 				DiffSuppressFunc: structure.SuppressJsonDiff,
 			},
 
+			"enforcement_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(policy.Default),
+					string(policy.DoNotEnforce),
+				}, false),
+			},
+
 			"not_scopes": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -129,7 +139,7 @@ func resourceArmPolicyAssignmentCreateUpdate(d *schema.ResourceData, meta interf
 
 	name := d.Get("name").(string)
 	scope := d.Get("scope").(string)
-
+	enforcementMode := policy.EnforcementMode(d.Get("enforcement_mode").(string))
 	policyDefinitionId := d.Get("policy_definition_id").(string)
 	displayName := d.Get("display_name").(string)
 
@@ -151,6 +161,7 @@ func resourceArmPolicyAssignmentCreateUpdate(d *schema.ResourceData, meta interf
 			PolicyDefinitionID: utils.String(policyDefinitionId),
 			DisplayName:        utils.String(displayName),
 			Scope:              utils.String(scope),
+			EnforcementMode:    enforcementMode,
 		},
 	}
 

--- a/azurerm/internal/services/policy/policy_assignment_resource.go
+++ b/azurerm/internal/services/policy/policy_assignment_resource.go
@@ -135,7 +135,7 @@ func resourceArmPolicyAssignmentCreateUpdate(d *schema.ResourceData, meta interf
 
 	name := d.Get("name").(string)
 	scope := d.Get("scope").(string)
-	enforcementMode := convertEnforcementMode(utils.Bool(d.Get("enforcement_mode").(bool)))
+	enforcementMode := convertEnforcementMode(d.Get("enforcement_mode").(bool))
 	policyDefinitionId := d.Get("policy_definition_id").(string)
 	displayName := d.Get("display_name").(string)
 
@@ -258,7 +258,7 @@ func resourceArmPolicyAssignmentRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("policy_definition_id", props.PolicyDefinitionID)
 		d.Set("description", props.Description)
 		d.Set("display_name", props.DisplayName)
-		d.Set("enforcement_mode", props.EnforcementMode)
+		d.Set("enforcement_mode", props.EnforcementMode == policy.Default)
 
 		if params := props.Parameters; params != nil {
 			json, err := flattenParameterValuesValueToString(params)
@@ -348,8 +348,8 @@ func expandAzureRmPolicyNotScopes(d *schema.ResourceData) *[]string {
 	return &notScopesRes
 }
 
-func convertEnforcementMode(mode *bool) policy.EnforcementMode {
-	if *mode {
+func convertEnforcementMode(mode bool) policy.EnforcementMode {
+	if mode {
 		return policy.Default
 	} else {
 		return policy.DoNotEnforce

--- a/azurerm/internal/services/policy/tests/policy_assignment_resource_test.go
+++ b/azurerm/internal/services/policy/tests/policy_assignment_resource_test.go
@@ -138,6 +138,24 @@ func TestAccAzureRMPolicyAssignment_not_scopes(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMPolicyAssignment_enforcement_mode(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_policy_assignment", "test")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMPolicyAssignmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAzureRMPolicyAssignment_enforcement_mode(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMPolicyAssignmentExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMPolicyAssignmentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Policy.AssignmentsClient
@@ -503,6 +521,76 @@ resource "azurerm_policy_assignment" "test" {
   policy_definition_id = azurerm_policy_definition.test.id
   description          = "Policy Assignment created via an Acceptance Test"
   not_scopes           = [azurerm_resource_group.test.id]
+  display_name         = "Acceptance Test Run %d"
+
+  parameters = <<PARAMETERS
+{
+  "allowedLocations": {
+    "value": [ "%s" ]
+  }
+}
+PARAMETERS
+
+}
+`, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAzureRMPolicyAssignment_enforcement_mode(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_subscription" "current" {
+}
+
+resource "azurerm_policy_definition" "test" {
+  name         = "acctestpol-%d"
+  policy_type  = "Custom"
+  mode         = "All"
+  display_name = "acctestpol-%d"
+
+  policy_rule = <<POLICY_RULE
+	{
+    "if": {
+      "not": {
+        "field": "location",
+        "in": "[parameters('allowedLocations')]"
+      }
+    },
+    "then": {
+      "effect": "audit"
+    }
+  }
+POLICY_RULE
+
+
+  parameters = <<PARAMETERS
+	{
+    "allowedLocations": {
+      "type": "Array",
+      "metadata": {
+        "description": "The list of allowed locations for resources.",
+        "displayName": "Allowed locations",
+        "strongType": "location"
+      }
+    }
+  }
+PARAMETERS
+
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_policy_assignment" "test" {
+  name                 = "acctestpa-%d"
+  scope                = data.azurerm_subscription.current.id
+  policy_definition_id = azurerm_policy_definition.test.id
+  description          = "Policy Assignment created via an Acceptance Test"
+  enforcement_mode     = "DoNotEnforce"
   display_name         = "Acceptance Test Run %d"
 
   parameters = <<PARAMETERS

--- a/azurerm/internal/services/policy/tests/policy_assignment_resource_test.go
+++ b/azurerm/internal/services/policy/tests/policy_assignment_resource_test.go
@@ -590,7 +590,7 @@ resource "azurerm_policy_assignment" "test" {
   scope                = data.azurerm_subscription.current.id
   policy_definition_id = azurerm_policy_definition.test.id
   description          = "Policy Assignment created via an Acceptance Test"
-  enforcement_mode     = "DoNotEnforce"
+  enforcement_mode     = false
   display_name         = "Acceptance Test Run %d"
 
   parameters = <<PARAMETERS

--- a/website/docs/r/policy_assignment.html.markdown
+++ b/website/docs/r/policy_assignment.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `not_scopes` - (Optional) A list of the Policy Assignment's excluded scopes. The list must contain Resource IDs (such as Subscriptions e.g. `/subscriptions/00000000-0000-0000-000000000000` or Resource Groups e.g.`/subscriptions/00000000-0000-0000-000000000000/resourceGroups/myResourceGroup`).
 
-* `enforcement_mode`- (Optional) Can be set to 'Default' or 'DoNotEnforce' to control whether the assignment is enforced. Default is 'Default'.
+* `enforcement_mode`- (Optional) Can be set to 'true' or 'false' to control whether the assignment is enforced (true) or not (false). Default is 'true'.
 ---
 
 An `identity` block supports the following:

--- a/website/docs/r/policy_assignment.html.markdown
+++ b/website/docs/r/policy_assignment.html.markdown
@@ -96,6 +96,7 @@ The following arguments are supported:
 
 * `not_scopes` - (Optional) A list of the Policy Assignment's excluded scopes. The list must contain Resource IDs (such as Subscriptions e.g. `/subscriptions/00000000-0000-0000-000000000000` or Resource Groups e.g.`/subscriptions/00000000-0000-0000-000000000000/resourceGroups/myResourceGroup`).
 
+* `enforcement_mode`- (Optional) Can be set to 'Default' or 'DoNotEnforce' to control whether the assignment is enforced. Default is 'Default'.
 ---
 
 An `identity` block supports the following:


### PR DESCRIPTION
I added the parameter enforcement_mode to allow policies that are assigned to a scope to be set to "DoNotEnforce". Default behaviour is unchanged and still "Default".

Added the code of the implementation, update the documentation html and added a testcase. My first pull request for this project, so please if anything is missing.