### PR TITLE
azurerm_virtual_hub_connection: fix acctest

### DIFF
--- a/azurerm/internal/services/network/virtual_hub_connection_resource.go
+++ b/azurerm/internal/services/network/virtual_hub_connection_resource.go
@@ -213,7 +213,7 @@ func resourceArmVirtualHubConnectionRead(d *schema.ResourceData, meta interface{
 
 func resourceArmVirtualHubConnectionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Network.VirtualHubClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.ParseVirtualHubConnectionID(d.Id())


### PR DESCRIPTION
```bash
💤 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMVirtualHubConnection_complete'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMVirtualHubConnection_complete' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMVirtualHubConnection_complete
=== PAUSE TestAccAzureRMVirtualHubConnection_complete
=== CONT  TestAccAzureRMVirtualHubConnection_complete
--- PASS: TestAccAzureRMVirtualHubConnection_complete (1586.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       1586.394s
```