### PR TITLE
azurerm_express_route_gateway: fix acctest

### DIFF
--- a/azurerm/internal/services/network/tests/express_route_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/express_route_gateway_resource_test.go
@@ -175,7 +175,7 @@ func testAccAzureRMExpressRouteGateway_requiresImport(data acceptance.TestData) 
 
 resource "azurerm_express_route_gateway" "import" {
   name                = azurerm_express_route_gateway.test.name
-  resource_group_name = azurerm_express_route_gateway.test.name
+  resource_group_name = azurerm_express_route_gateway.test.resource_group_name
   location            = azurerm_express_route_gateway.test.location
   virtual_hub_id      = azurerm_express_route_gateway.test.virtual_hub_id
   scale_units         = azurerm_express_route_gateway.test.scale_units


### PR DESCRIPTION
Fix a typo to fix the acctest.

```bash
💤 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMExpressRouteGateway_requiresImport'     

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run TestAccAzureRMExpressRouteGateway_requiresImport -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMExpressRouteGateway_requiresImport
=== PAUSE TestAccAzureRMExpressRouteGateway_requiresImport
=== CONT  TestAccAzureRMExpressRouteGateway_requiresImport
--- PASS: TestAccAzureRMExpressRouteGateway_requiresImport (2978.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       2978.433s
```