### PR TITLE
azurerm_function_app: optional SyncFunctionTriggers on create\update

### DIFF
--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) An `connection_string` block as defined below.
 
-* `os_type` - (Optional) A string indicating the Operating System type for this function app. 
+* `os_type` - (Optional) A string indicating the Operating System type for this function app.
 
 ~> **NOTE:** This value will be `linux` for Linux Derivatives or an empty string for Windows (default). When set to `linux` you must also set `azurerm_app_service_plan` arguments as `kind = "FunctionApp"` and `reserved = true`
 
@@ -167,6 +167,8 @@ The following arguments are supported:
 * `site_config` - (Optional) A `site_config` object as defined below.
 
 * `identity` - (Optional) An `identity` block as defined below.
+
+* `sync_triggers` - (Optional) Call SyncFunctionTriggers API after every update to the resource? Defaults to `false`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Azure Functions have a support for `WEBSITE_RUN_FROM_PACKAGE` property which essentially means it is possible to create e2e pipeline to create and deploy Azure Functions purely with Terraform. (Sync Triggers docs: https://docs.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies#trigger-syncing)

In the pipeline, we prepare Zip file with the function and everything else is handled by Terraform (create infrastructure if missing, upload blob, generate sas, update Azure Function).

Unfortunately, Azure Functions require `SyncFunctionsTrigger` each time there is a change in triggers (which includes new timer functions e.g.). So, in order to make scenario work e2e, we have to use the provisioner to call this API via az cli.

It creates unnecessary complexity (when running via Azure DevOps task, we have to auth az cli..) while Terraform has all tools to support e2e.

This PR adds optional parameter that allows e2e scenario. Another unfortunate part of this API is that it works in `fire and forget` mode, so there is no way to check if it was successful. Azure Core Func Tool apporach is to wait 5 seconds before calling this API: https://bit.ly/312J1Eo so I replicated this in TF code.

Please let me know if you think this is something that can be included in the provider.

Thanks!