### PR TITLE
`azurerm_marketplace_agreement` - fix issue around import

### DIFF
--- a/azurerm/internal/services/compute/marketplace_agreement_resource.go
+++ b/azurerm/internal/services/compute/marketplace_agreement_resource.go
@@ -78,31 +78,37 @@ func resourceArmMarketplaceAgreementCreateUpdate(d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] Retrieving the Marketplace Terms for Publisher %q / Offer %q / Plan %q", publisher, offer, plan)
 
 	if features.ShouldResourcesBeImported() {
-		agreement, err := client.Get(ctx, publisher, offer, plan)
+		term, err := client.Get(ctx, publisher, offer, plan)
 		if err != nil {
-			if !utils.ResponseWasNotFound(agreement.Response) {
-				return fmt.Errorf("Error retrieving agreement for Publisher %q / Offer %q / Plan %q: %s", publisher, offer, plan, err)
+			if !utils.ResponseWasNotFound(term.Response) {
+				return fmt.Errorf("Error retrieving the Marketplace Terms for Publisher %q / Offer %q / Plan %q: %s", publisher, offer, plan, err)
 			}
 		}
 
 		accepted := false
-		if props := agreement.AgreementProperties; props != nil {
+		if props := term.AgreementProperties; props != nil {
 			if acc := props.Accepted; acc != nil {
 				accepted = *acc
 			}
 		}
 
 		if accepted {
+			agreement, err := client.GetAgreement(ctx, publisher, offer, plan)
+			if err != nil {
+				if !utils.ResponseWasNotFound(agreement.Response) {
+					return fmt.Errorf("Error retrieving agreement for Publisher %q / Offer %q / Plan %q: %s", publisher, offer, plan, err)
+				}
+			}
 			return tf.ImportAsExistsError("azurerm_marketplace_agreement", *agreement.ID)
 		}
 	}
 
 	terms, err := client.Get(ctx, publisher, offer, plan)
 	if err != nil {
-		return fmt.Errorf("Error retrieving agreement for Publisher %q / Offer %q / Plan %q: %s", publisher, offer, plan, err)
+		return fmt.Errorf("Error retrieving the Marketplace Terms for Publisher %q / Offer %q / Plan %q: %s", publisher, offer, plan, err)
 	}
 	if terms.AgreementProperties == nil {
-		return fmt.Errorf("Error retrieving agreement for Publisher %q / Offer %q / Plan %q: AgreementProperties was nil", publisher, offer, plan)
+		return fmt.Errorf("Error retrieving the Marketplace Terms for Publisher %q / Offer %q / Plan %q: AgreementProperties was nil", publisher, offer, plan)
 	}
 
 	terms.AgreementProperties.Accepted = utils.Bool(true)
@@ -137,22 +143,22 @@ func resourceArmMarketplaceAgreementRead(d *schema.ResourceData, meta interface{
 	offer := id.Path["offers"]
 	plan := id.Path["plans"]
 
-	resp, err := client.Get(ctx, publisher, offer, plan)
+	term, err := client.Get(ctx, publisher, offer, plan)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Agreement was not found for Publisher %q / Offer %q / Plan %q", publisher, offer, plan)
+		if utils.ResponseWasNotFound(term.Response) {
+			log.Printf("[DEBUG] The Marketplace Terms was not found for Publisher %q / Offer %q / Plan %q", publisher, offer, plan)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("Error retrieving agreement for Publisher %q / Offer %q / Plan %q: %s", publisher, offer, plan, err)
+		return fmt.Errorf("Error retrieving the Marketplace Terms for Publisher %q / Offer %q / Plan %q: %s", publisher, offer, plan, err)
 	}
 
 	d.Set("publisher", publisher)
 	d.Set("offer", offer)
 	d.Set("plan", plan)
 
-	if props := resp.AgreementProperties; props != nil {
+	if props := term.AgreementProperties; props != nil {
 		if accepted := props.Accepted != nil && *props.Accepted; !accepted {
 			// if props.Accepted is not true, the agreement does not exist
 			d.SetId("")

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -50,5 +50,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Marketplace Agreement can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_marketplace_agreement.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/offerTypes/virtualmachine/agreements/publisher1/offers/offer1/plans/plan1
+terraform import azurerm_marketplace_agreement.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.MarketplaceOrdering/agreements/publisher1/offers/offer1/plans/plan1
 ```


### PR DESCRIPTION
The import error message is incorrect, as this resource is using the
ID of `agreement` as its ID, it should use that ID to imform user to
import (while currently it is using the ID of `term` in the error
message).

In the meanwhile, modify some other log messages to convey the correct
intention.

Besides, fix a typo in another PR which fixes the import ID in the
document.

(fix: #7301)