### PR TITLE
Update `azurerm_linux|windows_virtual_machine_scale_set` - Make `roll_instances_when_required` effective when `upgrade_mode` is `Manual`

### DIFF
--- a/azurerm/internal/services/compute/virtual_machine_scale_set_update.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_update.go
@@ -52,11 +52,11 @@ func (metadata virtualMachineScaleSetUpdateMetaData) performUpdate(ctx context.C
 					return err
 				}
 			}
-		}
 
-		if upgradeMode == compute.Manual {
-			if err := metadata.upgradeInstancesForManualUpgradePolicy(ctx); err != nil {
-				return err
+			if upgradeMode == compute.Manual {
+				if err := metadata.upgradeInstancesForManualUpgradePolicy(ctx); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #7077 (despite it has been closed)