### PR TITLE
Remove incorrect validatefunc on azurerm_policy_remediation

### DIFF
--- a/azurerm/internal/services/policy/policy_remediation_resource.go
+++ b/azurerm/internal/services/policy/policy_remediation_resource.go
@@ -77,8 +77,6 @@ func resourceArmPolicyRemediation() *schema.Resource {
 				Optional: true,
 				// TODO: remove this suppression when github issue https://github.com/Azure/azure-rest-api-specs/issues/8353 is addressed
 				DiffSuppressFunc: suppress.CaseDifference,
-				// TODO: use the validation function in azurerm_policy_definition when implemented
-				ValidateFunc: validate.PolicyDefinitionID,
 			},
 		},
 	}

--- a/website/docs/r/policy_remediation.html.markdown
+++ b/website/docs/r/policy_remediation.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 * `policy_assignment_id` - (Required) The resource ID of the policy assignment that should be remediated.
 
-* `policy_definition_reference_id` - (Optional) The policy definition reference ID of the individual definition that should be remediated. Required when the policy assignment being remediated assigns a policy set definition. Note: this is not the resourceId of the policy definition, it is a unique id (within the policy set definition) for this policy definition.
+* `policy_definition_reference_id` - (Optional) The unique ID for the policy definition within the policy set definition that should be remediated. Required when the policy assignment being remediated assigns a policy set definition.
 
 * `location_filters` - (Optional) A list of the resource locations that will be remediated.
 

--- a/website/docs/r/policy_remediation.html.markdown
+++ b/website/docs/r/policy_remediation.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 * `policy_assignment_id` - (Required) The resource ID of the policy assignment that should be remediated.
 
-* `policy_definition_reference_id` - (Optional) The policy definition reference ID of the individual definition that should be remediated. Required when the policy assignment being remediated assigns a policy set definition.
+* `policy_definition_reference_id` - (Optional) The policy definition reference ID of the individual definition that should be remediated. Required when the policy assignment being remediated assigns a policy set definition. Note: this is not the resourceId of the policy definition, it is a unique id (within the policy set definition) for this policy definition.
 
 * `location_filters` - (Optional) A list of the resource locations that will be remediated.
 


### PR DESCRIPTION
fixes #7599 by removing incorrect validatefunc

As confirmed in the [official docs](https://docs.microsoft.com/en-us/rest/api/resources/policysetdefinitions/createorupdate#definitions) the PolicyDefinitionReferenceId is simply `A unique id (within the policy set definition) for this policy definition reference.` and is not a resource id to a policydefinition.
