### PR TITLE
Documentation Fix: `azurerm_virtual_network_peering`

### DIFF
--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
     remote virtual network.  Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to
-    create the virtual network. Changing this forces a new resource to be
+    create the virtual network peering. Changing this forces a new resource to be
     created.
 
 * `allow_virtual_network_access` - (Optional) Controls if the VMs in the remote


### PR DESCRIPTION
Missing the word "peering". Added in to make it clearer.