### PR TITLE
`azurerm_frontdoor` - Fix timeout for read operation to match documentation

### DIFF
--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -33,7 +33,7 @@ func resourceArmFrontDoor() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(6 * time.Hour),
-			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Read:   schema.DefaultTimeout(6 * time.Hour),
 			Update: schema.DefaultTimeout(6 * time.Hour),
 			Delete: schema.DefaultTimeout(6 * time.Hour),
 		},


### PR DESCRIPTION
I have increased the timeout in the resource code from 5 minutes to 6 hours per the documentation. While this may seem excessive for a read, the time may be necessary for the frontdoor resource to complete successfully especially when custom domain SSL certs have been defined.

(fixes #7405)