### PR TITLE
Generalized expand/flatten functions

### DIFF
--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -172,20 +172,17 @@ func FlattenSlicePtr(input interface{}, convert func(interface{}) interface{}) [
 	return result
 }
 
-// FlattenMap flattens the input map (key is of type string), whose value is of a certain type "t", into map (key is of type string), whose value is of type of `interface{}`.
+// FlattenStringMap flattens the input map (key is of type string), whose value is of a certain type "t", into map (key is of type string), whose value is of type of `interface{}`.
 // If "t" is different from the value type of output map, then user has to specify a customized converter via
 // "convert", which guides the conversion from value of the input map to the value of the output map.
 // Otherwise, user can pass a nil "convert".
-func FlattenMap(input interface{}, convert func(interface{}) interface{}) map[string]interface{} {
+func FlattenStringMap(input interface{}, convert func(interface{}) interface{}) map[string]interface{} {
 	v := reflect.ValueOf(input)
 	// safe guard
 	if v.Type().Kind() != reflect.Map {
 		panic("Invalid input: input is not a map")
 	}
-	if v.Len() == 0 {
-		return map[string]interface{}{}
-	}
-	if v.MapKeys()[0].Kind() != reflect.String {
+	if v.Type().Key().Kind() != reflect.String {
 		panic("Invalid input: key of input map is not a string")
 	}
 

--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -1,5 +1,7 @@
 package utils
 
+import "reflect"
+
 func ExpandStringSlice(input []interface{}) *[]string {
 	result := make([]string, 0)
 	for _, item := range input {
@@ -79,4 +81,48 @@ func FlattenInt32Slice(input *[]int32) []interface{} {
 		}
 	}
 	return result
+}
+
+// ExpandSlice expands the input slice into slice of element whose type is specified by "t".
+// If "t" is different from the element type of input, then user has to specify a customized converter via
+// "convert", which guides the conversion from element of the input slice to the element of the output slice.
+// Otherwise, user can pass a nil "convert".
+func ExpandSlice(input []interface{}, t interface{}, convert func(interface{}) interface{}) interface{} {
+	targetType := reflect.TypeOf(t)
+	result := reflect.MakeSlice(reflect.SliceOf(targetType), 0, 0)
+	for _, item := range input {
+		if item != nil {
+			var vitem reflect.Value
+			if convert == nil {
+				vitem = reflect.New(targetType).Elem()
+				vitem.Set(reflect.ValueOf(item))
+			} else {
+				vitem = reflect.ValueOf(convert(item))
+			}
+			result = reflect.Append(result, vitem)
+		} else {
+			result = reflect.Append(result, reflect.Zero(targetType))
+		}
+	}
+	return result.Interface()
+}
+
+// ExpandMap expands the input map (key is of type string) into map (key is of type string) where the type of value is specified by "t".
+// If "t" is different from the element type of input, then user has to specify a customized converter via
+// "convert", which guides the conversion from value of the input map to the value of the output map.
+// Otherwise, user can pass a nil "convert".
+func ExpandMap(input map[string]interface{}, t interface{}, convert func(interface{}) interface{}) interface{} {
+	targetType := reflect.TypeOf(t)
+	result := reflect.MakeMap(reflect.MapOf(reflect.TypeOf(""), targetType))
+	for k, v := range input {
+		var vv reflect.Value
+		if convert == nil {
+			vv = reflect.New(targetType).Elem()
+			vv.Set(reflect.ValueOf(v))
+		} else {
+			vv = reflect.ValueOf(convert(v))
+		}
+		result.SetMapIndex(reflect.ValueOf(k), vv)
+	}
+	return result.Interface()
 }

--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -104,7 +104,10 @@ func ExpandSlice(input []interface{}, t interface{}, convert func(interface{}) i
 			result = reflect.Append(result, reflect.Zero(targetType))
 		}
 	}
-	return result.Interface()
+
+	resultp := reflect.New(result.Type())
+	resultp.Elem().Set(result)
+	return resultp.Interface()
 }
 
 // ExpandMap expands the input map (key is of type string) into map (key is of type string) where the type of value is specified by "t".

--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -83,7 +83,7 @@ func FlattenInt32Slice(input *[]int32) []interface{} {
 	return result
 }
 
-// ExpandSlice expands the input slice into slice of element whose type is specified by "t".
+// ExpandSlice expands the input slice into pointer to slice of element whose type is specified by "t".
 // If "t" is different from the element type of input, then user has to specify a customized converter via
 // "convert", which guides the conversion from element of the input slice to the element of the output slice.
 // Otherwise, user can pass a nil "convert".

--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -129,3 +129,33 @@ func ExpandMap(input map[string]interface{}, t interface{}, convert func(interfa
 	}
 	return result.Interface()
 }
+
+// FlattenSlice flattens the input pointer to slice of element whose type is specified by "t", into slice.
+// If "t" is different from the element type of output, then user has to specify a customized converter via
+// "convert", which guides the conversion from element of the input slice to the element of the output slice.
+// Otherwise, user can pass a nil "convert".
+func FlattenSlicePtr(input interface{}, convert func(interface{}) interface{}) []interface{} {
+	v := reflect.ValueOf(input)
+	// safe guard
+	if v.Type().Kind() != reflect.Ptr {
+		panic("Invalid input: input is not a pointer")
+	}
+
+	ve := v.Elem()
+	if ve.Type().Kind() != reflect.Slice {
+		panic("Invalid input: value of input is not a slice")
+	}
+
+	result := make([]interface{}, 0)
+	if v.IsNil() {
+		return result
+	}
+	for i := 0; i < ve.Len(); i++ {
+		ev := ve.Index(i)
+		if convert != nil {
+			ev = reflect.ValueOf(convert(ev.Interface()))
+		}
+		result = append(result, ev.Interface())
+	}
+	return result
+}

--- a/azurerm/utils/common_marshal.go
+++ b/azurerm/utils/common_marshal.go
@@ -172,7 +172,7 @@ func FlattenSlicePtr(input interface{}, convert func(interface{}) interface{}) [
 	return result
 }
 
-// FlattenMap flattens the input map (key is of type string), whose value is of a certain type, into map (key is of type string), whose value is of type of `interface{}`.
+// FlattenMap flattens the input map (key is of type string), whose value is of a certain type "t", into map (key is of type string), whose value is of type of `interface{}`.
 // If "t" is different from the value type of output map, then user has to specify a customized converter via
 // "convert", which guides the conversion from value of the input map to the value of the output map.
 // Otherwise, user can pass a nil "convert".

--- a/azurerm/utils/common_marshal_test.go
+++ b/azurerm/utils/common_marshal_test.go
@@ -23,7 +23,7 @@ func TestExpandSlice(t *testing.T) {
 		{
 			input:  []interface{}{"a", "b"},
 			t:      "",
-			output: []string{"a", "b"},
+			output: ToPtr([]string{"a", "b"}),
 		},
 		// slice of string -> slice of customized string type
 		{
@@ -32,7 +32,7 @@ func TestExpandSlice(t *testing.T) {
 			convert: func(x interface{}) interface{} {
 				return T1(x.(string))
 			},
-			output: []T1{"a", "b"},
+			output: ToPtr([]T1{"a", "b"}),
 		},
 		// slice of string -> slice of customized structure containing string member
 		{
@@ -41,7 +41,7 @@ func TestExpandSlice(t *testing.T) {
 			convert: func(x interface{}) interface{} {
 				return T2{S: x.(string)}
 			},
-			output: []T2{{"a"}, {"b"}},
+			output: ToPtr([]T2{{"a"}, {"b"}}),
 		},
 		// slice of int -> slice of int32
 		{
@@ -50,7 +50,7 @@ func TestExpandSlice(t *testing.T) {
 			convert: func(x interface{}) interface{} {
 				return int32(x.(int))
 			},
-			output: []int32{1, 2},
+			output: ToPtr([]int32{1, 2}),
 		},
 		// slice of int -> slice of int64
 		{
@@ -59,13 +59,13 @@ func TestExpandSlice(t *testing.T) {
 			convert: func(x interface{}) interface{} {
 				return int64(x.(int))
 			},
-			output: []int64{1, 2},
+			output: ToPtr([]int64{1, 2}),
 		},
 		// slice of int -> slice of int
 		{
 			input:  []interface{}{1, 2},
 			t:      0,
-			output: []int{1, 2},
+			output: ToPtr([]int{1, 2}),
 		},
 		// slice of float64 -> slice of float32
 		{
@@ -74,13 +74,13 @@ func TestExpandSlice(t *testing.T) {
 			convert: func(x interface{}) interface{} {
 				return float32(x.(float64))
 			},
-			output: []float32{1, 2},
+			output: ToPtr([]float32{1, 2}),
 		},
 		// slice of float64 -> slice of float64
 		{
 			input:  []interface{}{float64(1), float64(2)},
 			t:      float64(0),
-			output: []float64{1, 2},
+			output: ToPtr([]float64{1, 2}),
 		},
 	}
 

--- a/azurerm/utils/common_marshal_test.go
+++ b/azurerm/utils/common_marshal_test.go
@@ -1,0 +1,210 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestExpandSlice(t *testing.T) {
+	type T1 string
+	type T2 struct {
+		S string
+	}
+
+	cases := []struct {
+		input   []interface{}
+		t       interface{}
+		convert func(interface{}) interface{}
+		output  interface{}
+	}{
+		// slice of string -> slice of string
+		{
+			input:  []interface{}{"a", "b"},
+			t:      "",
+			output: []string{"a", "b"},
+		},
+		// slice of string -> slice of customized string type
+		{
+			input: []interface{}{"a", "b"},
+			t:     T1(""),
+			convert: func(x interface{}) interface{} {
+				return T1(x.(string))
+			},
+			output: []T1{"a", "b"},
+		},
+		// slice of string -> slice of customized structure containing string member
+		{
+			input: []interface{}{"a", "b"},
+			t:     T2{},
+			convert: func(x interface{}) interface{} {
+				return T2{S: x.(string)}
+			},
+			output: []T2{{"a"}, {"b"}},
+		},
+		// slice of int32 -> slice of int32
+		{
+			input:  []interface{}{int32(1), int32(2)},
+			t:      int32(0),
+			output: []int32{1, 2},
+		},
+		// slice of int32 -> slice of int64
+		{
+			input: []interface{}{int32(1), int32(2)},
+			t:     int64(0),
+			convert: func(x interface{}) interface{} {
+				return int64(x.(int32))
+			},
+			output: []int64{1, 2},
+		},
+		// slice of int32 -> slice of int
+		{
+			input: []interface{}{int32(1), int32(2)},
+			t:     0,
+			convert: func(x interface{}) interface{} {
+				return int(x.(int32))
+			},
+			output: []int{1, 2},
+		},
+		// slice of float64 -> slice of float32
+		{
+			input: []interface{}{float64(1), float64(2)},
+			t:     float32(0),
+			convert: func(x interface{}) interface{} {
+				return float32(x.(float64))
+			},
+			output: []float32{1, 2},
+		},
+		// slice of float64 -> slice of float64
+		{
+			input:  []interface{}{float64(1), float64(2)},
+			t:      float64(0),
+			output: []float64{1, 2},
+		},
+	}
+
+	for idx, c := range cases {
+		out := ExpandSlice(c.input, c.t, c.convert)
+		if !reflect.DeepEqual(out, c.output) {
+			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(out), spew.Sdump(c.output))
+		}
+	}
+}
+
+func TestExpandMap(t *testing.T) {
+	type T1 string
+	type T2 struct {
+		S string
+	}
+
+	cases := []struct {
+		input   map[string]interface{}
+		t       interface{}
+		convert func(interface{}) interface{}
+		output  interface{}
+	}{
+		// map[string]string -> map[string]string
+		{
+			input: map[string]interface{}{
+				"a": "b",
+			},
+			t: "",
+			output: map[string]string{
+				"a": "b",
+			},
+		},
+		// map[string]string -> map[string](customized string type)
+		{
+			input: map[string]interface{}{
+				"a": "b",
+			},
+			t: T1(""),
+			convert: func(x interface{}) interface{} {
+				return T1(x.(string))
+			},
+			output: map[string]T1{
+				"a": "b",
+			},
+		},
+		// map[string]string -> map[string](customized type structure containing string member)
+		{
+			input: map[string]interface{}{
+				"a": "b",
+			},
+			t: T2{},
+			convert: func(x interface{}) interface{} {
+				return T2{S: x.(string)}
+			},
+			output: map[string]T2{
+				"a": {"b"},
+			},
+		},
+		// map[string]int32  -> map[string]int32
+		{
+			input: map[string]interface{}{
+				"a": int32(1),
+			},
+			t: int32(0),
+			output: map[string]int32{
+				"a": 1,
+			},
+		},
+		// map[string]int32  -> map[string]int64
+		{
+			input: map[string]interface{}{
+				"a": int32(1),
+			},
+			t: int64(0),
+			convert: func(x interface{}) interface{} {
+				return int64(x.(int32))
+			},
+			output: map[string]int64{
+				"a": 1,
+			},
+		},
+		// map[string]int32 -> map[string]int
+		{
+			input: map[string]interface{}{
+				"a": int32(1),
+			},
+			t: 0,
+			convert: func(x interface{}) interface{} {
+				return int(x.(int32))
+			},
+			output: map[string]int{
+				"a": 1,
+			},
+		},
+		// map[string]float64 -> map[string]float32
+		{
+			input: map[string]interface{}{
+				"a": float64(0),
+			},
+			t: float32(0),
+			convert: func(x interface{}) interface{} {
+				return float32(x.(float64))
+			},
+			output: map[string]float32{
+				"a": 0,
+			},
+		},
+		// map[string]float64 -> map[string]float64
+		{
+			input: map[string]interface{}{
+				"a": float64(0),
+			},
+			t: float64(0),
+			output: map[string]float64{
+				"a": 0,
+			},
+		},
+	}
+
+	for idx, c := range cases {
+		out := ExpandMap(c.input, c.t, c.convert)
+		if !reflect.DeepEqual(out, c.output) {
+			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(out), spew.Sdump(c.output))
+		}
+	}
+}

--- a/azurerm/utils/common_marshal_test.go
+++ b/azurerm/utils/common_marshal_test.go
@@ -82,12 +82,18 @@ func TestExpandSlice(t *testing.T) {
 			t:      float64(0),
 			output: ToPtr([]float64{1, 2}),
 		},
+		// slice of string contains nil -> slice of string
+		{
+			input:  []interface{}{"a", "b", nil},
+			t:      "",
+			output: ToPtr([]string{"a", "b", ""}),
+		},
 	}
 
 	for idx, c := range cases {
 		out := ExpandSlice(c.input, c.t, c.convert)
 		if !reflect.DeepEqual(out, c.output) {
-			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(out), spew.Sdump(c.output))
+			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(c.output), spew.Sdump(out))
 		}
 	}
 }
