### PR TITLE
azurerm_private_link_service_endpoint_connections: fix acc test

### DIFF
--- a/azurerm/internal/services/network/tests/private_link_service_endpoint_connections_data_source_test.go
+++ b/azurerm/internal/services/network/tests/private_link_service_endpoint_connections_data_source_test.go
@@ -32,13 +32,15 @@ func TestAccDataSourcePrivateLinkServiceEndpointConnections_complete(t *testing.
 }
 
 func testAccDataSourcePrivateLinkServiceEndpointConnections_complete(data acceptance.TestData) string {
+	// azurerm_private_link_service_endpoint_connections depends on azurerm_private_endpoint, we deliberately introduce
+	// this dependency here via reference, rather than using `depends_on` since `depends_on` on data source will make
+	// it never converge.
 	return fmt.Sprintf(`
 %s
 
 data "azurerm_private_link_service_endpoint_connections" "test" {
-  service_id          = azurerm_private_link_service.test.id
+  service_id          = azurerm_private_endpoint.test.private_service_connection.0.private_connection_resource_id
   resource_group_name = azurerm_resource_group.test.name
-  depends_on          = [azurerm_private_link_endpoint.test, ]
 }
 `, testAccAzureRMPrivateEndpoint_basic(data))
 }


### PR DESCRIPTION
There are two fixes:

1. The original version refers to a resource which is renamed from
`azurerm_private_link_endpoint` to `azurerm_private_endpoint`.
2. The `depends_on` used for data source will make the data source never
   converge. Instead, we use an explict reference to introduce the
   depedency on `azurerm_private_endpoint`.