### PR TITLE
new resource: azurerm_mysql_active_directory_administrator

### DIFF
--- a/azurerm/internal/services/mysql/client/client.go
+++ b/azurerm/internal/services/mysql/client/client.go
@@ -12,6 +12,7 @@ type Client struct {
 	ServersClient                     *mysql.ServersClient
 	ServerSecurityAlertPoliciesClient *mysql.ServerSecurityAlertPoliciesClient
 	VirtualNetworkRulesClient         *mysql.VirtualNetworkRulesClient
+	ServerAdministratorsClient        *mysql.ServerAdministratorsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -33,6 +34,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	VirtualNetworkRulesClient := mysql.NewVirtualNetworkRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&VirtualNetworkRulesClient.Client, o.ResourceManagerAuthorizer)
 
+	serverAdministratorsClient := mysql.NewServerAdministratorsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&serverAdministratorsClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		ConfigurationsClient:              &ConfigurationsClient,
 		DatabasesClient:                   &DatabasesClient,
@@ -40,5 +44,6 @@ func NewClient(o *common.ClientOptions) *Client {
 		ServersClient:                     &ServersClient,
 		ServerSecurityAlertPoliciesClient: &serverSecurityAlertPoliciesClient,
 		VirtualNetworkRulesClient:         &VirtualNetworkRulesClient,
+		ServerAdministratorsClient:        &serverAdministratorsClient,
 	}
 }

--- a/azurerm/internal/services/mysql/mysql_aad_administrator_resource.go
+++ b/azurerm/internal/services/mysql/mysql_aad_administrator_resource.go
@@ -1,0 +1,170 @@
+package mysql
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/mysql/mgmt/2017-12-01/mysql"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	uuid "github.com/satori/go.uuid"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmMySQLAdministrator() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmMySQLAdministratorCreateUpdate,
+		Read:   resourceArmMySQLAdministratorRead,
+		Update: resourceArmMySQLAdministratorCreateUpdate,
+		Delete: resourceArmMySQLAdministratorDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"server_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"login": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"object_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"tenant_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+		},
+	}
+}
+
+func resourceArmMySQLAdministratorCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MySQL.ServerAdministratorsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	serverName := d.Get("server_name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	login := d.Get("login").(string)
+	objectId := uuid.FromStringOrNil(d.Get("object_id").(string))
+	tenantId := uuid.FromStringOrNil(d.Get("tenant_id").(string))
+
+	if features.ShouldResourcesBeImported() && d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, serverName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing MySQL AD Administrator (Resource Group %q, Server %q): %+v", resGroup, serverName, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_mysql_active_directory_administrator", *existing.ID)
+		}
+	}
+
+	parameters := mysql.ServerAdministratorResource{
+		ServerAdministratorProperties: &mysql.ServerAdministratorProperties{
+			AdministratorType: utils.String("ActiveDirectory"),
+			Login:             utils.String(login),
+			Sid:               &objectId,
+			TenantID:          &tenantId,
+		},
+	}
+
+	future, err := client.CreateOrUpdate(ctx, resGroup, serverName, parameters)
+	if err != nil {
+		return fmt.Errorf("Error issuing create/update request for MySQL AD Administrator (Resource Group %q, Server %q): %+v", resGroup, serverName, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("Error waiting on create/update future for MySQL AD Administrator (Resource Group %q, Server %q): %+v", resGroup, serverName, err)
+	}
+
+	resp, err := client.Get(ctx, resGroup, serverName)
+	if err != nil {
+		return fmt.Errorf("Error issuing get request for MySQL AD Administrator (Resource Group %q, Server %q): %+v", resGroup, serverName, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	return nil
+}
+
+func resourceArmMySQLAdministratorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MySQL.ServerAdministratorsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	serverName := id.Path["servers"]
+
+	resp, err := client.Get(ctx, resourceGroup, serverName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] Error reading MySQL AD administrator %q - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error reading MySQL AD administrator: %+v", err)
+	}
+
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("server_name", serverName)
+	d.Set("login", resp.Login)
+	d.Set("object_id", resp.Sid.String())
+	d.Set("tenant_id", resp.TenantID.String())
+
+	return nil
+}
+
+func resourceArmMySQLAdministratorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MySQL.ServerAdministratorsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	serverName := id.Path["servers"]
+
+	_, err = client.Delete(ctx, resourceGroup, serverName)
+	if err != nil {
+		return fmt.Errorf("Error deleting MySQL AD Administrator: %+v", err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/mysql/registration.go
+++ b/azurerm/internal/services/mysql/registration.go
@@ -26,9 +26,10 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_mysql_configuration":        resourceArmMySQLConfiguration(),
-		"azurerm_mysql_database":             resourceArmMySqlDatabase(),
-		"azurerm_mysql_firewall_rule":        resourceArmMySqlFirewallRule(),
-		"azurerm_mysql_server":               resourceArmMySqlServer(),
-		"azurerm_mysql_virtual_network_rule": resourceArmMySSQLVirtualNetworkRule()}
+		"azurerm_mysql_configuration":                  resourceArmMySQLConfiguration(),
+		"azurerm_mysql_database":                       resourceArmMySqlDatabase(),
+		"azurerm_mysql_firewall_rule":                  resourceArmMySqlFirewallRule(),
+		"azurerm_mysql_server":                         resourceArmMySqlServer(),
+		"azurerm_mysql_virtual_network_rule":           resourceArmMySSQLVirtualNetworkRule(),
+		"azurerm_mysql_active_directory_administrator": resourceArmMySQLAdministrator()}
 }

