### PR TITLE
azurerm_stream_analytics_job: fix data source test

### DIFF
--- a/azurerm/internal/services/streamanalytics/tests/data_source_stream_analytics_job_test.go
+++ b/azurerm/internal/services/streamanalytics/tests/data_source_stream_analytics_job_test.go
@@ -20,6 +20,8 @@ func TestAccDataSourceAzureRMStreamAnalyticsJob_basic(t *testing.T) {
 				Config: testAccDataSourceAzureRMStreamAnalyticsJob_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(data.ResourceName, "job_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "streaming_units"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "transformation_query"),
 				),
 			},
 		},


### PR DESCRIPTION
according to the implementation of resource `stream analytics job`,  we should pass "transformation" as expand parameter to `client.Get` func to get `transformation` information.