### PR TITLE
azurerm_marketplace_agreement: update doc for importing ID

### DIFF
--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -50,5 +50,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Marketplace Agreement can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_marketplace_agreement.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/publishers/publisher1/offers/offer1/plans/plan1/agreements/current
+terraform import azurerm_marketplace_agreement.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/agreements/publisher1/offers/offer1/plans/plan1
 ```


### PR DESCRIPTION
The doc mistakenly used the ID of the `offertype`, rather than using `agreement` as the ID of the resource.

(fix: #7301)