### PR TITLE
`azurerm_api_management_identity_provider_aad` `client_secret` plan refresh is not empty

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
@@ -140,7 +140,6 @@ func resourceArmApiManagementIdentityProviderAADRead(d *schema.ResourceData, met
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
-		d.Set("client_secret", props.ClientSecret)
 		d.Set("allowed_tenants", props.AllowedTenants)
 	}
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aad_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aad_resource_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMApiManagementIdentityProviderAAD_basic(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderAADExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }
@@ -60,7 +60,7 @@ func TestAccAzureRMApiManagementIdentityProviderAAD_update(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.1", data.Client().TenantID),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }


### PR DESCRIPTION
Fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/7298

test:
=== RUN   TestAccAzureRMApiManagementIdentityProviderAAD_basic
=== PAUSE TestAccAzureRMApiManagementIdentityProviderAAD_basic
=== CONT  TestAccAzureRMApiManagementIdentityProviderAAD_basic
--- PASS: TestAccAzureRMApiManagementIdentityProviderAAD_basic (2416.87s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderAAD_update
=== PAUSE TestAccAzureRMApiManagementIdentityProviderAAD_update
=== CONT  TestAccAzureRMApiManagementIdentityProviderAAD_update
--- PASS: TestAccAzureRMApiManagementIdentityProviderAAD_update (2392.69s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderAAD_requiresImport
=== PAUSE TestAccAzureRMApiManagementIdentityProviderAAD_requiresImport
=== CONT  TestAccAzureRMApiManagementIdentityProviderAAD_requiresImport
--- PASS: TestAccAzureRMApiManagementIdentityProviderAAD_requiresImport (2855.40s)

