### PR TITLE
azurerm_kusto_cluster - supoport for zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## 2.16.0 (Unreleased)
 ## 2.15.0 (June 19, 2020)
 
 UPGRADE NOTES:

--- a/azurerm/internal/services/kusto/kusto_cluster_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_resource.go
@@ -93,6 +93,8 @@ func resourceArmKustoCluster() *schema.Resource {
 				},
 			},
 
+			"zones": azure.SchemaZones(),
+
 			"enable_disk_encryption": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -153,6 +155,8 @@ func resourceArmKustoClusterCreateUpdate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+	zones := azure.ExpandZones(d.Get("zones").([]interface{}))
+
 	clusterProperties := kusto.ClusterProperties{
 		EnableDiskEncryption:  utils.Bool(d.Get("enable_disk_encryption").(bool)),
 		EnableStreamingIngest: utils.Bool(d.Get("enable_streaming_ingest").(bool)),
@@ -165,6 +169,7 @@ func resourceArmKustoClusterCreateUpdate(d *schema.ResourceData, meta interface{
 		Name:              &name,
 		Location:          &location,
 		Sku:               sku,
+		Zones:             zones,
 		ClusterProperties: &clusterProperties,
 		Tags:              tags.Expand(t),
 	}
@@ -221,6 +226,10 @@ func resourceArmKustoClusterRead(d *schema.ResourceData, meta interface{}) error
 
 	if err := d.Set("sku", flattenKustoClusterSku(clusterResponse.Sku)); err != nil {
 		return fmt.Errorf("Error setting `sku`: %+v", err)
+	}
+
+	if err := d.Set("zones", azure.FlattenZones(clusterResponse.Zones)); err != nil {
+		return fmt.Errorf("Error setting `zones`: %+v", err)
 	}
 
 	if clusterProperties := clusterResponse.ClusterProperties; clusterProperties != nil {

--- a/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
+++ b/azurerm/internal/services/kusto/tests/kusto_cluster_resource_test.go
@@ -129,6 +129,26 @@ func TestAccAzureRMKustoCluster_sku(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMKustoCluster_zones(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cluster", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKustoClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKustoCluster_withZones(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKustoClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "zones.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "zones.0", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAzureRMKustoCluster_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -230,6 +250,32 @@ resource "azurerm_kusto_cluster" "test" {
     name     = "Standard_D11_v2"
     capacity = 2
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMKustoCluster_withZones(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  zones = ["1"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `sku` - (Required) A `sku` block as defined below.
 
+* `zones` - (Optional) A list of Availability Zones in which the cluster instances should be created in. Changing this forces a new resource to be created.
+
 * `enable_disk_encryption` - (Optional) Specifies if the cluster's disks are encrypted.
 
 * `enable_streaming_ingest` - (Optional) Specifies if the streaming ingest is enabled.

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -46,8 +46,6 @@ The following arguments are supported:
 
 * `sku` - (Required) A `sku` block as defined below.
 
-* `zones` - (Optional) A list of Availability Zones in which the cluster instances should be created in. Changing this forces a new resource to be created.
-
 * `identity` - (Optional) A identity block.
 
 * `enable_disk_encryption` - (Optional) Specifies if the cluster's disks are encrypted.
@@ -59,6 +57,8 @@ The following arguments are supported:
 * `virtual_network_configuration`- (Optional) A `virtual_network_configuration` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+* `zones` - (Optional) A list of Availability Zones in which the cluster instances should be created in. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
Enables to define availability zones for a Kusto Cluster.