### PR TITLE
fix tests for DNS records

### DIFF
--- a/azurerm/internal/services/dns/tests/dns_a_record_resource_test.go
+++ b/azurerm/internal/services/dns/tests/dns_a_record_resource_test.go
@@ -187,7 +187,7 @@ func TestAccAzureRMDnsARecord_AliasToRecords(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsARecordExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "records.#", "2"),
-					resource.TestCheckNoResourceAttr(data.ResourceName, "target_resource_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "target_resource_id", ""),
 				),
 			},
 			data.ImportStep(),

--- a/azurerm/internal/services/dns/tests/dns_aaaa_record_resource_test.go
+++ b/azurerm/internal/services/dns/tests/dns_aaaa_record_resource_test.go
@@ -187,7 +187,7 @@ func TestAccAzureRMDnsAaaaRecord_AliasToRecords(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMDnsAaaaRecordExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "records.#", "2"),
-					resource.TestCheckNoResourceAttr(data.ResourceName, "target_resource_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "target_resource_id", ""),
 				),
 			},
 			data.ImportStep(),


### PR DESCRIPTION
in the read faunction "target_resource_id" will alreadys have a value and be set.

It seems `resource.TestCheckNoResourceAttr` fails to check a value with `zero` value.