### PR TITLE
azurerm_hdinsights_*_cluster: loosen work node count validation

### DIFF
--- a/azurerm/helpers/azure/hdinsight.go
+++ b/azurerm/helpers/azure/hdinsight.go
@@ -520,7 +520,7 @@ func ExpandHDInsightsStorageAccounts(storageAccounts []interface{}, gen2storageA
 type HDInsightNodeDefinition struct {
 	CanSpecifyInstanceCount  bool
 	MinInstanceCount         int
-	MaxInstanceCount         int
+	MaxInstanceCount         *int
 	CanSpecifyDisks          bool
 	MaxNumberOfDisksPerNode  *int
 	FixedMinInstanceCount    *int32
@@ -665,6 +665,11 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 	}
 
 	if definition.CanSpecifyInstanceCount {
+		countValidation := validation.IntAtLeast(definition.MinInstanceCount)
+		if definition.MaxInstanceCount != nil {
+			countValidation = validation.IntBetween(definition.MinInstanceCount, *definition.MaxInstanceCount)
+		}
+
 		// TODO 3.0: remove this property
 		result["min_instance_count"] = &schema.Schema{
 			Type:         schema.TypeInt,
@@ -672,12 +677,12 @@ func SchemaHDInsightNodeDefinition(schemaLocation string, definition HDInsightNo
 			ForceNew:     true,
 			Computed:     true,
 			Deprecated:   "this has been deprecated from the API and will be removed in version 3.0 of the provider",
-			ValidateFunc: validation.IntBetween(definition.MinInstanceCount, definition.MaxInstanceCount),
+			ValidateFunc: countValidation,
 		}
 		result["target_instance_count"] = &schema.Schema{
 			Type:         schema.TypeInt,
 			Required:     true,
-			ValidateFunc: validation.IntBetween(definition.MinInstanceCount, definition.MaxInstanceCount),
+			ValidateFunc: countValidation,
 		}
 	}
 

--- a/azurerm/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -25,7 +25,7 @@ import (
 var hdInsightHadoopClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         2,
-	MaxInstanceCount:         2,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedMinInstanceCount:    utils.Int32(int32(1)),
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
@@ -34,14 +34,13 @@ var hdInsightHadoopClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightHadoopClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	MaxInstanceCount:        25,
 	CanSpecifyDisks:         false,
 }
 
 var hdInsightHadoopClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedMinInstanceCount:    utils.Int32(int32(1)),
 	FixedTargetInstanceCount: utils.Int32(int32(3)),

--- a/azurerm/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_hadoop_cluster_resource.go
@@ -40,7 +40,7 @@ var hdInsightHadoopClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightHadoopClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         utils.Int(2),
+	MaxInstanceCount:         utils.Int(3),
 	CanSpecifyDisks:          false,
 	FixedMinInstanceCount:    utils.Int32(int32(1)),
 	FixedTargetInstanceCount: utils.Int32(int32(3)),

--- a/azurerm/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_hbase_cluster_resource.go
@@ -21,7 +21,7 @@ import (
 var hdInsightHBaseClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         2,
-	MaxInstanceCount:         2,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
 }
@@ -29,14 +29,13 @@ var hdInsightHBaseClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightHBaseClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	MaxInstanceCount:        23,
 	CanSpecifyDisks:         false,
 }
 
 var hdInsightHBaseClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(3),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(3)),
 }

--- a/azurerm/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -21,7 +21,7 @@ import (
 var hdInsightInteractiveQueryClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         2,
-	MaxInstanceCount:         2,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
 }
@@ -29,14 +29,13 @@ var hdInsightInteractiveQueryClusterHeadNodeDefinition = azure.HDInsightNodeDefi
 var hdInsightInteractiveQueryClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	MaxInstanceCount:        9,
 	CanSpecifyDisks:         false,
 }
 
 var hdInsightInteractiveQueryClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(3),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(3)),
 }

--- a/azurerm/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_kafka_cluster_resource.go
@@ -21,7 +21,7 @@ import (
 var hdInsightKafkaClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         2,
-	MaxInstanceCount:         2,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
 }
@@ -29,7 +29,6 @@ var hdInsightKafkaClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightKafkaClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	MaxInstanceCount:        57,
 	CanSpecifyDisks:         true,
 	MaxNumberOfDisksPerNode: utils.Int(8),
 }
