### PR TITLE
azurerm_cosmosdb_account - support ignore_missing_vnet_service_endpoint

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -204,6 +204,11 @@ func resourceArmCosmosDbAccount() *schema.Resource {
 							Required:     true,
 							ValidateFunc: azure.ValidateResourceID,
 						},
+						"ignore_missing_vnet_service_endpoint": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 				Set: resourceAzureRMCosmosDBAccountVirtualNetworkRuleHash,
@@ -813,7 +818,10 @@ func expandAzureRmCosmosDBAccountVirtualNetworkRules(d *schema.ResourceData) *[]
 	s := make([]documentdb.VirtualNetworkRule, len(virtualNetworkRules))
 	for i, r := range virtualNetworkRules {
 		m := r.(map[string]interface{})
-		s[i] = documentdb.VirtualNetworkRule{ID: utils.String(m["id"].(string))}
+		s[i] = documentdb.VirtualNetworkRule{
+			ID:                               utils.String(m["id"].(string)),
+			IgnoreMissingVNetServiceEndpoint: utils.Bool(m["ignore_missing_vnet_service_endpoint"].(bool)),
+		}
 	}
 	return &s
 }
@@ -889,7 +897,8 @@ func flattenAzureRmCosmosDBAccountVirtualNetworkRules(rules *[]documentdb.Virtua
 	if rules != nil {
 		for _, r := range *rules {
 			rule := map[string]interface{}{
-				"id": *r.ID,
+				"id":                                   *r.ID,
+				"ignore_missing_vnet_service_endpoint": *r.IgnoreMissingVNetServiceEndpoint,
 			}
 			results.Add(rule)
 		}

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -106,6 +106,7 @@ The following arguments are supported:
 `virtual_network_rule` Configures the virtual network subnets allowed to access this Cosmos DB account and supports the following:
 
 * `id` - (Required) The ID of the virtual network subnet.
+* `ignore_missing_vnet_service_endpoint` - (Optional) If set to true, the specified subnet will be added as a virtual network rule even if its CosmosDB service endpoint is not active. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Added support for ignore_missing_vnet_service_endpoint in virtual_network_rule within azurerm_cosmosdb_account.

Added new test case for this specific case and updated documentation.

fixes #6712 