### PR TITLE
`azurerm_api_management_identity_provider_twitter` fix to pass all acctests

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
@@ -129,7 +129,6 @@ func resourceArmApiManagementIdentityProviderTwitterRead(d *schema.ResourceData,
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("api_key", props.ClientID)
-		d.Set("api_secret_key", props.ClientSecret)
 	}
 
 	return nil

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_twitter_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_twitter_resource_test.go
@@ -27,7 +27,7 @@ func TestAccAzureRMApiManagementIdentityProviderTwitter_basic(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderTwtterExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("api_secret_key"),
 		},
 	})
 }
@@ -47,18 +47,17 @@ func TestAccAzureRMApiManagementIdentityProviderTwitter_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderTwtterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "api_key", "00000000000000000000000000000000"),
-					resource.TestCheckResourceAttr(data.ResourceName, "api_secret_key", "00000000000000000000000000000000"),
 				),
 			},
+			data.ImportStep("api_secret_key"),
 			{
 				Config: updateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderTwtterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "api_key", "11111111111111111111111111111111"),
-					resource.TestCheckResourceAttr(data.ResourceName, "api_secret_key", "11111111111111111111111111111111"),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("api_secret_key"),
 		},
 	})
 }


### PR DESCRIPTION
=== RUN   TestAccAzureRMApiManagementIdentityProviderTwitter_basic
=== PAUSE TestAccAzureRMApiManagementIdentityProviderTwitter_basic
=== CONT  TestAccAzureRMApiManagementIdentityProviderTwitter_basic
--- PASS: TestAccAzureRMApiManagementIdentityProviderTwitter_basic (2546.86s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderTwitter_update
=== PAUSE TestAccAzureRMApiManagementIdentityProviderTwitter_update
=== CONT  TestAccAzureRMApiManagementIdentityProviderTwitter_update
--- PASS: TestAccAzureRMApiManagementIdentityProviderTwitter_update (2228.17s)
=== RUN   TestAccAzureRMApiManagementIdentityProviderTwitter_requiresImport
=== PAUSE TestAccAzureRMApiManagementIdentityProviderTwitter_requiresImport
=== CONT  TestAccAzureRMApiManagementIdentityProviderTwitter_requiresImport
--- PASS: TestAccAzureRMApiManagementIdentityProviderTwitter_requiresImport (2681.31s)
