### PR TITLE
firewall_resource: support `threat_intel_mode`

### DIFF
--- a/azurerm/internal/services/network/firewall_resource.go
+++ b/azurerm/internal/services/network/firewall_resource.go
@@ -79,6 +79,17 @@ func resourceArmFirewall() *schema.Resource {
 				},
 			},
 
+			"threat_intel_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(network.AzureFirewallThreatIntelModeAlert),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.AzureFirewallThreatIntelModeOff),
+					string(network.AzureFirewallThreatIntelModeAlert),
+					string(network.AzureFirewallThreatIntelModeDeny),
+				}, false),
+			},
+
 			"zones": azure.SchemaMultipleZones(),
 
 			"tags": tags.Schema(),
@@ -135,6 +146,7 @@ func resourceArmFirewallCreateUpdate(d *schema.ResourceData, meta interface{}) e
 		Tags:     tags.Expand(t),
 		AzureFirewallPropertiesFormat: &network.AzureFirewallPropertiesFormat{
 			IPConfigurations: ipConfigs,
+			ThreatIntelMode:  network.AzureFirewallThreatIntelMode(d.Get("threat_intel_mode").(string)),
 		},
 		Zones: zones,
 	}
@@ -212,6 +224,7 @@ func resourceArmFirewallRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("ip_configuration", flattenArmFirewallIPConfigurations(props.IPConfigurations)); err != nil {
 			return fmt.Errorf("Error setting `ip_configuration`: %+v", err)
 		}
+		d.Set("threat_intel_mode", string(props.ThreatIntelMode))
 	}
 
 	if err := d.Set("zones", azure.FlattenZones(read.Zones)); err != nil {

--- a/azurerm/internal/services/network/tests/firewall_resource_test.go
+++ b/azurerm/internal/services/network/tests/firewall_resource_test.go
@@ -326,6 +326,7 @@ resource "azurerm_firewall" "test" {
     subnet_id            = azurerm_subnet.test.id
     public_ip_address_id = azurerm_public_ip.test.id
   }
+  threat_intel_mode = "Deny"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -405,6 +406,7 @@ resource "azurerm_firewall" "import" {
     subnet_id            = azurerm_subnet.test.id
     public_ip_address_id = azurerm_public_ip.test.id
   }
+  threat_intel_mode = azurerm_firewall.test.threat_intel_mode
 }
 `, template)
 }

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `ip_configuration` - (Required) A `ip_configuration` block as documented below.
 
+* `threat_intel_mode` - (Optional) The operation mode for threat intelligence-based filtering. Possible values are: `Off`, `Alert` and `Deny`. Defaults to `Alert`
+
 * `zones` - (Optional) Specifies the availability zones in which the Azure Firewall should be created.
 
 -> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).


### PR DESCRIPTION
Add `threat_intel_mode` to `azurerm_firewall`

## Test Result

```bash
💤 via 🦉 v1.14.4 make testacc TEST=./azurerm/internal/services/compute/tests TESTARGS="-run='TestAccAzureRMMarketplaceAgreement'"                         
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/compute/tests -v -run='TestAccAzureRMMarketplaceAgreement' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMMarketplaceAgreement
=== RUN   TestAccAzureRMMarketplaceAgreement/basic
=== RUN   TestAccAzureRMMarketplaceAgreement/basic/basic
=== RUN   TestAccAzureRMMarketplaceAgreement/basic/requiresImport
=== RUN   TestAccAzureRMMarketplaceAgreement/basic/agreementCanceled
--- PASS: TestAccAzureRMMarketplaceAgreement (380.55s)
    --- PASS: TestAccAzureRMMarketplaceAgreement/basic (380.55s)
        --- PASS: TestAccAzureRMMarketplaceAgreement/basic/basic (144.67s)
        --- PASS: TestAccAzureRMMarketplaceAgreement/basic/requiresImport (149.40s)
        --- PASS: TestAccAzureRMMarketplaceAgreement/basic/agreementCanceled (86.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/tests       380.564s
```

(fix #7336 )