### PR TITLE
`azurerm_function_app` `app_settings` refresh plan is not empty

### DIFF
--- a/azurerm/internal/services/web/resource_arm_function_app.go
+++ b/azurerm/internal/services/web/resource_arm_function_app.go
@@ -661,9 +661,15 @@ func resourceArmFunctionAppRead(d *schema.ResourceData, meta interface{}) error 
 	dashboard, ok := appSettings["AzureWebJobsDashboard"]
 	d.Set("enable_builtin_logging", ok && dashboard != "")
 
-	delete(appSettings, "AzureWebJobsDashboard")
-	delete(appSettings, "AzureWebJobsStorage")
-	delete(appSettings, "FUNCTIONS_EXTENSION_VERSION")
+	if _, ok = d.GetOk("app_settings.AzureWebJobsDashboard"); !ok {
+		delete(appSettings, "AzureWebJobsDashboard")
+	}
+	if _, ok = d.GetOk("app_settings.AzureWebJobsStorage"); !ok {
+		delete(appSettings, "AzureWebJobsStorage")
+	}
+	if _, ok = d.GetOk("app_settings.FUNCTIONS_EXTENSION_VERSION"); !ok {
+		delete(appSettings, "FUNCTIONS_EXTENSION_VERSION")
+	}
 
 	// Let the user have a final say whether he wants to keep these 2 or not on
 	// Linux consumption plans. They shouldn't be there according to a bug


### PR DESCRIPTION
Fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/6909

TestAccAzureRMFunctionApp_siteConfigMulti test fails for it has a comment to allow its failure