@@ -37,7 +36,7 @@ var hdInsightKafkaClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightKafkaClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(3),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(3)),
 }

--- a/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
@@ -22,7 +22,7 @@ import (
 var hdInsightMLServicesClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         2,
-	MaxInstanceCount:         2,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedMinInstanceCount:    utils.Int32(int32(1)),
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
@@ -31,14 +31,13 @@ var hdInsightMLServicesClusterHeadNodeDefinition = azure.HDInsightNodeDefinition
 var hdInsightMLServicesClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	MaxInstanceCount:        16,
 	CanSpecifyDisks:         false,
 }
 
 var hdInsightMLServicesClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(3),
 	CanSpecifyDisks:          false,
 	FixedMinInstanceCount:    utils.Int32(int32(1)),
 	FixedTargetInstanceCount: utils.Int32(int32(3)),
@@ -47,7 +46,7 @@ var hdInsightMLServicesClusterZookeeperNodeDefinition = azure.HDInsightNodeDefin
 var hdInsightMLServicesClusterEdgeNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         1,
-	MaxInstanceCount:         1,
+	MaxInstanceCount:         utils.Int(1),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(1)),
 }

--- a/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
@@ -22,7 +22,7 @@ import (
 var hdInsightRServerClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         2,
-	MaxInstanceCount:         2,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedMinInstanceCount:    utils.Int32(int32(1)),
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
@@ -31,14 +31,13 @@ var hdInsightRServerClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightRServerClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	MaxInstanceCount:        16,
 	CanSpecifyDisks:         false,
 }
 
 var hdInsightRServerClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(3),
 	CanSpecifyDisks:          false,
 	FixedMinInstanceCount:    utils.Int32(int32(1)),
 	FixedTargetInstanceCount: utils.Int32(int32(3)),
@@ -47,7 +46,7 @@ var hdInsightRServerClusterZookeeperNodeDefinition = azure.HDInsightNodeDefiniti
 var hdInsightRServerClusterEdgeNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         1,
-	MaxInstanceCount:         1,
+	MaxInstanceCount:         utils.Int(1),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(1)),
 }

--- a/azurerm/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_spark_cluster_resource.go
@@ -21,7 +21,7 @@ import (
 var hdInsightSparkClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         2,
-	MaxInstanceCount:         2,
+	MaxInstanceCount:         utils.Int(2),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
 }
@@ -29,14 +29,13 @@ var hdInsightSparkClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightSparkClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	MaxInstanceCount:        19,
 	CanSpecifyDisks:         false,
 }
 
 var hdInsightSparkClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(3),
 	FixedTargetInstanceCount: utils.Int32(int32(3)),
 	CanSpecifyDisks:          false,
 }

--- a/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
@@ -21,7 +21,7 @@ import (
 var hdInsightStormClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         4,
-	MaxInstanceCount:         4,
+	MaxInstanceCount:         utils.Int(4),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(2)),
 }
@@ -29,15 +29,13 @@ var hdInsightStormClusterHeadNodeDefinition = azure.HDInsightNodeDefinition{
 var hdInsightStormClusterWorkerNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
-	// can't find a hard limit - appears to be limited by the subscription; setting something sensible for now
-	MaxInstanceCount: 9999,
-	CanSpecifyDisks:  false,
+	CanSpecifyDisks:         false,
 }
 
 var hdInsightStormClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition{
 	CanSpecifyInstanceCount:  false,
 	MinInstanceCount:         3,
-	MaxInstanceCount:         3,
+	MaxInstanceCount:         utils.Int(3),
 	CanSpecifyDisks:          false,
 	FixedTargetInstanceCount: utils.Int32(int32(3)),
 }


### PR DESCRIPTION
The limitation should be loosened for work nodes (there already exists this case in the current [code base](https://github.com/terraform-providers/terraform-provider-azurerm/blob/5e66b05b25c3d78a55d14ccbd544a58f089776b3/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go#L32)), and I can't find the source for current hard limits.

From the document: https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-supported-node-configuration

> If you need more than 32 worker nodes in a cluster, select a head node size with at least 8 cores and 14 GB of RAM.

And this is the exact behavior in Portal.

So I would suggest loosening the constraints for work node count.

(this fix #7342 )