### PR TITLE
`azurerm_local_network_gateway`- `address_space` order can now be changed

### DIFF
--- a/azurerm/internal/services/network/local_network_gateway_resource.go
+++ b/azurerm/internal/services/network/local_network_gateway_resource.go
@@ -111,22 +111,32 @@ func resourceArmLocalNetworkGatewayCreateUpdate(d *schema.ResourceData, meta int
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	ipAddress := d.Get("gateway_address").(string)
 
-	addressSpaces := expandLocalNetworkGatewayAddressSpaces(d)
-
 	t := d.Get("tags").(map[string]interface{})
 
 	gateway := network.LocalNetworkGateway{
 		Name:     &name,
 		Location: &location,
 		LocalNetworkGatewayPropertiesFormat: &network.LocalNetworkGatewayPropertiesFormat{
-			LocalNetworkAddressSpace: &network.AddressSpace{
-				AddressPrefixes: &addressSpaces,
-			},
-			GatewayIPAddress: &ipAddress,
-			BgpSettings:      expandLocalNetworkGatewayBGPSettings(d),
+			LocalNetworkAddressSpace: &network.AddressSpace{},
+			GatewayIPAddress:         &ipAddress,
+			BgpSettings:              expandLocalNetworkGatewayBGPSettings(d),
 		},
 		Tags: tags.Expand(t),
 	}
+
+	// There is a bug in the provider where the address space ordering doesn't change as expected.
+	// In the UI we have to remove the current list of addresses in the address space and re-add them in the new order and we'll copy that here.
+	if !d.IsNewResource() && d.HasChange("address_space") {
+		future, err := client.CreateOrUpdate(ctx, resGroup, name, gateway)
+		if err != nil {
+			return fmt.Errorf("error removing Local Network Gateway address space %q (Resource Group %q): %+v", name, resGroup, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("error waiting for completion of Local Network Gateway %q (Resource Group %q): %+v", name, resGroup, err)
+		}
+	}
+	gateway.LocalNetworkGatewayPropertiesFormat.LocalNetworkAddressSpace.AddressPrefixes = expandLocalNetworkGatewayAddressSpaces(d)
 
 	future, err := client.CreateOrUpdate(ctx, resGroup, name, gateway)
 	if err != nil {
@@ -250,14 +260,14 @@ func expandLocalNetworkGatewayBGPSettings(d *schema.ResourceData) *network.BgpSe
 	return &bgpSettings
 }
 
-func expandLocalNetworkGatewayAddressSpaces(d *schema.ResourceData) []string {
+func expandLocalNetworkGatewayAddressSpaces(d *schema.ResourceData) *[]string {
 	prefixes := make([]string, 0)
 
 	for _, pref := range d.Get("address_space").([]interface{}) {
 		prefixes = append(prefixes, pref.(string))
 	}
 
-	return prefixes
+	return &prefixes
 }
 
 func flattenLocalNetworkGatewayBGPSettings(input *network.BgpSettings) []interface{} {

--- a/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/local_network_gateway_resource_test.go
@@ -210,6 +210,32 @@ func TestAccAzureRMLocalNetworkGateway_bgpSettingsComplete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLocalNetworkGateway_updateAddressSpace(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_local_network_gateway", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_multipleAddressSpace(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMLocalNetworkGatewayConfig_multipleAddressSpaceUpdated(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLocalNetworkGatewayExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 // testCheckAzureRMLocalNetworkGatewayExists returns the resource.TestCheckFunc
 // which checks whether or not the expected local network gateway exists both
 // in the schema, and on Azure.
@@ -424,6 +450,48 @@ resource "azurerm_local_network_gateway" "test" {
     bgp_peering_address = "10.104.1.1"
     peer_weight         = 15
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMLocalNetworkGatewayConfig_multipleAddressSpace(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-%d"
+  location = "%s"
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  gateway_address     = "127.0.0.1"
+  address_space       = ["127.0.0.0/24", "127.0.1.0/24"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMLocalNetworkGatewayConfig_multipleAddressSpaceUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-%d"
+  location = "%s"
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlng-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  gateway_address     = "127.0.0.1"
+  address_space       = ["127.0.1.0/24", "127.0.0.0/24"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }


### PR DESCRIPTION
Fixes #7698

```
--- PASS: TestAccAzureRMLocalNetworkGateway_disappears (91.10s)
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettingsComplete (92.98s)
--- PASS: TestAccAzureRMLocalNetworkGateway_tags (93.77s)
--- PASS: TestAccAzureRMLocalNetworkGateway_basic (93.93s)
--- PASS: TestAccAzureRMLocalNetworkGateway_requiresImport (98.49s)
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettings (97.43s)
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettingsComplete (97.74s)
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettingsEnable (120.31s)
--- PASS: TestAccAzureRMLocalNetworkGateway_bgpSettingsDisable (122.73s)
```