### PR TITLE
azurerm_kubernetes_cluster: disable Kubernetes Dashboard addon configuration in Azure China

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_addons.go
+++ b/azurerm/internal/services/containers/kubernetes_addons.go
@@ -31,6 +31,7 @@ var unsupportedAddonsForEnvironment = map[string][]string{
 		aciConnectorKey,           // https://github.com/terraform-providers/terraform-provider-azurerm/issues/5510
 		azurePolicyKey,            // https://github.com/terraform-providers/terraform-provider-azurerm/issues/6462
 		httpApplicationRoutingKey, // https://github.com/terraform-providers/terraform-provider-azurerm/issues/5960
+		kubernetesDashboardKey,    // https://github.com/terraform-providers/terraform-provider-azurerm/issues/7487
 	},
 	azure.USGovernmentCloud.Name: {
 		azurePolicyKey,            // https://github.com/terraform-providers/terraform-provider-azurerm/issues/6702


### PR DESCRIPTION
fixes #7487.

It looks like the Kubernetes Dashboard addon does not support configuration in Azure China (for details, see the linked issue). This adds the key to the unsupported addon list.