### PR TITLE
Test Fix: Change `CdnEndPoint` host_name

### DIFF
--- a/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
+++ b/azurerm/internal/services/cdn/tests/cdn_endpoint_resource_test.go
@@ -82,10 +82,10 @@ func TestAccAzureRMCdnEndpoint_updateHostHeader(t *testing.T) {
 		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMCdnEndpoint_hostHeader(data, "www.example.com"),
+				Config: testAccAzureRMCdnEndpoint_hostHeader(data, "www.contoso.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMCdnEndpointExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "origin_host_header", "www.example.com"),
+					resource.TestCheckResourceAttr(data.ResourceName, "origin_host_header", "www.contoso.com"),
 				),
 			},
 			{
@@ -190,7 +190,7 @@ func TestAccAzureRMCdnEndpoint_fullFields(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "is_https_allowed", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "origin_path", "/origin-path"),
 					resource.TestCheckResourceAttr(data.ResourceName, "probe_path", "/origin-path/probe"),
-					resource.TestCheckResourceAttr(data.ResourceName, "origin_host_header", "www.example.com"),
+					resource.TestCheckResourceAttr(data.ResourceName, "origin_host_header", "www.contoso.com"),
 					resource.TestCheckResourceAttr(data.ResourceName, "optimization_type", "GeneralWebDelivery"),
 					resource.TestCheckResourceAttr(data.ResourceName, "querystring_caching_behaviour", "UseQueryString"),
 					resource.TestCheckResourceAttr(data.ResourceName, "content_types_to_compress.#", "1"),
@@ -458,7 +458,7 @@ resource "azurerm_cdn_endpoint" "test" {
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -479,7 +479,7 @@ resource "azurerm_cdn_endpoint" "import" {
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -514,7 +514,7 @@ resource "azurerm_cdn_endpoint" "test" {
 
   origin {
     name       = "acceptanceTestCdnOrigin2"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -553,7 +553,7 @@ resource "azurerm_cdn_endpoint" "test" {
 
   origin {
     name       = "acceptanceTestCdnOrigin2"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -592,7 +592,7 @@ resource "azurerm_cdn_endpoint" "test" {
 
   origin {
     name       = "acceptanceTestCdnOrigin2"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -634,7 +634,7 @@ resource "azurerm_cdn_endpoint" "test" {
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -683,7 +683,7 @@ resource "azurerm_cdn_endpoint" "test" {
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -719,14 +719,14 @@ resource "azurerm_cdn_endpoint" "test" {
   content_types_to_compress     = ["text/html"]
   is_compression_enabled        = true
   querystring_caching_behaviour = "UseQueryString"
-  origin_host_header            = "www.example.com"
+  origin_host_header            = "www.contoso.com"
   optimization_type             = "GeneralWebDelivery"
   origin_path                   = "/origin-path"
   probe_path                    = "/origin-path/probe"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -772,7 +772,7 @@ resource "azurerm_cdn_endpoint" "test" {
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -804,11 +804,11 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
+  origin_host_header = "www.contoso.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -847,11 +847,11 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
+  origin_host_header = "www.contoso.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -896,11 +896,11 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
+  origin_host_header = "www.contoso.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -932,11 +932,11 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
+  origin_host_header = "www.contoso.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -982,11 +982,11 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
+  origin_host_header = "www.contoso.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -1033,11 +1033,11 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
+  origin_host_header = "www.contoso.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }
@@ -1098,11 +1098,11 @@ resource "azurerm_cdn_endpoint" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
-  origin_host_header = "www.example.com"
+  origin_host_header = "www.contoso.com"
 
   origin {
     name       = "acceptanceTestCdnOrigin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     https_port = 443
     http_port  = 80
   }

--- a/examples/cdn/main.tf
+++ b/examples/cdn/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_cdn_endpoint" "example" {
 
   origin {
     name       = "${var.prefix}origin1"
-    host_name  = "www.example.com"
+    host_name  = "www.contoso.com"
     http_port  = 80
     https_port = 443
   }

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_cdn_endpoint" "example" {
 
   origin {
     name      = "example"
-    host_name = "www.example.com"
+    host_name = "www.contoso.com"
   }
 }
 ```


### PR DESCRIPTION
Fix test `TestAccAzureRMCdnEndpoint_basic` with error message

```
=== RUN   TestAccAzureRMCdnEndpoint_basic
=== PAUSE TestAccAzureRMCdnEndpoint_basic
=== CONT  TestAccAzureRMCdnEndpoint_basic
    TestAccAzureRMCdnEndpoint_basic: testing.go:640: Step 0 error: errors during apply:

        Error: Error waiting for CDN Endpoint "acctestcdnend200715142837789633" (Profile "acctestcdnprof200715142837789633" / Resource Group "acctestRG-200715142837789633") to finish creating: Code="CustomerOriginDoesNotAcceptThisHostVerizon" Message="\"This origin (IP or hostname) is not allowed due to meeting one of the following conditions:\r\n1.This origin is localhost or an internal ip address.\r\n2.This origin ends with edgecastcdn.net or edgecast.com.\r\n3.This origin contains a Verizon owned IP address block.\r\n4.This origin ends with a root CDN domain name."

          on C:\Users\lrxto\AppData\Local\Temp\tf-test058476495\main.tf line 18:
          (source code not available)


--- FAIL: TestAccAzureRMCdnEndpoint_basic (356.45s)
```