### PR TITLE
feature/enhanced-validation: enabling by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Version 2.0 of the AzureRM Provider requires Terraform 0.12.x and later.
 provider "azurerm" {
   # We recommend pinning to the specific version of the Azure Provider you're using
   # since new versions are released frequently
-  version = "=2.0.0"
+  version = "=2.20.0"
 
   features {}
 
@@ -48,7 +48,7 @@ Further [usage documentation is available on the Terraform website](https://www.
 ## Developer Requirements
 
 * [Terraform](https://www.terraform.io/downloads.html) version 0.12.x +
-* [Go](https://golang.org/doc/install) version 1.13.x (to build the provider plugin)
+* [Go](https://golang.org/doc/install) version 1.14.x (to build the provider plugin)
 
 If you're on Windows you'll also need:
 * [Make for Windows](http://gnuwin32.sourceforge.net/packages/make.htm)

--- a/azurerm/internal/features/enhanced_validation.go
+++ b/azurerm/internal/features/enhanced_validation.go
@@ -19,5 +19,5 @@ func EnhancedValidationEnabled() bool {
 		return true
 	}
 
-	return strings.EqualFold(os.Getenv("ARM_PROVIDER_ENHANCED_VALIDATION"), "true")
+	return strings.EqualFold(value, "true")
 }

--- a/azurerm/internal/features/enhanced_validation.go
+++ b/azurerm/internal/features/enhanced_validation.go
@@ -11,8 +11,13 @@ import (
 // This functionality calls out to the Azure MetaData Service to cache the list of supported
 // Azure Locations for the specified Endpoint - and then uses that to provide enhanced validation
 //
-// This can be enabled using the Environment Variable `ARM_PROVIDER_ENHANCED_VALIDATION` and
-// defaults to 'false' at the present time - but may change in a future release.
+// This is enabled by default as of version 2.20 of the Azure Provider, and can be disabled by
+// setting the Environment Variable `ARM_PROVIDER_ENHANCED_VALIDATION` to `false`.
 func EnhancedValidationEnabled() bool {
+	value := os.Getenv("ARM_PROVIDER_ENHANCED_VALIDATION")
+	if value == "" {
+		return true
+	}
+
 	return strings.EqualFold(os.Getenv("ARM_PROVIDER_ENHANCED_VALIDATION"), "true")
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -31,7 +31,7 @@ We recommend using either a Service Principal or Managed Service Identity when r
 # Configure the Azure Provider
 provider "azurerm" {
   # whilst the `version` attribute is optional, we recommend pinning to a given version of the Provider
-  version = "=2.0.0"
+  version = "=2.20.0"
   features {}
 }
 


### PR DESCRIPTION
#6927 introduced opt-in "enhanced validation" for locations - where upon launch we load/cache a list of supported locations for the Azure Environment being used from the Azure Metadata Service. These locations can then be used to provide enhanced validation for the `location` fields within resources/data sources to ensure that the location value being used is a supported Azure Location - which ultimately allows us to catch configuration errors at `terraform plan` time, rather than `terraform apply` time.

This functionality shipped in an opt-in state in version 2.10 of the Azure Provider - configurable by setting the environment variable `ARM_PROVIDER_ENHANCED_VALIDATION` to `true`. As mentioned in the changelog for version 2.10 - this functionality will be enabled by default in a future version - as such this PR enables this functionality by default which'll ship in version 2.20 of the Azure Provider.

Where this is now enabled by default this can be opted-out by setting the environment variable `ARM_PROVIDER_ENHANCED_VALIDATION` to `false`.

Fixes #7561

---

The changelog for this probably wants to be:

```
UPGRADE NOTES

* **Enhanced Validation for Locations** - the Azure Provider now validates that the value for the `location` argument is a supported Azure Region within the Azure Environment being used (from the Azure Metadata Service) - which allows us to catch configuration errors for this field at `terraform plan` time, rather than during a `terraform apply`. This functionality is now enabled by default, and can be opted-out of by setting the Environment Variable `ARM_PROVIDER_ENHANCED_VALIDATION` to `false`
```