### PR TITLE
data source `azurerm_dns_zone`: make `resource_group_name` required

### DIFF
--- a/azurerm/internal/services/dns/dns_zone_data_source.go
+++ b/azurerm/internal/services/dns/dns_zone_data_source.go
@@ -90,7 +90,11 @@ func dataSourceArmDnsZoneRead(d *schema.ResourceData, meta interface{}) error {
 		resp = *zone
 	}
 
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("failed reading ID for DNS Zone %q (Resource Group %q)", name, resourceGroup)
+	}
 	d.SetId(*resp.ID)
+
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)
 

--- a/azurerm/internal/services/dns/tests/dns_zone_data_source_test.go
+++ b/azurerm/internal/services/dns/tests/dns_zone_data_source_test.go
@@ -47,7 +47,8 @@ func TestAccDataSourceAzureRMDNSZone_tags(t *testing.T) {
 
 func TestAccDataSourceAzureRMDNSZone_withoutResourceGroupName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_dns_zone", "test")
-	resourceGroupName := fmt.Sprintf("acctestRG-%d", data.RandomInteger)
+	// resource group of DNS zone is always small case
+	resourceGroupName := fmt.Sprintf("acctestrg-%d", data.RandomInteger)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },


### PR DESCRIPTION
according to https://docs.microsoft.com/en-us/azure/dns/dns-zones-records#dns-zones, dns zone name is only unique in resource group. Different resource group could use the same dns zone name. it's not unique global.

So I think it does not make sense to search all resource group and return first found result.