### PR TITLE
monitor_diagnostic_setting: suppress diff on metric/log against default value

### DIFF
--- a/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -129,7 +129,7 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 						},
 					},
 				},
-				Set: monitorDiagnosticSettingHash("log"),
+				DiffSuppressFunc: diagLogSettingSuppress("log"),
 			},
 
 			"metric": {
@@ -169,7 +169,7 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 						},
 					},
 				},
-				Set: monitorDiagnosticSettingHash("log"),
+				DiffSuppressFunc: diagMetricSettingSuppress("metric"),
 			},
 		},
 	}
@@ -413,19 +413,11 @@ func expandMonitorDiagnosticsSettingsLogs(input []interface{}) []insights.LogSet
 	return results
 }
 
-func flattenMonitorDiagnosticLogs(input *[]insights.LogSettings) *schema.Set {
+func flattenMonitorDiagnosticLogs(input *[]insights.LogSettings) []interface{} {
+	results := make([]interface{}, 0)
 	if input == nil {
-		return nil
+		return results
 	}
-
-	s := schema.Set{
-		F: monitorDiagnosticSettingHash("log"),
-	}
-	// Always adding a placeholder so as to match the hash of the default settings, whose hash is 0.
-	s.Add(map[string]interface{}{
-		"enabled":          false,
-		"retention_policy": []interface{}{},
-	})
 
 	for _, v := range *input {
 		output := make(map[string]interface{})
@@ -456,10 +448,10 @@ func flattenMonitorDiagnosticLogs(input *[]insights.LogSettings) *schema.Set {
 
 		output["retention_policy"] = policies
 
-		s.Add(output)
+		results = append(results, output)
 	}
 
-	return &s
+	return results
 }
 
 func expandMonitorDiagnosticsSettingsMetrics(input []interface{}) []insights.MetricSettings {
@@ -494,19 +486,11 @@ func expandMonitorDiagnosticsSettingsMetrics(input []interface{}) []insights.Met
 	return results
 }
 
-func flattenMonitorDiagnosticMetrics(input *[]insights.MetricSettings) *schema.Set {
+func flattenMonitorDiagnosticMetrics(input *[]insights.MetricSettings) []interface{} {
+	results := make([]interface{}, 0)
 	if input == nil {
-		return nil
+		return results
 	}
-
-	s := schema.Set{
-		F: monitorDiagnosticSettingHash("metric"),
-	}
-	// Always adding a placeholder so as to match the hash of the default settings, whose hash is 0.
-	s.Add(map[string]interface{}{
-		"enabled":          false,
-		"retention_policy": []interface{}{},
-	})
 
 	for _, v := range *input {
 		output := make(map[string]interface{})
@@ -537,10 +521,10 @@ func flattenMonitorDiagnosticMetrics(input *[]insights.MetricSettings) *schema.S
 
 		output["retention_policy"] = policies
 
-		s.Add(output)
+		results = append(results, output)
 	}
 
-	return &s
+	return results
 }
 
 type monitorDiagnosticId struct {
@@ -561,47 +545,31 @@ func parseMonitorDiagnosticId(monitorId string) (*monitorDiagnosticId, error) {
 	return &identifier, nil
 }
 
-// diagLogSettingSuppress suppresses the not specified log settings which have the default value (disabled) set in service.
+// diagLogSettingSuppress suppresses the not specified log settings which have the default value (0/disabled) set in service.
 // Otherwise, user always has to specify all the possible log settings in the terraform config.
 func diagLogSettingSuppress(key string) func(k string, old string, new string, d *schema.ResourceData) bool {
 	return func(k string, old string, new string, d *schema.ResourceData) bool {
-		// Hack: this function will be called multiple times for the nested keys of the set (e.g. "key.#", "key.0.category")
-		//       we only want to check the whole set for one time, so we simply skip invocation on keys other than "key.#",
-		//       which is guaranteed to be invoked for exactly one time.
-		if k != key+".#" {
-			return false
-		}
-
 		o, n := d.GetChange(key)
 
 		if o == nil || n == nil {
 			return false
 		}
 
+		oset, nset := o.(*schema.Set), n.(*schema.Set)
+
 		// If new set contains more settings than old one, which mostly indicates the new resource case.
 		// (NOTE: d.IsNewResource() seems not work here)
-		if n.(*schema.Set).Difference(o.(*schema.Set)).Len() > 0 {
+		if nset.Difference(oset).Len() > 0 {
 			return false
 		}
 
-		os, ns := expandMonitorDiagnosticsSettingsLogs(o.(*schema.Set).List()), expandMonitorDiagnosticsSettingsLogs(n.(*schema.Set).List())
-
-		nmap := map[string]insights.LogSettings{}
-		for i := range ns {
-			if ns[i].Category == nil {
-				continue
-			}
-			nmap[*(ns[i].Category)] = ns[i]
+		// There is diff in the intersection elements, then don't suppress diff
+		if !oset.Intersection(nset).Equal(nset.Intersection(oset)) {
+			return false
 		}
 
 		// Check those only appear in old settings to see if they have the default disabled value
-		for _, osetting := range os {
-			if osetting.Category == nil {
-				continue
-			}
-			if _, ok := nmap[*osetting.Category]; ok {
-				continue
-			}
+		for _, osetting := range expandMonitorDiagnosticsSettingsLogs(oset.Difference(nset).List()) {
 			if osetting.Enabled != nil && *osetting.Enabled != false {
 				return false
 			}
@@ -618,47 +586,31 @@ func diagLogSettingSuppress(key string) func(k string, old string, new string, d
 	}
 }
 
-// diagMetricSettingSuppress suppresses the not specified metric settings which have the default value (disabled) set in service.
+// diagMetricSettingSuppress suppresses the not specified metric settings which have the default value (0/disabled) set in service.
 // Otherwise, user always has to specify all the possible metric settings in the terraform config.
 func diagMetricSettingSuppress(key string) func(k string, old string, new string, d *schema.ResourceData) bool {
 	return func(k string, old string, new string, d *schema.ResourceData) bool {
-		// Hack: this function will be called multiple times for the nested keys of the set (e.g. "key.#", "key.0.category")
-		//       we only want to check the whole set for one time, so we simply skip invocation on keys other than "key.#",
-		//       which is guaranteed to be invoked for exactly one time.
-		if k != key+".#" {
-			return false
-		}
-
 		o, n := d.GetChange(key)
 
 		if o == nil || n == nil {
 			return false
 		}
 
+		oset, nset := o.(*schema.Set), n.(*schema.Set)
+
 		// If new set contains more settings than old one, which mostly indicates the new resource case.
 		// (NOTE: d.IsNewResource() seems not work here)
-		if n.(*schema.Set).Difference(o.(*schema.Set)).Len() > 0 {
+		if nset.Difference(oset).Len() > 0 {
 			return false
 		}
 
-		os, ns := expandMonitorDiagnosticsSettingsMetrics(o.(*schema.Set).List()), expandMonitorDiagnosticsSettingsMetrics(n.(*schema.Set).List())
-
-		nmap := map[string]insights.MetricSettings{}
-		for i := range ns {
-			if ns[i].Category == nil {
-				continue
-			}
-			nmap[*(ns[i].Category)] = ns[i]
+		// There is diff in the intersection elements, then don't suppress diff
+		if !oset.Intersection(nset).Equal(nset.Intersection(oset)) {
+			return false
 		}
 
 		// Check those only appear in old settings to see if they have the default disabled value
-		for _, osetting := range os {
-			if osetting.Category == nil {
-				continue
-			}
-			if _, ok := nmap[*osetting.Category]; ok {
-				continue
-			}
+		for _, osetting := range expandMonitorDiagnosticsSettingsMetrics(oset.Difference(nset).List()) {
 			if osetting.Enabled != nil && *osetting.Enabled != false {
 				return false
 			}
@@ -672,23 +624,5 @@ func diagMetricSettingSuppress(key string) func(k string, old string, new string
 			}
 		}
 		return true
-	}
-}
-
-func monitorDiagnosticSettingHash(k string) func(interface{}) int {
-	return func(v interface{}) int {
-		if m, ok := v.(map[string]interface{}); ok {
-			if m["enabled"].(bool) == false {
-				b := m["retention_policy"].([]interface{})
-				if len(b) == 0 {
-					return 0
-				}
-				policy := b[0].(map[string]interface{})
-				if policy["enabled"] == false && policy["days"] == 0 {
-					return 0
-				}
-			}
-		}
-		return schema.HashResource(resourceArmMonitorDiagnosticSetting().Schema[k].Elem.(*schema.Resource))(v)
 	}
 }

--- a/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -129,6 +129,11 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 						},
 					},
 				},
+				// Service side has a predefined set of diagnostic settings for a certain resource, and it will
+				// always return that set of settings in the returned response.
+				// This suppress function is used to suppress diff only in follow situation:
+				// The intersection part of old state and new state is the same, and the extra part of old state
+				// contains only the default value.
 				DiffSuppressFunc: diagLogSettingSuppress("log"),
 			},
 
@@ -169,6 +174,11 @@ func resourceArmMonitorDiagnosticSetting() *schema.Resource {
 						},
 					},
 				},
+				// Service side has a predefined set of diagnostic settings for a certain resource, and it will
+				// always return that set of settings in the returned response.
+				// This suppress function is used to suppress diff only in follow situation:
+				// The intersection part of old state and new state is the same, and the extra part of old state
+				// contains only the default value.
 				DiffSuppressFunc: diagMetricSettingSuppress("metric"),
 			},
 		},

--- a/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/azurerm/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -570,11 +570,11 @@ func diagLogSettingSuppress(key string) func(k string, old string, new string, d
 
 		// Check those only appear in old settings to see if they have the default disabled value
 		for _, osetting := range expandMonitorDiagnosticsSettingsLogs(oset.Difference(nset).List()) {
-			if osetting.Enabled != nil && *osetting.Enabled != false {
+			if osetting.Enabled != nil && *osetting.Enabled {
 				return false
 			}
 			if policy := osetting.RetentionPolicy; policy != nil {
-				if policy.Enabled != nil && *policy.Enabled != false {
+				if policy.Enabled != nil && *policy.Enabled {
 					return false
 				}
 				if policy.Days != nil && *policy.Days != 0 {
@@ -611,11 +611,11 @@ func diagMetricSettingSuppress(key string) func(k string, old string, new string
 
 		// Check those only appear in old settings to see if they have the default disabled value
 		for _, osetting := range expandMonitorDiagnosticsSettingsMetrics(oset.Difference(nset).List()) {
-			if osetting.Enabled != nil && *osetting.Enabled != false {
+			if osetting.Enabled != nil && *osetting.Enabled {
 				return false
 			}
 			if policy := osetting.RetentionPolicy; policy != nil {
-				if policy.Enabled != nil && *policy.Enabled != false {
+				if policy.Enabled != nil && *policy.Enabled {
 					return false
 				}
 				if policy.Days != nil && *policy.Days != 0 {

--- a/azurerm/internal/services/monitor/tests/monitor_diagnostic_setting_resource_test.go
+++ b/azurerm/internal/services/monitor/tests/monitor_diagnostic_setting_resource_test.go
@@ -314,10 +314,18 @@ resource "azurerm_virtual_network" "test" {
   address_space       = ["10.0.0.0/16"]
 }
 
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctest-LAW-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
 resource "azurerm_monitor_diagnostic_setting" "test" {
   name                           = "acctest-DS-%[1]d"
   target_resource_id             = azurerm_virtual_network.test.id
-  log_analytics_workspace_id     = "/subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourcegroups/magodo-rg/providers/microsoft.operationalinsights/workspaces/magodo-log"
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.test.id
 
   metric {
     category = "AllMetrics"

--- a/azurerm/internal/services/monitor/tests/monitor_diagnostic_setting_resource_test.go
+++ b/azurerm/internal/services/monitor/tests/monitor_diagnostic_setting_resource_test.go
@@ -320,9 +320,9 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "test" {
-  name                           = "acctest-DS-%[1]d"
-  target_resource_id             = azurerm_virtual_network.test.id
-  log_analytics_workspace_id     = azurerm_log_analytics_workspace.test.id
+  name                       = "acctest-DS-%[1]d"
+  target_resource_id         = azurerm_virtual_network.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
 
   metric {
     category = "AllMetrics"

--- a/azurerm/internal/services/monitor/tests/monitor_diagnostic_setting_resource_test.go
+++ b/azurerm/internal/services/monitor/tests/monitor_diagnostic_setting_resource_test.go
@@ -160,9 +160,6 @@ func TestAccAzureRMMonitorDiagnosticSetting_activityLog(t *testing.T) {
 				Config: testAccAzureRMMonitorDiagnosticSetting_activityLog(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMonitorDiagnosticSettingExists(data.ResourceName),
-					resource.TestCheckResourceAttrSet(data.ResourceName, "storage_account_id"),
-					resource.TestCheckResourceAttr(data.ResourceName, "log.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "log.782743152.category", "Administrative"),
 				),
 			},
 			data.ImportStep(),


### PR DESCRIPTION
Some resource type (specified by `target_resource_id`) has its own set of diagnostic settings. If the user didn't explicitly specify some of the settings in `PUT` request body, the representation of the diag settings will still contain those settings, with the default values (0/disabled). This is not an idempotent API, IMHO.

Under this situation, each time user has to specify all the available diagnostic settings of the target resource, even though some of these settings are just contain the default value(0/disbaled). This violates the **convention over configuration** principle.

This PR adds suppress function for those settings (`metric` and `log`), the function will suppress diff only when the old settings have "net" more elements than the new one, and the delta settings have default value.

## Test Result

```bash
💤 via 🦉 v1.14.4 make testacc TEST=./azurerm/internal/services/monitor/tests TESTARGS='-run TestAccAzureRMMonitorDiagnosticSetting_'       

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/monitor/tests -v -run TestAccAzureRMMonitorDiagnosticSetting_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMMonitorDiagnosticSetting_eventhub
=== PAUSE TestAccAzureRMMonitorDiagnosticSetting_eventhub
=== RUN   TestAccAzureRMMonitorDiagnosticSetting_metricOnly
=== PAUSE TestAccAzureRMMonitorDiagnosticSetting_metricOnly
=== RUN   TestAccAzureRMMonitorDiagnosticSetting_requiresImport
=== PAUSE TestAccAzureRMMonitorDiagnosticSetting_requiresImport
=== RUN   TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspace
=== PAUSE TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspace
=== RUN   TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated
=== PAUSE TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated
=== RUN   TestAccAzureRMMonitorDiagnosticSetting_storageAccount
=== PAUSE TestAccAzureRMMonitorDiagnosticSetting_storageAccount
=== RUN   TestAccAzureRMMonitorDiagnosticSetting_activityLog
=== PAUSE TestAccAzureRMMonitorDiagnosticSetting_activityLog
=== CONT  TestAccAzureRMMonitorDiagnosticSetting_eventhub
=== CONT  TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated
=== CONT  TestAccAzureRMMonitorDiagnosticSetting_activityLog
=== CONT  TestAccAzureRMMonitorDiagnosticSetting_metricOnly
=== CONT  TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspace
=== CONT  TestAccAzureRMMonitorDiagnosticSetting_storageAccount
=== CONT  TestAccAzureRMMonitorDiagnosticSetting_requiresImport
    TestAccAzureRMMonitorDiagnosticSetting_requiresImport: testing.go:640: Step 0 error: errors during apply:
        
        Error: ID was missing the `AuthorizationRules` element
        
          on /tmp/tf-test209852923/main.tf line 29:
          (source code not available)
        
        
    TestAccAzureRMMonitorDiagnosticSetting_eventhub: testing.go:640: Step 0 error: errors during apply:
        
        Error: ID was missing the `AuthorizationRules` element
        
          on /tmp/tf-test193034397/main.tf line 29:
          (source code not available)
        
        
    TestAccAzureRMMonitorDiagnosticSetting_eventhub: testing.go:701: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: ID was missing the `AuthorizationRules` element
        
        State: <nil>
--- FAIL: TestAccAzureRMMonitorDiagnosticSetting_eventhub (169.80s)
    TestAccAzureRMMonitorDiagnosticSetting_requiresImport: testing.go:701: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during refresh: ID was missing the `AuthorizationRules` element
        
        State: <nil>
--- FAIL: TestAccAzureRMMonitorDiagnosticSetting_requiresImport (170.61s)
--- PASS: TestAccAzureRMMonitorDiagnosticSetting_activityLog (201.61s)
--- PASS: TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspaceDedicated (219.37s)
--- PASS: TestAccAzureRMMonitorDiagnosticSetting_metricOnly (265.58s)
--- PASS: TestAccAzureRMMonitorDiagnosticSetting_storageAccount (339.96s)
--- PASS: TestAccAzureRMMonitorDiagnosticSetting_logAnalyticsWorkspace (347.12s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/monitor/tests       347.171s
FAIL
make: *** [GNUmakefile:98: testacc] Error 1
```

The two failures are not related to this PR, but has its own issue: #7310 

## Further Thoughts

The implementation of the suppress function is not ideal as it will be called multiple times for the including elements of the `Set` (because the implementation of `Set` in terraform store its elements via a map). This means there will be a little performance penalty.

On the other hand, Tom has suggested using a custom hash function, while it seems not fit to fix this issue.

(fix: #7235)