### PR TITLE
azurerm_monitor_activity_log_alert: support `properties.recommendationType`

### DIFF
--- a/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -123,9 +123,35 @@ func resourceArmMonitorActivityLogAlert() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"recommendation_type": {
+						"recommendation_category": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"Cost",
+								"Reliability",
+								"OperationalExcellence",
+								"Performance",
+							},
+								false,
+							),
+							ConflictsWith: []string{"criteria.0.recommendation_type"},
+						},
+						"recommendation_impact": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"High",
+								"Medium",
+								"Low",
+							},
+								false,
+							),
+							ConflictsWith: []string{"criteria.0.recommendation_type"},
+						},
+						"recommendation_type": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							ConflictsWith: []string{"criteria.0.recommendation_category", "criteria.0.recommendation_impact"},
 						},
 					},
 				},
@@ -359,6 +385,20 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) *insights.Activi
 		})
 	}
 
+	if recommendationCategory := v["recommendation_category"].(string); recommendationCategory != "" {
+		conditions = append(conditions, insights.ActivityLogAlertLeafCondition{
+			Field:  utils.String("properties.recommendationCategory"),
+			Equals: utils.String(recommendationCategory),
+		})
+	}
+
+	if recommendationImpact := v["recommendation_impact"].(string); recommendationImpact != "" {
+		conditions = append(conditions, insights.ActivityLogAlertLeafCondition{
+			Field:  utils.String("properties.recommendationImpact"),
+			Equals: utils.String(recommendationImpact),
+		})
+	}
+
 	return &insights.ActivityLogAlertAllOfCondition{
 		AllOf: &conditions,
 	}
@@ -407,8 +447,12 @@ func flattenMonitorActivityLogAlertCriteria(input *insights.ActivityLogAlertAllO
 				result["resource_id"] = *condition.Equals
 			case "substatus":
 				result["sub_status"] = *condition.Equals
-			case "recommendationType":
+			case "properties.recommendationtype":
 				result["recommendation_type"] = *condition.Equals
+			case "properties.recommendationcategory":
+				result["recommendation_category"] = *condition.Equals
+			case "properties.recommendationimpact":
+				result["recommendation_impact"] = *condition.Equals
 			case "caller", "category", "level", "status":
 				result[*condition.Field] = *condition.Equals
 			}

--- a/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -123,6 +123,10 @@ func resourceArmMonitorActivityLogAlert() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"recommendation_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -348,6 +352,12 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) *insights.Activi
 			Equals: utils.String(subStatus),
 		})
 	}
+	if recommendationType := v["recommendation_type"].(string); recommendationType != "" {
+		conditions = append(conditions, insights.ActivityLogAlertLeafCondition{
+			Field:  utils.String("properties.recommendationType"),
+			Equals: utils.String(recommendationType),
+		})
+	}
 
 	return &insights.ActivityLogAlertAllOfCondition{
 		AllOf: &conditions,
@@ -397,6 +407,8 @@ func flattenMonitorActivityLogAlertCriteria(input *insights.ActivityLogAlertAllO
 				result["resource_id"] = *condition.Equals
 			case "substatus":
 				result["sub_status"] = *condition.Equals
+			case "recommendationType":
+				result["recommendation_type"] = *condition.Equals
 			case "caller", "category", "level", "status":
 				result[*condition.Field] = *condition.Equals
 			}

--- a/azurerm/internal/services/monitor/tests/monitor_activity_log_alert_resource_test.go
+++ b/azurerm/internal/services/monitor/tests/monitor_activity_log_alert_resource_test.go
@@ -105,9 +105,6 @@ func TestAccAzureRMMonitorActivityLogAlert_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.resource_type", "Microsoft.Storage/storageAccounts"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "criteria.0.resource_group"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "criteria.0.resource_id"),
-					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.caller", "user@example.com"),
-					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.level", "Error"),
-					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.status", "Failed"),
 					resource.TestCheckResourceAttr(data.ResourceName, "action.#", "2"),
 				),
 			},
@@ -154,9 +151,6 @@ func TestAccAzureRMMonitorActivityLogAlert_basicAndCompleteUpdate(t *testing.T) 
 					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.resource_type", "Microsoft.Storage/storageAccounts"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "criteria.0.resource_group"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "criteria.0.resource_id"),
-					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.caller", "user@example.com"),
-					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.level", "Error"),
-					resource.TestCheckResourceAttr(data.ResourceName, "criteria.0.status", "Failed"),
 					resource.TestCheckResourceAttr(data.ResourceName, "action.#", "2"),
 				),
 			},
@@ -306,15 +300,14 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   ]
 
   criteria {
-    operation_name    = "Microsoft.Storage/storageAccounts/write"
-    category          = "Recommendation"
-    resource_provider = "Microsoft.Storage"
-    resource_type     = "Microsoft.Storage/storageAccounts"
-    resource_group    = azurerm_resource_group.test.name
-    resource_id       = azurerm_storage_account.test.id
-    caller            = "user@example.com"
-    level             = "Error"
-    status            = "Failed"
+    operation_name          = "Microsoft.Storage/storageAccounts/write"
+    category                = "Recommendation"
+    resource_provider       = "Microsoft.Storage"
+    resource_type           = "Microsoft.Storage/storageAccounts"
+    resource_group          = azurerm_resource_group.test.name
+    resource_id             = azurerm_storage_account.test.id
+    recommendation_category = "OperationalExcellence"
+    recommendation_impact   = "High"
   }
 
   action {

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -94,6 +94,9 @@ A `criteria` block supports the following:
 * `status` - (Optional) The status of the event. For example, `Started`, `Failed`, or `Succeeded`.
 * `sub_status` - (Optional) The sub status of the event.
 * `recommendation_type` - (Optional) The recommendation type of the event. It is only allowed when `category` is `Recommendation`.
+* `recommendation_category` - (Optional) The recommendation category of the event. Possible values are `Cost`, `Reliability`, `OperationalExcellence` and `Performance`. It is only allowed when `category` is `Recommendation`.
+* `recommendation_impact` - (Optional) The recommendation impact of the event. Possible values are `High`, `Medium` and `Low`. It is only allowed when `category` is `Recommendation`.
+
 
 ## Attributes Reference
 

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -93,6 +93,7 @@ A `criteria` block supports the following:
 * `level` - (Optional) The severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
 * `status` - (Optional) The status of the event. For example, `Started`, `Failed`, or `Succeeded`.
 * `sub_status` - (Optional) The sub status of the event.
+* `recommendation_type` - (Optional) The recommendation type of the event. It is only allowed when `category` is `Recommendation`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
 azurerm_monitor_activity_log_alert: support `properties.recommendationType` for recommendation alerts.

There is no document for this field, but via inspecting the API flow in portal, the mode is like below:

```json
        "condition": {
            "allOf": [
                {
                    "field": "category",
                    "equals": "Recommendation",
                    "containsAny": null,
                    "odata.type": null
                },
                {
                    "field": "operationName",
                    "equals": "Microsoft.Advisor/recommendations/available/action",
                    "containsAny": null,
                    "odata.type": null
                },
                {
                    "field": "properties.recommendationType",
                    "equals": "2b5eac39-9f50-4d8d-bc9b-1e1e07c5c37e",
                    "containsAny": null,
                    "odata.type": null
                }
            ],
            "odata.type": null
        },
```

The id can be got from `azurerm_advisor_recommendation` data source or by other means.

(fix: #7300)