### PR TITLE
Fix requiresimport test for RP: stream analytics

### DIFF
--- a/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_function_javascript_udf_test.go
+++ b/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_function_javascript_udf_test.go
@@ -161,12 +161,18 @@ func testAccAzureRMStreamAnalyticsFunctionJavaScriptUDF_requiresImport(data acce
 %s
 
 resource "azurerm_stream_analytics_function_javascript_udf" "import" {
-  name                      = "${azurerm_stream_analytics_function_javascript_udf.test.name}"
-  stream_analytics_job_name = "${azurerm_stream_analytics_function_javascript_udf.test.stream_analytics_job_name}"
-  resource_group_name       = "${azurerm_stream_analytics_function_javascript_udf.test.resource_group_name}"
-  script                    = "${azurerm_stream_analytics_function_javascript_udf.test.script}"
-  inputs                    = "${azurerm_stream_analytics_function_javascript_udf.test.inputs}"
-  output                    = "${azurerm_stream_analytics_function_javascript_udf.test.output}"
+  name                      = azurerm_stream_analytics_function_javascript_udf.test.name
+  stream_analytics_job_name = azurerm_stream_analytics_function_javascript_udf.test.stream_analytics_job_name
+  resource_group_name       = azurerm_stream_analytics_function_javascript_udf.test.resource_group_name
+  script                    = azurerm_stream_analytics_function_javascript_udf.test.script
+
+  input {
+    type = azurerm_stream_analytics_function_javascript_udf.test.input.0.type
+  }
+
+  output {
+    type = azurerm_stream_analytics_function_javascript_udf.test.output.0.type
+  }
 }
 `, template)
 }

--- a/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_blob_test.go
+++ b/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_blob_test.go
@@ -292,9 +292,9 @@ resource "azurerm_stream_analytics_output_blob" "import" {
   dynamic "serialization" {
     for_each = azurerm_stream_analytics_output_blob.test.serialization
     content {
-      encoding        = lookup(serialization.value, "encoding", null)
-      format          = lookup(serialization.value, "format", null)
-      type            = serialization.value.type
+      encoding = lookup(serialization.value, "encoding", null)
+      format   = lookup(serialization.value, "format", null)
+      type     = serialization.value.type
     }
   }
 }

--- a/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_blob_test.go
+++ b/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_blob_test.go
@@ -293,7 +293,6 @@ resource "azurerm_stream_analytics_output_blob" "import" {
     for_each = azurerm_stream_analytics_output_blob.test.serialization
     content {
       encoding        = lookup(serialization.value, "encoding", null)
-      field_delimiter = lookup(serialization.value, "field_delimiter", null)
       format          = lookup(serialization.value, "format", null)
       type            = serialization.value.type
     }

--- a/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_eventhub_test.go
+++ b/azurerm/internal/services/streamanalytics/tests/resource_arm_stream_analytics_output_eventhub_test.go
@@ -332,6 +332,12 @@ resource "azurerm_stream_analytics_output_eventhub" "import" {
   servicebus_namespace      = azurerm_stream_analytics_output_eventhub.test.servicebus_namespace
   shared_access_policy_key  = azurerm_stream_analytics_output_eventhub.test.shared_access_policy_key
   shared_access_policy_name = azurerm_stream_analytics_output_eventhub.test.shared_access_policy_name
+
+  serialization {
+    type     = azurerm_stream_analytics_output_eventhub.test.serialization.0.type
+    encoding = azurerm_stream_analytics_output_eventhub.test.serialization.0.encoding
+    format   = azurerm_stream_analytics_output_eventhub.test.serialization.0.format
+  }
 }
 `, template)
 }


### PR DESCRIPTION
`testAccAzureRMStreamAnalyticsFunctionJavaScriptUDF_requiresImport`:
- `input` not `inputs`
- `input` and `output` are nested object list

`testAccAzureRMStreamAnalyticsOutputBlob_requiresImport`
- in template config, there is no `field_delimiter` in `content` list

`testAccAzureRMStreamAnalyticsOutputEventHub_requiresImport`
- `serialization` is required