### PR TITLE
make `ip_rules`, `virtual_network_subnet_ids` could become zero - `azurerm_storage_account_network_rules`

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_account_network_rules.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account_network_rules.go
@@ -11,7 +11,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
@@ -116,7 +115,7 @@ func resourceArmStorageAccountNetworkRulesCreateUpdate(d *schema.ResourceData, m
 		return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): %+v", storageAccountName, resourceGroup, err)
 	}
 
-	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+	if d.IsNewResource() {
 		if storageAccount.AccountProperties == nil {
 			return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): `properties` was nil", storageAccountName, resourceGroup)
 		}
@@ -132,18 +131,9 @@ func resourceArmStorageAccountNetworkRulesCreateUpdate(d *schema.ResourceData, m
 	}
 
 	rules.DefaultAction = storage.DefaultAction(d.Get("default_action").(string))
-
-	if v, ok := d.GetOk("bypass"); ok {
-		rules.Bypass = expandStorageAccountNetworkRuleBypass(v.(*schema.Set).List())
-	}
-
-	if v, ok := d.GetOk("ip_rules"); ok {
-		rules.IPRules = expandStorageAccountNetworkRuleIpRules(v.(*schema.Set).List())
-	}
-
-	if v, ok := d.GetOk("virtual_network_subnet_ids"); ok {
-		rules.VirtualNetworkRules = expandStorageAccountNetworkRuleVirtualRules(v.(*schema.Set).List())
-	}
+	rules.Bypass = expandStorageAccountNetworkRuleBypass(d.Get("bypass").(*schema.Set).List())
+	rules.IPRules = expandStorageAccountNetworkRuleIpRules(d.Get("ip_rules").(*schema.Set).List())
+	rules.VirtualNetworkRules = expandStorageAccountNetworkRuleVirtualRules(d.Get("virtual_network_subnet_ids").(*schema.Set).List())
 
 	opts := storage.AccountUpdateParameters{
 		AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_network_rules_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_network_rules_test.go
@@ -50,6 +50,13 @@ func TestAccAzureRMStorageAccountNetworkRules_update(t *testing.T) {
 			},
 			data.ImportStep(),
 			{
+				Config: testAccAzureRMStorageAccountNetworkRules_empty(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists("azurerm_storage_account.test"),
+				),
+			},
+			data.ImportStep(),
+			{
 				Config: testAccAzureRMStorageAccountNetworkRules_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists("azurerm_storage_account.test"),
@@ -213,8 +220,10 @@ resource "azurerm_storage_account_network_rules" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   storage_account_name = azurerm_storage_account.test.name
 
-  default_action = "Deny"
-  bypass         = ["Metrics"]
+  default_action             = "Deny"
+  bypass                     = ["None"]
+  ip_rules                   = []
+  virtual_network_subnet_ids = []
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }


### PR DESCRIPTION
fix #7357 

"getOk" will ignore the zero value, and the rules will always contain last value
we could directly get the vaules and pass them

![image](https://user-images.githubusercontent.com/2786738/84989124-c0abdc80-b175-11ea-8a67-786419661fcf.png)