### PR TITLE
`azurerm_role_definition` - terraform import now sets scope to prevent a force recreate

### DIFF
--- a/azurerm/internal/services/authorization/role_definition_resource.go
+++ b/azurerm/internal/services/authorization/role_definition_resource.go
@@ -189,6 +189,7 @@ func resourceArmRoleDefinitionRead(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error parsing Role Definition ID: %+v", err)
 		}
 		if roleDefinitionId != nil {
+			d.Set("scope", roleDefinitionId.scope)
 			d.Set("role_definition_id", roleDefinitionId.roleDefinitionId)
 		}
 	}
@@ -351,9 +352,9 @@ func parseRoleDefinitionId(input string) (*roleDefinitionId, error) {
 		return nil, fmt.Errorf("Expected Role Definition ID to be in the format `{scope}/providers/Microsoft.Authorization/roleDefinitions/{name}` but got %q", input)
 	}
 
-	// /{scope}/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}
+	// {scope}/providers/Microsoft.Authorization/roleDefinitions/{roleDefinitionId}
 	id := roleDefinitionId{
-		scope:            strings.TrimPrefix(segments[0], "/"),
+		scope:            segments[0],
 		roleDefinitionId: segments[1],
 	}
 	return &id, nil


### PR DESCRIPTION
When running `terraform import` for `azurerm_role_definition` resources, Read operation doesn't expand `Scope`. 

As a result, on `terraform apply` or `terraform plan`, this resource is forced to be recreated which is impossible due to existing role assignments.

This is a simple fix to populate `scope` from `id`.

Also, removed `trim /` from `parseResourceId`, unclear why this is required. `Delete` operation works regardless of `/` symbol + input requires scope to use `/` as a first symbol.