### PR TITLE
azurerm_mssql_database - support min_capacity up to 5

### DIFF
--- a/azurerm/internal/services/mssql/mssql_database_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_resource.go
@@ -123,7 +123,7 @@ func resourceArmMsSqlDatabase() *schema.Resource {
 				Type:         schema.TypeFloat,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: azValidate.FloatInSlice([]float64{0.5, 0.75, 1, 1.25, 1.5, 1.75, 2}),
+				ValidateFunc: azValidate.FloatInSlice([]float64{0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 3, 4, 5}),
 			},
 
 			"restore_point_in_time": {


### PR DESCRIPTION
Minimum capacities for `GP_S_Gen5` serverless databases go from `0.5` to `5` ([docs](https://docs.microsoft.com/en-us/azure/azure-sql/database/resource-limits-vcore-single-databases#general-purpose---serverless-compute---gen5)), but the current validator function only allows `min_capacity` up to `2`. This PR updates the validator to allow all documented minimum capacities for serverless databases.