### PR TITLE
Avoid setting `azurerm_api_management_openid_connect_provider` attribute `client_secret` on read, as it is not returned in the API response

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_openid_connect_provider_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_openid_connect_provider_resource.go
@@ -151,7 +151,6 @@ func resourceArmApiManagementOpenIDConnectProviderRead(d *schema.ResourceData, m
 
 	if props := resp.OpenidConnectProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
-		d.Set("client_secret", props.ClientSecret)
 		d.Set("description", props.Description)
 		d.Set("display_name", props.DisplayName)
 		d.Set("metadata_endpoint", props.MetadataEndpoint)

--- a/azurerm/internal/services/apimanagement/tests/api_management_openid_connect_provider_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_openid_connect_provider_resource_test.go
@@ -25,7 +25,7 @@ func TestAccAzureRMApiManagementOpenIDConnectProvider_basic(t *testing.T) {
 					testCheckAzureRMApiManagementOpenIDConnectProviderExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }
@@ -69,7 +69,7 @@ func TestAccAzureRMApiManagementOpenIDConnectProvider_update(t *testing.T) {
 					testCheckAzureRMApiManagementOpenIDConnectProviderExists(data.ResourceName),
 				),
 			},
-			data.ImportStep(),
+			data.ImportStep("client_secret"),
 		},
 	})
 }


### PR DESCRIPTION
Fixes #7757.