### PR TITLE
azurerm_network_service_tag: fix acctest

### DIFF
--- a/azurerm/internal/services/network/tests/network_service_tags_data_source_test.go
+++ b/azurerm/internal/services/network/tests/network_service_tags_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceAzureRMServiceTags_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceAzureRMServiceTags_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "address_prefixes.#", "210"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "address_prefixes.#"),
 				),
 			},
 		},
@@ -34,7 +34,7 @@ func TestAccDataSourceAzureRMServiceTags_region(t *testing.T) {
 			{
 				Config: testAccDataSourceAzureRMServiceTags_region(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "address_prefixes.#", "3"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "address_prefixes.#"),
 				),
 			},
 		},
@@ -43,14 +43,14 @@ func TestAccDataSourceAzureRMServiceTags_region(t *testing.T) {
 
 func testAccDataSourceAzureRMServiceTags_basic() string {
 	return `data "azurerm_network_service_tags" "test" {
-  location = "northeurope"
+  location = "westcentralus"
   service  = "AzureKeyVault"
 }`
 }
 
 func testAccDataSourceAzureRMServiceTags_region() string {
 	return `data "azurerm_network_service_tags" "test" {
-  location        = "northeurope"
+  location        = "westcentralus"
   service         = "AzureKeyVault"
   location_filter = "australiacentral"
 }`

--- a/website/docs/d/network_service_tags.html.markdown
+++ b/website/docs/d/network_service_tags.html.markdown
@@ -14,7 +14,7 @@ Use this data source to access information about Service Tags.
 
 ```hcl
 data "azurerm_network_service_tags" "example" {
-  location        = "West Europe"
+  location        = "westcentralus"
   service         = "AzureKeyVault"
   location_filter = "northeurope"
 }


### PR DESCRIPTION
This API only works in limited locations, which don't include `north europe`/`west europe`.
Additionally, the original test against length of `address_prefixes` is not robust, as the supported address prefixes might vary. 