### PR TITLE
azurerm_firewall: support snat private ip ranges

### DIFF
--- a/azurerm/internal/services/network/tests/firewall_resource_test.go
+++ b/azurerm/internal/services/network/tests/firewall_resource_test.go
@@ -326,6 +326,8 @@ resource "azurerm_firewall" "test" {
     subnet_id            = azurerm_subnet.test.id
     public_ip_address_id = azurerm_public_ip.test.id
   }
+
+  private_ip_ranges = ["IANAPrivateRanges", "10.0.0.0/16"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -66,6 +66,8 @@ The following arguments are supported:
 
 * `ip_configuration` - (Required) A `ip_configuration` block as documented below.
 
+* `private_ip_ranges` - (Optional) A list of SNAT private CIDR IP ranges, or the special string `IANAPrivateRanges`, which indicates Azure Firewall does not SNAT when the destination IP address is a private range per IANA RFC 1918. Defaults to a list contains only `IANAPrivateRanges`.
+
 * `zones` - (Optional) Specifies the availability zones in which the Azure Firewall should be created.
 
 -> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview).


### PR DESCRIPTION
Support [SNAT](https://docs.microsoft.com/en-us/azure/firewall/snat-private-range) private ip ranges in `azurerm_firewall`.

## Test Result

```bash
💤 via 🦉 v1.14.4 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMFirewall_basic'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMFirewall_basic' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMFirewall_basic
=== PAUSE TestAccAzureRMFirewall_basic
=== CONT  TestAccAzureRMFirewall_basic
--- PASS: TestAccAzureRMFirewall_basic (1044.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       1044.638s

```

(Fix #7504)