### PR TITLE
Acceptance Testing - `metadata_url` support

### DIFF
--- a/azurerm/internal/acceptance/data.go
+++ b/azurerm/internal/acceptance/data.go
@@ -47,6 +47,9 @@ type TestData struct {
 	// EnvironmentName is the name of the Azure Environment where we're running
 	EnvironmentName string
 
+	// MetadataURL is the url of the endpoint where the environment is obtained
+	MetadataURL string
+
 	// resourceLabel is the local used for the resource - generally "test""
 	resourceLabel string
 }
@@ -66,6 +69,7 @@ func BuildTestData(t *testing.T, resourceType string, resourceLabel string) Test
 		ResourceName:    fmt.Sprintf("%s.%s", resourceType, resourceLabel),
 		Environment:     *env,
 		EnvironmentName: EnvironmentName(),
+		MetadataURL:     os.Getenv("ARM_METADATA_URL"),
 
 		ResourceType:  resourceType,
 		resourceLabel: resourceLabel,

--- a/azurerm/internal/acceptance/testing.go
+++ b/azurerm/internal/acceptance/testing.go
@@ -1,6 +1,7 @@
 package acceptance
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -46,7 +47,8 @@ func EnvironmentName() string {
 
 func Environment() (*azure.Environment, error) {
 	envName := EnvironmentName()
-	return authentication.DetermineEnvironment(envName)
+	metadataURL := os.Getenv("ARM_METADATA_URL")
+	return authentication.AzureEnvironmentByNameFromEndpoint(context.TODO(), metadataURL, envName)
 }
 
 func GetAuthConfig(t *testing.T) *authentication.Config {
@@ -63,6 +65,7 @@ func GetAuthConfig(t *testing.T) *authentication.Config {
 		TenantID:       os.Getenv("ARM_TENANT_ID"),
 		ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
 		Environment:    environment,
+		MetadataURL:    os.Getenv("ARM_METADATA_URL"),
 
 		// we intentionally only support Client Secret auth for tests (since those variables are used all over)
 		SupportsClientSecretAuth: true,


### PR DESCRIPTION
Tested this locally with various environment variables set:

ARM_ENVIRONMENT=public
```
--- PASS: TestAccAzureRMResourceGroup_basic (68.84s)
```

ARM_ENVIRONMENT=bad
ARM_METADATA_URL=management.azure.com
```
    TestAccAzureRMResourceGroup_basic: data.go:63: Error retrieving Environment: unable to find environment "bad" from endpoint "management.azure.com"
```

ARM_ENVIRONMENT="AzureCloud"
ARM_METADATA_URL="management.azure.com"
```
--- PASS: TestAccAzureRMResourceGroup_basic (68.22s)
```

ARM_ENVIRONMENT="AzureCloud"
ARM_METADATA_URL="badurl"
```
TestAccAzureRMResourceGroup_basic: data.go:63: Error retrieving Environment: retrieving environments from Azure MetaData service: Get "https://badurl/metadata/endpoints?api-version=2019-05-01"
```