### PR TITLE
application_gateway - Clarify use of PathBasedRouting

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -376,6 +376,8 @@ A `request_routing_rule` block supports the following:
 
 * `rewrite_rule_set_name` - (Optional) The Name of the Rewrite Rule Set which should be used for this Routing Rule. Only valid for v2 SKUs.
 
+-> **NOTE:** `backend_address_pool_name`, `backend_http_settings_name`, `redirect_configuration_name`, and `rewrite_rule_set_name` are applicable only when `rule_type` is `Basic`.
+
 * `url_path_map_name` - (Optional) The Name of the URL Path Map which should be associated with this Routing Rule.
 
 ---


### PR DESCRIPTION
Some attributes in `request_routing_rule` only take effect when `rule_type` is `Basic`. If these attributes are specified when `rule_type` is `PathBasedRouting`,  they cause the resource to be recreated on every plan and apply.

Adding a note to the documentation clarifying the usage.

Closes #7389 