### PR TITLE
azurerm_route: fix acctest

### DIFF
--- a/azurerm/internal/services/network/tests/route_resource_test.go
+++ b/azurerm/internal/services/network/tests/route_resource_test.go
@@ -308,13 +308,22 @@ resource "azurerm_route_table" "test" {
   resource_group_name = azurerm_resource_group.test.name
 }
 
-resource "azurerm_route" "test1" {
+resource "azurerm_route" "test" {
   name                = "acctestroute%d"
+  resource_group_name = azurerm_resource_group.test.name
+  route_table_name    = azurerm_route_table.test.name
+
+  address_prefix = "10.1.0.0/16"
+  next_hop_type  = "vnetlocal"
+}
+
+resource "azurerm_route" "test1" {
+  name                = "acctestroute%d1"
   resource_group_name = azurerm_resource_group.test.name
   route_table_name    = azurerm_route_table.test.name
 
   address_prefix = "10.2.0.0/16"
   next_hop_type  = "none"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }


### PR DESCRIPTION
## Test Result

```bash
💤 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMRoute_multipleRoutes'                             

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run TestAccAzureRMRoute_multipleRoutes -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMRoute_multipleRoutes
=== PAUSE TestAccAzureRMRoute_multipleRoutes
=== CONT  TestAccAzureRMRoute_multipleRoutes
^T--- PASS: TestAccAzureRMRoute_multipleRoutes (137.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       137.918s
```