### PR TITLE
Support Azure Data Factory Linked Service OData

### DIFF
--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -91,15 +91,13 @@ func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
 			"tenant": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-				// ValidateFunc: validation.StringIsValidRegExp("[a-z 0-9]{8}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{12}"),
+				ValidateFunc: validation.IsUUID,
 			},
 
 			"service_principal_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-				// ValidateFunc: validation.StringIsValidRegExp("[a-z 0-9]{8}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{12}"),
+				ValidateFunc: validation.IsUUID,
 			},
 
 			"aad_service_principal_credential_type": {

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -82,7 +82,7 @@ func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
-			"aad_resource_id": {
+			"azuread_resource_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
@@ -100,7 +100,7 @@ func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 
-			"aad_service_principal_credential_type": {
+			"azuread_service_principal_credential_type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
@@ -184,9 +184,9 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 
 	if authenticationType == string(datafactory.ODataAuthenticationTypeAadServicePrincipal) {
 		servicePrincipalId := d.Get("service_principal_id").(string)
-		aadServicePrincipalCredentialType := d.Get("aad_service_principal_credential_type").(string)
+		aadServicePrincipalCredentialType := d.Get("azuread_service_principal_credential_type").(string)
 		tenant := d.Get("tenant").(string)
-		aadResourceID := d.Get("aad_resource_id").(string)
+		aadResourceID := d.Get("azuread_resource_id").(string)
 
 		if aadServicePrincipalCredentialType == string(datafactory.ServicePrincipalCert) {
 			servicePrincipalEmbeddedCertSecureString := datafactory.SecureString{
@@ -329,10 +329,10 @@ func resourceArmDataFactoryLinkedServiceODataRead(d *schema.ResourceData, meta i
 		d.Set("password", props.Password)
 	}
 	if props.AuthenticationType == datafactory.ODataAuthenticationTypeAadServicePrincipal {
-		d.Set("aad_resource_id", props.AadResourceID)
+		d.Set("azuread_resource_id", props.AadResourceID)
 		d.Set("tenant", props.Tenant)
 		d.Set("service_principal_id", props.ServicePrincipalID)
-		d.Set("aad_service_principal_credential_type", props.AadServicePrincipalCredentialType)
+		d.Set("azuread_service_principal_credential_type", props.AadServicePrincipalCredentialType)
 		switch props.AadServicePrincipalCredentialType {
 		case datafactory.ServicePrincipalCert:
 			d.Set("service_principal_embedded_cert", props.ServicePrincipalEmbeddedCert)
@@ -340,7 +340,7 @@ func resourceArmDataFactoryLinkedServiceODataRead(d *schema.ResourceData, meta i
 		case datafactory.ServicePrincipalKey:
 			d.Set("service_principal_key", props.ServicePrincipalKey)
 		default:
-			return fmt.Errorf("Unsupported `aad_service_principal_credential_type`: %+v", props.AadServicePrincipalCredentialType)
+			return fmt.Errorf("Unsupported `azuread_service_principal_credential_type`: %+v", props.AadServicePrincipalCredentialType)
 		}
 	}
 

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -153,8 +153,7 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 		odataLinkedService.ODataLinkedServiceTypeProperties = servicePrincipalAuthProperties
 	}
 
-	if authenticationType == "Anonymous" {
-		// TODO string compare with datafactory.ODataAuthenticationTypeAnonymous
+	if authenticationType == string(datafactory.ODataAuthenticationTypeAnonymous) {
 		anonAuthProperties := &datafactory.ODataLinkedServiceTypeProperties{
 			AuthenticationType: datafactory.ODataAuthenticationType(authenticationType),
 			URL:                utils.String(url),
@@ -162,8 +161,7 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 		odataLinkedService.ODataLinkedServiceTypeProperties = anonAuthProperties
 	}
 
-	if authenticationType == "Basic" || authenticationType == "Windows" {
-		// TODO string compare with datafactory.ODataAuthenticationTypeBasic
+	if authenticationType == string(datafactory.ODataAuthenticationTypeBasic) || authenticationType == string(datafactory.ODataAuthenticationTypeWindows) {
 		username := d.Get("username").(string)
 		password := d.Get("password").(string)
 		passwordSecureString := datafactory.SecureString{

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -82,6 +82,41 @@ func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			"aad_resource_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"tenant": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				// ValidateFunc: validation.StringIsValidRegExp("[a-z 0-9]{8}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{12}"),
+			},
+
+			"service_principal_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				// ValidateFunc: validation.StringIsValidRegExp("[a-z 0-9]{8}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{4}-[a-z 0-9]{12}"),
+			},
+
+			"aad_service_principal_credential_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(datafactory.ServicePrincipalCert),
+					string(datafactory.ServicePrincipalKey),
+				}, false),
+			},
+
+			"service_principal_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -153,7 +153,7 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 			AuthenticationType: datafactory.ODataAuthenticationType(authenticationType),
 			URL:                utils.String(url),
 			UserName:           username,
-			Password:           passwordSecureString,
+			Password:           &passwordSecureString,
 		}
 		odataLinkedService.ODataLinkedServiceTypeProperties = basicAuthProperties
 	}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -55,7 +55,12 @@ func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
 			"authentication_type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(datafactory.ODataAuthenticationTypeAadServicePrincipal),
+					string(datafactory.ODataAuthenticationTypeAnonymous),
+					string(datafactory.ODataAuthenticationTypeBasic),
+					string(datafactory.ODataAuthenticationTypeWindows),
+				}, false),
 			},
 
 			"url": {

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -141,7 +141,7 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 		odataLinkedService.ODataLinkedServiceTypeProperties = anonAuthProperties
 	}
 
-	if authenticationType == "Basic" {
+	if authenticationType == "Basic" || authenticationType == "Windows" {
 		// TODO string compare with datafactory.ODataAuthenticationTypeBasic
 		username := d.Get("username").(string)
 		password := d.Get("password").(string)
@@ -232,7 +232,7 @@ func resourceArmDataFactoryLinkedServiceODataRead(d *schema.ResourceData, meta i
 	props := odata.ODataLinkedServiceTypeProperties
 	d.Set("authentication_type", props.AuthenticationType)
 	d.Set("url", props.URL)
-	if props.AuthenticationType == datafactory.ODataAuthenticationTypeBasic {
+	if props.AuthenticationType == datafactory.ODataAuthenticationTypeBasic || props.AuthenticationType == datafactory.ODataAuthenticationTypeWindows {
 		d.Set("username", props.UserName)
 		d.Set("password", props.Password)
 	}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -183,7 +183,6 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 	authenticationType := d.Get("authentication_type").(string)
 
 	if authenticationType == string(datafactory.ODataAuthenticationTypeAadServicePrincipal) {
-
 		servicePrincipalId := d.Get("service_principal_id").(string)
 		aadServicePrincipalCredentialType := d.Get("aad_service_principal_credential_type").(string)
 		tenant := d.Get("tenant").(string)
@@ -209,7 +208,6 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 				AadResourceID:                        utils.String(aadResourceID),
 			}
 			odataLinkedService.ODataLinkedServiceTypeProperties = servicePrincipalAuthProperties
-
 		} else if aadServicePrincipalCredentialType == string(datafactory.ServicePrincipalKey) {
 			servicePrincipalKeySecureString := datafactory.SecureString{
 				Value: utils.String(d.Get("service_principal_key").(string)),

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -230,9 +230,9 @@ func resourceArmDataFactoryLinkedServiceODataRead(d *schema.ResourceData, meta i
 	}
 
 	props := odata.ODataLinkedServiceTypeProperties
+	d.Set("authentication_type", props.AuthenticationType)
 	d.Set("url", props.URL)
 	if props.AuthenticationType == datafactory.ODataAuthenticationTypeBasic {
-		d.Set("authentication_type", props.AuthenticationType)
 		d.Set("username", props.UserName)
 		d.Set("password", props.Password)
 	}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -245,6 +245,11 @@ func resourceArmDataFactoryLinkedServiceODataRead(d *schema.ResourceData, meta i
 		return fmt.Errorf("Error setting `annotations`: %+v", err)
 	}
 
+	parameters := flattenDataFactoryParameters(odata.Parameters)
+	if err := d.Set("parameters", parameters); err != nil {
+		return fmt.Errorf("Error setting `parameters`: %+v", err)
+	}
+
 	if connectVia := odata.ConnectVia; connectVia != nil {
 		if connectVia.ReferenceName != nil {
 			d.Set("integration_runtime_name", connectVia.ReferenceName)

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -262,12 +262,13 @@ func resourceArmDataFactoryLinkedServiceODataRead(d *schema.ResourceData, meta i
 		d.Set("tenant", props.Tenant)
 		d.Set("service_principal_id", props.ServicePrincipalID)
 		d.Set("aad_service_principal_credential_type", props.AadServicePrincipalCredentialType)
-		if props.AadServicePrincipalCredentialType == datafactory.ServicePrincipalCert {
+		switch props.AadServicePrincipalCredentialType {
+		case datafactory.ServicePrincipalCert:
 			d.Set("service_principal_embedded_cert", props.ServicePrincipalEmbeddedCert)
 			d.Set("service_principal_embedded_cert_password", props.ServicePrincipalEmbeddedCertPassword)
-		} else if props.AadServicePrincipalCredentialType == datafactory.ServicePrincipalKey {
+		case datafactory.ServicePrincipalKey:
 			d.Set("service_principal_key", props.ServicePrincipalKey)
-		} else {
+		default:
 			return fmt.Errorf("Unsupported `aad_service_principal_credential_type`: %+v", props.AadServicePrincipalCredentialType)
 		}
 	}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -132,7 +132,7 @@ func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData
 	url := d.Get("url").(string)
 	authenticationType := d.Get("authentication_type").(string)
 
-	if authenticationType == "AadServicePrincipal" {
+	if authenticationType == string(datafactory.ODataAuthenticationTypeAadServicePrincipal) {
 		servicePrincipalId := d.Get("service_principal_id").(string)
 		aadServicePrincipalCredentialType := d.Get("aad_service_principal_credential_type").(string)
 		tenant := d.Get("tenant").(string)

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -114,6 +114,18 @@ func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+			"service_principal_embedded_cert": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"service_principal_embedded_cert_password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
 
 			"description": {
 				Type:         schema.TypeString,

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -1,0 +1,278 @@
+package datafactory
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datafactory/mgmt/2018-06-01/datafactory"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDataFactoryLinkedServiceODataCreateUpdate,
+		Read:   resourceArmDataFactoryLinkedServiceODataRead,
+		Update: resourceArmDataFactoryLinkedServiceWebCreateUpdate,
+		Delete: resourceArmDataFactoryLinkedServiceODataDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAzureRMDataFactoryLinkedServiceDatasetName,
+			},
+
+			"data_factory_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DataFactoryName(),
+			},
+
+			// There's a bug in the Azure API where this is returned in lower-case
+			// BUG: https://github.com/Azure/azure-rest-api-specs/issues/5788
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+
+			"authentication_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"url": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"username": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"integration_runtime_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"annotations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceArmDataFactoryLinkedServiceODataCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	dataFactoryName := d.Get("data_factory_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing Data Factory Linked Service OData Anonymous %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_data_factory_linked_service_odata", *existing.ID)
+		}
+	}
+
+	description := d.Get("description").(string)
+
+	odataLinkedService := &datafactory.ODataLinkedService{
+		Description: &description,
+		Type:        datafactory.TypeOData,
+	}
+
+	url := d.Get("url").(string)
+	authenticationType := d.Get("authentication_type").(string)
+
+	if authenticationType == "Anonymous" {
+		// TODO string compare with datafactory.ODataAuthenticationTypeAnonymous
+		anonAuthProperties := &datafactory.ODataLinkedServiceTypeProperties{
+			AuthenticationType: datafactory.ODataAuthenticationType(authenticationType),
+			URL:                utils.String(url),
+		}
+		odataLinkedService.ODataLinkedServiceTypeProperties = anonAuthProperties
+	}
+
+	if authenticationType == "Basic" {
+		// TODO string compare with datafactory.ODataAuthenticationTypeBasic
+		username := d.Get("username").(string)
+		password := d.Get("password").(string)
+		passwordSecureString := datafactory.SecureString{
+			Value: &password,
+			Type:  datafactory.TypeSecureString,
+		}
+		basicAuthProperties := &datafactory.ODataLinkedServiceTypeProperties{
+			AuthenticationType: datafactory.ODataAuthenticationType(authenticationType),
+			URL:                utils.String(url),
+			UserName:           username,
+			Password:           passwordSecureString,
+		}
+		odataLinkedService.ODataLinkedServiceTypeProperties = basicAuthProperties
+	}
+
+	if v, ok := d.GetOk("parameters"); ok {
+		odataLinkedService.Parameters = expandDataFactoryParameters(v.(map[string]interface{}))
+	}
+
+	if v, ok := d.GetOk("integration_runtime_name"); ok {
+		odataLinkedService.ConnectVia = expandDataFactoryLinkedServiceIntegrationRuntime(v.(string))
+	}
+
+	if v, ok := d.GetOk("additional_properties"); ok {
+		odataLinkedService.AdditionalProperties = v.(map[string]interface{})
+	}
+
+	if v, ok := d.GetOk("annotations"); ok {
+		annotations := v.([]interface{})
+		odataLinkedService.Annotations = &annotations
+	}
+
+	linkedService := datafactory.LinkedServiceResource{
+		Properties: odataLinkedService,
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, dataFactoryName, name, linkedService, ""); err != nil {
+		return fmt.Errorf("Error creating/updating Data Factory Linked Service OData Anonymous %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Data Factory Linked Service OData Anonymous %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read Data Factory Linked Service OData Anonymous %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmDataFactoryLinkedServiceODataRead(d, meta)
+}
+
+func resourceArmDataFactoryLinkedServiceODataRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving Data Factory Linked Service Web %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("data_factory_name", dataFactoryName)
+
+	odata, ok := resp.Properties.AsODataLinkedService()
+	if !ok {
+		return fmt.Errorf("Error classifiying Data Factory Linked Service Web %q (Data Factory %q / Resource Group %q): Expected: %q Received: %q", name, dataFactoryName, resourceGroup, datafactory.TypeWeb, *resp.Type)
+	}
+
+	props := odata.ODataLinkedServiceTypeProperties
+	d.Set("url", props.URL)
+	if props.AuthenticationType == datafactory.ODataAuthenticationTypeBasic {
+		d.Set("authentication_type", props.AuthenticationType)
+		d.Set("username", props.UserName)
+		d.Set("password", props.Password)
+	}
+
+	d.Set("additional_properties", odata.AdditionalProperties)
+	d.Set("description", odata.Description)
+
+	annotations := flattenDataFactoryAnnotations(odata.Annotations)
+	if err := d.Set("annotations", annotations); err != nil {
+		return fmt.Errorf("Error setting `annotations`: %+v", err)
+	}
+
+	if connectVia := odata.ConnectVia; connectVia != nil {
+		if connectVia.ReferenceName != nil {
+			d.Set("integration_runtime_name", connectVia.ReferenceName)
+		}
+	}
+
+	return nil
+}
+
+func resourceArmDataFactoryLinkedServiceODataDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	dataFactoryName := id.Path["factories"]
+	name := id.Path["linkedservices"]
+
+	response, err := client.Delete(ctx, resourceGroup, dataFactoryName, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(response) {
+			return fmt.Errorf("Error deleting Data Factory Linked Service OData %q (Data Factory %q / Resource Group %q): %+v", name, dataFactoryName, resourceGroup, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource.go
@@ -53,8 +53,8 @@ func resourceArmDataFactoryLinkedServiceOData() *schema.Resource {
 			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 			"authentication_type": {
-				Type:         schema.TypeString,
-				Required:     true,
+				Type:     schema.TypeString,
+				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(datafactory.ODataAuthenticationTypeAadServicePrincipal),
 					string(datafactory.ODataAuthenticationTypeAnonymous),

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource_test.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_odata_resource_test.go
@@ -1,0 +1,165 @@
+package datafactory_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMDataFactoryLinkedServiceOData_anon_auth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_odata", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataFactoryLinkedServiceODataDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataFactoryLinkedServiceOData_anon_auth(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataFactoryLinkedServiceODataExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDataFactoryLinkedServiceOData_basic_auth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_factory_linked_service_odata", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataFactoryLinkedServiceODataDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataFactoryLinkedServiceOData_basic_auth(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataFactoryLinkedServiceODataExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func testCheckAzureRMDataFactoryLinkedServiceODataExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).DataFactory.LinkedServiceClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		dataFactoryName := rs.Primary.Attributes["data_factory_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for Data Factory: %s", name)
+		}
+
+		resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on dataFactoryLinkedServiceClient: %+v", err)
+		}
+
+		if utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("Bad: Data Factory Linked Service OData %q (data factory name: %q / resource group: %q) does not exist", name, dataFactoryName, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMDataFactoryLinkedServiceODataDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).DataFactory.LinkedServiceClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_data_factory_linked_service_odata" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		dataFactoryName := rs.Primary.Attributes["data_factory_name"]
+
+		resp, err := client.Get(ctx, resourceGroup, dataFactoryName, name, "")
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Data Factory Linked Service OData still exists:\n%#v", resp.Properties)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureRMDataFactoryLinkedServiceOData_anon_auth(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_service_odata" "test" {
+  name                = "acctestlsodata%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_type = "Anonymous"
+  url                 = "https://services.odata.org/v4/TripPinServiceRW/People"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMDataFactoryLinkedServiceOData_basic_auth(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-df-%d"
+  location = "%s"
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctestdf%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_data_factory_linked_service_odata" "test" {
+  name                = "acctestlsodata%d"
+  resource_group_name = azurerm_resource_group.test.name
+  data_factory_name   = azurerm_data_factory.test.name
+  authentication_type = "Basic"
+  url                 = "https://services.odata.org/v4/TripPinServiceRW/People"
+  username            = "emma"
+  password            = "Ch4ngeM3!"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/datafactory/registration.go
+++ b/azurerm/internal/services/datafactory/registration.go
@@ -46,6 +46,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_data_factory_linked_service_data_lake_storage_gen2": resourceArmDataFactoryLinkedServiceDataLakeStorageGen2(),
 		"azurerm_data_factory_linked_service_key_vault":              resourceArmDataFactoryLinkedServiceKeyVault(),
 		"azurerm_data_factory_linked_service_mysql":                  resourceArmDataFactoryLinkedServiceMySQL(),
+		"azurerm_data_factory_linked_service_odata":                  resourceArmDataFactoryLinkedServiceOData(),
 		"azurerm_data_factory_linked_service_postgresql":             resourceArmDataFactoryLinkedServicePostgreSQL(),
 		"azurerm_data_factory_linked_service_sftp":                   resourceArmDataFactoryLinkedServiceSFTP(),
 		"azurerm_data_factory_linked_service_sql_server":             resourceArmDataFactoryLinkedServiceSQLServer(),

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1541,6 +1541,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/data_factory_linked_service_odata.html">azurerm_data_factory_linked_service_odata</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/data_factory_linked_service_postgresql.html">azurerm_data_factory_linked_service_postgresql</a>
                 </li>
 

--- a/website/docs/r/data_factory_linked_service_odata.html.markdown
+++ b/website/docs/r/data_factory_linked_service_odata.html.markdown
@@ -43,6 +43,19 @@ resource "azurerm_data_factory_linked_service_odata" "basic" {
   username            = "emma"
   password            = "Ch4ngeM3!"
 }
+
+resource "azurerm_data_factory_linked_service_odata" "aad_sp_key" {
+  name                                  = "example"
+  resource_group_name                   = azurerm_resource_group.example.name
+  data_factory_name                     = azurerm_data_factory.example.name
+  authentication_type                   = "AadServicePrincipal"
+  url                                   = "https://services.odata.org/v4/TripPinServiceRW/People"
+  service_principal_id                  = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  aad_service_principal_credential_type = "ServicePrincipalKey"
+  tenant                                = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  aad_resource_id                       = "xxx"
+  service_principal_key                 = "xxx"
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/data_factory_linked_service_odata.html.markdown
+++ b/website/docs/r/data_factory_linked_service_odata.html.markdown
@@ -1,0 +1,100 @@
+---
+subcategory: "Data Factory"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_factory_linked_service_odata"
+description: |-
+  Manages a Linked Service (connection) between a Database and Azure Data Factory through OData protocol.
+---
+
+# azurerm_data_factory_linked_service_odata
+
+Manages a Linked Service (connection) between a Database and Azure Data Factory through OData protocol.
+
+~> **Note:** All arguments including the client secret will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "northeurope"
+}
+
+resource "azurerm_data_factory" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_data_factory_linked_service_odata" "anonymous" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  data_factory_name   = azurerm_data_factory.example.name
+  authentication_type = "Anonymous"
+  url                 = "https://services.odata.org/v4/TripPinServiceRW/People"
+}
+
+resource "azurerm_data_factory_linked_service_odata" "basic" {
+  name                = "example"
+  resource_group_name = azurerm_resource_group.example.name
+  data_factory_name   = azurerm_data_factory.example.name
+  authentication_type = "Basic"
+  url                 = "https://services.odata.org/v4/TripPinServiceRW/People"
+  username            = "emma"
+  password            = "Ch4ngeM3!"
+}
+```
+
+## Argument Reference
+
+The following supported arguments are common across all Azure Data Factory Linked Services:
+
+* `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/en-us/azure/data-factory/naming-rules) for all restrictions.
+
+* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory Linked Service. Changing this forces a new resource
+
+* `data_factory_name` - (Required) The Data Factory name in which to associate the Linked Service with. Changing this forces a new resource.
+
+* `description` - (Optional) The description for the Data Factory Linked Service.
+
+* `integration_runtime_name` - (Optional) The integration runtime reference to associate with the Data Factory Linked Service.
+
+* `annotations` - (Optional) List of tags that can be used for describing the Data Factory Linked Service.
+
+* `parameters` - (Optional) A map of parameters to associate with the Data Factory Linfked Service.
+
+* `additional_properties` - (Optional) A map of additional properties to associate with the Data Factory Linked Service.
+
+The following supported arguments are specific to OData Linked Service:
+
+* `authentication_type` - (Required) The type of authentication used to connect to the OData source. Valid options are `Anonymous` and `Basic` (`AadServicePrincipal`, `ManagedServiceIdentity` and `Windows` are not supported at this moment by this provider)
+
+* `url` - (Required) The URL of the OData service endpoint (e.g. https://services.odata.org/v4/TripPinServiceRW/People).
+
+* `username` - (Optional) The username which can be used to authenticate to the OData endpoint.
+
+* `password` - (Optional) The password associated with the username, which can be used to authenticate to the OData endpoint.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Data Factory Linked Service.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Factory Linked Service.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Factory Linked Service.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory Linked Service.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Factory Linked Service.
+
+## Import
+
+Data Factory Linked Service's can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_factory_linked_service_odata.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/example/providers/Microsoft.DataFactory/factories/example/linkedservices/example
+```

--- a/website/docs/r/data_factory_linked_service_odata.html.markdown
+++ b/website/docs/r/data_factory_linked_service_odata.html.markdown
@@ -67,7 +67,7 @@ The following supported arguments are common across all Azure Data Factory Linke
 
 The following supported arguments are specific to OData Linked Service:
 
-* `authentication_type` - (Required) The type of authentication used to connect to the OData source. Valid options are `Anonymous` and `Basic` (`AadServicePrincipal`, `ManagedServiceIdentity` and `Windows` are not supported at this moment by this provider)
+* `authentication_type` - (Required) The type of authentication used to connect to the OData source. Valid options are `Anonymous`, `Basic` and `Windows` (`AadServicePrincipal`, `ManagedServiceIdentity` are not supported at this moment by this provider)
 
 * `url` - (Required) The URL of the OData service endpoint (e.g. https://services.odata.org/v4/TripPinServiceRW/People).
 

--- a/website/docs/r/data_factory_linked_service_odata.html.markdown
+++ b/website/docs/r/data_factory_linked_service_odata.html.markdown
@@ -45,16 +45,16 @@ resource "azurerm_data_factory_linked_service_odata" "basic" {
 }
 
 resource "azurerm_data_factory_linked_service_odata" "aad_sp_key" {
-  name                                  = "example"
-  resource_group_name                   = azurerm_resource_group.example.name
-  data_factory_name                     = azurerm_data_factory.example.name
-  authentication_type                   = "AadServicePrincipal"
-  url                                   = "https://services.odata.org/v4/TripPinServiceRW/People"
-  service_principal_id                  = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  aad_service_principal_credential_type = "ServicePrincipalKey"
-  tenant                                = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  aad_resource_id                       = "xxx"
-  service_principal_key                 = "xxx"
+  name                                      = "example"
+  resource_group_name                       = azurerm_resource_group.example.name
+  data_factory_name                         = azurerm_data_factory.example.name
+  authentication_type                       = "AadServicePrincipal"
+  url                                       = "https://services.odata.org/v4/TripPinServiceRW/People"
+  service_principal_id                      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  azuread_service_principal_credential_type = "ServicePrincipalKey"
+  tenant                                    = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  azuread_resource_id                       = "xxx"
+  service_principal_key                     = "xxx"
 }
 ```
 
@@ -90,7 +90,7 @@ The following supported arguments are specific to OData Linked Service:
 
 * `service_principal_id` - (Optional) The Azure Active Directory Service Principal ID.
 
-* `aad_service_principal_credential_type` - (Optional) Specify the credential type to use for service principal authentication. Allowed values are: `ServicePrincipalKey` or `ServicePrincipalCert`.
+* `azuread_service_principal_credential_type` - (Optional) Specify the credential type to use for service principal authentication. Allowed values are: `ServicePrincipalKey` or `ServicePrincipalCert`.
 
 * `service_principal_key` - (Optional) The service principal key associated to the `service_principal_id` used for the authentication.
 
@@ -100,7 +100,7 @@ The following supported arguments are specific to OData Linked Service:
 
 * `tenant` - (Optional) The tenant ID in which to authenticate against the Azure Data Factory Linked Service account.
 
-* `aad_resource_id` - (Optional) The AAD resource ID concerning the authorization request.
+* `azuread_resource_id` - (Optional) The AAD resource ID concerning the authorization request.
 
 ## Attributes Reference
 

--- a/website/docs/r/data_factory_linked_service_odata.html.markdown
+++ b/website/docs/r/data_factory_linked_service_odata.html.markdown
@@ -67,7 +67,7 @@ The following supported arguments are common across all Azure Data Factory Linke
 
 The following supported arguments are specific to OData Linked Service:
 
-* `authentication_type` - (Required) The type of authentication used to connect to the OData source. Valid options are `Anonymous`, `Basic` and `Windows` (`AadServicePrincipal`, `ManagedServiceIdentity` are not supported at this moment by this provider)
+* `authentication_type` - (Required) The type of authentication used to connect to the OData source. Valid options are `AadServicePrincipal`, `Anonymous`, `Basic` and `Windows` (`ManagedServiceIdentity` are is supported at this moment by this provider)
 
 * `url` - (Required) The URL of the OData service endpoint (e.g. https://services.odata.org/v4/TripPinServiceRW/People).
 
@@ -75,6 +75,19 @@ The following supported arguments are specific to OData Linked Service:
 
 * `password` - (Optional) The password associated with the username, which can be used to authenticate to the OData endpoint.
 
+* `service_principal_id` - (Optional) The Azure Active Directory Service Principal ID.
+
+* `aad_service_principal_credential_type` - (Optional) Specify the credential type to use for service principal authentication. Allowed values are: `ServicePrincipalKey` or `ServicePrincipalCert`.
+
+* `service_principal_key` - (Optional) The service principal key associated to the `service_principal_id` used for the authentication.
+
+* `service_principal_embedded_cert` - (Optional) The base64 encoded certificate used for authentication with Service Principale credential type `ServicePrincipalCert`.
+
+* `service_principal_embedded_cert_password` - (Optional) The certificate's password used for authentication with Service Principale credential type `ServicePrincipalCert`.
+
+* `tenant` - (Optional) The tenant ID in which to authenticate against the Azure Data Factory Linked Service account.
+
+* `aad_resource_id` - (Optional) The AAD resource ID concerning the authorization request.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add support for Terraform configuration for Azure Data Factory Linked Service of type OData.

New resource `azurerm_data_factory_linked_service_odata`

```hcl
resource "azurerm_data_factory_linked_service_odata" "example" {
  name                = "example"
  resource_group_name = azurerm_resource_group.example.name
  data_factory_name   = azurerm_data_factory.example.name
  authentication_type = "Anonymous"
  url                 = "https://services.odata.org/v4/TripPinServiceRW/People"
}
```

Documentation : https://docs.microsoft.com/en-us/azure/data-factory/connector-odata