@@ -140,7 +146,7 @@ func TestExpandMap(t *testing.T) {
 				"a": {"b"},
 			},
 		},
-		// map[string]int  -> map[string]int32
+		// map[string]int -> map[string]int32
 		{
 			input: map[string]interface{}{
 				"a": 1,
@@ -153,7 +159,7 @@ func TestExpandMap(t *testing.T) {
 				"a": 1,
 			},
 		},
-		// map[string]int  -> map[string]int64
+		// map[string]int -> map[string]int64
 		{
 			input: map[string]interface{}{
 				"a": 1,
@@ -199,12 +205,250 @@ func TestExpandMap(t *testing.T) {
 				"a": 0,
 			},
 		},
+		// map[string]string contains nil -> map[string]string
+		{
+			input: map[string]interface{}{
+				"a": "b",
+				"c": nil,
+			},
+			t: "",
+			output: map[string]string{
+				"a": "b",
+				"c": "",
+			},
+		},
 	}
 
 	for idx, c := range cases {
 		out := ExpandMap(c.input, c.t, c.convert)
 		if !reflect.DeepEqual(out, c.output) {
-			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(out), spew.Sdump(c.output))
+			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(c.output), spew.Sdump(out))
+		}
+	}
+}
+
+func TestFlattenSlice(t *testing.T) {
+	type T1 string
+	type T2 struct {
+		S string
+	}
+
+	cases := []struct {
+		input   interface{}
+		convert func(interface{}) interface{}
+		output  []interface{}
+	}{
+		// slice of string -> slice of string
+		{
+			input:  ToPtr([]string{"a", "b"}),
+			output:[]interface{}{"a", "b"},
+		},
+		// slice of customized string type -> slice of string
+		{
+			input: ToPtr([]T1{"a", "b"}),
+			convert: func(x interface{}) interface{} {
+				return string(x.(T1))
+			},
+			output: []interface{}{"a", "b"},
+		},
+		// slice of customized structure containing string member -> slice of string
+		{
+			input: ToPtr([]T2{{"a"}, {"b"}}),
+			convert: func(x interface{}) interface{} {
+				return x.(T2).S
+			},
+			output: []interface{}{"a", "b"},
+		},
+		// slice of int32 -> slice of int
+		{
+			input: ToPtr([]int32{1, 2}),
+			convert: func(x interface{}) interface{} {
+				return int(x.(int32))
+			},
+			output:[]interface{}{1, 2},
+		},
+		// slice of int64 -> slice of int
+		{
+			input: ToPtr([]int64{1, 2}),
+			convert: func(x interface{}) interface{} {
+				return int(x.(int64))
+			},
+			output: []interface{}{1, 2},
+		},
+		// slice of int -> slice of int
+		{
+			input:  ToPtr([]int{1, 2}),
+			output: []interface{}{1, 2},
+		},
+		//  slice of float32 -> slice of float64
+		{
+			input: ToPtr([]float32{1, 2}),
+			convert: func(x interface{}) interface{} {
+				return float64(x.(float32))
+			},
+			output: []interface{}{1.0, 2.0},
+		},
+		// slice of float64 -> slice of float64
+		{
+			input: ToPtr([]float64{1, 2}),
+			output: []interface{}{1.0, 2.0},
+		},
+		// slice of string pointer -> slice of string
+		{
+			input:  ToPtr([]*string{String("a"), String("b")}),
+			convert: func(x interface{}) interface{} {
+				return *(x.(*string))
+			},
+			output:[]interface{}{"a", "b"},
+		},
+		// slice of string pointer contains nil -> slice of string
+		{
+			input:  ToPtr([]*string{String("a"), String("b"), nil}),
+			convert: func(x interface{}) interface{} {
+				return *(x.(*string))
+			},
+			output:[]interface{}{"a", "b", ""},
+		},
+	}
+
+	for idx, c := range cases {
+		out := FlattenSlicePtr(c.input, c.convert)
+		if !reflect.DeepEqual(out, c.output) {
+			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(c.output), spew.Sdump(out))
+		}
+	}
+}
+
+func TestFlattenMap(t *testing.T) {
+	type T1 string
+	type T2 struct {
+		S string
+	}
+
+	cases := []struct {
+		input   interface{}
+		convert func(interface{}) interface{}
+		output  map[string]interface{}
+	}{
+		// map[string]string -> map[string]string
+		{
+			input: map[string]string{
+				"a": "b",
+			},
+			output: map[string]interface{}{
+				"a": "b",
+			},
+		},
+		// map[string](customized string type) -> map[string]string
+		{
+			input: map[string]T1{
+				"a": "b",
+			},
+			convert: func(x interface{}) interface{} {
+				return string(x.(T1))
+			},
+			output: map[string]interface{}{
+				"a": "b",
+			},
+		},
+		// map[string](customized type structure containing string member) -> map[string]string
+		{
+			input: map[string]T2{
+				"a": {"b"},
+			},
+			convert: func(x interface{}) interface{} {
+				return x.(T2).S
+			},
+			output: map[string]interface{}{
+				"a": "b",
+			},
+		},
+		// map[string]int32 -> map[string]int
+		{
+			input: map[string]int32{
+				"a": 1,
+			},
+			convert: func(x interface{}) interface{} {
+				return int(x.(int32))
+			},
+			output: map[string]interface{}{
+				"a": 1,
+			},
+		},
+		// map[string]int64 -> map[string]int
+		{
+			input: map[string]int64{
+				"a": 1,
+			},
+			convert: func(x interface{}) interface{} {
+				return int(x.(int64))
+			},
+			output: map[string]interface{}{
+				"a": 1,
+			},
+		},
+		// map[string]int -> map[string]int
+		{
+			input: map[string]int{
+				"a": 1,
+			},
+			output: map[string]interface{}{
+				"a": 1,
+			},
+		},
+		// map[string]float32 -> map[string]float64
+		{
+			input: map[string]float32{
+				"a": 0,
+			},
+			convert: func(x interface{}) interface{} {
+				return float64(x.(float32))
+			},
+			output: map[string]interface{}{
+				"a": 0.0,
+			},
+		},
+		// map[string]float64 -> map[string]float64
+		{
+			input: map[string]float64{
+				"a": 0,
+			},
+			output: map[string]interface{}{
+				"a": 0.0,
+			},
+		},
+		// map[string]*string -> map[string]string
+		{
+			input: map[string]*string{
+				"a": String("b"),
+			},
+			convert: func(x interface{}) interface{} {
+				return 	*(x.(*string))
+			},
+			output: map[string]interface{}{
+				"a": "b",
+			},
+		},
+		// map[string]*string contains nil -> map[string]string
+		{
+			input: map[string]*string{
+				"a": String("b"),
+				"c": nil,
+			},
+			convert: func(x interface{}) interface{} {
+				return 	*(x.(*string))
+			},
+			output: map[string]interface{}{
+				"a": "b",
+				"c": "",
+			},
+		},
+	}
+
+	for idx, c := range cases {
+		out := FlattenMap(c.input, c.convert)
+		if !reflect.DeepEqual(out, c.output) {
+			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(c.output), spew.Sdump(out))
 		}
 	}
 }

