### PR TITLE
Update path validation for azure_rm_api_management_api

### DIFF
--- a/azurerm/helpers/validate/api_management.go
+++ b/azurerm/helpers/validate/api_management.go
@@ -71,7 +71,7 @@ func ApiManagementApiName(v interface{}, k string) (ws []string, es []error) {
 func ApiManagementApiPath(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^(?:|[\w][\w-/.]{0,398}[\w-])$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^(?:|[\w.][\w-/.]{0,398}[\w-])$`).Match([]byte(value)); !matched {
 		es = append(es, fmt.Errorf("%q may only be up to 400 characters in length, not start or end with `/` and only contain valid url characters", k))
 	}
 	return ws, es

--- a/azurerm/helpers/validate/api_management_test.go
+++ b/azurerm/helpers/validate/api_management_test.go
@@ -127,6 +127,10 @@ func TestAzureRMApiManagementApiPath_validation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    ".well-known",
+			ErrCount: 0,
+		},
+		{
 			Value:    s.Repeat("x", 401),
 			ErrCount: 1,
 		},


### PR DESCRIPTION
This fixes #7477 bug for path validation being too strict.

The Azure RM API Management API can support paths that begin with a period, such as ".well-known".

This updates the validation logic for this field so that Terraform will allow this type of path.