### PR TITLE
azurerm_lb_rule: strip read-only properties before sending request

### DIFF
--- a/azurerm/internal/services/network/tests/loadbalancer_rule_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_rule_resource_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
@@ -76,10 +75,9 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 	var lb network.LoadBalancer
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	lbRule_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestRG-lb-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
-		subscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
+		data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -105,10 +103,9 @@ func TestAccAzureRMLoadBalancerRule_complete(t *testing.T) {
 	var lb network.LoadBalancer
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	lbRule_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestRG-lb-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
-		subscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
+		data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -134,10 +131,9 @@ func TestAccAzureRMLoadBalancerRule_update(t *testing.T) {
 	var lb network.LoadBalancer
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	lbRule_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestRG-lb-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
-		subscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
+		data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -184,10 +180,9 @@ func TestAccAzureRMLoadBalancerRule_requiresImport(t *testing.T) {
 	var lb network.LoadBalancer
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	lbRule_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestRG-lb-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
-		subscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
+		data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -272,14 +267,13 @@ func TestAccAzureRMLoadBalancerRule_updateMultipleRules(t *testing.T) {
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 	lbRule2Name := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	lbRuleID := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestRG-lb-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
-		subscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
+		data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
 
 	lbRule2ID := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestRG-lb-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
-		subscriptionID, data.RandomInteger, data.RandomInteger, lbRule2Name)
+		data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger, lbRule2Name)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -345,10 +339,9 @@ func TestAccAzureRMLoadBalancerRule_vmssBackendPool(t *testing.T) {
 	var lb network.LoadBalancer
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
-	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	lbRule_id := fmt.Sprintf(
 		"/subscriptions/%s/resourceGroups/acctestRG-lb-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
-		subscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
+		data.Client().SubscriptionID, data.RandomInteger, data.RandomInteger, lbRuleName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -604,6 +597,7 @@ resource "azurerm_lb_rule" "test2" {
 }
 
 func testAccAzureRMLoadBalancerRule_vmssBackendPoolRemoveRule(data acceptance.TestData, sku string) string {
+	template := testAccAzureRMLoadBalancerRule_template(data, sku)
 	return fmt.Sprintf(`
 %[1]s
 
@@ -621,7 +615,7 @@ resource "azurerm_virtual_network" "test" {
 }
 
 resource "azurerm_subnet" "test" {
-  name                = "acctest-lb-subnet-%[2]d"
+  name                 = "acctest-lb-subnet-%[2]d"
   resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.1.0/24"]
@@ -679,10 +673,11 @@ resource "azurerm_virtual_machine_scale_set" "hbtest" {
     }
   }
 }
-`, testAccAzureRMLoadBalancerRule_template(data, sku), data.RandomInteger)
+`, template, data.RandomInteger)
 }
 
 func testAccAzureRMLoadBalancerRule_vmssBackendPool(data acceptance.TestData, lbRuleName, sku string) string {
+	template := testAccAzureRMLoadBalancerRule_vmssBackendPoolRemoveRule(data, sku)
 	return fmt.Sprintf(`
 %s
 
@@ -695,6 +690,6 @@ resource "azurerm_lb_rule" "test" {
   backend_port                   = 3389
   backend_address_pool_id        = azurerm_lb_backend_address_pool.test.id
   frontend_ip_configuration_name = azurerm_lb.test.frontend_ip_configuration.0.name
-}`, testAccAzureRMLoadBalancerRule_vmssBackendPoolRemoveRule(data, sku), lbRuleName)
-
+}
+`, template, lbRuleName)
 }


### PR DESCRIPTION
This is a workaround for #7691 

The reason for that issue is that service can't tolerate the client sending `properties.backendAddressPools.n.properties.backendIPConfigurations` in request body for load balancer resource since 2020-05-01, as it is a READ-ONLY attribute (this only occurs when `azurerm_lb`'s sku is `Standard`).
Currently, Azure Go SDK can trim the READ-ONLY attributes during marshaling, but only for the root level attributes, so, in this case, Go SDK will still marshal the attribute into the request body. This is tracked in issue: Azure/autorest.go#438.

## Test Result

<details open>
<summary>Before this change</summary>
<pre>
💢 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMLoadBalancerRule_vmssBackendPool'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMLoadBalancerRule_vmssBackendPool' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLoadBalancerRule_vmssBackendPool
=== PAUSE TestAccAzureRMLoadBalancerRule_vmssBackendPool
=== CONT  TestAccAzureRMLoadBalancerRule_vmssBackendPool
    TestAccAzureRMLoadBalancerRule_vmssBackendPool: testing.go:684: Step 2 error: errors during apply:
        
        Error: Error Creating/Updating Load Balancer "arm-test-loadbalancer-200714173426984953" (Resource Group "acctestRG-lb-200714173426984953"): network.LoadBalancersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidRequestFormat" Message="Cannot parse the request." Details=[{"code":"DuplicateIpConfigurationReferenceOnBackendAddressPool","message":"Found duplicate ipConfiguration reference /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/networkInterfaces/|providers|Microsoft.Compute|virtualMachineScaleSets|acctest-lb-vmss-200714173426984953|virtualMachines|0|networkInterfaces|primary/ipConfigurations/primary on backend pool addresses /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools//loadBalancerBackendAddresses/ and /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools/acctest-lb-BAP-200714173426984953/loadBalancerBackendAddresses/5c4d25d2-7957-4dc6-a30c-ffbb301fa9a1."},{"code":"DuplicateIpConfigurationReferenceOnBackendAddressPool","message":"Found duplicate ipConfiguration reference /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/networkInterfaces/|providers|Microsoft.Compute|virtualMachineScaleSets|acctest-lb-vmss-200714173426984953|virtualMachines|1|networkInterfaces|primary/ipConfigurations/primary on backend pool addresses /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools//loadBalancerBackendAddresses/ and /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools/acctest-lb-BAP-200714173426984953/loadBalancerBackendAddresses/f169c430-34c1-49e5-8308-b34c07aa4174."},{"code":"DuplicateIpConfigurationReferenceOnBackendAddressPool","message":"Found duplicate ipConfiguration reference /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/networkInterfaces/|providers|Microsoft.Compute|virtualMachineScaleSets|acctest-lb-vmss-200714173426984953|virtualMachines|2|networkInterfaces|primary/ipConfigurations/primary on backend pool addresses /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools//loadBalancerBackendAddresses/ and /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools/acctest-lb-BAP-200714173426984953/loadBalancerBackendAddresses/6a9b9e0c-1193-4606-b9fe-5f6b7332925a."}]
        
        
    TestAccAzureRMLoadBalancerRule_vmssBackendPool: testing.go:745: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: errors during apply: 2 problems:
        
        - Error Creating/Updating Load Balancer "arm-test-loadbalancer-200714173426984953" (Resource Group "acctestRG-lb-200714173426984953"): network.LoadBalancersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidRequestFormat" Message="Cannot parse the request." Details=[{"code":"DuplicateIpConfigurationReferenceOnBackendAddressPool","message":"Found duplicate ipConfiguration reference /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/networkInterfaces/|providers|Microsoft.Compute|virtualMachineScaleSets|acctest-lb-vmss-200714173426984953|virtualMachines|0|networkInterfaces|primary/ipConfigurations/primary on backend pool addresses /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools//loadBalancerBackendAddresses/ and /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools/acctest-lb-BAP-200714173426984953/loadBalancerBackendAddresses/7bb8efbe-ca52-4859-b363-b114958cc03a."},{"code":"DuplicateIpConfigurationReferenceOnBackendAddressPool","message":"Found duplicate ipConfiguration reference /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/networkInterfaces/|providers|Microsoft.Compute|virtualMachineScaleSets|acctest-lb-vmss-200714173426984953|virtualMachines|1|networkInterfaces|primary/ipConfigurations/primary on backend pool addresses /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools//loadBalancerBackendAddresses/ and /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools/acctest-lb-BAP-200714173426984953/loadBalancerBackendAddresses/c3e48329-e5e7-4b0e-84ac-bdbee7319e27."},{"code":"DuplicateIpConfigurationReferenceOnBackendAddressPool","message":"Found duplicate ipConfiguration reference /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/networkInterfaces/|providers|Microsoft.Compute|virtualMachineScaleSets|acctest-lb-vmss-200714173426984953|virtualMachines|2|networkInterfaces|primary/ipConfigurations/primary on backend pool addresses /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools//loadBalancerBackendAddresses/ and /subscriptions//resourceGroups//providers/Microsoft.Network/loadBalancers//backendAddressPools/acctest-lb-BAP-200714173426984953/loadBalancerBackendAddresses/91c528c2-ea70-4d4b-a42e-31b93bcc80ff."}]
        - Error Creating/Updating LoadBalancer: network.LoadBalancersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidResourceReference" Message="Resource /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/backendAddressPools/acctest-lb-BAP-200714173426984953 referenced by resource /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/loadBalancingRules/LbRule-zavcukaf was not found. Please make sure that the referenced resource exists, and that both resources are in the same region." Details=[]
        
        State: azurerm_lb.test:
          ID = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953
          provider = provider.azurerm
          frontend_ip_configuration.# = 1
          frontend_ip_configuration.0.id = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/frontendIPConfigurations/one-200714173426984953
          frontend_ip_configuration.0.inbound_nat_rules.# = 0
          frontend_ip_configuration.0.load_balancer_rules.# = 1
          frontend_ip_configuration.0.load_balancer_rules.434067275 = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/loadBalancingRules/LbRule-zavcukaf
          frontend_ip_configuration.0.name = one-200714173426984953
          frontend_ip_configuration.0.outbound_rules.# = 0
          frontend_ip_configuration.0.private_ip_address = 
          frontend_ip_configuration.0.private_ip_address_allocation = Dynamic
          frontend_ip_configuration.0.private_ip_address_version = IPv4
          frontend_ip_configuration.0.public_ip_address_id = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/publicIPAddresses/test-ip-200714173426984953
          frontend_ip_configuration.0.public_ip_prefix_id = 
          frontend_ip_configuration.0.subnet_id = 
          frontend_ip_configuration.0.zones.# = 0
          location = eastus2
          name = arm-test-loadbalancer-200714173426984953
          private_ip_address = 
          private_ip_addresses.# = 0
          resource_group_name = acctestRG-lb-200714173426984953
          sku = Standard
          tags.% = 0
        
          Dependencies:
            azurerm_public_ip.test
            azurerm_resource_group.test
        azurerm_lb_backend_address_pool.test:
          ID = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/backendAddressPools/acctest-lb-BAP-200714173426984953
          provider = provider.azurerm
          backend_ip_configurations.# = 3
          backend_ip_configurations.1963658510 = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Compute/virtualMachineScaleSets/acctest-lb-vmss-200714173426984953/virtualMachines/1/networkInterfaces/primary/ipConfigurations/primary
          backend_ip_configurations.3479046425 = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Compute/virtualMachineScaleSets/acctest-lb-vmss-200714173426984953/virtualMachines/2/networkInterfaces/primary/ipConfigurations/primary
          backend_ip_configurations.482865411 = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Compute/virtualMachineScaleSets/acctest-lb-vmss-200714173426984953/virtualMachines/0/networkInterfaces/primary/ipConfigurations/primary
          load_balancing_rules.# = 1
          load_balancing_rules.434067275 = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/loadBalancingRules/LbRule-zavcukaf
          loadbalancer_id = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953
          name = acctest-lb-BAP-200714173426984953
          resource_group_name = acctestRG-lb-200714173426984953
        azurerm_lb_rule.test:
          ID = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/loadBalancingRules/LbRule-zavcukaf
          provider = provider.azurerm
          backend_address_pool_id = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/backendAddressPools/acctest-lb-BAP-200714173426984953
          backend_port = 3389
          disable_outbound_snat = false
          enable_floating_ip = false
          enable_tcp_reset = false
          frontend_ip_configuration_id = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953/frontendIPConfigurations/one-200714173426984953
          frontend_ip_configuration_name = one-200714173426984953
          frontend_port = 3389
          idle_timeout_in_minutes = 4
          load_distribution = Default
          loadbalancer_id = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-200714173426984953
          name = LbRule-zavcukaf
          protocol = Tcp
          resource_group_name = acctestRG-lb-200714173426984953
        azurerm_public_ip.test:
          ID = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953/providers/Microsoft.Network/publicIPAddresses/test-ip-200714173426984953
          provider = provider.azurerm
          allocation_method = Static
          idle_timeout_in_minutes = 4
          ip_address = 52.184.221.196
          ip_version = IPv4
          location = eastus2
          name = test-ip-200714173426984953
          resource_group_name = acctestRG-lb-200714173426984953
          sku = Standard
          tags.% = 0
          zones.# = 0
        
          Dependencies:
            azurerm_resource_group.test
        azurerm_resource_group.test:
          ID = /subscriptions/67a9759d-d099-4aa8-8675-e6cfd669c3f4/resourceGroups/acctestRG-lb-200714173426984953
          provider = provider.azurerm
          location = eastus2
          name = acctestRG-lb-200714173426984953
          tags.% = 0
--- FAIL: TestAccAzureRMLoadBalancerRule_vmssBackendPool (342.64s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       342.673s
FAIL
make: *** [GNUmakefile:98: testacc] Error 1
</pre>
</details>

<details open>
<summary>After this change</summary>
<pre>
💢 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS="-run='TestAccAzureRMLoadBalancerRule_vmssBackendPool'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run='TestAccAzureRMLoadBalancerRule_vmssBackendPool' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMLoadBalancerRule_vmssBackendPool
=== PAUSE TestAccAzureRMLoadBalancerRule_vmssBackendPool
=== CONT  TestAccAzureRMLoadBalancerRule_vmssBackendPool
--- PASS: TestAccAzureRMLoadBalancerRule_vmssBackendPool (403.26s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       403.293s
</pre>
</details>

(fix #7691)