--- a/azurerm/utils/common_marshal_test.go
+++ b/azurerm/utils/common_marshal_test.go
@@ -43,28 +43,28 @@ func TestExpandSlice(t *testing.T) {
 			},
 			output: []T2{{"a"}, {"b"}},
 		},
-		// slice of int32 -> slice of int32
+		// slice of int -> slice of int32
 		{
-			input:  []interface{}{int32(1), int32(2)},
-			t:      int32(0),
+			input: []interface{}{1, 2},
+			t:     int32(0),
+			convert: func(x interface{}) interface{} {
+				return int32(x.(int))
+			},
 			output: []int32{1, 2},
 		},
-		// slice of int32 -> slice of int64
+		// slice of int -> slice of int64
 		{
-			input: []interface{}{int32(1), int32(2)},
+			input: []interface{}{1, 2},
 			t:     int64(0),
 			convert: func(x interface{}) interface{} {
-				return int64(x.(int32))
+				return int64(x.(int))
 			},
 			output: []int64{1, 2},
 		},
-		// slice of int32 -> slice of int
+		// slice of int -> slice of int
 		{
-			input: []interface{}{int32(1), int32(2)},
-			t:     0,
-			convert: func(x interface{}) interface{} {
-				return int(x.(int32))
-			},
+			input:  []interface{}{1, 2},
+			t:      0,
 			output: []int{1, 2},
 		},
 		// slice of float64 -> slice of float32
