### PR TITLE
`azurerm_api_management_identity_provider_facebook` fix to pass all acctests

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource.go
@@ -129,7 +129,6 @@ func resourceArmApiManagementIdentityProviderFacebookRead(d *schema.ResourceData
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("app_id", props.ClientID)
-		d.Set("app_secret", props.ClientSecret)
 	}
 
 	return nil

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_facebook_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_facebook_resource_test.go
@@ -27,7 +27,7 @@ func TestAccAzureRMApiManagementIdentityProviderFacebook_basic(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderFacebookExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("app_secret"),
 		},
 	})
 }
@@ -47,18 +47,17 @@ func TestAccAzureRMApiManagementIdentityProviderFacebook_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderFacebookExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "app_id", "00000000000000000000000000000000"),
-					resource.TestCheckResourceAttr(data.ResourceName, "app_secret", "00000000000000000000000000000000"),
 				),
 			},
+			data.ImportStep("app_secret"),
 			{
 				Config: updateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderFacebookExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "app_id", "11111111111111111111111111111111"),
-					resource.TestCheckResourceAttr(data.ResourceName, "app_secret", "11111111111111111111111111111111"),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("app_secret"),
 		},
 	})
 }


### PR DESCRIPTION
=== RUN   TestAccAzureRMApiManagementIdentityProviderFacebook_basic
=== PAUSE TestAccAzureRMApiManagementIdentityProviderFacebook_basic
=== CONT  TestAccAzureRMApiManagementIdentityProviderFacebook_basic
--- PASS: TestAccAzureRMApiManagementIdentityProviderFacebook_basic (2488.86s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderFacebook_update
=== PAUSE TestAccAzureRMApiManagementIdentityProviderFacebook_update
=== CONT  TestAccAzureRMApiManagementIdentityProviderFacebook_update
--- PASS: TestAccAzureRMApiManagementIdentityProviderFacebook_update (2465.20s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderFacebook_requiresImport
=== PAUSE TestAccAzureRMApiManagementIdentityProviderFacebook_requiresImport
=== CONT  TestAccAzureRMApiManagementIdentityProviderFacebook_requiresImport
--- PASS: TestAccAzureRMApiManagementIdentityProviderFacebook_requiresImport (2444.74s)
