### PR TITLE
provider: metadata_url -> metadata_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The following Environment Variables must be set in your shell prior to running a
 - `ARM_SUBSCRIPTION_ID`
 - `ARM_TENANT_ID`
 - `ARM_ENVIRONMENT`
+- `ARM_METADATA_HOST`
 - `ARM_TEST_LOCATION`
 - `ARM_TEST_LOCATION_ALT`
 - `ARM_TEST_LOCATION_ALT2`

--- a/azurerm/internal/acceptance/data.go
+++ b/azurerm/internal/acceptance/data.go
@@ -69,7 +69,7 @@ func BuildTestData(t *testing.T, resourceType string, resourceLabel string) Test
 		ResourceName:    fmt.Sprintf("%s.%s", resourceType, resourceLabel),
 		Environment:     *env,
 		EnvironmentName: EnvironmentName(),
-		MetadataURL:     os.Getenv("ARM_METADATA_URL"),
+		MetadataURL:     os.Getenv("ARM_METADATA_HOST"),
 
 		ResourceType:  resourceType,
 		resourceLabel: resourceLabel,

--- a/azurerm/internal/provider/provider.go
+++ b/azurerm/internal/provider/provider.go
@@ -97,11 +97,19 @@ func azureProvider(supportLegacyTestSuite bool) terraform.ResourceProvider {
 				Description: "The Cloud Environment which should be used. Possible values are public, usgovernment, german, and china. Defaults to public.",
 			},
 
-			"metadata_url": {
+			"metadata_host": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ARM_METADATA_URL", ""),
-				Description: "The Metadata URL which will be used to obtain the Cloud Environment.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_METADATA_HOSTNAME", ""),
+				Description: "The Hostname which should be used for the Azure Metadata Service.",
+			},
+
+			"metadata_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				// TODO: remove in 3.0
+				Deprecated:  "use `metadata_host` instead",
+				Description: "Deprecated - replaced by `metadata_host`.",
 			},
 
 			// Client Certificate specific fields
@@ -211,6 +219,15 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			return nil, fmt.Errorf("The provider only supports 3 auxiliary tenant IDs")
 		}
 
+		metadataHost := d.Get("metadata_host").(string)
+		// TODO: remove in 3.0
+		// note: this is inline to avoid calling out deprecations for users not setting this
+		if v := d.Get("metadata_url").(string); v != "" {
+			metadataHost = v
+		} else if v := os.Getenv("ARM_METADATA_URL"); v != "" {
+			metadataHost = v
+		}
+
 		builder := &authentication.Builder{
 			SubscriptionID:     d.Get("subscription_id").(string),
 			ClientID:           d.Get("client_id").(string),
@@ -218,7 +235,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
 			TenantID:           d.Get("tenant_id").(string),
 			AuxiliaryTenantIDs: auxTenants,
 			Environment:        d.Get("environment").(string),
-			MetadataURL:        d.Get("metadata_url").(string),
+			MetadataURL:        metadataHost, // TODO: rename this in Helpers too
 			MsiEndpoint:        d.Get("msi_endpoint").(string),
 			ClientCertPassword: d.Get("client_certificate_password").(string),
 			ClientCertPath:     d.Get("client_certificate_path").(string),

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -95,10 +95,6 @@ The following arguments are supported:
 
 * `tenant_id` - (Optional) The Tenant ID which should be used. This can also be sourced from the `ARM_TENANT_ID` Environment Variable.
 
-* `metadata_url` - (Optional) The Metadata URL which will be used to obtain the Cloud Environment.
-
-~> **Note:** `environment` must be set to the requested environment name in the list of available environments held in the `metadata_url`.
-
 ---
 
 When authenticating as a Service Principal using a Client Certificate, the following fields can be set:
@@ -132,6 +128,10 @@ More information on [how to configure a Service Principal using Managed Service 
 For some advanced scenarios, such as where more granular permissions are necessary - the following properties can be set:
 
 * `disable_terraform_partner_id` - (Optional) Disable sending the Terraform Partner ID if a custom `partner_id` isn't specified, which allows Microsoft to better understand the usage of Terraform. The Partner ID does not give HashiCorp any direct access to usage information. This can also be sourced from the `ARM_DISABLE_TERRAFORM_PARTNER_ID` environment variable. Defaults to `false`.
+
+* `metadata_host` - (Optional) The Hostname of the Azure Metadata Service (for example `management.azure.com`), used to obtain the Cloud Environment when using a Custom Azure Environment. This can also be sourced from the `ARM_METADATA_HOST` Environment Variable.
+
+~> **Note:** `environment` must be set to the requested environment name in the list of available environments held in the `metadata_host`.
 
 * `partner_id` - (Optional) A GUID/UUID that is [registered](https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution#register-guids-and-offers) with Microsoft to facilitate partner resource usage attribution. This can also be sourced from the `ARM_PARTNER_ID` Environment Variable.
 


### PR DESCRIPTION
This field contains the hostname, not the URL - so let's call it that.

The existing `metadata_url` field will continue to work - but is deprecated and should be replaced by `metadata_host`.