### PR TITLE
`azurerm_kusto_cluster` - Support for `optimized_auto_scale`

### DIFF
--- a/azurerm/internal/services/kusto/kusto_cluster_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_resource.go
@@ -102,11 +102,6 @@ func resourceArmKustoCluster() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  true,
-						},
 						"minimum_instances": {
 							Type:         schema.TypeInt,
 							Required:     true,
@@ -424,21 +419,16 @@ func validateAzureRMKustoClusterName(v interface{}, k string) (warnings []string
 }
 
 func expandOptimizedAutoScale(input []interface{}) *kusto.OptimizedAutoscale {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 
 	config := input[0].(map[string]interface{})
-	enabled := config["enabled"].(bool)
-	minimumInstances := int32(config["minimum_instances"].(int))
-	maximumInstances := int32(config["maximum_instances"].(int))
-
-	var version int32 = 1
 	optimizedAutoScale := &kusto.OptimizedAutoscale{
-		Version:   &version,
-		IsEnabled: &enabled,
-		Minimum:   &minimumInstances,
-		Maximum:   &maximumInstances,
+		Version:   utils.Int32(1),
+		IsEnabled: utils.Bool(true),
+		Minimum:   utils.Int32(int32(config["minimum_instances"].(int))),
+		Maximum:   utils.Int32(int32(config["maximum_instances"].(int))),
 	}
 
 	return optimizedAutoScale
@@ -447,11 +437,6 @@ func expandOptimizedAutoScale(input []interface{}) *kusto.OptimizedAutoscale {
 func flattenOptimizedAutoScale(optimizedAutoScale *kusto.OptimizedAutoscale) []interface{} {
 	if optimizedAutoScale == nil {
 		return []interface{}{}
-	}
-
-	enabled := false
-	if optimizedAutoScale.IsEnabled != nil {
-		enabled = *optimizedAutoScale.IsEnabled
 	}
 
 	maxInstances := 0
@@ -466,7 +451,6 @@ func flattenOptimizedAutoScale(optimizedAutoScale *kusto.OptimizedAutoscale) []i
 
 	return []interface{}{
 		map[string]interface{}{
-			"enabled":           enabled,
 			"maximum_instances": maxInstances,
 			"minimum_instances": minInstances,
 		},

--- a/azurerm/internal/services/kusto/kusto_cluster_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_resource.go
@@ -227,7 +227,7 @@ func resourceArmKustoClusterCreateUpdate(d *schema.ResourceData, meta interface{
 	if optimizedAutoScale != nil && *optimizedAutoScale.IsEnabled {
 		// if Capacity has not been set use min instances
 		if *sku.Capacity == 0 {
-			sku.Capacity = utils.Int32(int32(*optimizedAutoScale.Minimum))
+			sku.Capacity = utils.Int32(*optimizedAutoScale.Minimum)
 		}
 
 		// Capacity must be set for the initial creation when using OptimizedAutoScaling but cannot be updated

--- a/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
+++ b/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
@@ -241,7 +241,6 @@ func TestAccAzureRMKustoCluster_optimizedAutoScale(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.minimum_instances", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.maximum_instances", "3"),
-					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.enabled", "true"),
 				),
 			},
 			data.ImportStep(),
@@ -252,17 +251,13 @@ func TestAccAzureRMKustoCluster_optimizedAutoScale(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.minimum_instances", "3"),
 					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.maximum_instances", "4"),
-					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.enabled", "true"),
 				),
 			},
+			data.ImportStep(),
 			{
-				Config: testAccAzureRMKustoCluster_optimizedAutoScaleDisable(data),
+				Config: testAccAzureRMKustoCluster_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKustoClusterExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.minimum_instances", "3"),
-					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.maximum_instances", "4"),
-					resource.TestCheckResourceAttr(data.ResourceName, "optimized_auto_scale.0.enabled", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -559,35 +554,6 @@ resource "azurerm_kusto_cluster" "test" {
   optimized_auto_scale {
     minimum_instances = 3
     maximum_instances = 4
-  }
-}
-`, data.RandomInteger, data.Locations.Primary, data.RandomString)
-}
-
-func testAccAzureRMKustoCluster_optimizedAutoScaleDisable(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
-resource "azurerm_kusto_cluster" "test" {
-  name                = "acctestkc%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-
-  sku {
-    name = "Standard_D11_v2"
-  }
-
-  optimized_auto_scale {
-    minimum_instances = 3
-    maximum_instances = 4
-    enabled           = false
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -103,8 +103,6 @@ An `identity` block supports the following:
 
 A `optimized_auto_scale` block supports the following:
 
-* `enabled` - (Optional) A boolean value that indicate if the optimized autoscale feature is enabled or not. Default is `true`.
-
 * `minimum_instances` - (Required) The minimum number of allowed instances. Must between `0` and `1000`.
 
 * `maximum_instances` - (Required) The maximum number of allowed instances. Must between `0` and `1000`.

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -58,6 +58,8 @@ The following arguments are supported:
 
 * `language_extensions` - (Optional) An list of `language_extensions` to enable. Valid values are: `PYTHON` and `R`.
 
+* `optimized_auto_scale` - (Optional) An `optimized_auto_scale` block as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `zones` - (Optional) A list of Availability Zones in which the cluster instances should be created in. Changing this forces a new resource to be created.
@@ -68,7 +70,10 @@ A `sku` block supports the following:
 
 * `name` - (Required) The name of the SKU. Valid values are: `Dev(No SLA)_Standard_D11_v2`, `Dev(No SLA)_Standard_E2a_v4`, `Standard_D11_v2`, `Standard_D12_v2`, `Standard_D13_v2`, `Standard_D14_v2`, `Standard_DS13_v2+1TB_PS`, `Standard_DS13_v2+2TB_PS`, `Standard_DS14_v2+3TB_PS`, `Standard_DS14_v2+4TB_PS`, `Standard_E16as_v4+3TB_PS`, `Standard_E16as_v4+4TB_PS`, `Standard_E16a_v4`, `Standard_E2a_v4`, `Standard_E4a_v4`, `Standard_E8as_v4+1TB_PS`, `Standard_E8as_v4+2TB_PS`, `Standard_E8a_v4`, `Standard_L16s`, `Standard_L4s` and `Standard_L8s`
 
-* `capacity` - (Required) Specifies the node count for the cluster. Boundaries depend on the sku name.
+* `capacity` - (Optional) Specifies the node count for the cluster. Boundaries depend on the sku name.
+
+~> **NOTE:** If no `optimized_auto_scale` block is defined, then the capacity is required.
+~> **NOTE:** If an `optimized_auto_scale` block is defined and no capacity is set, then the capacatiy is initially set to the value of `minimum_instances`.
 
 ---
 
@@ -93,6 +98,16 @@ An `identity` block supports the following:
 * `identity_ids` - (Computed) The list of user identities associated with the Kusto cluster.
 
 ~> **NOTE:** When `type` is set to `SystemAssigned`, the Principal ID can be retrieved after the cluster has been created. More details are available below. See [documentation](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview) for additional information.
+
+---
+
+A `optimized_auto_scale` block supports the following:
+
+* `enabled` - (Optional) A boolean value that indicate if the optimized autoscale feature is enabled or not. Default is `true`.
+
+* `minimum_instances` - (Required) The minimum number of allowed instances. Must between `0` and `1000`.
+
+* `maximum_instances` - (Required) The maximum number of allowed instances. Must between `0` and `1000`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Enables the usage of the optimized auto scale feature of a Kusto Cluster.