### PR TITLE
`azurerm_api_management_openid_connect_provider` fix to pass all acctests

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_openid_connect_provider_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_openid_connect_provider_resource.go
@@ -151,7 +151,6 @@ func resourceArmApiManagementOpenIDConnectProviderRead(d *schema.ResourceData, m
 
 	if props := resp.OpenidConnectProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
-		d.Set("client_secret", props.ClientSecret)
 		d.Set("description", props.Description)
 		d.Set("display_name", props.DisplayName)
 		d.Set("metadata_endpoint", props.MetadataEndpoint)

--- a/azurerm/internal/services/apimanagement/tests/api_management_openid_connect_provider_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_openid_connect_provider_resource_test.go
@@ -25,7 +25,7 @@ func TestAccAzureRMApiManagementOpenIDConnectProvider_basic(t *testing.T) {
 					testCheckAzureRMApiManagementOpenIDConnectProviderExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }
@@ -63,13 +63,14 @@ func TestAccAzureRMApiManagementOpenIDConnectProvider_update(t *testing.T) {
 					testCheckAzureRMApiManagementOpenIDConnectProviderExists(data.ResourceName),
 				),
 			},
+			data.ImportStep("client_secret"),
 			{
 				Config: testAccAzureRMApiManagementOpenIDConnectProvider_complete(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementOpenIDConnectProviderExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }


### PR DESCRIPTION
=== RUN   TestAccAzureRMApiManagementOpenIDConnectProvider_basic
=== PAUSE TestAccAzureRMApiManagementOpenIDConnectProvider_basic
=== CONT  TestAccAzureRMApiManagementOpenIDConnectProvider_basic
--- PASS: TestAccAzureRMApiManagementOpenIDConnectProvider_basic (2348.37s)
=== RUN   TestAccAzureRMApiManagementOpenIDConnectProvider_requiresImport
=== PAUSE TestAccAzureRMApiManagementOpenIDConnectProvider_requiresImport
=== CONT  TestAccAzureRMApiManagementOpenIDConnectProvider_requiresImport
--- PASS: TestAccAzureRMApiManagementOpenIDConnectProvider_requiresImport (2370.27s)
=== RUN   TestAccAzureRMApiManagementOpenIDConnectProvider_update
=== PAUSE TestAccAzureRMApiManagementOpenIDConnectProvider_update
=== CONT  TestAccAzureRMApiManagementOpenIDConnectProvider_update
--- PASS: TestAccAzureRMApiManagementOpenIDConnectProvider_update (2506.11s)