### PR TITLE
Update syntax for address_prefix

### DIFF
--- a/examples/container-instance/network-profile/main.tf
+++ b/examples/container-instance/network-profile/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_subnet" "example" {
   name                 = "${var.prefix}subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.1.0.0/24"]
+  address_prefix       = "10.1.0.0/24"
 
   delegation {
     name = "delegation"


### PR DESCRIPTION
Solve Terraform Error: Missing required argument

```
Error: Missing required argument
The argument "address_prefix" is required, but no definition was found.
```