### PR TITLE
Update eventhub_namespace for ZoneRedundant property

### DIFF
--- a/azurerm/internal/services/eventhub/eventhub_namespace_data_source.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_data_source.go
@@ -48,6 +48,11 @@ func dataSourceEventHubNamespace() *schema.Resource {
 				Computed: true,
 			},
 
+			"zone_redundant": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
 			"capacity": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -141,6 +146,7 @@ func dataSourceEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
 		d.Set("kafka_enabled", props.KafkaEnabled)
 		d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
+		d.Set("zone_redundant", props.ZoneRedundant)
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -331,6 +331,7 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 	if props := resp.EHNamespaceProperties; props != nil {
 		d.Set("auto_inflate_enabled", props.IsAutoInflateEnabled)
 		d.Set("maximum_throughput_units", int(*props.MaximumThroughputUnits))
+		d.Set("zone_redundant", props.ZoneRedundant)
 	}
 
 	ruleset, err := client.GetNetworkRuleSet(ctx, resGroup, name)

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -79,6 +79,12 @@ func resourceArmEventHubNamespace() *schema.Resource {
 				Default:  false,
 			},
 
+			"zone_redundant": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"maximum_throughput_units": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -226,6 +232,7 @@ func resourceArmEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta inter
 	capacity := int32(d.Get("capacity").(int))
 	t := d.Get("tags").(map[string]interface{})
 	autoInflateEnabled := d.Get("auto_inflate_enabled").(bool)
+	zoneRedundant := d.Get("zone_redundant").(bool)
 
 	parameters := eventhub.EHNamespace{
 		Location: &location,
@@ -236,6 +243,7 @@ func resourceArmEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta inter
 		},
 		EHNamespaceProperties: &eventhub.EHNamespaceProperties{
 			IsAutoInflateEnabled: utils.Bool(autoInflateEnabled),
+			ZoneRedundant: utils.Bool(zoneRedundant),
 		},
 		Tags: tags.Expand(t),
 	}

--- a/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/azurerm/internal/services/eventhub/eventhub_namespace_resource.go
@@ -243,7 +243,7 @@ func resourceArmEventHubNamespaceCreateUpdate(d *schema.ResourceData, meta inter
 		},
 		EHNamespaceProperties: &eventhub.EHNamespaceProperties{
 			IsAutoInflateEnabled: utils.Bool(autoInflateEnabled),
-			ZoneRedundant: utils.Bool(zoneRedundant),
+			ZoneRedundant:        utils.Bool(zoneRedundant),
 		},
 		Tags: tags.Expand(t),
 	}

--- a/azurerm/internal/services/eventhub/tests/eventhub_namespace_resource_test.go
+++ b/azurerm/internal/services/eventhub/tests/eventhub_namespace_resource_test.go
@@ -200,6 +200,25 @@ func TestAccAzureRMEventHubNamespace_maximumThroughputUnits(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMEventHubNamespace_zoneRedundant(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMEventHubNamespace_zoneRedundant(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMEventHubNamespaceExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMEventHubNamespace_NonStandardCasing(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_eventhub_namespace", "test")
 
@@ -700,6 +719,28 @@ resource "azurerm_eventhub_namespace" "test" {
   capacity                 = "2"
   auto_inflate_enabled     = true
   maximum_throughput_units = 20
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMEventHubNamespace_zoneRedundant(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctesteventhubnamespace-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  capacity            = "2"
+  zone_redundant      = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/d/eventhub_namespace.html.markdown
+++ b/website/docs/d/eventhub_namespace.html.markdown
@@ -42,7 +42,7 @@ output "eventhub_namespace_id" {
 
 * `maximum_throughput_units` -  Specifies the maximum number of throughput units when Auto Inflate is Enabled.
 
-* `zone_redundant` - Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.
+* `zone_redundant` - Is this EventHub Namespace deployed across Availability Zones?
 
 * `tags` - A mapping of tags to assign to the EventHub Namespace.
 

--- a/website/docs/d/eventhub_namespace.html.markdown
+++ b/website/docs/d/eventhub_namespace.html.markdown
@@ -42,6 +42,8 @@ output "eventhub_namespace_id" {
 
 * `maximum_throughput_units` -  Specifies the maximum number of throughput units when Auto Inflate is Enabled.
 
+* `zone_redundant` - Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.
+
 * `tags` - A mapping of tags to assign to the EventHub Namespace.
 
 The following attributes are exported only if there is an authorization rule named

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `maximum_throughput_units` - (Optional) Specifies the maximum number of throughput units when Auto Inflate is Enabled. Valid values range from `1` - `20`.
 
-* `zone_redundant` - (Optional) Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.
+* `zone_redundant` - (Optional) Specifies if the EventHub Namespace should be Zone Redundant (created across Availability Zones).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/eventhub_namespace.html.markdown
+++ b/website/docs/r/eventhub_namespace.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 
 * `maximum_throughput_units` - (Optional) Specifies the maximum number of throughput units when Auto Inflate is Enabled. Valid values range from `1` - `20`.
 
+* `zone_redundant` - (Optional) Enabling this property creates a Standard Event Hubs Namespace in regions supported availability zones.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 * `network_rulesets` - (Optional) A `network_rulesets` block as defined below.


### PR DESCRIPTION
Adds `zone_redundant` property to `eventhub_namespace` resource and
datasource.

Fixes #4872