### PR TITLE
Deprecate the prefix property of azurerm_cosmosdb_account since API's behavior has been changed

### DIFF
--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -144,7 +144,7 @@ func resourceArmCosmosDbAccount() *schema.Resource {
 								regexp.MustCompile("^[-a-z0-9]{3,50}$"),
 								"Cosmos DB location prefix (ID) must be 3 - 50 characters long, contain only lowercase letters, numbers and hyphens.",
 							),
-							Deprecated: "This field is used to set Cosmos DB location ID and previously this ID property allows to be changed by API. However, now it has been updated to readonly field on API level. So it has to be deprecated since it doesn't take effect anymore. See more details from https://github.com/Azure/azure-sdk-for-go/pull/4640.",
+							Deprecated: "This is deprecated because the service no longer accepts this as an input since Apr 25, 2019",
 						},
 
 						"id": {

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -144,7 +144,7 @@ func resourceArmCosmosDbAccount() *schema.Resource {
 								regexp.MustCompile("^[-a-z0-9]{3,50}$"),
 								"Cosmos DB location prefix (ID) must be 3 - 50 characters long, contain only lowercase letters, numbers and hyphens.",
 							),
-							Deprecated: "This field has been updated to readonly field. See more details from https://github.com/Azure/azure-sdk-for-go/pull/4640.",
+							Deprecated: "This field is used to set Cosmos DB location ID and previously this ID property allows to be changed by API. However, now it has been updated to readonly field on API level. So it has to be deprecated since it doesn't take effect anymore. See more details from https://github.com/Azure/azure-sdk-for-go/pull/4640.",
 						},
 
 						"id": {

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -685,7 +685,7 @@ func resourceArmCosmosDbAccountApiUpsert(client *documentdb.DatabaseAccountsClie
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"Creating", "Updating", "Deleting", "Initializing"},
 		Target:     []string{"Succeeded"},
-		Timeout:    180 * time.Minute,
+		Timeout:    d.Timeout(schema.TimeoutUpdate),
 		MinTimeout: 30 * time.Second,
 		Delay:      30 * time.Second, // required because it takes some time before the 'creating' location shows up
 		Refresh: func() (interface{}, string, error) {

--- a/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_account_resource.go
@@ -318,7 +318,7 @@ func resourceArmCosmosDbAccountCreate(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("CosmosDB Account %s already exists, please import the resource via terraform import", name)
 		}
 	}
-	geoLocations, err := expandAzureRmCosmosDBAccountGeoLocations(name, d)
+	geoLocations, err := expandAzureRmCosmosDBAccountGeoLocations(d)
 	if err != nil {
 		return fmt.Errorf("Error expanding CosmosDB Account %q (Resource Group %q) geo locations: %+v", name, resourceGroup, err)
 	}
@@ -386,7 +386,7 @@ func resourceArmCosmosDbAccountUpdate(d *schema.ResourceData, meta interface{}) 
 	enableAutomaticFailover := d.Get("enable_automatic_failover").(bool)
 	enableMultipleWriteLocations := d.Get("enable_multiple_write_locations").(bool)
 
-	newLocations, err := expandAzureRmCosmosDBAccountGeoLocations(name, d)
+	newLocations, err := expandAzureRmCosmosDBAccountGeoLocations(d)
 	if err != nil {
 		return fmt.Errorf("Error expanding CosmosDB Account %q (Resource Group %q) geo locations: %+v", name, resourceGroup, err)
 	}
@@ -536,7 +536,7 @@ func resourceArmCosmosDbAccountRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error setting CosmosDB Account %q `consistency_policy` (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	if err = d.Set("geo_location", flattenAzureRmCosmosDBAccountGeoLocations(d, resp)); err != nil {
+	if err = d.Set("geo_location", flattenAzureRmCosmosDBAccountGeoLocations(resp)); err != nil {
 		return fmt.Errorf("Error setting `geo_location`: %+v", err)
 	}
 
@@ -748,7 +748,7 @@ func resourceArmCosmosDbAccountGenerateDefaultId(databaseName string, location s
 	return fmt.Sprintf("%s-%s", databaseName, location)
 }
 
-func expandAzureRmCosmosDBAccountGeoLocations(databaseName string, d *schema.ResourceData) ([]documentdb.Location, error) {
+func expandAzureRmCosmosDBAccountGeoLocations(d *schema.ResourceData) ([]documentdb.Location, error) {
 	locations := make([]documentdb.Location, 0)
 	for _, l := range d.Get("geo_location").(*schema.Set).List() {
 		data := l.(map[string]interface{})
@@ -825,7 +825,7 @@ func flattenAzureRmCosmosDBAccountConsistencyPolicy(policy *documentdb.Consisten
 	return []interface{}{result}
 }
 
-func flattenAzureRmCosmosDBAccountGeoLocations(d *schema.ResourceData, account documentdb.DatabaseAccount) *schema.Set {
+func flattenAzureRmCosmosDBAccountGeoLocations(account documentdb.DatabaseAccount) *schema.Set {
 	locationSet := schema.Set{
 		F: resourceAzureRMCosmosDBAccountGeoLocationHash,
 	}

--- a/azurerm/internal/services/cosmos/tests/cosmos_db_account_data_source_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmos_db_account_data_source_test.go
@@ -2,11 +2,11 @@ package tests
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 )
 
@@ -40,8 +40,8 @@ func TestAccDataSourceAzureRMCosmosDBAccount_complete(t *testing.T) {
 				Config: testAccDataSourceAzureRMCosmosDBAccount_complete(data),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 3),
-					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.0.location", strings.ToLower(data.Locations.Primary)),
-					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.1.location", strings.ToLower(data.Locations.Secondary)),
+					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.0.location", azure.NormalizeLocation(data.Locations.Primary)),
+					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.1.location", azure.NormalizeLocation(data.Locations.Secondary)),
 					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.0.failover_priority", "0"),
 					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.1.failover_priority", "1"),
 				),

--- a/azurerm/internal/services/cosmos/tests/cosmos_db_account_data_source_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmos_db_account_data_source_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2015-04-08/documentdb"
@@ -38,9 +39,9 @@ func TestAccDataSourceAzureRMCosmosDBAccount_complete(t *testing.T) {
 			{
 				Config: testAccDataSourceAzureRMCosmosDBAccount_complete(data),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 2),
-					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.0.location", data.Locations.Primary),
-					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.1.location", data.Locations.Secondary),
+					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 3),
+					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.0.location", strings.ToLower(data.Locations.Primary)),
+					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.1.location", strings.ToLower(data.Locations.Secondary)),
 					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.0.failover_priority", "0"),
 					resource.TestCheckResourceAttr(data.ResourceName, "geo_location.1.failover_priority", "1"),
 				),

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
@@ -232,6 +232,13 @@ func testAccAzureRMCosmosDBAccount_updateWith(t *testing.T, kind documentdb.Data
 				),
 			},
 			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDBAccount_basic(data, kind, documentdb.Eventual),
+				Check:  resource.ComposeAggregateTestCheckFunc(
+				// checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 1),
+				),
+			},
+			data.ImportStep(),
 		},
 	})
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
@@ -232,13 +232,6 @@ func testAccAzureRMCosmosDBAccount_updateWith(t *testing.T, kind documentdb.Data
 				),
 			},
 			data.ImportStep(),
