### PR TITLE
Update `azurerm_shared_image` - flip `generalized` to `specialized`

### DIFF
--- a/azurerm/internal/services/compute/shared_image_data_source.go
+++ b/azurerm/internal/services/compute/shared_image_data_source.go
@@ -44,7 +44,7 @@ func dataSourceArmSharedImage() *schema.Resource {
 				Computed: true,
 			},
 
-			"generalized": {
+			"specialized": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
@@ -130,7 +130,7 @@ func dataSourceArmSharedImageRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("description", props.Description)
 		d.Set("eula", props.Eula)
 		d.Set("os_type", string(props.OsType))
-		d.Set("generalized", props.OsState != compute.Specialized)
+		d.Set("specialized", props.OsState == compute.Specialized)
 		d.Set("hyper_v_generation", string(props.HyperVGeneration))
 		d.Set("privacy_statement_uri", props.PrivacyStatementURI)
 		d.Set("release_note_uri", props.ReleaseNoteURI)

--- a/azurerm/internal/services/compute/shared_image_resource.go
+++ b/azurerm/internal/services/compute/shared_image_resource.go
@@ -69,13 +69,6 @@ func resourceArmSharedImage() *schema.Resource {
 				}, false),
 			},
 
-			"generalized": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-				ForceNew: true,
-			},
-
 			"hyper_v_generation": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -129,6 +122,12 @@ func resourceArmSharedImage() *schema.Resource {
 				Optional: true,
 			},
 
+			"specialized": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 	}
@@ -172,10 +171,10 @@ func resourceArmSharedImageCreateUpdate(d *schema.ResourceData, meta interface{}
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
-	if d.Get("generalized").(bool) {
-		image.GalleryImageProperties.OsState = compute.Generalized
-	} else {
+	if d.Get("specialized").(bool) {
 		image.GalleryImageProperties.OsState = compute.Specialized
+	} else {
+		image.GalleryImageProperties.OsState = compute.Generalized
 	}
 
 	future, err := client.CreateOrUpdate(ctx, resourceGroup, galleryName, name, image)
@@ -233,7 +232,7 @@ func resourceArmSharedImageRead(d *schema.ResourceData, meta interface{}) error 
 		d.Set("description", props.Description)
 		d.Set("eula", props.Eula)
 		d.Set("os_type", string(props.OsType))
-		d.Set("generalized", props.OsState != compute.Specialized)
+		d.Set("specialized", props.OsState == compute.Specialized)
 		d.Set("hyper_v_generation", string(props.HyperVGeneration))
 		d.Set("privacy_statement_uri", props.PrivacyStatementURI)
 		d.Set("release_note_uri", props.ReleaseNoteURI)

--- a/azurerm/internal/services/compute/tests/shared_image_resource_test.go
+++ b/azurerm/internal/services/compute/tests/shared_image_resource_test.go
@@ -200,7 +200,6 @@ resource "azurerm_shared_image" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   os_type             = "Linux"
-  generalized         = true
   hyper_v_generation  = var.hyper_v_generation != "" ? var.hyper_v_generation : null
 
   identifier {
@@ -239,7 +238,7 @@ resource "azurerm_shared_image" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   os_type             = "Linux"
-  generalized         = false
+  specialized         = true
   hyper_v_generation  = var.hyper_v_generation != "" ? var.hyper_v_generation : null
 
   identifier {

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -43,7 +43,7 @@ The following attributes are exported:
 
 * `location` - The supported Azure location where the Shared Image Gallery exists.
 
-* `generalized` - Is the Operating System present in this Shared Image generalized or not. `false` indicates this image is specialized which for windows images means they have been sysprepped.
+* `specialized` - Is the Operating System present in this Shared Image specialized or not. `true` indicates this image is specialized which for windows images means they have been sysprepped.
 
 * `identifier` - An `identifier` block as defined below.
 

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `eula` - (Optional) The End User Licence Agreement for the Shared Image.
 
-* `generalized` - (Optional) Should the Operating System present in this Shared Image be generalized? Defaults to `true`. Setting this to `false` creates a specialized imagine which is the equivalent of sysprepping in windows. Changing this forces a new resource to be created.
+* `specialized` - (Optional) Should the Operating System present in this Shared Image be specialized? Defaults to `false`. Setting this to `true` creates a specialized imagine which is the equivalent of sysprepping in windows. Changing this forces a new resource to be created.
 
 * `hyper_v_generation` - (Optional) The generation of HyperV that the Virtual Machine used to create the Shared Image is based on. Possible values are `V1` and `V2`. Defaults to `V1`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Since the changes on `azurerm_shared_image` has not been released yet, this should not be a breaking change. I suppose it could make more sense if we name this new attribute `specialized` to emphasize when we are assigning a non-zero value to it, the image is specialized. Rather than previous behaviour that we assign `generalized` to `false` to indicate this is specialized.