### PR TITLE
azurerm_managed_disk - increase the maximum disk_size_gb to 65536 GB.

### DIFF
--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -168,9 +168,13 @@ func validateDiskSizeGB(v interface{}, _ string) (warnings []string, errors []er
 
 func validateManagedDiskSizeGB(v interface{}, _ string) (warnings []string, errors []error) {
 	value := v.(int)
-	if value < 0 || value > 32767 {
+	if value < 0 || value > 65536 {
 		errors = append(errors, fmt.Errorf(
-			"The `disk_size_gb` can only be between 0 and 32767"))
+			"The `disk_size_gb` can only be between 0 and 65536"))
+	}
+	if value > 32767 {
+		warnings = append(warnings,
+			"The `disk_size_gb` can be higher than 32767 only for `storage_account_type` UltraSSDLRS")
 	}
 	return warnings, errors
 }

--- a/azurerm/internal/services/compute/validation.go
+++ b/azurerm/internal/services/compute/validation.go
@@ -172,10 +172,6 @@ func validateManagedDiskSizeGB(v interface{}, _ string) (warnings []string, erro
 		errors = append(errors, fmt.Errorf(
 			"The `disk_size_gb` can only be between 0 and 65536"))
 	}
-	if value > 32767 {
-		warnings = append(warnings,
-			"The `disk_size_gb` can be higher than 32767 only for `storage_account_type` UltraSSDLRS")
-	}
 	return warnings, errors
 }
 


### PR DESCRIPTION
Azure Ultra SSD Managed Disk (_storage_account_type_ **UltraSSD_LRS**) supports more than 32767 GB.

This code fix this limitation, allowing the max of 65536 for Ultra SSD.

Fixes #7672