### PR TITLE
Refactor - Update disk encryption set related tests on `azurerm_linux|windows_virtual_machine_scale_set`

### DIFF
--- a/azurerm/internal/services/compute/tests/disk_encryption_set_resource_test.go
+++ b/azurerm/internal/services/compute/tests/disk_encryption_set_resource_test.go
@@ -2,10 +2,8 @@ package tests
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
@@ -147,38 +145,6 @@ func testCheckAzureRMDiskEncryptionSetDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-// nolint unparam
-func enableSoftDeleteAndPurgeProtectionForKeyVault(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).KeyVault.VaultsClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		// TODO: use keyvault's custom ID parse function when implemented
-		vaultName := rs.Primary.Attributes["name"]
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-
-		vaultPatch := keyvault.VaultPatchParameters{
-			Properties: &keyvault.VaultPatchProperties{
-				EnableSoftDelete:      utils.Bool(true),
-				EnablePurgeProtection: utils.Bool(true),
-			},
-		}
-		log.Printf("[DEBUG] Enabling Soft Delete & Purge Protection on Key Vault %q (Resource Group %q)..", vaultName, resourceGroup)
-		_, err := client.Update(ctx, resourceGroup, vaultName, vaultPatch)
-		if err != nil {
-			return fmt.Errorf("Bad: error updating KeyVault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
-		}
-		log.Printf("[DEBUG] Enabled Soft Delete & Purge Protection on Key Vault %q (Resource Group %q)..", vaultName, resourceGroup)
-
-		return nil
-	}
 }
 
 func testAccAzureRMDiskEncryptionSet_dependencies(data acceptance.TestData) string {

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_resource_disk_os_test.go
@@ -465,11 +465,6 @@ resource "azurerm_linux_virtual_machine" "test" {
 }
 
 func testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data acceptance.TestData) string {
-	// whilst this is in Preview it's only supported in: West Central US, Canada Central, North Europe
-	// TODO: switch back to default location
-	// once that's done this can also use the same template as everything else too
-	location := "westus2"
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -562,7 +557,7 @@ resource "azurerm_network_interface" "test" {
     private_ip_address_allocation = "Dynamic"
   }
 }
-`, data.RandomInteger, location, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
 
 func testLinuxVirtualMachine_diskOSDiskDiskEncryptionSetResource(data acceptance.TestData) string {

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_disk_data_resource_test.go
@@ -76,18 +76,14 @@ func TestAccAzureRMLinuxVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet(t 
 		CheckDestroy: testCheckAzureRMLinuxVirtualMachineScaleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
-				Config: testAccAzureRMLinuxVirtualMachineScaleSet_disksDataDisk_diskEncryptionSetDependencies(data),
-				Check: resource.ComposeTestCheckFunc(
-					enableSoftDeleteAndPurgeProtectionForKeyVault("azurerm_key_vault.test"),
-				),
-			},
-			{
 				Config: testAccAzureRMLinuxVirtualMachineScaleSet_disksDataDisk_diskEncryptionSet(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
+			data.ImportStep(
+				"admin_password",
+			),
 		},
 	})
 }
@@ -432,10 +428,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
 }
 
 func testAccAzureRMLinuxVirtualMachineScaleSet_disksDataDisk_diskEncryptionSetDependencies(data acceptance.TestData) string {
-	// whilst this is in Preview it's only supported in: West Central US, Canada Central, North Europe
-	// TODO: switch back to default location
-	location := "westus2"
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -509,7 +501,7 @@ resource "azurerm_subnet" "test" {
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefix       = "10.0.2.0/24"
 }
-`, data.RandomInteger, location, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 
 func testAccAzureRMLinuxVirtualMachineScaleSet_disksDataDisk_diskEncryptionSetResource(data acceptance.TestData) string {

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_resource_disk_os_test.go
@@ -487,11 +487,6 @@ resource "azurerm_windows_virtual_machine" "test" {
 }
 
 func testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetDependencies(data acceptance.TestData) string {
-	// whilst this is in Preview it's only supported in: West Central US, Canada Central, North Europe
-	// TODO: switch back to default location
-	// once that's done this can also use the same template as everything else too
-	location := "westus2"
-
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -582,7 +577,7 @@ resource "azurerm_network_interface" "test" {
     private_ip_address_allocation = "Dynamic"
   }
 }
-`, data.RandomString, data.RandomInteger, location, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
 
 func testWindowsVirtualMachine_diskOSDiskDiskEncryptionSetResource(data acceptance.TestData) string {

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_data_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_disk_data_resource_test.go
@@ -76,18 +76,14 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_disksDataDiskDiskEncryptionSet(
 		CheckDestroy: testCheckAzureRMWindowsVirtualMachineScaleSetDestroy,
 		Steps: []resource.TestStep{
 			{
-				// TODO: After applying soft-delete and purge-protection in keyVault, this extra step can be removed.
-				Config: testAccAzureRMWindowsVirtualMachineScaleSet_disksDataDisk_diskEncryptionSetDependencies(data),
-				Check: resource.ComposeTestCheckFunc(
-					enableSoftDeleteAndPurgeProtectionForKeyVault("azurerm_key_vault.test"),
-				),
-			},
-			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_disksDataDisk_diskEncryptionSet(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
+			data.ImportStep(
+				"admin_password",
+			),
 		},
 	})
 }
@@ -475,10 +471,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 }
 
 func testAccAzureRMWindowsVirtualMachineScaleSet_disksDataDisk_diskEncryptionSetDependencies(data acceptance.TestData) string {
-	// whilst this is in Preview it's only supported in: West Central US, Canada Central, North Europe
-	// TODO: switch back to default location
-	location := "westus2"
-
 	return fmt.Sprintf(`
 locals {
   vm_name = "acctestVM-%d"
@@ -496,6 +488,8 @@ resource "azurerm_key_vault" "test" {
   resource_group_name         = azurerm_resource_group.test.name
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   sku_name                    = "premium"
+  soft_delete_enabled         = true
+  purge_protection_enabled    = true
   enabled_for_disk_encryption = true
 }
 
@@ -549,7 +543,7 @@ resource "azurerm_subnet" "test" {
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefix       = "10.0.2.0/24"
 }
-`, data.RandomInteger, data.RandomInteger, location, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger)
 }
 
 func testAccAzureRMWindowsVirtualMachineScaleSet_disksDataDisk_diskEncryptionSetResource(data acceptance.TestData) string {


### PR DESCRIPTION
When those tests are first composed, the keyvault does not support enabling soft delete and purge protection, therefore the corresponding tests has to do some work around.

Now that disk encryption set has already GA (for quite a bit time), these work arounds are no longer needed, and the location is no longer needed to pin to a hard-coded value.