=== RUN   TestAccAzureRMFunctionApp_appSettings
=== PAUSE TestAccAzureRMFunctionApp_appSettings
=== CONT  TestAccAzureRMFunctionApp_appSettings
--- PASS: TestAccAzureRMFunctionApp_appSettings (373.24s)
=== RUN   TestAccAzureRMFunctionApp_basic
=== PAUSE TestAccAzureRMFunctionApp_basic
=== CONT  TestAccAzureRMFunctionApp_basic
--- PASS: TestAccAzureRMFunctionApp_basic (200.02s)
=== RUN   TestAccAzureRMFunctionApp_deprecatedConnectionString
=== PAUSE TestAccAzureRMFunctionApp_deprecatedConnectionString
=== CONT  TestAccAzureRMFunctionApp_deprecatedConnectionString
--- PASS: TestAccAzureRMFunctionApp_deprecatedConnectionString (182.47s)
=== RUN   TestAccAzureRMFunctionApp_deprecatedConnectionStringMissingError
=== PAUSE TestAccAzureRMFunctionApp_deprecatedConnectionStringMissingError
=== CONT  TestAccAzureRMFunctionApp_deprecatedConnectionStringMissingError
--- PASS: TestAccAzureRMFunctionApp_deprecatedConnectionStringMissingError (100.85s)
=== RUN   TestAccAzureRMFunctionApp_deprecatedNeedBothSAAtrributesError
=== PAUSE TestAccAzureRMFunctionApp_deprecatedNeedBothSAAtrributesError
=== CONT  TestAccAzureRMFunctionApp_deprecatedNeedBothSAAtrributesError
--- PASS: TestAccAzureRMFunctionApp_deprecatedNeedBothSAAtrributesError (105.36s)
=== RUN   TestAccAzureRMFunctionApp_requiresImport
=== PAUSE TestAccAzureRMFunctionApp_requiresImport
=== CONT  TestAccAzureRMFunctionApp_requiresImport
--- PASS: TestAccAzureRMFunctionApp_requiresImport (197.67s)
=== RUN   TestAccAzureRMFunctionApp_tags
=== PAUSE TestAccAzureRMFunctionApp_tags
=== CONT  TestAccAzureRMFunctionApp_tags
--- PASS: TestAccAzureRMFunctionApp_tags (184.50s)
=== RUN   TestAccAzureRMFunctionApp_tagsUpdate
=== PAUSE TestAccAzureRMFunctionApp_tagsUpdate
=== CONT  TestAccAzureRMFunctionApp_tagsUpdate
--- PASS: TestAccAzureRMFunctionApp_tagsUpdate (236.73s)
=== RUN   TestAccAzureRMFunctionApp_siteConfig
=== PAUSE TestAccAzureRMFunctionApp_siteConfig
=== CONT  TestAccAzureRMFunctionApp_siteConfig
--- PASS: TestAccAzureRMFunctionApp_siteConfig (203.37s)
=== RUN   TestAccAzureRMFunctionApp_linuxFxVersion
=== PAUSE TestAccAzureRMFunctionApp_linuxFxVersion
=== CONT  TestAccAzureRMFunctionApp_linuxFxVersion
--- PASS: TestAccAzureRMFunctionApp_linuxFxVersion (210.94s)
=== RUN   TestAccAzureRMFunctionApp_connectionStrings
=== PAUSE TestAccAzureRMFunctionApp_connectionStrings
=== CONT  TestAccAzureRMFunctionApp_connectionStrings
--- PASS: TestAccAzureRMFunctionApp_connectionStrings (235.29s)
=== RUN   TestAccAzureRMFunctionApp_updateVersion
=== PAUSE TestAccAzureRMFunctionApp_updateVersion
=== CONT  TestAccAzureRMFunctionApp_updateVersion
--- PASS: TestAccAzureRMFunctionApp_updateVersion (253.16s)
=== RUN   TestAccAzureRMFunctionApp_3264bit
=== PAUSE TestAccAzureRMFunctionApp_3264bit
=== CONT  TestAccAzureRMFunctionApp_3264bit
--- PASS: TestAccAzureRMFunctionApp_3264bit (245.15s)
=== RUN   TestAccAzureRMFunctionApp_httpsOnly
=== PAUSE TestAccAzureRMFunctionApp_httpsOnly
=== CONT  TestAccAzureRMFunctionApp_httpsOnly
--- PASS: TestAccAzureRMFunctionApp_httpsOnly (233.81s)
=== RUN   TestAccAzureRMFunctionApp_dailyMemoryTimeQuota
=== PAUSE TestAccAzureRMFunctionApp_dailyMemoryTimeQuota
=== CONT  TestAccAzureRMFunctionApp_dailyMemoryTimeQuota
--- PASS: TestAccAzureRMFunctionApp_dailyMemoryTimeQuota (461.59s)
=== RUN   TestAccAzureRMFunctionApp_consumptionPlan
=== PAUSE TestAccAzureRMFunctionApp_consumptionPlan
=== CONT  TestAccAzureRMFunctionApp_consumptionPlan
--- PASS: TestAccAzureRMFunctionApp_consumptionPlan (267.14s)
=== RUN   TestAccAzureRMFunctionApp_consumptionPlanUppercaseName
=== PAUSE TestAccAzureRMFunctionApp_consumptionPlanUppercaseName
=== CONT  TestAccAzureRMFunctionApp_consumptionPlanUppercaseName
--- PASS: TestAccAzureRMFunctionApp_consumptionPlanUppercaseName (231.85s)
=== RUN   TestAccAzureRMFunctionApp_createIdentity
=== PAUSE TestAccAzureRMFunctionApp_createIdentity
=== CONT  TestAccAzureRMFunctionApp_createIdentity
--- PASS: TestAccAzureRMFunctionApp_createIdentity (298.92s)
=== RUN   TestAccAzureRMFunctionApp_updateIdentity
=== PAUSE TestAccAzureRMFunctionApp_updateIdentity
=== CONT  TestAccAzureRMFunctionApp_updateIdentity
--- PASS: TestAccAzureRMFunctionApp_updateIdentity (320.03s)
=== RUN   TestAccAzureRMFunctionApp_userAssignedIdentity
=== PAUSE TestAccAzureRMFunctionApp_userAssignedIdentity
=== CONT  TestAccAzureRMFunctionApp_userAssignedIdentity
--- PASS: TestAccAzureRMFunctionApp_userAssignedIdentity (354.79s)
=== RUN   TestAccAzureRMFunctionApp_loggingDisabled
=== PAUSE TestAccAzureRMFunctionApp_loggingDisabled
=== CONT  TestAccAzureRMFunctionApp_loggingDisabled
--- PASS: TestAccAzureRMFunctionApp_loggingDisabled (185.11s)
=== RUN   TestAccAzureRMFunctionApp_updateLogging
=== PAUSE TestAccAzureRMFunctionApp_updateLogging
=== CONT  TestAccAzureRMFunctionApp_updateLogging
--- PASS: TestAccAzureRMFunctionApp_updateLogging (369.63s)
=== RUN   TestAccAzureRMFunctionApp_authSettings
=== PAUSE TestAccAzureRMFunctionApp_authSettings
=== CONT  TestAccAzureRMFunctionApp_authSettings
--- PASS: TestAccAzureRMFunctionApp_authSettings (185.78s)
=== RUN   TestAccAzureRMFunctionApp_corsSettings
=== PAUSE TestAccAzureRMFunctionApp_corsSettings
=== CONT  TestAccAzureRMFunctionApp_corsSettings
--- PASS: TestAccAzureRMFunctionApp_corsSettings (195.02s)
=== RUN   TestAccAzureRMFunctionApp_enableHttp2
=== PAUSE TestAccAzureRMFunctionApp_enableHttp2
=== CONT  TestAccAzureRMFunctionApp_enableHttp2
--- PASS: TestAccAzureRMFunctionApp_enableHttp2 (196.20s)
=== RUN   TestAccAzureRMFunctionApp_minTlsVersion
=== PAUSE TestAccAzureRMFunctionApp_minTlsVersion
=== CONT  TestAccAzureRMFunctionApp_minTlsVersion
--- PASS: TestAccAzureRMFunctionApp_minTlsVersion (199.97s)
=== RUN   TestAccAzureRMFunctionApp_ftpsState
=== PAUSE TestAccAzureRMFunctionApp_ftpsState
=== CONT  TestAccAzureRMFunctionApp_ftpsState
--- PASS: TestAccAzureRMFunctionApp_ftpsState (245.58s)
=== RUN   TestAccAzureRMFunctionApp_preWarmedInstanceCount
=== PAUSE TestAccAzureRMFunctionApp_preWarmedInstanceCount
=== CONT  TestAccAzureRMFunctionApp_preWarmedInstanceCount
--- PASS: TestAccAzureRMFunctionApp_preWarmedInstanceCount (259.39s)
=== RUN   TestAccAzureRMFunctionApp_oneIpRestriction
=== PAUSE TestAccAzureRMFunctionApp_oneIpRestriction
=== CONT  TestAccAzureRMFunctionApp_oneIpRestriction
--- PASS: TestAccAzureRMFunctionApp_oneIpRestriction (245.58s)
=== RUN   TestAccAzureRMFunctionApp_oneVNetSubnetIpRestriction
=== PAUSE TestAccAzureRMFunctionApp_oneVNetSubnetIpRestriction
=== CONT  TestAccAzureRMFunctionApp_oneVNetSubnetIpRestriction
--- PASS: TestAccAzureRMFunctionApp_oneVNetSubnetIpRestriction (214.37s)
=== RUN   TestAccAzureRMFunctionApp_ipRestrictionRemoved
=== PAUSE TestAccAzureRMFunctionApp_ipRestrictionRemoved
=== CONT  TestAccAzureRMFunctionApp_ipRestrictionRemoved
--- PASS: TestAccAzureRMFunctionApp_ipRestrictionRemoved (332.78s)
=== RUN   TestAccAzureRMFunctionApp_manyIpRestrictions
=== PAUSE TestAccAzureRMFunctionApp_manyIpRestrictions
=== CONT  TestAccAzureRMFunctionApp_manyIpRestrictions
--- PASS: TestAccAzureRMFunctionApp_manyIpRestrictions (273.04s)
=== RUN   TestAccAzureRMFunctionApp_updateStorageAccountKey
=== PAUSE TestAccAzureRMFunctionApp_updateStorageAccountKey
=== CONT  TestAccAzureRMFunctionApp_updateStorageAccountKey
--- PASS: TestAccAzureRMFunctionApp_updateStorageAccountKey (318.79s)