-			{
-				Config: testAccAzureRMCosmosDBAccount_basic(data, kind, documentdb.Eventual),
-				Check:  resource.ComposeAggregateTestCheckFunc(
-				// checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 1),
-				),
-			},
-			data.ImportStep(),
 		},
 	})
 }
@@ -607,8 +600,9 @@ resource "azurerm_cosmosdb_account" "test" {
   kind                = "%[3]s"
 
   consistency_policy {
-    consistency_level    = "%[4]s"
-    max_staleness_prefix = 170000
+    consistency_level       = "%[4]s"
+    max_interval_in_seconds = 360
+    max_staleness_prefix    = 170000
   }
 
   is_virtual_network_filter_enabled = true

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
@@ -583,7 +583,6 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   geo_location {
-    prefix            = "acctest-%[2]d-custom-id"
     location          = "%[5]s"
     failover_priority = 1
   }
@@ -626,13 +625,11 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   geo_location {
-    prefix            = "acctest-%[2]d-custom-id-updated"
     location          = "%[5]s"
     failover_priority = 1
   }
 
   geo_location {
-    prefix            = "acctest-%[2]d-custom-id-added"
     location          = "%[6]s"
     failover_priority = 2
   }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
@@ -472,8 +472,8 @@ resource "azurerm_cosmosdb_account" "import" {
   }
 
   geo_location {
-    location          = "${element(azurerm_cosmosdb_account.test.geo_location[*].location, 3358314097)}"
-    failover_priority = "${element(azurerm_cosmosdb_account.test.geo_location[*].failover_priority, 3358314097)}"
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
   }
 }
 `, testAccAzureRMCosmosDBAccount_basic(data, "GlobalDocumentDB", consistency))

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
@@ -468,12 +468,12 @@ resource "azurerm_cosmosdb_account" "import" {
   offer_type          = azurerm_cosmosdb_account.test.offer_type
 
   consistency_policy {
-    consistency_level = azurerm_cosmosdb_account.consistency_policy[0].consistency_level
+    consistency_level = azurerm_cosmosdb_account.test.consistency_policy[0].consistency_level
   }
 
   geo_location {
-    location          = azurerm_cosmosdb_account.geo_location[0].location
-    failover_priority = azurerm_cosmosdb_account.geo_location[0].location
+    location          = "${element(azurerm_cosmosdb_account.test.geo_location[*].location, 3358314097)}"
+    failover_priority = "${element(azurerm_cosmosdb_account.test.geo_location[*].failover_priority, 3358314097)}"
   }
 }
 `, testAccAzureRMCosmosDBAccount_basic(data, "GlobalDocumentDB", consistency))

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
@@ -142,13 +142,13 @@ func testAccAzureRMCosmosDBAccount_updateConsistency(t *testing.T, kind document
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMCosmosDBAccount_consistency(data, kind, documentdb.Eventual, 7, 770),
-				Check:  checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 1),
+				Config: testAccAzureRMCosmosDBAccount_consistency(data, kind, documentdb.BoundedStaleness, 7, 770),
+				Check:  checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 1),
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMCosmosDBAccount_consistency(data, kind, documentdb.Eventual, 77, 700),
-				Check:  checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 1),
+				Config: testAccAzureRMCosmosDBAccount_consistency(data, kind, documentdb.BoundedStaleness, 77, 700),
+				Check:  checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 1),
 			},
 			data.ImportStep(),
 			{
@@ -181,9 +181,9 @@ func testAccAzureRMCosmosDBAccount_completeWith(t *testing.T, kind documentdb.Da
 		CheckDestroy: testCheckAzureRMCosmosDBAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMCosmosDBAccount_complete(data, kind, documentdb.Eventual),
+				Config: testAccAzureRMCosmosDBAccount_complete(data, kind, documentdb.BoundedStaleness),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 3),
+					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 3),
 				),
 			},
 			data.ImportStep(),
