### PR TITLE
Doc Fix: private_endpoint.html.markdown

### DIFF
--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_subnet" "service" {
   name                 = "service"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.1.0/24"
+  address_prefixes     = ["10.0.1.0/24"]
 
   enforce_private_link_service_network_policies = true
 }
@@ -42,7 +42,7 @@ resource "azurerm_subnet" "endpoint" {
   name                 = "endpoint"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefix       = "10.0.2.0/24"
+  address_prefixes     = ["10.0.2.0/24"]
 
   enforce_private_link_endpoint_network_policies = true
 }


### PR DESCRIPTION
Use address_prefixes instead of deprecated address_prefix in example.