### PR TITLE
azurerm_virtual_hub: fix acc test and make the `address_prefix` as `ForceNew`

### DIFF
--- a/azurerm/internal/services/network/tests/virtual_hub_resource_test.go
+++ b/azurerm/internal/services/network/tests/virtual_hub_resource_test.go
@@ -52,32 +52,6 @@ func TestAccAzureRMVirtualHub_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMVirtualHub_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_virtual_hub", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMVirtualHubDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMVirtualHub_basic(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMVirtualHubExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
-			{
-				Config: testAccAzureRMVirtualHub_updated(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMVirtualHubExists(data.ResourceName),
-				),
-			},
-			data.ImportStep(),
-		},
-	})
-}
-
 func TestAccAzureRMVirtualHub_routes(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub", "test")
 
@@ -195,24 +169,10 @@ resource "azurerm_virtual_hub" "import" {
   name                = azurerm_virtual_hub.test.name
   location            = azurerm_virtual_hub.test.location
   resource_group_name = azurerm_virtual_hub.test.resource_group_name
-  address_prefix      = "10.0.1.0/24"
+  virtual_wan_id      = azurerm_virtual_hub.test.virtual_wan_id
+  address_prefix      = azurerm_virtual_hub.test.address_prefix
 }
 `, template)
-}
-
-func testAccAzureRMVirtualHub_updated(data acceptance.TestData) string {
-	template := testAccAzureRMVirtualHub_template(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_virtual_hub" "test" {
-  name                = "acctestVHUB-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  virtual_wan_id      = azurerm_virtual_wan.test.id
-  address_prefix      = "10.0.2.0/24"
-}
-`, template, data.RandomInteger)
 }
 
 func testAccAzureRMVirtualHub_route(data acceptance.TestData) string {

--- a/azurerm/internal/services/network/virtual_hub_resource.go
+++ b/azurerm/internal/services/network/virtual_hub_resource.go
@@ -54,6 +54,7 @@ func resourceArmVirtualHub() *schema.Resource {
 			"address_prefix": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.CIDR,
 			},
 

--- a/website/docs/r/virtual_hub.html.markdown
+++ b/website/docs/r/virtual_hub.html.markdown
@@ -43,9 +43,9 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Virtual Hub should exist. Changing this forces a new resource to be created.
 
-* `address_prefix` - (Required) The Address Prefix which should be used for this Virtual Hub.
+* `address_prefix` - (Required) The Address Prefix which should be used for this Virtual Hub. Changing this forces a new resource to be created.
 
-* `virtual_wan_id` - (Required) The ID of a Virtual WAN within which the Virtual Hub should be created.
+* `virtual_wan_id` - (Required) The ID of a Virtual WAN within which the Virtual Hub should be created. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
`address_prefix` is not updatable at least since we do the project layout refactor (as the TC test history shows). So I just mark it as `ForceNew` and remove the update test case for vhub (while there are other separate update test cases).