### PR TITLE
Added new 0.1 version to WAF managed_rule_set to support Microsoft_BotManagerRuleSet creation

### DIFF
--- a/azurerm/helpers/validate/web_application_firewall_policy.go
+++ b/azurerm/helpers/validate/web_application_firewall_policy.go
@@ -28,6 +28,7 @@ var ValidateWebApplicationFirewallPolicyRuleGroupName = validation.StringInSlice
 }, false)
 
 var ValidateWebApplicationFirewallPolicyRuleSetVersion = validation.StringInSlice([]string{
+	"0.1",
 	"1.0",
 	"2.2.9",
 	"3.0",

--- a/azurerm/helpers/validate/web_application_firewall_policy.go
+++ b/azurerm/helpers/validate/web_application_firewall_policy.go
@@ -29,6 +29,7 @@ var ValidateWebApplicationFirewallPolicyRuleGroupName = validation.StringInSlice
 
 var ValidateWebApplicationFirewallPolicyRuleSetVersion = validation.StringInSlice([]string{
 	"0.1",
+	"1.0",
 	"2.2.9",
 	"3.0",
 	"3.1",

--- a/azurerm/helpers/validate/web_application_firewall_policy.go
+++ b/azurerm/helpers/validate/web_application_firewall_policy.go
@@ -29,7 +29,6 @@ var ValidateWebApplicationFirewallPolicyRuleGroupName = validation.StringInSlice
 
 var ValidateWebApplicationFirewallPolicyRuleSetVersion = validation.StringInSlice([]string{
 	"0.1",
-	"1.0",
 	"2.2.9",
 	"3.0",
 	"3.1",

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -187,7 +187,7 @@ The `managed_rule_set` block supports the following:
 
 * `type` - (Optional) The rule set type. Possible values: `OWASP`, `Microsoft_BotManagerRuleSet`.
 
-* `version` - (Required) The rule set version. Possible values: `0.1`, `1.0`, `2.2.9`, `3.0`, `3.1`.
+* `version` - (Required) The rule set version. Possible values: `0.1`, `2.2.9`, `3.0`, `3.1`.
 
 * `rule_group_override` - (Optional) One or more `rule_group_override` block defined below.
 

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -185,9 +185,9 @@ The `exclusion` block supports the following:
 
 The `managed_rule_set` block supports the following:
 
-* `type` - (Optional) The rule set type.
+* `type` - (Optional) The rule set type. Possible values: `OWASP`, `Microsoft_BotManagerRuleSet`.
 
-* `version` - (Required) The rule set version.
+* `version` - (Required) The rule set version. Possible values: `0.1`, `1.0`, `2.2.9`, `3.0`, `3.1`.
 
 * `rule_group_override` - (Optional) One or more `rule_group_override` block defined below.
 

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -185,9 +185,9 @@ The `exclusion` block supports the following:
 
 The `managed_rule_set` block supports the following:
 
-* `type` - (Optional) The rule set type. Possible values: `OWASP`, `Microsoft_BotManagerRuleSet`.
+* `type` - (Optional) The rule set type. Possible values: `Microsoft_BotManagerRuleSet` and `OWASP`.
 
-* `version` - (Required) The rule set version. Possible values: `0.1`, `2.2.9`, `3.0`, `3.1`.
+* `version` - (Required) The rule set version. Possible values: `0.1`, `1.0`, `2.2.9`, `3.0` and `3.1`.
 
 * `rule_group_override` - (Optional) One or more `rule_group_override` block defined below.
 


### PR DESCRIPTION
Hey,

This is my first PR here. I wanted to fix an issue with **Microsoft_BotManagerRuleSet** version **0.1** not being supported in azurerm_web_application_firewall_policy.managed_rules.managed_rule_set. Currently accepted version numbers are: 

```
var ValidateWebApplicationFirewallPolicyRuleSetVersion = validation.StringInSlice([]string{
	"1.0",
	"2.2.9",
	"3.0",
	"3.1",
}, false)
```

<img width="1103" alt="Screenshot 2020-07-03 at 14 37 49" src="https://user-images.githubusercontent.com/45555255/86470176-2b931100-bd3b-11ea-85c1-5e951d22b15b.png">

<img width="1103" alt="Screenshot 2020-07-03 at 14 38 05" src="https://user-images.githubusercontent.com/45555255/86470185-2fbf2e80-bd3b-11ea-88fb-fa1d6eb47bd1.png">

It looks like a Microsoft thing - they have recently changed version 1.0 to 0.1... Added **0.1** version and updated doc files. Not sure if this validation makes sense here, maybe it's better to provide just a full rule name without type and version and be less strict about it?

- https://docs.microsoft.com/en-us/azure/web-application-firewall/ag/bot-protection-overview (new 0.1)
- https://azure.microsoft.com/en-us/updates/new-bot-protection-rule-set-in-public-preview-for-web-application-firewall-waf-with-azure-front-door-service/ (old 1.0 reference)

Thanks,
Jakub