### PR TITLE
Test Fix - `azurerm_network_security_group`  import test

### DIFF
--- a/azurerm/internal/services/network/tests/network_security_group_resource_test.go
+++ b/azurerm/internal/services/network/tests/network_security_group_resource_test.go
@@ -358,7 +358,7 @@ func testAccAzureRMNetworkSecurityGroup_requiresImport(data acceptance.TestData)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_network_security_group" "test" {
+resource "azurerm_network_security_group" "import" {
   name                = azurerm_network_security_group.test.name
   location            = azurerm_network_security_group.test.location
   resource_group_name = azurerm_network_security_group.test.resource_group_name


### PR DESCRIPTION
`azurerm_network_security_group`: acctest fix the import test

```bash
💤 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMNetworkSecurityGroup_requiresImport'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run TestAccAzureRMNetworkSecurityGroup_requiresImport -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMNetworkSecurityGroup_requiresImport
=== PAUSE TestAccAzureRMNetworkSecurityGroup_requiresImport
=== CONT  TestAccAzureRMNetworkSecurityGroup_requiresImport
--- PASS: TestAccAzureRMNetworkSecurityGroup_requiresImport (124.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       124.790s
```