### PR TITLE
azurerm_express_route_circuit: fix acctest (actually a bug)

### DIFF
--- a/azurerm/internal/services/network/express_route_circuit_resource.go
+++ b/azurerm/internal/services/network/express_route_circuit_resource.go
@@ -3,9 +3,10 @@ package network
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"

--- a/azurerm/internal/services/network/express_route_circuit_resource.go
+++ b/azurerm/internal/services/network/express_route_circuit_resource.go
@@ -1,7 +1,9 @@
 package network
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"log"
 	"time"
 
@@ -220,6 +222,21 @@ func resourceArmExpressRouteCircuitCreateUpdate(d *schema.ResourceData, meta int
 		return fmt.Errorf("Error Creating/Updating ExpressRouteCircuit %q (Resource Group %q): %+v", name, resGroup, err)
 	}
 
+	// API has bug, which appears to be eventually consistent on creation. Tracked by this issue: https://github.com/Azure/azure-rest-api-specs/issues/10148
+	log.Printf("[DEBUG] Waiting for Express Route Circuit %q (Resource Group %q) to be able to be queried", name, resGroup)
+	stateConf := &resource.StateChangeConf{
+		Pending:                   []string{"NotFound"},
+		Target:                    []string{"Exists"},
+		Refresh:                   expressRouteCircuitCreationRefreshFunc(ctx, client, resGroup, name),
+		PollInterval:              3 * time.Second,
+		ContinuousTargetOccurence: 3,
+		Timeout:                   d.Timeout(schema.TimeoutCreate),
+	}
+
+	if _, err = stateConf.WaitForState(); err != nil {
+		return fmt.Errorf("Error for Express Route Circuit %q (Resource Group %q) to be able to be queried: %+v", name, resGroup, err)
+	}
+
 	read, err := client.Get(ctx, resGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error Retrieving ExpressRouteCircuit %q (Resource Group %q): %+v", name, resGroup, err)
@@ -327,5 +344,20 @@ func flattenExpressRouteCircuitSku(sku *network.ExpressRouteCircuitSku) []interf
 			"tier":   string(sku.Tier),
 			"family": string(sku.Family),
 		},
+	}
+}
+
+func expressRouteCircuitCreationRefreshFunc(ctx context.Context, client *network.ExpressRouteCircuitsClient, resGroup, name string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		res, err := client.Get(ctx, resGroup, name)
+		if err != nil {
+			if utils.ResponseWasNotFound(res.Response) {
+				return nil, "NotFound", nil
+			}
+
+			return nil, "", fmt.Errorf("Error polling to check if the Express Route Circuit has been created: %+v", err)
+		}
+
+		return res, "Exists", nil
 	}
 }


### PR DESCRIPTION
Express Route Circuit appears to be eventually consisitent on creation (maybe only when recreated), which is tracked in issue: Azure/azure-rest-api-specs#10148.

## Test Result

💢 make testacc TEST=./azurerm/internal/services/network/tests TESTARGS='-run TestAccAzureRMExpressRouteCircuit_bandwidthReduction'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/network/tests -v -run TestAccAzureRMExpressRouteCircuit_bandwidthReduction -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMExpressRouteCircuit_bandwidthReduction
--- PASS: TestAccAzureRMExpressRouteCircuit_bandwidthReduction (332.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/tests       332.661s
