### PR TITLE
azurerm_postgresql_server: Updated "storage_profile" and removed  some args

### DIFF
--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -30,17 +30,17 @@ resource "azurerm_postgresql_server" "example" {
   administrator_login          = "psqladminun"
   administrator_login_password = "H@Sh1CoR3!"
 
-  sku_name   = "GP_Gen5_4"
-  version    = "9.6"  
-  
+  sku_name = "GP_Gen5_4"
+  version  = "9.6"
+
   storage_profile {
     storage_mb            = 640000
     backup_retention_days = 7
     geo_redundant_backup  = "Disabled"
     auto_grow             = "Enabled"
   }
-  
-  ssl_enforcement          = "Enabled"
+
+  ssl_enforcement = "Enabled"
 
 }
 ```

--- a/website/docs/r/postgresql_server.html.markdown
+++ b/website/docs/r/postgresql_server.html.markdown
@@ -31,16 +31,17 @@ resource "azurerm_postgresql_server" "example" {
   administrator_login_password = "H@Sh1CoR3!"
 
   sku_name   = "GP_Gen5_4"
-  version    = "9.6"
-  storage_mb = 640000
+  version    = "9.6"  
+  
+  storage_profile {
+    storage_mb            = 640000
+    backup_retention_days = 7
+    geo_redundant_backup  = "Disabled"
+    auto_grow             = "Enabled"
+  }
+  
+  ssl_enforcement          = "Enabled"
 
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = true
-  auto_grow_enabled            = true
-
-  public_network_access_enabled    = false
-  ssl_enforcement_enabled          = true
-  ssl_minimal_tls_version_enforced = "TLS1_2"
 }
 ```
 
@@ -62,31 +63,21 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Optional) The Password associated with the `administrator_login` for the PostgreSQL Server. Required when `create_mode` is `Default`.
 
-* `auto_grow_enabled` - (Optional) Enable/Disable auto-growing of the storage. Storage auto-grow prevents your server from running out of storage and becoming read-only. If storage auto grow is enabled, the storage automatically grows without impacting the workload. The default value if not explicitly specified is `true`.
-
-* `backup_retention_days` - (Optional) Backup retention days for the server, supported values are between `7` and `35` days.
-
 * `create_mode` - (Optional) The creation mode. Can be used to restore or replicate existing servers. Possible values are `Default`, `Replica`, `GeoRestore`, and `PointInTimeRestore`. Defaults to `Default.`
 
 * `creation_source_server_id` - (Optional) For creation modes other then default the source server ID to use.
-
-* `geo_redundant_backup_enabled` - (Optional) Turn Geo-redundant server backups on/off. This allows you to choose between locally redundant or geo-redundant backup storage in the General Purpose and Memory Optimized tiers. When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. This provides better protection and ability to restore your server in a different region in the event of a disaster. This is not support for the Basic tier.
 
 * `infrastructure_encryption_enabled` - (Optional) Whether or not infrastructure is encrypted for this server. Defaults to `false`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This property is currently still in development and not supported by Microsoft. If the `infrastructure_encryption_enabled` attribute is set to `true` the postgreSQL instance will incur a substantial performance degradation due to a second encryption pass on top of the existing default encryption that is already provided by Azure Storage. It is strongly suggested to leave this value `false` as not doing so can lead to unclear error messages.
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this server. Defaults to `true`.
-
 * `restore_point_in_time` - (Optional) When `create_mode` is `PointInTimeRestore` the point in time to restore from `creation_source_server_id`. 
 
-* `ssl_enforcement_enabled` - (Optional) Specifies if SSL should be enforced on connections. Possible values are `true` and `false`.
-
-* `ssl_minimal_tls_version_enforced` - (Optional) The mimimun TLS version to support on the sever. Possible values are `TLSEnforcementDisabled`, `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLSEnforcementDisabled`.
+* `ssl_enforcement` - (Required) Specifies if SSL should be enforced on connections. Possible values are `Enabled` and `Disabled`.
  
-* `storage_mb` - (Optional) Max storage allowed for a server. Possible values are between `5120` MB(5GB) and `1048576` MB(1TB) for the Basic SKU and between `5120` MB(5GB) and `4194304` MB(4TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/en-us/rest/api/postgresql/servers/create#StorageProfile).
-
 * `threat_detection_policy` - (Optional) Threat detection policy configuration, known in the API as Server Security Alerts Policy. The `threat_detection_policy` block supports fields documented below.
+
+* `storage_profile` - (Required) A `storage_profile` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.  
 
@@ -116,6 +107,16 @@ The following attributes are exported:
 * `id` - The ID of the PostgreSQL Server.
 
 * `fqdn` - The FQDN of the PostgreSQL Server.
+---
+A `storage_profile` block supports the following:
+* `auto_grow` - (Optional) Enable/Disable auto-growing of the storage. Storage auto-grow prevents your server from running out of storage and becoming read-only. If storage auto grow is enabled, the storage automatically grows without impacting the workload. The default value if not explicitly specified is `Enabled`.
+
+* `storage_mb` - (Required) Max storage allowed for a server. Possible values are between `5120` MB(5GB) and `1048576` MB(1TB) for the Basic SKU and between `5120` MB(5GB) and `4194304` MB(4TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/en-us/rest/api/postgresql/servers/create#StorageProfile).
+
+* `backup_retention_days` - (Optional) Backup retention days for the server, supported values are between `7` and `35` days. Default value is `7`.
+
+* `geo_redundant_backup` - (Optional) Turn Geo-redundant server backups on/off. This allows you to choose between locally redundant or geo-redundant backup storage in the General Purpose and Memory Optimized tiers. When the backups are stored in geo-redundant backup storage, they are not only stored within the region in which your server is hosted, but are also replicated to a paired data center. This provides better protection and ability to restore your server in a different region in the event of a disaster. This is not support for the Basic tier. Supported values are `Enabled` or `Disabled` whereby `Disabled` is the default value.
+
 
 ## Timeouts
 


### PR DESCRIPTION
Updated the documentation for "azurerm_postgresql_server"
a) Updated "storage_profile" block
b) Removed the following as it seems the azurerm 2.0 doesn't support these arguments
- "public_network_access_enabled" 
- "ssl_minimal_tls_version_enforced"