### PR TITLE
azurerm_template_deployment: fix test

### DIFF
--- a/azurerm/internal/services/resource/tests/resource_arm_template_deployment_test.go
+++ b/azurerm/internal/services/resource/tests/resource_arm_template_deployment_test.go
@@ -167,7 +167,7 @@ func TestAccAzureRMTemplateDeployment_withError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAzureRMTemplateDeployment_withError(data),
-				ExpectError: regexp.MustCompile("Error validating Template for Deployment"),
+				ExpectError: regexp.MustCompile("Error waiting for deployment"),
 			},
 		},
 	})


### PR DESCRIPTION
in the config of test, the storage account name "badStorageAccountNameTooLong" is not valid, so this acctest is expected to be error.

It seems the `client.Validate` func only checks the syntax of `template_body`, so there is no problem when validating. It will only reports error when applying.

The original `ExpectError: regexp.MustCompile("Error validating Template for Deployment")` hopes error message is reported in `validate`, so it will failed.
