### PR TITLE
`azurerm_api_management_identity_provider_microsoft` fix to pass all acctests

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_microsoft_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_microsoft_resource.go
@@ -129,7 +129,6 @@ func resourceArmApiManagementIdentityProviderMicrosoftRead(d *schema.ResourceDat
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
-		d.Set("client_secret", props.ClientSecret)
 	}
 
 	return nil

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_microsoft_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_microsoft_resource_test.go
@@ -27,7 +27,7 @@ func TestAccAzureRMApiManagementIdentityProviderMicrosoft_basic(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderMicrosoftExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }
@@ -47,18 +47,17 @@ func TestAccAzureRMApiManagementIdentityProviderMicrosoft_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderMicrosoftExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "00000000-0000-0000-0000-000000000000"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "00000000000000000000000000000000"),
 				),
 			},
+			data.ImportStep("client_secret"),
 			{
 				Config: updateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderMicrosoftExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "11111111-1111-1111-1111-111111111111"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "11111111111111111111111111111111"),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }


### PR DESCRIPTION
=== RUN   TestAccAzureRMApiManagementIdentityProviderMicrosoft_basic
=== PAUSE TestAccAzureRMApiManagementIdentityProviderMicrosoft_basic
=== CONT  TestAccAzureRMApiManagementIdentityProviderMicrosoft_basic
--- PASS: TestAccAzureRMApiManagementIdentityProviderMicrosoft_basic (2484.12s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderMicrosoft_update
=== PAUSE TestAccAzureRMApiManagementIdentityProviderMicrosoft_update
=== CONT  TestAccAzureRMApiManagementIdentityProviderMicrosoft_update
--- PASS: TestAccAzureRMApiManagementIdentityProviderMicrosoft_update (2468.72s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderMicrosoft_requiresImport
=== PAUSE TestAccAzureRMApiManagementIdentityProviderMicrosoft_requiresImport
=== CONT  TestAccAzureRMApiManagementIdentityProviderMicrosoft_requiresImport
--- PASS: TestAccAzureRMApiManagementIdentityProviderMicrosoft_requiresImport (2676.11s)