### PR TITLE
Fix #7376 - azurerm_storage_data_lake_gen2_filesystem crashes during plan if SA deleted

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_data_lake_gen2_filesystem.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_data_lake_gen2_filesystem.go
@@ -165,6 +165,7 @@ func resourceArmStorageDataLakeGen2FileSystemUpdate(d *schema.ResourceData, meta
 }
 
 func resourceArmStorageDataLakeGen2FileSystemRead(d *schema.ResourceData, meta interface{}) error {
+	accountsClient := meta.(*clients.Client).Storage.AccountsClient
 	client := meta.(*clients.Client).Storage.FileSystemsClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -172,6 +173,23 @@ func resourceArmStorageDataLakeGen2FileSystemRead(d *schema.ResourceData, meta i
 	id, err := filesystems.ParseResourceID(d.Id())
 	if err != nil {
 		return err
+	}
+
+	storageID, err := parsers.ParseAccountID(d.Get("storage_account_id").(string))
+	if err != nil {
+		return err
+	}
+
+	// confirm the storage account exists, otherwise Data Plane API requests will fail
+	storageAccount, err := accountsClient.GetProperties(ctx, storageID.ResourceGroup, storageID.Name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(storageAccount.Response) {
+			log.Printf("[INFO] Storage Account %q does not exist removing from state...", id.AccountName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error checking for existence of Storage Account %q for File System %q (Resource Group %q): %+v", storageID.Name, id.DirectoryName, storageID.ResourceGroup, err)
 	}
 
 	// TODO: what about when this has been removed?

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_data_lake_gen2_filesystem_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_data_lake_gen2_filesystem_test.go
@@ -76,6 +76,34 @@ func TestAccAzureRMStorageDataLakeGen2FileSystem_properties(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMStorageDataLakeGen2FileSystem_handlesStorageAccountDeletion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_data_lake_gen2_filesystem", "test")
+	config := testAccAzureRMStorageDataLakeGen2FileSystem_basic(data)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMStorageDataLakeGen2FileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageDataLakeGen2FileSystemExists(data.ResourceName),
+					testAzureRMStorageDataLakeGen2StorageAccountDelete(data.ResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageDataLakeGen2FileSystemExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMStorageDataLakeGen2FileSystemExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Storage.FileSystemsClient
@@ -99,6 +127,29 @@ func testCheckAzureRMStorageDataLakeGen2FileSystemExists(resourceName string) re
 			}
 
 			return fmt.Errorf("Bad: Get on FileSystemsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAzureRMStorageDataLakeGen2StorageAccountDelete(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Storage.AccountsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		storageID, err := parsers.ParseAccountID(rs.Primary.Attributes["storage_account_id"])
+		if err != nil {
+			return err
+		}
+
+		if _, err := client.Delete(ctx, storageID.ResourceGroup, storageID.Name); err != nil {
+			return fmt.Errorf("Unable to delete azurerm_storage_account: %+v", storageID.Name)
 		}
 
 		return nil
@@ -189,6 +240,7 @@ resource "azurerm_storage_account" "test" {
   account_kind             = "BlobStorage"
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  is_hns_enabled           = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION
added fix to check storage account exists before attempting to read the filesystem
added test
changed filesystem acc tests to use hns

This PR address the issue #7376 