### PR TITLE
azurerm_loadbalancer_outbound_rule: fix acctest

### DIFF
--- a/azurerm/internal/services/network/tests/loadbalancer_outbound_rule_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_outbound_rule_resource_test.go
@@ -113,8 +113,8 @@ func TestAccAzureRMLoadBalancerOutboundRule_removal(t *testing.T) {
 }
 
 func TestAccAzureRMLoadBalancerOutboundRule_update(t *testing.T) {
-	data1 := acceptance.BuildTestData(t, "azurerm_lb_nat_rule", "test")
-	data2 := acceptance.BuildTestData(t, "azurerm_lb_nat_rule", "test2")
+	data1 := acceptance.BuildTestData(t, "azurerm_lb_outbound_rule", "test")
+	data2 := acceptance.BuildTestData(t, "azurerm_lb_outbound_rule", "test2")
 
 	var lb network.LoadBalancer
 	outboundRuleName := fmt.Sprintf("OutboundRule-%d", data1.RandomInteger)
@@ -131,18 +131,20 @@ func TestAccAzureRMLoadBalancerOutboundRule_update(t *testing.T) {
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerOutboundRuleExists(outboundRuleName, &lb),
 					testCheckAzureRMLoadBalancerOutboundRuleExists(outboundRule2Name, &lb),
-					resource.TestCheckResourceAttr(data2.ResourceName, "protocol", "Udp"),
 				),
 			},
+			data1.ImportStep(),
+			data2.ImportStep(),
 			{
 				Config: testAccAzureRMLoadBalancerOutboundRule_multipleRulesUpdate(data1, outboundRuleName, outboundRule2Name),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerOutboundRuleExists(outboundRuleName, &lb),
 					testCheckAzureRMLoadBalancerOutboundRuleExists(outboundRule2Name, &lb),
-					resource.TestCheckResourceAttr(data2.ResourceName, "protocol", "All"),
 				),
 			},
+			data1.ImportStep(),
+			data2.ImportStep(),
 		},
 	})
 }


### PR DESCRIPTION
The target under test is misconfigured. Additionally, make use of import step to verify all-state for the targets under test.

```bash
💤 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMLoadBalancerOutboundRule_update'   

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run TestAccAzureRMLoadBalancerOutboundRule_update -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLoadBalancerOutboundRule_update
=== PAUSE TestAccAzureRMLoadBalancerOutboundRule_update
=== CONT  TestAccAzureRMLoadBalancerOutboundRule_update
--- PASS: TestAccAzureRMLoadBalancerOutboundRule_update (243.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       243.637s
```