### PR TITLE
Docs fixes for AzureAD migration guide

### DIFF
--- a/website/docs/guides/migrating-to-azuread.html.markdown
+++ b/website/docs/guides/migrating-to-azuread.html.markdown
@@ -104,7 +104,7 @@ The method for performing this differs between Terraform v0.11 and Terraform v0.
 
 Firstly, it's a good idea to create a backup of your statefile. For a local statefile, simply create a copy. If you are using a Remote State Backend, ensure your backend platform is creating snapshots or backups for rollback purposes.
 
-let's list the existing items in the state - we can do this by running `terraform state list`, for example:
+Let's list the existing items in the state - we can do this by running `terraform state list`, for example:
 
 ```shell
 $ terraform state list
@@ -133,7 +133,7 @@ With Terraform v0.12 (or later), this operation needs to be performed manually. 
 $ terraform state pull >current.tfstate
 ```
 
-Once you have a local copy of your statefile, you can run the following command to replace the necessary values for your resources. This will work on all matching resources in your state, and you will need the [jq][jq-download] tool (version 1.5 or later).
+Once you have a local copy of your statefile, you can run the following command to replace the necessary values for your resources. This will work on all matching resources in your state, and you will need the [jq](https://stedolan.github.io/jq/download/) tool (version 1.5 or later).
 
 ```shell
 $ jq '
@@ -176,7 +176,7 @@ There should be no unexpected or unrelated changes in your diff output.
 
 For remote state, you will need to push the new statefile to your backend.
 
-```shell script
+```shell
 $ terraform state push new.tfstate
 ```
 
@@ -202,5 +202,3 @@ actions need to be performed.
 ```
 
 At this point you've switched over to using [the new Azure Active Directory provider](http://terraform.io/docs/providers/azuread/index.html)! You can stay up to date with Releases (and file Feature Requests/Bugs) [on the Github repository](https://github.com/terraform-providers/terraform-provider-azuread).
-
-[jq-download]: https://stedolan.github.io/jq/download/


### PR DESCRIPTION
* Markdown parser seems unhappy with reference link format
* Fix bad language ID in code block
* Grammer