### PR TITLE
Move HDInsight tests to 4.0 and mark 3.6 only resources deprecated

### DIFF
--- a/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
@@ -58,10 +58,10 @@ func resourceArmHDInsightMLServicesCluster() *schema.Resource {
 More information on the HDInsight 3.6 deprecation can be found at:
 
 https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions`,
-		Create:             resourceArmHDInsightMLServicesClusterCreate,
-		Read:               resourceArmHDInsightMLServicesClusterRead,
-		Update:             hdinsightClusterUpdate("MLServices", resourceArmHDInsightMLServicesClusterRead),
-		Delete:             hdinsightClusterDelete("MLServices"),
+		Create: resourceArmHDInsightMLServicesClusterCreate,
+		Read:   resourceArmHDInsightMLServicesClusterRead,
+		Update: hdinsightClusterUpdate("MLServices", resourceArmHDInsightMLServicesClusterRead),
+		Delete: hdinsightClusterDelete("MLServices"),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
@@ -53,7 +53,11 @@ var hdInsightMLServicesClusterEdgeNodeDefinition = azure.HDInsightNodeDefinition
 
 func resourceArmHDInsightMLServicesCluster() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Due to HDInsight 3.6 retirement on December 31, 2020",
+		DeprecationMessage: `HDInsight 3.6 will be retired on 2020-12-31 - MLServices is not supported in HDInsight 4.0 and so this resource will be removed in the next major version of the AzureRM Terraform Provider.
+		
+More information on the HDInsight 3.6 deprecation can be found at:
+
+https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions`,
 		Create:             resourceArmHDInsightMLServicesClusterCreate,
 		Read:               resourceArmHDInsightMLServicesClusterRead,
 		Update:             hdinsightClusterUpdate("MLServices", resourceArmHDInsightMLServicesClusterRead),

--- a/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_ml_services_cluster_resource.go
@@ -53,10 +53,11 @@ var hdInsightMLServicesClusterEdgeNodeDefinition = azure.HDInsightNodeDefinition
 
 func resourceArmHDInsightMLServicesCluster() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmHDInsightMLServicesClusterCreate,
-		Read:   resourceArmHDInsightMLServicesClusterRead,
-		Update: hdinsightClusterUpdate("MLServices", resourceArmHDInsightMLServicesClusterRead),
-		Delete: hdinsightClusterDelete("MLServices"),
+		DeprecationMessage: "Due to HDInsight 3.6 retirement on December 31, 2020",
+		Create:             resourceArmHDInsightMLServicesClusterCreate,
+		Read:               resourceArmHDInsightMLServicesClusterRead,
+		Update:             hdinsightClusterUpdate("MLServices", resourceArmHDInsightMLServicesClusterRead),
+		Delete:             hdinsightClusterDelete("MLServices"),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
@@ -53,7 +53,11 @@ var hdInsightRServerClusterEdgeNodeDefinition = azure.HDInsightNodeDefinition{
 
 func resourceArmHDInsightRServerCluster() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Due to HDInsight 3.6 retirement on December 31, 2020",
+		DeprecationMessage: `HDInsight 3.6 will be retired on 2020-12-31 - R Server is not supported in HDInsight 4.0 and so this resource will be removed in the next major version of the AzureRM Terraform Provider.
+		
+More information on the HDInsight 3.6 deprecation can be found at:
+
+https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions`,
 		Create:             resourceArmHDInsightRServerClusterCreate,
 		Read:               resourceArmHDInsightRServerClusterRead,
 		Update:             hdinsightClusterUpdate("RServer", resourceArmHDInsightRServerClusterRead),

--- a/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
@@ -58,10 +58,10 @@ func resourceArmHDInsightRServerCluster() *schema.Resource {
 More information on the HDInsight 3.6 deprecation can be found at:
 
 https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions`,
-		Create:             resourceArmHDInsightRServerClusterCreate,
-		Read:               resourceArmHDInsightRServerClusterRead,
-		Update:             hdinsightClusterUpdate("RServer", resourceArmHDInsightRServerClusterRead),
-		Delete:             hdinsightClusterDelete("RServer"),
+		Create: resourceArmHDInsightRServerClusterCreate,
+		Read:   resourceArmHDInsightRServerClusterRead,
+		Update: hdinsightClusterUpdate("RServer", resourceArmHDInsightRServerClusterRead),
+		Delete: hdinsightClusterDelete("RServer"),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_rserver_cluster_resource.go
@@ -53,10 +53,11 @@ var hdInsightRServerClusterEdgeNodeDefinition = azure.HDInsightNodeDefinition{
 
 func resourceArmHDInsightRServerCluster() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmHDInsightRServerClusterCreate,
-		Read:   resourceArmHDInsightRServerClusterRead,
-		Update: hdinsightClusterUpdate("RServer", resourceArmHDInsightRServerClusterRead),
-		Delete: hdinsightClusterDelete("RServer"),
+		DeprecationMessage: "Due to HDInsight 3.6 retirement on December 31, 2020",
+		Create:             resourceArmHDInsightRServerClusterCreate,
+		Read:               resourceArmHDInsightRServerClusterRead,
+		Update:             hdinsightClusterUpdate("RServer", resourceArmHDInsightRServerClusterRead),
+		Delete:             hdinsightClusterDelete("RServer"),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
@@ -42,10 +42,11 @@ var hdInsightStormClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition
 
 func resourceArmHDInsightStormCluster() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmHDInsightStormClusterCreate,
-		Read:   resourceArmHDInsightStormClusterRead,
-		Update: hdinsightClusterUpdate("Storm", resourceArmHDInsightStormClusterRead),
-		Delete: hdinsightClusterDelete("Storm"),
+		DeprecationMessage: "Due to HDInsight 3.6 retirement on December 31, 2020",
+		Create:             resourceArmHDInsightStormClusterCreate,
+		Read:               resourceArmHDInsightStormClusterRead,
+		Update:             hdinsightClusterUpdate("Storm", resourceArmHDInsightStormClusterRead),
+		Delete:             hdinsightClusterDelete("Storm"),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
@@ -42,7 +42,11 @@ var hdInsightStormClusterZookeeperNodeDefinition = azure.HDInsightNodeDefinition
 
 func resourceArmHDInsightStormCluster() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Due to HDInsight 3.6 retirement on December 31, 2020",
+		DeprecationMessage: `HDInsight 3.6 will be retired on 2020-12-31 - Storm is not supported in HDInsight 4.0 and so this resource will be removed in the next major version of the AzureRM Terraform Provider.
+		
+More information on the HDInsight 3.6 deprecation can be found at:
+
+https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions`,
 		Create:             resourceArmHDInsightStormClusterCreate,
 		Read:               resourceArmHDInsightStormClusterRead,
 		Update:             hdinsightClusterUpdate("Storm", resourceArmHDInsightStormClusterRead),

--- a/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
+++ b/azurerm/internal/services/hdinsight/hdinsight_storm_cluster_resource.go
@@ -47,10 +47,10 @@ func resourceArmHDInsightStormCluster() *schema.Resource {
 More information on the HDInsight 3.6 deprecation can be found at:
 
 https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions`,
-		Create:             resourceArmHDInsightStormClusterCreate,
-		Read:               resourceArmHDInsightStormClusterRead,
-		Update:             hdinsightClusterUpdate("Storm", resourceArmHDInsightStormClusterRead),
-		Delete:             hdinsightClusterDelete("Storm"),
+		Create: resourceArmHDInsightStormClusterCreate,
+		Read:   resourceArmHDInsightStormClusterRead,
+		Update: hdinsightClusterUpdate("Storm", resourceArmHDInsightStormClusterRead),
+		Delete: hdinsightClusterDelete("Storm"),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_hadoop_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_hadoop_cluster_resource_test.go
@@ -589,11 +589,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
 
   gateway {
@@ -735,11 +735,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
 
   gateway {
@@ -787,11 +787,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
 
   gateway {
@@ -857,11 +857,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
 
   gateway {
@@ -929,11 +929,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
 
   gateway {
@@ -991,11 +991,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
 
   gateway {
@@ -1053,10 +1053,10 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
   gateway {
     enabled  = true
@@ -1116,10 +1116,10 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
   gateway {
     enabled  = true
@@ -1239,11 +1239,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   tls_min_version     = "1.2"
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
   gateway {
     enabled  = true
@@ -1327,10 +1327,10 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
   gateway {
     enabled  = true
@@ -1416,10 +1416,10 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
   gateway {
     enabled  = true
@@ -1477,11 +1477,11 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
 
   gateway {
@@ -1533,10 +1533,10 @@ resource "azurerm_hdinsight_hadoop_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    hadoop = "2.7"
+    hadoop = "3.1"
   }
   gateway {
     username = "acctestusrgw"

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_hbase_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_hbase_cluster_resource_test.go
@@ -434,11 +434,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {
@@ -486,11 +486,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {
@@ -570,7 +570,6 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          ssh_keys           = lookup(head_node.value, "ssh_keys", null)
           subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
           virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
@@ -582,7 +581,6 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
@@ -595,7 +593,6 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          ssh_keys           = lookup(zookeeper_node.value, "ssh_keys", null)
           subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
           virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
@@ -621,11 +618,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {
@@ -673,11 +670,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {
@@ -743,11 +740,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {
@@ -815,11 +812,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {
@@ -949,12 +946,12 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   tls_min_version     = "1.2"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {
@@ -1043,10 +1040,10 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
   gateway {
     enabled  = true
@@ -1132,10 +1129,10 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
   gateway {
     enabled  = true
@@ -1193,11 +1190,11 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    hbase = "1.1"
+    hbase = "2.1"
   }
 
   gateway {

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_interactive_query_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_interactive_query_cluster_resource_test.go
@@ -434,11 +434,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {
@@ -488,11 +488,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {
@@ -572,7 +572,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          ssh_keys           = lookup(head_node.value, "ssh_keys", null)
           subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
           virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
@@ -584,7 +583,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
@@ -597,7 +595,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          ssh_keys           = lookup(zookeeper_node.value, "ssh_keys", null)
           subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
           virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
@@ -623,11 +620,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {
@@ -675,11 +672,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {
@@ -745,11 +742,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {
@@ -817,11 +814,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {
@@ -949,12 +946,12 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   tls_min_version     = "1.2"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {
@@ -1043,10 +1040,10 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
   gateway {
     enabled  = true
@@ -1132,10 +1129,10 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
   gateway {
     enabled  = true
@@ -1193,11 +1190,11 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    interactive_hive = "2.1"
+    interactive_hive = "3.1"
   }
 
   gateway {

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_kafka_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_kafka_cluster_resource_test.go
@@ -437,11 +437,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {
@@ -492,11 +492,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {
@@ -577,7 +577,6 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          ssh_keys           = lookup(head_node.value, "ssh_keys", null)
           subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
           virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
@@ -590,7 +589,6 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
         content {
           number_of_disks_per_node = worker_node.value.number_of_disks_per_node
           password                 = lookup(worker_node.value, "password", null)
-          ssh_keys                 = lookup(worker_node.value, "ssh_keys", null)
           subnet_id                = lookup(worker_node.value, "subnet_id", null)
           target_instance_count    = worker_node.value.target_instance_count
           username                 = worker_node.value.username
@@ -603,7 +601,6 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          ssh_keys           = lookup(zookeeper_node.value, "ssh_keys", null)
           subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
           virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
@@ -629,11 +626,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {
@@ -682,11 +679,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {
@@ -753,11 +750,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {
@@ -826,11 +823,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {
@@ -959,12 +956,12 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   tls_min_version     = "1.2"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {
@@ -1054,10 +1051,10 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
   gateway {
     enabled  = true
@@ -1144,10 +1141,10 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
   gateway {
     enabled  = true
@@ -1206,11 +1203,11 @@ resource "azurerm_hdinsight_kafka_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    kafka = "1.1"
+    kafka = "2.1"
   }
 
   gateway {

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_spark_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_spark_cluster_resource_test.go
@@ -434,11 +434,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {
@@ -488,11 +488,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   location            = "${azurerm_resource_group.test.location}"
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {
@@ -572,7 +572,6 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          ssh_keys           = lookup(head_node.value, "ssh_keys", null)
           subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
           virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
@@ -584,7 +583,6 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
@@ -597,7 +595,6 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          ssh_keys           = lookup(zookeeper_node.value, "ssh_keys", null)
           subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
           virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
@@ -623,11 +620,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {
@@ -675,11 +672,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {
@@ -745,11 +742,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {
@@ -817,11 +814,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {
@@ -949,12 +946,12 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   tls_min_version     = "1.2"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {
@@ -1043,10 +1040,10 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
   gateway {
     enabled  = true
@@ -1132,10 +1129,10 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
   gateway {
     enabled  = true
@@ -1193,11 +1190,11 @@ resource "azurerm_hdinsight_spark_cluster" "test" {
   name                = "acctesthdi-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cluster_version     = "3.6"
+  cluster_version     = "4.0"
   tier                = "Standard"
 
   component_version {
-    spark = "2.3"
+    spark = "2.4"
   }
 
   gateway {

--- a/azurerm/internal/services/hdinsight/tests/hdinsight_storm_cluster_resource_test.go
+++ b/azurerm/internal/services/hdinsight/tests/hdinsight_storm_cluster_resource_test.go
@@ -492,7 +492,6 @@ resource "azurerm_hdinsight_storm_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          ssh_keys           = lookup(head_node.value, "ssh_keys", null)
           subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
           virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
@@ -504,7 +503,6 @@ resource "azurerm_hdinsight_storm_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          ssh_keys              = lookup(worker_node.value, "ssh_keys", null)
           subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
@@ -517,7 +515,6 @@ resource "azurerm_hdinsight_storm_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          ssh_keys           = lookup(zookeeper_node.value, "ssh_keys", null)
           subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
           virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)

--- a/website/docs/r/hdinsight_ml_services_cluster.html.markdown
+++ b/website/docs/r/hdinsight_ml_services_cluster.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a HDInsight ML Services Cluster.
 
+~> **NOTE:** This resource has been deprecated due to HDInsight 3.6 retirement on December 31, 2020. More details: https://docs.microsoft.com/en-us/azure/hdinsight/r-server/r-server-overview#simple-secure-and-high-scale-operationalization-and-administration
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/hdinsight_ml_services_cluster.html.markdown
+++ b/website/docs/r/hdinsight_ml_services_cluster.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a HDInsight ML Services Cluster.
 
-~> **NOTE:** This resource has been deprecated due to HDInsight 3.6 retirement on December 31, 2020. More details: https://docs.microsoft.com/en-us/azure/hdinsight/r-server/r-server-overview#simple-secure-and-high-scale-operationalization-and-administration
+!> **Note:** [HDInsight 3.6 is deprecated and will be retired on 2020-12-31 - HDInsight 4.0 no longer supports ML Services Clusters](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions) - as such this Terraform resource is deprecated and will be removed in the next major version of the AzureRM Terraform Provider.
 
 ## Example Usage
 

--- a/website/docs/r/hdinsight_rserver_cluster.html.markdown
+++ b/website/docs/r/hdinsight_rserver_cluster.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a HDInsight RServer Cluster.
 
-~> **NOTE:** This resource has been deprecated due to HDInsight 3.6 retirement on December 31, 2020. More details: https://docs.microsoft.com/en-us/azure/hdinsight/r-server/r-server-overview#simple-secure-and-high-scale-operationalization-and-administration
+!> **Note:** [HDInsight 3.6 is deprecated and will be retired on 2020-12-31 - HDInsight 4.0 no longer supports RServer Clusters](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions) - as such this Terraform resource is deprecated and will be removed in the next major version of the AzureRM Terraform Provider.
 
 ## Example Usage
 

--- a/website/docs/r/hdinsight_rserver_cluster.html.markdown
+++ b/website/docs/r/hdinsight_rserver_cluster.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a HDInsight RServer Cluster.
 
+~> **NOTE:** This resource has been deprecated due to HDInsight 3.6 retirement on December 31, 2020. More details: https://docs.microsoft.com/en-us/azure/hdinsight/r-server/r-server-overview#simple-secure-and-high-scale-operationalization-and-administration
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/hdinsight_storm_cluster.html.markdown
+++ b/website/docs/r/hdinsight_storm_cluster.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Manages a HDInsight Storm Cluster.
 
+~> **NOTE:** This resource has been deprecated due to HDInsight 3.6 retirement on December 31, 2020 and Apache Storm isn't supported in HDInsight 4.0. More details about available versions of HDInsight: https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions 
+
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/hdinsight_storm_cluster.html.markdown
+++ b/website/docs/r/hdinsight_storm_cluster.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a HDInsight Storm Cluster.
 
-~> **NOTE:** This resource has been deprecated due to HDInsight 3.6 retirement on December 31, 2020 and Apache Storm isn't supported in HDInsight 4.0. More details about available versions of HDInsight: https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions 
+!> **Note:** [HDInsight 3.6 is deprecated and will be retired on 2020-12-31 - HDInsight 4.0 no longer supports Storm Clusters](https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-component-versioning#available-versions) - as such this Terraform resource is deprecated and will be removed in the next major version of the AzureRM Terraform Provider.
 
 
 ## Example Usage


### PR DESCRIPTION
Implements 2.x parts for https://github.com/terraform-providers/terraform-provider-azurerm/issues/7670

* Updated acceptance tests for HDInsight compatible resources to 4.0
* Marked storm, rserver and ml_services as deprecated
* Fixed requiresImport tests (were broken since 0.12 migration)

Note ml_services an rserver tests are very flaky and fail with `HDI Version'3.6' is not supported for clusterType 'MLServices' and componentVersion 'default'.` most of the time
Tests for other 6 resource types are green.