### PR TITLE
azurerm_mssql_database - support `GP_S_Gen5` SKUs up to `GP_S_Gen5_40`

### DIFF
--- a/azurerm/internal/services/mssql/validate/mssql_database.go
+++ b/azurerm/internal/services/mssql/validate/mssql_database.go
@@ -41,7 +41,7 @@ func MsSqlDatabaseAutoPauseDelay(i interface{}, k string) (warnings []string, er
 
 func MsSqlDBSkuName() schema.SchemaValidateFunc {
 	return validation.StringMatch(
-		regexp.MustCompile(`(?i)(^(GP_S_Gen5_(1|2|4|6|8|10|12|14|16))$|^((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))$|^((GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80))$|^(BC_M_(8|10|12|14|16|18|20|24|32|64|128))$|^(Basic)$|^(ElasticPool)$|^(S(0|1|2|3|4|6|7|9|12))$|^(P(1|2|4|6|11|15))$|^(DW(1|2|3|4|5|10|15|20)00c)$|^(DS(1|2|3|4|5|6|10|12|15|20)00)$)`),
+		regexp.MustCompile(`(?i)(^(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))$|^((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))$|^((GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80))$|^(BC_M_(8|10|12|14|16|18|20|24|32|64|128))$|^(Basic)$|^(ElasticPool)$|^(S(0|1|2|3|4|6|7|9|12))$|^(P(1|2|4|6|11|15))$|^(DW(1|2|3|4|5|10|15|20)00c)$|^(DS(1|2|3|4|5|6|10|12|15|20)00)$)`),
 
 		`This is not a valid sku name. For example, a valid sku name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
 	)


### PR DESCRIPTION
SKUs for `GP_S_Gen5` databases go up to `GP_S_Gen5_40` ([docs](https://docs.microsoft.com/en-us/azure/azure-sql/database/resource-limits-vcore-single-databases#general-purpose---serverless-compute---gen5)), but the current validator function only allows up to `GP_S_Gen5_16`. This PR updates the validator to allow all documented serverless SKUs.

This is my first contribution to this, or any Terraform Provider, so please let me know what validation or testing steps I need to do on my end to button up this pull request.