### PR TITLE
Update data source `azurerm_managed_disk` - Fix acc tests

### DIFF
--- a/azurerm/internal/services/compute/managed_disk_data_source.go
+++ b/azurerm/internal/services/compute/managed_disk_data_source.go
@@ -55,7 +55,7 @@ func dataSourceArmManagedDisk() *schema.Resource {
 			},
 
 			"image_reference_id": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 

--- a/azurerm/internal/services/compute/managed_disk_data_source.go
+++ b/azurerm/internal/services/compute/managed_disk_data_source.go
@@ -54,6 +54,11 @@ func dataSourceArmManagedDisk() *schema.Resource {
 				Computed: true,
 			},
 
+			"image_reference_id": {
+				Type: schema.TypeString,
+				Computed: true,
+			},
+
 			"os_type": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/website/docs/d/managed_disk.html.markdown
+++ b/website/docs/d/managed_disk.html.markdown
@@ -39,6 +39,8 @@ output "id" {
 
 * `disk_size_gb` - The size of the Managed Disk in gigabytes.
 
+* `image_reference_id` - The ID of the source image used for creating this Managed Disk.
+
 * `os_type` - The operating system used for this Managed Disk.
 
 * `storage_account_type` - The storage account type for the Managed Disk.

--- a/website/docs/r/automation_credential.html.markdown
+++ b/website/docs/r/automation_credential.html.markdown
@@ -22,7 +22,7 @@ resource "azurerm_automation_account" "example" {
   name                = "account1"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
-  sku_name = "Basic"
+  sku_name            = "Basic"
 }
 
 resource "azurerm_automation_credential" "example" {


### PR DESCRIPTION
Error message: 
```
panic: Invalid address to set: []string{"image_reference_id"}
```

The data source of `azurerm_managed_disk` is setting a non-existing attribute `image_reference_id` and therefore the test panics

This PR adds the attribute `image_reference_id` to the data source and hence the tests are fixed