### PR TITLE
azurerm_vpn_server_configuration: fix acctest

### DIFF
--- a/azurerm/internal/services/network/tests/vpn_server_configuration_resource_test.go
+++ b/azurerm/internal/services/network/tests/vpn_server_configuration_resource_test.go
@@ -204,6 +204,8 @@ func testAccAzureRMAzureRMVPNServerConfiguration_azureAD(data acceptance.TestDat
 	return fmt.Sprintf(`
 %s
 
+data "azurerm_subscription" "current" {}
+
 resource "azurerm_vpn_server_configuration" "test" {
   name                     = "acctestVPNSC-%d"
   resource_group_name      = azurerm_resource_group.test.name
@@ -211,9 +213,9 @@ resource "azurerm_vpn_server_configuration" "test" {
   vpn_authentication_types = ["AAD"]
 
   azure_active_directory_authentication {
-    audience = "https://www.example.com/"
-    issuer   = "https://login.windows.net/"
-    tenant   = "example.onmicrosoft.com"
+    audience = "00000000-abcd-abcd-abcd-999999999999"
+    issuer   = "https://sts.windows.net/${data.azurerm_subscription.current.tenant_id}/"
+    tenant   = "https://login.microsoftonline.com/${data.azurerm_subscription.current.tenant_id}"
   }
 }
 `, template, data.RandomInteger)


### PR DESCRIPTION
The format of audience/issuer/tenant will be checked at service side, so make sure they are valid.

```bash
💢 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMVPNServerConfiguration_multipleAuth'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMVPNServerConfiguration_multipleAuth' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMVPNServerConfiguration_multipleAuth
=== PAUSE TestAccAzureRMVPNServerConfiguration_multipleAuth
=== CONT  TestAccAzureRMVPNServerConfiguration_multipleAuth
--- PASS: TestAccAzureRMVPNServerConfiguration_multipleAuth (493.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       493.097s
```