### PR TITLE
azurerm_web_application_firewall_policy: `custom_rules.match_conditions` support `transforms`

### DIFF
--- a/azurerm/internal/services/network/tests/web_application_firewall_policy_resource_test.go
+++ b/azurerm/internal/services/network/tests/web_application_firewall_policy_resource_test.go
@@ -71,7 +71,7 @@ func TestAccAzureRMWebApplicationFirewallPolicy_complete(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.operator", "Contains"),
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.negation_condition", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.match_values.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.match_values.0", "Windows"),
+					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.match_values.0", "windows"),
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.action", "Block"),
 					resource.TestCheckResourceAttr(data.ResourceName, "managed_rules.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "managed_rules.0.exclusion.#", "2"),
@@ -146,7 +146,7 @@ func TestAccAzureRMWebApplicationFirewallPolicy_update(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.operator", "Contains"),
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.negation_condition", "false"),
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.match_values.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.match_values.0", "Windows"),
+					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.match_conditions.1.match_values.0", "windows"),
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rules.1.action", "Block"),
 					resource.TestCheckResourceAttr(data.ResourceName, "managed_rules.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "managed_rules.0.exclusion.#", "2"),
@@ -310,7 +310,8 @@ resource "azurerm_web_application_firewall_policy" "test" {
 
       operator           = "Contains"
       negation_condition = false
-      match_values       = ["Windows"]
+      match_values       = ["windows"]
+      transforms         = ["Lowercase"]
     }
 
     action = "Block"

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -117,7 +117,7 @@ The following arguments are supported:
 
 * `policy_settings` - (Optional) A `policy_settings` block as defined below.
 
-* `managed_rules` - (Optional) A `managed_rules` blocks as defined below.
+* `managed_rules` - (Required) A `managed_rules` blocks as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the Web Application Firewall Policy.
 
@@ -141,11 +141,13 @@ The `match_conditions` block supports the following:
 
 * `match_variables` - (Required) One or more `match_variables` blocks as defined below.
 
+* `match_values` - (Required) A list of match values.
+
 * `operator` - (Required) Describes operator to be matched.
 
 * `negation_condition` - (Optional) Describes if this is negate condition or not
 
-* `match_values` - (Required) A list of match values.
+* `transforms` - (Optional) A list of transformations to do before the match is attempted.
 
 ---
 


### PR DESCRIPTION
Support `transforms` for custom rule condition in waf policy. Additionally, modify the document a bit to mark `manged_rules` as `required`, as defined in schema.

## Test Result

```bash
terraform-provider-azurerm on  waf_policy_custom_rule_support_transform [$!] took 3m 16s 
💤 😡 130 via 🦉 v1.14.4 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMWebApplicationFirewallPolicy_update'
                                                                                                                                                                                     
==> Checking that code complies with gofmt requirements...                      
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...           
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run TestAccAzureRMWebApplicationFirewallPolicy_update -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMWebApplicationFirewallPolicy_update                   
=== PAUSE TestAccAzureRMWebApplicationFirewallPolicy_update
=== CONT  TestAccAzureRMWebApplicationFirewallPolicy_update
--- PASS: TestAccAzureRMWebApplicationFirewallPolicy_update (211.65s)         
PASS                                                                                                                                                                                                                                                                                                                                                                       
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       211.667s   
```

(fix #5359 )