@@ -140,38 +140,38 @@ func TestExpandMap(t *testing.T) {
 				"a": {"b"},
 			},
 		},
-		// map[string]int32  -> map[string]int32
+		// map[string]int  -> map[string]int32
 		{
 			input: map[string]interface{}{
-				"a": int32(1),
+				"a": 1,
 			},
 			t: int32(0),
+			convert: func(x interface{}) interface{} {
+				return int32(x.(int))
+			},
 			output: map[string]int32{
 				"a": 1,
 			},
 		},
-		// map[string]int32  -> map[string]int64
+		// map[string]int  -> map[string]int64
 		{
 			input: map[string]interface{}{
-				"a": int32(1),
+				"a": 1,
 			},
 			t: int64(0),
 			convert: func(x interface{}) interface{} {
-				return int64(x.(int32))
+				return int64(x.(int))
 			},
 			output: map[string]int64{
 				"a": 1,
 			},
 		},
-		// map[string]int32 -> map[string]int
+		// map[string]int -> map[string]int
 		{
 			input: map[string]interface{}{
-				"a": int32(1),
+				"a": 1,
 			},
 			t: 0,
-			convert: func(x interface{}) interface{} {
-				return int(x.(int32))
-			},
 			output: map[string]int{
 				"a": 1,
 			},

--- a/azurerm/utils/pointer.go
+++ b/azurerm/utils/pointer.go
@@ -1,5 +1,7 @@
 package utils
 
+import "reflect"
+
 func Bool(input bool) *bool {
 	return &input
 }
@@ -22,4 +24,12 @@ func Float(input float64) *float64 {
 
 func String(input string) *string {
 	return &input
+}
+
+// ToPtr create a new object from the passed in "obj" and return its address back.
+func ToPtr(obj interface{}) interface{} {
+	v := reflect.ValueOf(obj)
+	vp := reflect.New(v.Type())
+	vp.Elem().Set(v)
+	return vp.Interface()
 }

--- a/azurerm/utils/pointer_test.go
+++ b/azurerm/utils/pointer_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestToPtr(t *testing.T) {
+	cases := []struct {
+		in  interface{}
+		out interface{}
+	}{
+		{
+			in:  1,
+			out: Int(1),
+		},
+		{
+			in:  "a",
+			out: String("a"),
+		},
+		{
+			in:  true,
+			out: Bool(true),
+		},
+	}
+	for idx, c := range cases {
+		out := ToPtr(c.in)
+		if !reflect.DeepEqual(out, c.out) {
+			t.Fatalf("%d failed\nexpected:\n%s\nactual:\n%s\n", idx, spew.Sdump(out), spew.Sdump(c.out))
+		}
+	}
+
+}


### PR DESCRIPTION
## Motivation

The existing helper functions for expanding and flattening have met a big amount of use cases. While there are some other cases users have to write its own expanding/flattening logic.

### Example 1: new type definition against native type

Say we have a SDK type defined as below:

```go
type Foo string

type Bar struct {
  Foos *[]Foo
  //...
}
```

When we are expanding for `Bar.Foos`, we can't use `ExpandStringSlice()` as it only allows the expanded-to type is `*[]string`. In this case, users have to write the almost same logic as it is defined in `ExpandStringSlice()`, just to make the compiler happy.

### Expample 2: new type of struct contains only one member of native type

Say we have a SDK type defined as below:

```go
type Foo struct {
  Bar string
}

type Baz struct {
  Foos *[]Foo
  //...
}
```
As we`Foo` only has one member, so it is likely to flatten `Foo.Bar` out to the `Baz` level in terraform schema. Then, when we are expanding that property, there is no helper function available for now, and users have to write the almost same logic as it is defined in `ExpandStringSlice`, which is also a boilerplate.

## Solution

This PR leverages the `reflect` package in stdlib to handle arbitrary types. The penalty caused by using reflection should be minor and there are already some other usage of reflection used (indirectly) by current provider (e.g. mapstruct, encoding/json). Hence it should be OK to use reflection.

To make it both easier to implement by me and to reason about by users, I have split each scenario into two flavors, for either slice and map.

So with this PR, the expanding and flattening of above code could be simplified as below:

```go

// Example 1

	ExpandSlice(
	        d.Get("foos"),
		Foo(""),
		func(x interface{}) interface{} {
			return Foo(x.(string))
		},
	)

	FlattenSlicePtr(
		resp,
		func(x interface{}) interface{} {
			return string(x.(Foo))
		},
	)

// Example 2

	ExpandSlice(
	        d.Get("foos"),
		Foo{},
		func(x interface{}) interface{} {
			return Foo{Bar: x.(string)}
		},
	)

	FlattenSlicePtr(
		resp,
		func(x interface{}) interface{} {
			return x.(Foo).Bar
		},
	)
```

The unit test includes more other use cases, including some edge cases (e.g. input contains nil, empty input, invalid input type).