@@ -219,16 +219,16 @@ func testAccAzureRMCosmosDBAccount_updateWith(t *testing.T, kind documentdb.Data
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMCosmosDBAccount_complete(data, kind, documentdb.Eventual),
+				Config: testAccAzureRMCosmosDBAccount_complete(data, kind, documentdb.BoundedStaleness),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 3),
+					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 3),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMCosmosDBAccount_completeUpdated(data, kind, documentdb.Eventual),
+				Config: testAccAzureRMCosmosDBAccount_completeUpdated(data, kind, documentdb.BoundedStaleness),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 3),
+					checkAccAzureRMCosmosDBAccount_basic(data, documentdb.BoundedStaleness, 3),
 				),
 			},
 			data.ImportStep(),

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 * `location` - (Required) The name of the Azure region to host replicated data.
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
 
-~> **NOTE:** The field `prefix` has been deprecated since it has been updated to readonly field. See more details from https://github.com/Azure/azure-sdk-for-go/pull/4640.
+~> **NOTE:** The field `prefix` is used to set Cosmos DB location ID and previously this ID property allows to be changed by API. However, now it has been updated to readonly field on API level. So it has to be deprecated since it doesn't take effect anymore. See more details from https://github.com/Azure/azure-sdk-for-go/pull/4640.
 
 `capabilities` Configures the capabilities to enable for this Cosmos DB account:
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -92,8 +92,11 @@ The following arguments are supported:
 
 `geo_location` Configures the geographic locations the data is replicated to and supports the following:
 
+* `prefix` - (Optional) The string used to generate the document endpoints for this region. If not specified it defaults to `${cosmosdb_account.name}-${location}`. Changing this causes the location to be deleted and re-provisioned and cannot be changed for the location with failover priority `0`.
 * `location` - (Required) The name of the Azure region to host replicated data.
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
+
+~> **NOTE:** The field `prefix` has been deprecated since it has been updated to readonly field. See more details from https://github.com/Azure/azure-sdk-for-go/pull/4640.
 
 `capabilities` Configures the capabilities to enable for this Cosmos DB account:
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -44,7 +44,6 @@ resource "azurerm_cosmosdb_account" "db" {
   }
 
   geo_location {
-    prefix            = "tfex-cosmos-db-${random_integer.ri.result}-customid"
     location          = azurerm_resource_group.rg.location
     failover_priority = 0
   }
@@ -93,7 +92,6 @@ The following arguments are supported:
 
 `geo_location` Configures the geographic locations the data is replicated to and supports the following:
 
-* `prefix` - (Optional) The string used to generate the document endpoints for this region. If not specified it defaults to `${cosmosdb_account.name}-${location}`. Changing this causes the location to be deleted and re-provisioned and cannot be changed for the location with failover priority `0`.
 * `location` - (Required) The name of the Azure region to host replicated data.
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
 
@@ -101,7 +99,7 @@ The following arguments are supported:
 
 * `name` - (Required) The capability to enable - Possible values are `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`,`EnableMongo`, `EnableTable`, `MongoDBv3.4`, and `mongoEnableDocLevelTTL`.
 
-**NOTE:** The `prefix` and `failover_priority` fields of a location cannot be changed for the location with a failover priority of `0`.
+**NOTE:** The `failover_priority` field of a location cannot be changed for the location with a failover priority of `0`.
 
 `virtual_network_rule` Configures the virtual network subnets allowed to access this Cosmos DB account and supports the following:
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 * `location` - (Required) The name of the Azure region to host replicated data.
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
 
-~> **NOTE:** The field `prefix` is used to set Cosmos DB location ID and previously this ID property allows to be changed by API. However, now it has been updated to readonly field on API level. So it has to be deprecated since it doesn't take effect anymore. See more details from https://github.com/Azure/azure-sdk-for-go/pull/4640.
+~> **NOTE:** The field `prefix` has been deprecated because the service no longer accepts this as an input since Apr 25, 2019.
 
 `capabilities` Configures the capabilities to enable for this Cosmos DB account:
 


### PR DESCRIPTION
fixes terraform-providers/terraform-provider-azurerm#5347