### PR TITLE
azurerm_frontdoor - Update documentation of redirect_type

### DIFF
--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -222,7 +222,7 @@ The `redirect_configuration` block supports the following:
 
 * `redirect_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HttpOnly`, `HttpsOnly`, or `MatchRequest`. Defaults to `MatchRequest`
 
-* `redirect_type` - (Optional) Status code for the redirect. Valida options are `Moved`, `Found`, `TemporaryRedirect`, `PermanentRedirect`. Defaults to `Found`
+* `redirect_type` - (Required) Status code for the redirect. Valida options are `Moved`, `Found`, `TemporaryRedirect`, `PermanentRedirect`.
 
 * `custom_fragment` - (Optional) The destination fragment in the portion of URL after '#'. Set this to add a fragment to the redirect URL.
 


### PR DESCRIPTION
redirect_type is required and has no defaults


https://github.com/terraform-providers/terraform-provider-azurerm/blob/40a653362e0b90f2b673890ce7fcb1d42d581cdf/azurerm/internal/services/frontdoor/frontdoor_resource.go#L174-L177