### PR TITLE
app_service_environment resource - allow "Web, Publishing" for the internal_load_balancing_mode argument

### DIFF
--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -24,6 +24,10 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+const (
+	InternalLoadBalancingModeWebPublishing web.InternalLoadBalancingMode = "Web, Publishing"
+)
+
 func resourceArmAppServiceEnvironment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmAppServiceEnvironmentCreate,
@@ -66,6 +70,7 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 					string(web.InternalLoadBalancingModeNone),
 					string(web.InternalLoadBalancingModePublishing),
 					string(web.InternalLoadBalancingModeWeb),
+					string(InternalLoadBalancingModeWebPublishing),
 				}, false),
 			},
 

--- a/azurerm/internal/services/web/app_service_environment_resource.go
+++ b/azurerm/internal/services/web/app_service_environment_resource.go
@@ -65,6 +65,7 @@ func resourceArmAppServiceEnvironment() *schema.Resource {
 			"internal_load_balancing_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Default:  string(web.InternalLoadBalancingModeNone),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(web.InternalLoadBalancingModeNone),

--- a/azurerm/internal/services/web/tests/app_service_environment_resource_test.go
+++ b/azurerm/internal/services/web/tests/app_service_environment_resource_test.go
@@ -159,6 +159,26 @@ func TestAccAzureRMAppServiceEnvironment_withCertificatePfx(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServiceEnvironment_internalLoadBalancer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceEnvironment_internalLoadBalancerAndWhitelistedIpRanges(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceEnvironmentExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "internal_load_balancing_mode", "Web, Publishing"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMAppServiceEnvironmentExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Web.AppServiceEnvironmentsClient
@@ -378,26 +398,6 @@ resource "azurerm_subnet" "gateway" {
   address_prefix       = "10.0.2.0/24"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
-}
-
-func TestAccAzureRMAppServiceEnvironment_internalLoadBalancer(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMAppServiceEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMAppServiceEnvironment_internalLoadBalancerAndWhitelistedIpRanges(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMAppServiceEnvironmentExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "internal_load_balancing_mode", "Web, Publishing"),
-				),
-			},
-			data.ImportStep(),
-		},
-	})
 }
 
 func testAccAzureRMAppServiceEnvironment_internalLoadBalancerAndWhitelistedIpRanges(data acceptance.TestData) string {

--- a/azurerm/internal/services/web/tests/app_service_environment_resource_test.go
+++ b/azurerm/internal/services/web/tests/app_service_environment_resource_test.go
@@ -379,3 +379,39 @@ resource "azurerm_subnet" "gateway" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
+
+func TestAccAzureRMAppServiceEnvironment_internalLoadBalancer(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_environment", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServiceEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServiceEnvironment_internalLoadBalancerAndWhitelistedIpRanges(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServiceEnvironmentExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "internal_load_balancing_mode", "Web, Publishing"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testAccAzureRMAppServiceEnvironment_internalLoadBalancerAndWhitelistedIpRanges(data acceptance.TestData) string {
+	template := testAccAzureRMAppServiceEnvironment_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_service_environment" "test" {
+  name                         = "acctest-ase-%d"
+  subnet_id                    = azurerm_subnet.ase.id
+  pricing_tier                 = "I1"
+  front_end_scale_factor       = 5
+  internal_load_balancing_mode = "Web, Publishing"
+  user_whitelisted_ip_ranges   = ["11.22.33.44/32", "55.66.77.0/24"]
+}
+`, template, data.RandomInteger)
+}

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -61,8 +61,6 @@ resource "azurerm_app_service_environment" "example" {
 
 * `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web`, `Publishing` and combined value `"Web, Publishing"`. Defaults to `None`.
 
-~> **NOTE** You should prefer to select value either `None` or combined value `"Web, Publishing"` as the other values might become deprecated in the future.
-
 * `pricing_tier` - (Optional) Pricing tier for the front end instances. Possible values are `I1`, `I2` and `I3`. Defaults to `I1`.
 
 * `front_end_scale_factor` - (Optional) Scale factor for front end instances. Possible values are between `5` and `15`. Defaults to `15`.

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -41,11 +41,12 @@ resource "azurerm_subnet" "gateway" {
 }
 
 resource "azurerm_app_service_environment" "example" {
-  name                       = "example-ase"
-  subnet_id                  = azurerm_subnet.ase.id
-  pricing_tier               = "I2"
-  front_end_scale_factor     = 10
-  user_whitelisted_ip_ranges = ["11.22.33.44/32", "55.66.77.0/24"]
+  name                         = "example-ase"
+  subnet_id                    = azurerm_subnet.ase.id
+  pricing_tier                 = "I2"
+  front_end_scale_factor       = 10
+  internal_load_balancing_mode = "Web, Publishing"
+  user_whitelisted_ip_ranges   = ["11.22.33.44/32", "55.66.77.0/24"]
 }
 
 ```
@@ -58,7 +59,9 @@ resource "azurerm_app_service_environment" "example" {
 
 ~> **NOTE** a /24 or larger CIDR is required. Once associated with an ASE this size cannot be changed.
 
-* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web` and `Publishing`. Defaults to `None`.
+* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web`, `Publishing` and combined value `"Web, Publishing"`. Defaults to `None`.
+
+~> **NOTE** You should prefer to select value either `None` or combined value `"Web, Publishing"` as the other values might become deprecated in the future.
 
 * `pricing_tier` - (Optional) Pricing tier for the front end instances. Possible values are `I1`, `I2` and `I3`. Defaults to `I1`.
 


### PR DESCRIPTION
Currently the resource app_service_environment supports only three modes for InternalLoadBalancingMode argument:

0. None
1. Web
2. Publishing

But ASE supports one more ILB mode. It is combined value: "Web, Publishing"

0. None = public VIP only
1. Web = only ports 80/443 are mapped to ILB VIP
2. Publishing = only FTP ports are mapped to ILB VIP
3. Web, Publishing = both ports 80/443 and FTP ports are mapped to an ILB VIP.

This fix is accepting additional ILB mode number 3.

resource "azurerm_app_service_environment" "ase" {
name = var.aseName
resource_group_name = var.resourceGroupName
subnet_id = data.azurerm_subnet.aseSubnet.id
pricing_tier = "I2"
front_end_scale_factor = 10
internal_load_balancing_mode = "Web, Publishing"
}