### PR TITLE
new resource: log_analytics_datasource_azure_activity_log_resource

### DIFF
--- a/azurerm/internal/services/loganalytics/log_analytics_datasource_azure_activity_log_resource.go
+++ b/azurerm/internal/services/loganalytics/log_analytics_datasource_azure_activity_log_resource.go
@@ -1,0 +1,153 @@
+package loganalytics
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/operationalinsights/mgmt/2015-11-01-preview/operationalinsights"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmLogAnalyticsDataSourceAzureActivityLog() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmLogAnalyticsDataSourceAzureActivityLogCreate,
+		Read:   resourceArmLogAnalyticsDataSourceAzureActivityLogRead,
+		Delete: resourceArmLogAnalyticsDataSourceAzureActivityLogDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImportThen(func(id string) error {
+			_, err := parse.LogAnalyticsDataSourceID(id)
+			return err
+		}, importLogAnalyticsDataSource(operationalinsights.AzureActivityLog)),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"workspace_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     ValidateAzureRmLogAnalyticsWorkspaceName,
+			},
+		},
+	}
+}
+
+type dataSourceAzureActivityLog struct {
+	LinkedResourceId string `json:"linkedResourceId"`
+}
+
+func resourceArmLogAnalyticsDataSourceAzureActivityLogCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	workspaceName := d.Get("workspace_name").(string)
+
+	if d.IsNewResource() {
+		resp, err := client.Get(ctx, resourceGroup, workspaceName, name)
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("checking for existing Log Analytics Data Source Azure Activity Log %q (Resource Group %q / Workspace: %q): %+v", name, resourceGroup, workspaceName, err)
+			}
+		}
+
+		if resp.ID != nil && *resp.ID != "" {
+			return tf.ImportAsExistsError("azurerm_log_analytics_datasource_azure_activity_log", *resp.ID)
+		}
+	}
+
+	params := operationalinsights.DataSource{
+		Kind: operationalinsights.AzureActivityLog,
+		Properties: &dataSourceAzureActivityLog{
+			LinkedResourceId: fmt.Sprintf("/subscriptions/%s/providers/microsoft.insights/eventtypes/management", client.SubscriptionID),
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, workspaceName, name, params); err != nil {
+		return fmt.Errorf("failed to create Log Analytics DataSource Azure Activitay Log %q (Resource Group %q / Workspace: %q): %+v", name, resourceGroup, workspaceName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, workspaceName, name)
+	if err != nil {
+		return fmt.Errorf("retrieving Log Analytics Data Source Azure Activity Log %q (Resource Group %q / Workspace: %q): %+v", name, resourceGroup, workspaceName, err)
+	}
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("empty or nil ID returned for Log Analytics Data Source Azure Activity Log %q (Resource Group %q / Workspace: %q) ID", name, resourceGroup, workspaceName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmLogAnalyticsDataSourceAzureActivityLogRead(d, meta)
+}
+
+func resourceArmLogAnalyticsDataSourceAzureActivityLogRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LogAnalyticsDataSourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Log Analytics Data Source Azure Activity Log %q was not found in Resource Group %q in Workspace %q - removing from state!", id.Name, id.ResourceGroup, id.Workspace)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Log Analytics Data Source Azure Activity Log %q (Resource Group %q / Workspace: %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("workspace_name", id.Workspace)
+
+	return nil
+}
+
+func resourceArmLogAnalyticsDataSourceAzureActivityLogDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.LogAnalyticsDataSourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+		return fmt.Errorf("deleting Log Analytics Data Source Azure Activity Log %q (Resource Group %q / Workspace %q): %+v", id.Name, id.ResourceGroup, id.Workspace, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/loganalytics/registration.go
+++ b/azurerm/internal/services/loganalytics/registration.go
@@ -30,6 +30,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_log_analytics_linked_service":                         resourceArmLogAnalyticsLinkedService(),
 		"azurerm_log_analytics_solution":                               resourceArmLogAnalyticsSolution(),
 		"azurerm_log_analytics_workspace":                              resourceArmLogAnalyticsWorkspace(),
+		"azurerm_log_analytics_datasource_azure_activity_log":          resourceArmLogAnalyticsDataSourceAzureActivityLog(),
 		"azurerm_log_analytics_datasource_windows_event":               resourceArmLogAnalyticsDataSourceWindowsEvent(),
 		"azurerm_log_analytics_datasource_windows_performance_counter": resourceArmLogAnalyticsDataSourceWindowsPerformanceCounter(),
 	}

--- a/azurerm/internal/services/loganalytics/tests/log_analytics_datasource_azure_activity_log_test.go
+++ b/azurerm/internal/services/loganalytics/tests/log_analytics_datasource_azure_activity_log_test.go
@@ -1,0 +1,150 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_azure_activity_log", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceAzureActivityLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceAzureActivityLogExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_datasource_azure_activity_log", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLogAnalyticsDataSourceAzureActivityLogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLogAnalyticsDataSourceAzureActivityLogExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMLogAnalyticsDataSourceAzureActivityLogExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).LogAnalytics.DataSourcesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Log Analytics Data Source Azure Activity Log not found: %s", resourceName)
+		}
+
+		id, err := parse.LogAnalyticsDataSourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name); err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Log Analytics Data Source Azure Activity Log %q (Resource Group %q) does not exist", id.Name, id.ResourceGroup)
+			}
+			return fmt.Errorf("Getting on LogAnalytics.DataSources: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMLogAnalyticsDataSourceAzureActivityLogDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).LogAnalytics.DataSourcesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_log_analytics_datasource_azure_activity_log" {
+			continue
+		}
+
+		id, err := parse.LogAnalyticsDataSourceID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Get(ctx, id.ResourceGroup, id.Workspace, id.Name)
+		if err == nil {
+			return fmt.Errorf("LogAnalytics.DataSources still exists")
+		}
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Getting on LogAnalytics.DataSources: %+v", err)
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_azure_activity_log" "test" {
+  name                = "acctestLADS-AAL-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_datasource_azure_activity_log" "import" {
+  name                = azurerm_log_analytics_datasource_azure_activity_log.test.name
+  resource_group_name = azurerm_log_analytics_datasource_azure_activity_log.test.resource_group_name
+  workspace_name      = azurerm_log_analytics_datasource_azure_activity_log.test.workspace_name
+}
+`, template)
+}
+
+func testAccAzureRMLogAnalyticsDataSourceAzureActivityLog_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-la-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1766,6 +1766,10 @@
               <a href="#">Log Analytics Resources</a>
               <ul class="nav">
                 <li>
+                  <a href="/docs/providers/azurerm/r/log_analytics_datasource_azure_activity_log.html">azurerm_log_analytics_datasource_azure_activity_log</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/log_analytics_datasource_windows_event.html">azurerm_log_analytics_datasource_windows_event</a>
                 </li>
 

--- a/website/docs/r/log_analytics_datasource_azure_activity_log.html.markdown
+++ b/website/docs/r/log_analytics_datasource_azure_activity_log.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Log Analytics"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_log_analytics_datasource_azure_activity_log"
+description: |-
+  Manages a Log Analytics Azure Activity Log DataSource.
+---
+
+# azurerm_log_analytics_datasource_azure_activity_log
+
+Manages a Log Analytics Azure Activity Log DataSource.
+
+## Example Usage
+
+```hcl
+resource "azurerm_log_analytics_datasource_azure_activity_log" "example" {
+  name                = "example"
+  resource_group_name = "example"
+  workspace_name      = "example"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Log Analytics Azure Activity Log DataSource. Changing this forces a new Log Analytics Azure Activity Log DataSource to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Log Analytics Azure Activity Log DataSource should exist. Changing this forces a new Log Analytics Azure Activity Log DataSource to be created.
+
+* `workspace_name` - (Required) The name of the Log Analytics Workspace where the Log Analytics Azure Activity Log DataSource should exist. Changing this forces a new Log Analytics Azure Activity Log DataSource to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Log Analytics Azure Activity Log DataSource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Log Analytics Azure Activity Log DataSource.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Log Analytics Azure Activity Log DataSource.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Log Analytics Azure Activity Log DataSource.
+
+## Import
+
+Log Analytics Azure Activity Log DataSources can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_log_analytics_data_source_azure_activity_log.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/datasources/datasource1
+```


### PR DESCRIPTION
Support the legacy way to send platform log to log analytics workspace. This is required in issue #7008.

**NOTE**: as the azure activity log is a toggle like resource in workspace level, so it is potentially better to be as a field in `azurerm_log_analytics_workspace`. While the utility code has been written in PR #6449, while that PR has been blocked. To DRY, I just make it a seperate resource for now, if it seems better fit to be integrated to workspace, then just close this PR and wait for #6449 to be merged and move on.

## Test Result

```bash
💤 😡 130 via 🦉 v1.14.4 make testacc TEST=./azurerm/internal/services/loganalytics/tests TESTARGS='-run TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/loganalytics/tests -v -run TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic
=== RUN   TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_requiresImport
=== PAUSE TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_requiresImport
=== CONT  TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic
=== CONT  TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_requiresImport
--- PASS: TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_basic (124.63s)
--- PASS: TestAccAzureRMLogAnalyticsDataSourceAzureActivityLog_requiresImport (138.36s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/loganalytics/tests  138.406s
```
