### PR TITLE
`azurerm_sql_database` fix to pass all acctests

### DIFF
--- a/azurerm/internal/services/sql/tests/resource_arm_sql_database_test.go
+++ b/azurerm/internal/services/sql/tests/resource_arm_sql_database_test.go
@@ -92,7 +92,7 @@ func TestAccAzureRMSqlDatabase_elasticPool(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "elastic_pool_name", fmt.Sprintf("acctestep%d", data.RandomInteger)),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("create_mode"),
 		},
 	})
 }
@@ -654,7 +654,7 @@ resource "azurerm_sql_database" "test" {
   location                         = azurerm_resource_group.test.location
   edition                          = "DataWarehouse"
   collation                        = "SQL_Latin1_General_CP1_CI_AS"
-  requested_service_objective_name = "DW400"
+  requested_service_objective_name = "DW400c"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
=== RUN   TestAccAzureRMSqlDatabase_basic
=== PAUSE TestAccAzureRMSqlDatabase_basic
=== CONT  TestAccAzureRMSqlDatabase_basic
--- PASS: TestAccAzureRMSqlDatabase_basic (247.11s)
=== RUN   TestAccAzureRMSqlDatabase_requiresImport
=== PAUSE TestAccAzureRMSqlDatabase_requiresImport
=== CONT  TestAccAzureRMSqlDatabase_requiresImport
--- PASS: TestAccAzureRMSqlDatabase_requiresImport (251.39s)
=== RUN   TestAccAzureRMSqlDatabase_disappears
=== PAUSE TestAccAzureRMSqlDatabase_disappears
=== CONT  TestAccAzureRMSqlDatabase_disappears
--- PASS: TestAccAzureRMSqlDatabase_disappears (230.42s)
=== RUN   TestAccAzureRMSqlDatabase_elasticPool
=== PAUSE TestAccAzureRMSqlDatabase_elasticPool
=== CONT  TestAccAzureRMSqlDatabase_elasticPool
--- PASS: TestAccAzureRMSqlDatabase_elasticPool (279.13s)
=== RUN   TestAccAzureRMSqlDatabase_withTags
=== PAUSE TestAccAzureRMSqlDatabase_withTags
=== CONT  TestAccAzureRMSqlDatabase_withTags
--- PASS: TestAccAzureRMSqlDatabase_withTags (276.74s)
=== RUN   TestAccAzureRMSqlDatabase_dataWarehouse
=== PAUSE TestAccAzureRMSqlDatabase_dataWarehouse
=== CONT  TestAccAzureRMSqlDatabase_dataWarehouse
--- PASS: TestAccAzureRMSqlDatabase_dataWarehouse (437.65s)
=== RUN   TestAccAzureRMSqlDatabase_restorePointInTime
=== PAUSE TestAccAzureRMSqlDatabase_restorePointInTime
=== CONT  TestAccAzureRMSqlDatabase_restorePointInTime
--- PASS: TestAccAzureRMSqlDatabase_restorePointInTime (1449.99s)
=== RUN   TestAccAzureRMSqlDatabase_collation
=== PAUSE TestAccAzureRMSqlDatabase_collation
=== CONT  TestAccAzureRMSqlDatabase_collation
--- PASS: TestAccAzureRMSqlDatabase_collation (331.65s)
=== RUN   TestAccAzureRMSqlDatabase_requestedServiceObjectiveName
=== PAUSE TestAccAzureRMSqlDatabase_requestedServiceObjectiveName
=== CONT  TestAccAzureRMSqlDatabase_requestedServiceObjectiveName
--- PASS: TestAccAzureRMSqlDatabase_requestedServiceObjectiveName (335.54s)
=== RUN   TestAccAzureRMSqlDatabase_threatDetectionPolicy
=== PAUSE TestAccAzureRMSqlDatabase_threatDetectionPolicy
=== CONT  TestAccAzureRMSqlDatabase_threatDetectionPolicy
--- PASS: TestAccAzureRMSqlDatabase_threatDetectionPolicy (299.76s)
=== RUN   TestAccAzureRMSqlDatabase_readScale
=== PAUSE TestAccAzureRMSqlDatabase_readScale
=== CONT  TestAccAzureRMSqlDatabase_readScale
--- PASS: TestAccAzureRMSqlDatabase_readScale (327.25s)
=== RUN   TestAccAzureRMSqlDatabase_zoneRedundant
=== PAUSE TestAccAzureRMSqlDatabase_zoneRedundant
=== CONT  TestAccAzureRMSqlDatabase_zoneRedundant
--- PASS: TestAccAzureRMSqlDatabase_zoneRedundant (430.62s)
=== RUN   TestAccAzureRMSqlDatabase_bacpac
=== PAUSE TestAccAzureRMSqlDatabase_bacpac
=== CONT  TestAccAzureRMSqlDatabase_bacpac
--- PASS: TestAccAzureRMSqlDatabase_bacpac (395.04s)
=== RUN   TestAccAzureRMSqlDatabase_withBlobAuditingPolices
=== PAUSE TestAccAzureRMSqlDatabase_withBlobAuditingPolices
=== CONT  TestAccAzureRMSqlDatabase_withBlobAuditingPolices
--- PASS: TestAccAzureRMSqlDatabase_withBlobAuditingPolices (365.43s)
=== RUN   TestAccAzureRMSqlDatabase_withBlobAuditingPolicesUpdate
=== PAUSE TestAccAzureRMSqlDatabase_withBlobAuditingPolicesUpdate
=== CONT  TestAccAzureRMSqlDatabase_withBlobAuditingPolicesUpdate
--- PASS: TestAccAzureRMSqlDatabase_withBlobAuditingPolicesUpdate (307.87s)
=== RUN   TestAccAzureRMSqlDatabase_onlineSecondaryMode
=== PAUSE TestAccAzureRMSqlDatabase_onlineSecondaryMode
=== CONT  TestAccAzureRMSqlDatabase_onlineSecondaryMode
--- PASS: TestAccAzureRMSqlDatabase_onlineSecondaryMode (389.17s)