### PR TITLE
azurerm_network_interface_application_security_group_association fix documentation example

### DIFF
--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -45,9 +45,9 @@ resource "azurerm_network_interface" "example" {
   resource_group_name = azurerm_resource_group.example.name
 
   ip_configuration {
-    name                           = "testconfiguration1"
-    subnet_id                      = azurerm_subnet.example.id
-    private_ip_address_allocation  = "Dynamic"
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.example.id
+    private_ip_address_allocation = "Dynamic"
   }
 }
 

--- a/website/docs/r/network_interface_application_security_group_association.html.markdown
+++ b/website/docs/r/network_interface_application_security_group_association.html.markdown
@@ -48,7 +48,6 @@ resource "azurerm_network_interface" "example" {
     name                           = "testconfiguration1"
     subnet_id                      = azurerm_subnet.example.id
     private_ip_address_allocation  = "Dynamic"
-    application_security_group_ids = [azurerm_application_security_group.example.id]
   }
 }
 


### PR DESCRIPTION
Hi all,

I just updated the example because the attribute `application_security_group_ids` was not allowed at that point.

Kind regards