--- a/azurerm/internal/services/mysql/tests/mysql_administrator_resource_test.go
+++ b/azurerm/internal/services/mysql/tests/mysql_administrator_resource_test.go
@@ -1,0 +1,247 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureMySqlAdministrator_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mysql_active_directory_administrator", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureMySqlAdministratorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureMySqlAdministrator_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureMySqlAdministratorExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "login", "sqladmin"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureMySqlAdministrator_withUpdates(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureMySqlAdministratorExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "login", "sqladmin2"),
+				),
+			},
+		},
+	})
+}
+func TestAccAzureMySqlAdministrator_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mysql_active_directory_administrator", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureMySqlAdministratorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureMySqlAdministrator_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureMySqlAdministratorExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "login", "sqladmin"),
+				),
+			},
+			{
+				Config:      testAccAzureMySqlAdministrator_requiresImport(data),
+				ExpectError: acceptance.RequiresImportError("azurerm_mysql_active_directory_administrator"),
+			},
+		},
+	})
+}
+
+func TestAccAzureMySqlAdministrator_disappears(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mysql_active_directory_administrator", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureMySqlAdministratorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureMySqlAdministrator_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureMySqlAdministratorExists(data.ResourceName),
+					testCheckAzureMySqlAdministratorDisappears(data.ResourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testCheckAzureMySqlAdministratorExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).MySQL.ServerAdministratorsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serverName := rs.Primary.Attributes["server_name"]
+
+		_, err := client.Get(ctx, resourceGroup, serverName)
+		return err
+	}
+}
+
+func testCheckAzureMySqlAdministratorDisappears(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).MySQL.ServerAdministratorsClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serverName := rs.Primary.Attributes["server_name"]
+
+		if _, err := client.Delete(ctx, resourceGroup, serverName); err != nil {
+			return fmt.Errorf("Bad: Delete on mysqlAdministratorClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureMySqlAdministratorDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).MySQL.ServerAdministratorsClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_mysql_active_directory_administrator" {
+			continue
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serverName := rs.Primary.Attributes["server_name"]
+
+		resp, err := client.Get(ctx, resourceGroup, serverName)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil
+			}
+
+			return err
+		}
+
+		return fmt.Errorf("MySQL AD Administrator (server %q / resource group %q) still exists: %+v", serverName, resourceGroup, resp)
+	}
+
+	return nil
+}
+
+func testAccAzureMySqlAdministrator_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_mysql_server" "test" {
+  name                = "acctestmysqlsvr-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "GP_Gen5_2"
+
+  storage_profile {
+    storage_mb            = 51200
+    backup_retention_days = 7
+    geo_redundant_backup  = "Disabled"
+  }
+
+  administrator_login          = "acctestun"
+  administrator_login_password = "H@Sh1CoR3!"
+  version                      = "5.7"
+  ssl_enforcement_enabled      = true
+}
+
+resource "azurerm_mysql_active_directory_administrator" "test" {
+  server_name         = azurerm_mysql_server.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  login               = "sqladmin"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = data.azurerm_client_config.current.client_id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureMySqlAdministrator_requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mysql_active_directory_administrator" "import" {
+  server_name         = azurerm_mysql_active_directory_administrator.test.server_name
+  resource_group_name = azurerm_mysql_active_directory_administrator.test.resource_group_name
+  login               = azurerm_mysql_active_directory_administrator.test.login
+  tenant_id           = azurerm_mysql_active_directory_administrator.test.tenant_id
+  object_id           = azurerm_mysql_active_directory_administrator.test.object_id
+}
+`, testAccAzureMySqlAdministrator_basic(data))
+}
+
+func testAccAzureMySqlAdministrator_withUpdates(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_mysql_server" "test" {
+  name                = "acctestmysqlsvr-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku_name = "GP_Gen5_2"
+
+  storage_profile {
+    storage_mb            = 51200
+    backup_retention_days = 7
+    geo_redundant_backup  = "Disabled"
+  }
+
+  administrator_login          = "acctestun"
+  administrator_login_password = "H@Sh1CoR3!"
+  version                      = "5.7"
+  ssl_enforcement_enabled      = true
+}
+
+resource "azurerm_mysql_active_directory_administrator" "test" {
+  server_name         = azurerm_mysql_server.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  login               = "sqladmin2"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = data.azurerm_client_config.current.client_id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1292,6 +1292,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/mysql_active_directory_administrator.html">azurerm_mysql_active_directory_administrator</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/mysql_configuration.html">azurerm_mysql_configuration</a>
                 </li>
 

--- a/website/docs/r/mysql_active_directory_administrator.html.markdown
+++ b/website/docs/r/mysql_active_directory_administrator.html.markdown
@@ -1,0 +1,80 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource manager: azurerm_mysql_active_directory_administrator"
+description: |-
+  Manages an Active Directory administrator on a MySQL server
+---
+
+# azurerm_mysql_active_directory_administrator
+
+Allows you to set a user or group as the AD administrator for an MySQL server in Azure
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West US"
+}
+
+resource "azurerm_mysql_server" "example" {
+  name                = "example-mysqlserver"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  administrator_login          = "mysqladminun"
+  administrator_login_password = "H@Sh1CoR3!"
+
+  sku_name   = "B_Gen5_2"
+  storage_mb = 5120
+  version    = "5.7"
+}
+
+resource "azurerm_mysql_active_directory_administrator" "example" {
+  server_name         = azurerm_mysql_server.example.name
+  resource_group_name = azurerm_resource_group.example.name
+  login               = "sqladmin"
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  object_id           = data.azurerm_client_config.current.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `server_name` - (Required) The name of the MySQL Server on which to set the administrator. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group for the MySQL server. Changing this forces a new resource to be created.
+
+* `login` - (Required) The login name of the principal to set as the server administrator
+
+* `object_id` - (Required) The ID of the principal to set as the server administrator
+
+* `tenant_id` - (Required) The Azure Tenant ID
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the MySQL Active Directory Administrator.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the MySQL Active Directory Administrator.
+* `update` - (Defaults to 30 minutes) Used when updating the MySQL Active Directory Administrator.
+* `read` - (Defaults to 5 minutes) Used when retrieving the MySQL Active Directory Administrator.
+* `delete` - (Defaults to 30 minutes) Used when deleting the MySQL Active Directory Administrator.
+
+## Import
+
+A MySQL Active Directory Administrator can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_mysql_active_directory_administrator.administrator /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.DBforMySQL/servers/myserver/administrators/activeDirectory
+```


### PR DESCRIPTION
Fixes #7607
```
TF_ACC=1 go test -timeout 0 -v "./azurerm/internal/services/mysql/tests" -run="TestAccAzureMySqlAdministrator"
--- PASS: TestAccAzureMySqlAdministrator_requiresImport (376.06s)
--- PASS: TestAccAzureMySqlAdministrator_disappears (845.01s)
--- PASS: TestAccAzureMySqlAdministrator_basic (1546.86s)
PASS
```