### PR TITLE
`azurerm_monitor_autoscale_settings` support for time_aggregation = "Last"

### DIFF
--- a/azurerm/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/azurerm/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -151,6 +151,7 @@ func resourceArmMonitorAutoScaleSetting() *schema.Resource {
 														string(insights.TimeAggregationTypeMaximum),
 														string(insights.TimeAggregationTypeMinimum),
 														string(insights.TimeAggregationTypeTotal),
+														string(insights.TimeAggregationTypeLast),
 													}, true),
 													DiffSuppressFunc: suppress.CaseDifference,
 												},

--- a/azurerm/internal/services/monitor/tests/monitor_autoscale_setting_resource_test.go
+++ b/azurerm/internal/services/monitor/tests/monitor_autoscale_setting_resource_test.go
@@ -27,6 +27,7 @@ func TestAccAzureRMMonitorAutoScaleSetting_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "profile.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "profile.0.name", "metricRules"),
 					resource.TestCheckResourceAttr(data.ResourceName, "profile.0.rule.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "profile.0.rule.0.metric_trigger.0.time_aggregation", "Last"),
 					resource.TestCheckResourceAttr(data.ResourceName, "notification.#", "0"),
 					resource.TestCheckNoResourceAttr(data.ResourceName, "tags.$type"),
 				),
@@ -363,7 +364,7 @@ resource "azurerm_monitor_autoscale_setting" "test" {
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
-        time_aggregation   = "Average"
+        time_aggregation   = "Last"
         operator           = "GreaterThan"
         threshold          = 75
       }


### PR DESCRIPTION
Fixes #3328