### PR TITLE
Hiding sensitive kube_* values

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -552,8 +552,9 @@ func resourceArmKubernetesCluster() *schema.Resource {
 			},
 
 			"kube_admin_config": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:      schema.TypeList,
+				Computed:  true,
+				Sensitive: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"host": {
@@ -595,8 +596,9 @@ func resourceArmKubernetesCluster() *schema.Resource {
 			},
 
 			"kube_config": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:      schema.TypeList,
+				Computed:  true,
+				Sensitive: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"host": {


### PR DESCRIPTION
This change will prevent leaking secrets during plan phase. This issue keeps getting punted between terraform core and this provider. This change will hide the entire block which seems safer to me than leaking secrets in deployment logs.

#7238
#5730
#5083
#4621