### PR TITLE
"state" only allows "Disabled" or "Enabled".

### DIFF
--- a/website/docs/r/mssql_server_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_server_security_alert_policy.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `server_name` - (Required) Specifies the name of the MS SQL Server. Changing this forces a new resource to be created.
 
-* `state` - (Required) Specifies the state of the policy, whether it is enabled or disabled or a policy has not been applied yet on the specific database server. Allowed values are: `Disabled`, `Enabled`, `New`.
+* `state` - (Required) Specifies the state of the policy, whether it is enabled or disabled or a policy has not been applied yet on the specific database server. Allowed values are: `Disabled`, `Enabled`.
 
 * `disabled_alerts` - (Optional) Specifies an array of alerts that are disabled. Allowed values are: `Sql_Injection`, `Sql_Injection_Vulnerability`, `Access_Anomaly`, `Data_Exfiltration`, `Unsafe_Action`.
 


### PR DESCRIPTION
"state" only allows "Disabled" or "Enabled" and NOT "New". 
Altered documentation to reflect this.

Error when using "New" in terraform is:

Error: error updataing mssql server security alert policy: sql.ServerSecurityAlertPoliciesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="DataSecurityInvalidUserSuppliedParameter" Message="Invalid parameter 'state'. Allowed values are 'Enabled' or 'Disabled'.\r\nParameter name: state"

  on ../../modules/sqlserver/sqlserver.tf line 18, in resource "azurerm_mssql_server_security_alert_policy" "sqlserver":
  18: resource "azurerm_mssql_server_security_alert_policy" "sqlserver" {