### PR TITLE
`azurerm_api_management_identity_provider_google` fix to pass all acctests

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource.go
@@ -130,7 +130,6 @@ func resourceArmApiManagementIdentityProviderGoogleRead(d *schema.ResourceData, 
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
-		d.Set("client_secret", props.ClientSecret)
 	}
 
 	return nil

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_google_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_google_resource_test.go
@@ -26,7 +26,7 @@ func TestAccAzureRMApiManagementIdentityProviderGoogle_basic(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderGoogleExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }
@@ -44,18 +44,17 @@ func TestAccAzureRMApiManagementIdentityProviderGoogle_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderGoogleExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "00000000.apps.googleusercontent.com"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "00000000000000000000000000000000"),
 				),
 			},
+			data.ImportStep("client_secret"),
 			{
 				Config: testAccAzureRMApiManagementIdentityProviderGoogle_update(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderGoogleExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "11111111.apps.googleusercontent.com"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "11111111111111111111111111111111"),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }


### PR DESCRIPTION
=== RUN   TestAccAzureRMApiManagementIdentityProviderGoogle_basic
=== PAUSE TestAccAzureRMApiManagementIdentityProviderGoogle_basic
=== CONT  TestAccAzureRMApiManagementIdentityProviderGoogle_basic
--- PASS: TestAccAzureRMApiManagementIdentityProviderGoogle_basic (2469.77s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderGoogle_update
=== PAUSE TestAccAzureRMApiManagementIdentityProviderGoogle_update
=== CONT  TestAccAzureRMApiManagementIdentityProviderGoogle_update
--- PASS: TestAccAzureRMApiManagementIdentityProviderGoogle_update (2826.55s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderGoogle_requiresImport
=== PAUSE TestAccAzureRMApiManagementIdentityProviderGoogle_requiresImport
=== CONT  TestAccAzureRMApiManagementIdentityProviderGoogle_requiresImport
--- PASS: TestAccAzureRMApiManagementIdentityProviderGoogle_requiresImport (2529.91s)