### PR TITLE
Support autoscaling Cosmos DB databases and containers 

### DIFF
--- a/azurerm/helpers/validate/cosmos.go
+++ b/azurerm/helpers/validate/cosmos.go
@@ -54,7 +54,6 @@ func CosmosMaxThroughput(v interface{}, k string) (warnings []string, errors []e
 	if value > 1000000 {
 		errors = append(errors, fmt.Errorf(
 			"%s must be a maximum of 1000000", k))
-
 	}
 
 	if value%1000 != 0 {

--- a/azurerm/helpers/validate/cosmos.go
+++ b/azurerm/helpers/validate/cosmos.go
@@ -43,20 +43,24 @@ func CosmosThroughput(v interface{}, k string) (warnings []string, errors []erro
 	return warnings, errors
 }
 
-func CosmosMaxThroughput(v interface{}, k string) (warnings []string, errors []error) {
-	value := v.(int)
+func CosmosMaxThroughput(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(int)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be int", k))
+		return
+	}
 
-	if value < 4000 {
+	if v < 4000 {
 		errors = append(errors, fmt.Errorf(
 			"%s must be a minimum of 4000", k))
 	}
 
-	if value > 1000000 {
+	if v > 1000000 {
 		errors = append(errors, fmt.Errorf(
 			"%s must be a maximum of 1000000", k))
 	}
 
-	if value%1000 != 0 {
+	if v%1000 != 0 {
 		errors = append(errors, fmt.Errorf(
 			"%q must be set in increments of 1000", k))
 	}

--- a/azurerm/helpers/validate/cosmos.go
+++ b/azurerm/helpers/validate/cosmos.go
@@ -42,3 +42,25 @@ func CosmosThroughput(v interface{}, k string) (warnings []string, errors []erro
 
 	return warnings, errors
 }
+
+func CosmosMaxThroughput(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(int)
+
+	if value < 4000 {
+		errors = append(errors, fmt.Errorf(
+			"%s must be a minimum of 4000", k))
+	}
+
+	if value > 1000000 {
+		errors = append(errors, fmt.Errorf(
+			"%s must be a maximum of 1000000", k))
+
+	}
+
+	if value%1000 != 0 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be set in increments of 1000", k))
+	}
+
+	return warnings, errors
+}

--- a/azurerm/helpers/validate/cosmos_test.go
+++ b/azurerm/helpers/validate/cosmos_test.go
@@ -98,3 +98,55 @@ func TestCosmosThroughput(t *testing.T) {
 		}
 	}
 }
+
+func TestCosmosMaxThroughput(t *testing.T) {
+	cases := []struct {
+		Value  interface{}
+		Errors int
+	}{
+		{
+			Value:  400,
+			Errors: 2,
+		},
+		{
+			Value:  1000,
+			Errors: 1,
+		},
+		{
+			Value:  4000,
+			Errors: 0,
+		},
+		{
+			Value:  4001,
+			Errors: 1,
+		},
+		{
+			Value:  10000,
+			Errors: 0,
+		},
+		{
+			Value:  54000,
+			Errors: 0,
+		},
+		{
+			Value:  1000000,
+			Errors: 0,
+		},
+		{
+			Value:  1100000,
+			Errors: 1,
+		},
+		{
+			Value: "400",
+			Errors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := CosmosMaxThroughput(tc.Value, "throughput")
+		if len(errors) != tc.Errors {
+			t.Fatalf("Expected CosmosMaxThroughput to trigger '%d' errors for '%d' - got '%d'", tc.Errors, tc.Value, len(errors))
+		}
+	}
+}
+

--- a/azurerm/helpers/validate/cosmos_test.go
+++ b/azurerm/helpers/validate/cosmos_test.go
@@ -137,7 +137,7 @@ func TestCosmosMaxThroughput(t *testing.T) {
 			Errors: 1,
 		},
 		{
-			Value: "400",
+			Value:  "400",
 			Errors: 1,
 		},
 	}
@@ -149,4 +149,3 @@ func TestCosmosMaxThroughput(t *testing.T) {
 		}
 	}
 }
-

--- a/azurerm/internal/services/cosmos/common/autoscale_settings.go
+++ b/azurerm/internal/services/cosmos/common/autoscale_settings.go
@@ -19,11 +19,6 @@ func ExpandCosmosDbAutoscaleSettings(d *schema.ResourceData) *documentdb.Autosca
 	autoscaleSettings := documentdb.AutoscaleSettings{}
 
 	if maxThroughput, ok := input["max_throughput"].(int); ok {
-		log.Printf("[DEBUG] Cosmos DB resource has an autoscale max_throughput of %d", maxThroughput)
-		if maxThroughput == 0 {
-			maxThroughput = 4000
-		}
-
 		autoscaleSettings.MaxThroughput = utils.Int32(int32(maxThroughput))
 	}
 

--- a/azurerm/internal/services/cosmos/common/autoscale_settings.go
+++ b/azurerm/internal/services/cosmos/common/autoscale_settings.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"log"
+)
+
+func ExpandCosmosDbAutoscaleSettings(d *schema.ResourceData) *documentdb.AutoscaleSettings {
+	i := d.Get("autoscale_settings").([]interface{})
+	if len(i) == 0 || i[0] == nil {
+		log.Printf("[DEBUG] Cosmos DB autoscale settings are not set on the resource")
+		return nil
+	}
+	input := i[0].(map[string]interface{})
+
+	autoscaleSettings := documentdb.AutoscaleSettings{}
+
+	if maxThroughput, ok := input["max_throughput"].(int); ok {
+		log.Printf("[DEBUG] Cosmos DB resource has an autoscale max_throughput of %d", maxThroughput)
+		if maxThroughput == 0 {
+			maxThroughput = 4000
+		}
+
+		autoscaleSettings.MaxThroughput = utils.Int32(int32(maxThroughput))
+	}
+
+	return &autoscaleSettings
+}
+
+func FlattenCosmosDbAutoscaleSettings(throughputResponse documentdb.ThroughputSettingsGetResults) []interface{} {
+	results := make([]interface{}, 0)
+
+	props := throughputResponse.ThroughputSettingsGetProperties
+	if props == nil {
+		return results
+	}
+
+	res := props.Resource
+	if res == nil {
+		return results
+	}
+
+	autoscaleSettings := res.AutoscaleSettings
+	if autoscaleSettings == nil {
+		log.Printf("[DEBUG] Cosmos DB autoscale settings are not set on the throughput response")
+		return results
+	}
+
+	result := make(map[string]interface{})
+
+	if autoscaleSettings.MaxThroughput != nil {
+		result["max_throughput"] = autoscaleSettings.MaxThroughput
+	}
+
+	return append(results, result)
+}
+
+func ExpandCosmosDbAutoscaleSettingsResource(d *schema.ResourceData) *documentdb.AutoscaleSettingsResource {
+	autoscaleSettings := ExpandCosmosDbAutoscaleSettings(d)
+	autoscaleSettingResource := documentdb.AutoscaleSettingsResource{}
+
+	autoscaleSettingResource.MaxThroughput = autoscaleSettings.MaxThroughput
+	return &autoscaleSettingResource
+}

--- a/azurerm/internal/services/cosmos/common/autoscale_settings.go
+++ b/azurerm/internal/services/cosmos/common/autoscale_settings.go
@@ -1,10 +1,11 @@
 package common
 
 import (
+	"log"
+
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-	"log"
 )
 
 func ExpandCosmosDbAutoscaleSettings(d *schema.ResourceData) *documentdb.AutoscaleSettings {

--- a/azurerm/internal/services/cosmos/common/schema.go
+++ b/azurerm/internal/services/cosmos/common/schema.go
@@ -30,3 +30,10 @@ func ContainerAutoscaleSettingsSchema() *schema.Schema {
 
 	return autoscaleSettingsDatabaseSchema
 }
+
+func MongoCollectionAutoscaleSettingsSchema() *schema.Schema {
+	autoscaleSettingsDatabaseSchema := DatabaseAutoscaleSettingsSchema()
+	autoscaleSettingsDatabaseSchema.RequiredWith = []string{"shard_key"}
+
+	return autoscaleSettingsDatabaseSchema
+}

--- a/azurerm/internal/services/cosmos/common/schema.go
+++ b/azurerm/internal/services/cosmos/common/schema.go
@@ -1,0 +1,25 @@
+package common
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+)
+
+func DatabaseAutoscaleSettingsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"max_throughput": {
+					Type:          schema.TypeInt,
+					Optional:      true,
+					Computed:      true,
+					ConflictsWith: []string{"throughput"},
+					ValidateFunc:  validate.CosmosMaxThroughput,
+				},
+			},
+		},
+	}
+}

--- a/azurerm/internal/services/cosmos/common/schema.go
+++ b/azurerm/internal/services/cosmos/common/schema.go
@@ -23,3 +23,10 @@ func DatabaseAutoscaleSettingsSchema() *schema.Schema {
 		},
 	}
 }
+
+func ContainerAutoscaleSettingsSchema() *schema.Schema {
+	autoscaleSettingsDatabaseSchema := DatabaseAutoscaleSettingsSchema()
+	autoscaleSettingsDatabaseSchema.RequiredWith = []string{"partition_key_path"}
+
+	return autoscaleSettingsDatabaseSchema
+}

--- a/azurerm/internal/services/cosmos/common/throughput.go
+++ b/azurerm/internal/services/cosmos/common/throughput.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"

--- a/azurerm/internal/services/cosmos/common/throughput.go
+++ b/azurerm/internal/services/cosmos/common/throughput.go
@@ -2,10 +2,11 @@ package common
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-	"log"
 )
 
 func GetThroughputFromResult(throughputResponse documentdb.ThroughputSettingsGetResults) *int32 {

--- a/azurerm/internal/services/cosmos/common/throughput.go
+++ b/azurerm/internal/services/cosmos/common/throughput.go
@@ -34,8 +34,8 @@ func ExpandCosmosDBThroughputSettingsUpdateParameters(d *schema.ResourceData) *d
 		},
 	}
 
-	if d.Get("throughput").(int) != 0 {
-		throughputParameters.ThroughputSettingsUpdateProperties.Resource.Throughput = ConvertThroughputFromResourceData(d.Get("throughput"))
+	if v, exists := d.GetOk("throughput"); exists {
+		throughputParameters.ThroughputSettingsUpdateProperties.Resource.Throughput = ConvertThroughputFromResourceData(v)
 	}
 
 	if d.HasChange("autoscale_settings") && d.Get("throughput").(int) == 0 {

--- a/azurerm/internal/services/cosmos/common/throughput.go
+++ b/azurerm/internal/services/cosmos/common/throughput.go
@@ -38,7 +38,7 @@ func ExpandCosmosDBThroughputSettingsUpdateParameters(d *schema.ResourceData) *d
 		throughputParameters.ThroughputSettingsUpdateProperties.Resource.Throughput = ConvertThroughputFromResourceData(v)
 	}
 
-	if d.HasChange("autoscale_settings") && d.Get("throughput").(int) == 0 {
+	if _, hasManualThroughput := d.GetOk("throughput"); !hasManualThroughput && d.HasChange("autoscale_settings") {
 		log.Printf("[DEBUG] Cosmos DB autoscale settings have changed")
 		throughputParameters.ThroughputSettingsUpdateProperties.Resource.Throughput = nil
 		throughputParameters.ThroughputSettingsUpdateProperties.Resource.AutoscaleSettings = ExpandCosmosDbAutoscaleSettingsResource(d)

--- a/azurerm/internal/services/cosmos/common/throughput.go
+++ b/azurerm/internal/services/cosmos/common/throughput.go
@@ -1,8 +1,11 @@
 package common
 
 import (
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/services/cosmos-db/mgmt/2020-04-01/documentdb"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"log"
 )
 
 func GetThroughputFromResult(throughputResponse documentdb.ThroughputSettingsGetResults) *int32 {
@@ -21,4 +24,46 @@ func GetThroughputFromResult(throughputResponse documentdb.ThroughputSettingsGet
 
 func ConvertThroughputFromResourceData(throughput interface{}) *int32 {
 	return utils.Int32(int32(throughput.(int)))
+}
+
+func ExpandCosmosDBThroughputSettingsUpdateParameters(d *schema.ResourceData) *documentdb.ThroughputSettingsUpdateParameters {
+	throughputParameters := documentdb.ThroughputSettingsUpdateParameters{
+		ThroughputSettingsUpdateProperties: &documentdb.ThroughputSettingsUpdateProperties{
+			Resource: &documentdb.ThroughputSettingsResource{},
+		},
+	}
+
+	if d.Get("throughput").(int) != 0 {
+		throughputParameters.ThroughputSettingsUpdateProperties.Resource.Throughput = ConvertThroughputFromResourceData(d.Get("throughput"))
+	}
+
+	if d.HasChange("autoscale_settings") && d.Get("throughput").(int) == 0 {
+		log.Printf("[DEBUG] Cosmos DB autoscale settings have changed")
+		throughputParameters.ThroughputSettingsUpdateProperties.Resource.Throughput = nil
+		throughputParameters.ThroughputSettingsUpdateProperties.Resource.AutoscaleSettings = ExpandCosmosDbAutoscaleSettingsResource(d)
+	}
+
+	return &throughputParameters
+}
+
+func SetResourceDataThroughputFromResponse(throughputResponse documentdb.ThroughputSettingsGetResults, d *schema.ResourceData) {
+	d.Set("throughput", GetThroughputFromResult(throughputResponse))
+
+	autoscaleSettings := FlattenCosmosDbAutoscaleSettings(throughputResponse)
+	d.Set("autoscale_settings", autoscaleSettings)
+	if len(autoscaleSettings) != 0 {
+		d.Set("throughput", nil)
+	}
+}
+
+func CheckForChangeFromAutoscaleAndManualThroughput(d *schema.ResourceData) error {
+	if d.HasChange("throughput") && d.HasChange("autoscale_settings") {
+		return fmt.Errorf("Switching between autoscale and manual provisioned throughput is not supported at this time.")
+	}
+
+	return nil
+}
+
+func HasThroughputChange(d *schema.ResourceData) bool {
+	return d.HasChanges("throughput", "autoscale_settings")
 }

--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -79,6 +79,8 @@ func resourceArmCosmosDbGremlinGraph() *schema.Resource {
 				ValidateFunc: validate.CosmosThroughput,
 			},
 
+			"autoscale_settings": common.ContainerAutoscaleSettingsSchema(),
+
 			"partition_key_path": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -232,7 +234,13 @@ func resourceArmCosmosDbGremlinGraphCreate(d *schema.ResourceData, meta interfac
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
-		db.GremlinGraphCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		if throughput != 0 {
+			db.GremlinGraphCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		}
+	}
+
+	if _, hasAutoscaleSettings := d.GetOk("autoscale_settings"); hasAutoscaleSettings {
+		db.GremlinGraphCreateUpdateProperties.Options.AutoscaleSettings = common.ExpandCosmosDbAutoscaleSettings(d)
 	}
 
 	future, err := client.CreateUpdateGremlinGraph(ctx, resourceGroup, account, database, name, db)
@@ -266,6 +274,11 @@ func resourceArmCosmosDbGremlinGraphUpdate(d *schema.ResourceData, meta interfac
 	id, err := parse.GremlinGraphID(d.Id())
 	if err != nil {
 		return err
+	}
+
+	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
+	if err != nil {
+		return fmt.Errorf("Error updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
 	}
 
 	partitionkeypaths := d.Get("partition_key_path").(string)
@@ -302,16 +315,9 @@ func resourceArmCosmosDbGremlinGraphUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error waiting on create/update future for Cosmos Gremlin Graph %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
 	}
 
-	if d.HasChange("throughput") {
-		throughputParameters := documentdb.ThroughputSettingsUpdateParameters{
-			ThroughputSettingsUpdateProperties: &documentdb.ThroughputSettingsUpdateProperties{
-				Resource: &documentdb.ThroughputSettingsResource{
-					Throughput: common.ConvertThroughputFromResourceData(d.Get("throughput")),
-				},
-			},
-		}
-
-		throughputFuture, err := client.UpdateGremlinGraphThroughput(ctx, id.ResourceGroup, id.Account, id.Database, id.Name, throughputParameters)
+	if common.HasThroughputChange(d) {
+		throughputParameters := common.ExpandCosmosDBThroughputSettingsUpdateParameters(d)
+		throughputFuture, err := client.UpdateGremlinGraphThroughput(ctx, id.ResourceGroup, id.Account, id.Database, id.Name, *throughputParameters)
 		if err != nil {
 			if response.WasNotFound(throughputFuture.Response()) {
 				return fmt.Errorf("Error setting Throughput for Cosmos Gremlin Graph %q (Account: %q, Database: %q): %+v - "+
@@ -391,9 +397,10 @@ func resourceArmCosmosDbGremlinGraphRead(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error reading Throughput on Gremlin Graph %q (Account: %q, Database: %q) ID: %v", id.Name, id.Account, id.Database, err)
 		} else {
 			d.Set("throughput", nil)
+			d.Set("autoscale_settings", nil)
 		}
 	} else {
-		d.Set("throughput", common.GetThroughputFromResult(throughputResp))
+		common.SetResourceDataThroughputFromResponse(throughputResp, d)
 	}
 
 	return nil

--- a/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_gremlin_graph_resource.go
@@ -278,7 +278,7 @@ func resourceArmCosmosDbGremlinGraphUpdate(d *schema.ResourceData, meta interfac
 
 	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
 	if err != nil {
-		return fmt.Errorf("Error updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
+		return fmt.Errorf("Error updating Cosmos Gremlin Graph %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
 	}
 
 	partitionkeypaths := d.Get("partition_key_path").(string)

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -92,6 +92,9 @@ func resourceArmCosmosDbMongoCollection() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validate.CosmosThroughput,
 			},
+
+			"autoscale_settings": common.DatabaseAutoscaleSettingsSchema(),
+
 			"index": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -173,7 +176,13 @@ func resourceArmCosmosDbMongoCollectionCreate(d *schema.ResourceData, meta inter
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
-		db.MongoDBCollectionCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		if throughput != 0 {
+			db.MongoDBCollectionCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		}
+	}
+
+	if _, hasAutoscaleSettings := d.GetOk("autoscale_settings"); hasAutoscaleSettings {
+		db.MongoDBCollectionCreateUpdateProperties.Options.AutoscaleSettings = common.ExpandCosmosDbAutoscaleSettings(d)
 	}
 
 	if shardKey := d.Get("shard_key").(string); shardKey != "" {
@@ -215,6 +224,11 @@ func resourceArmCosmosDbMongoCollectionUpdate(d *schema.ResourceData, meta inter
 		return err
 	}
 
+	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
+	if err != nil {
+		return fmt.Errorf("Error updating Cosmos Mongo Collection %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
+	}
+
 	var ttl *int
 	if v := d.Get("default_ttl_seconds").(int); v > 0 {
 		ttl = utils.Int(v)
@@ -245,16 +259,9 @@ func resourceArmCosmosDbMongoCollectionUpdate(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error waiting on create/update future for Cosmos Mongo Collection %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
 	}
 
-	if d.HasChange("throughput") {
-		throughputParameters := documentdb.ThroughputSettingsUpdateParameters{
-			ThroughputSettingsUpdateProperties: &documentdb.ThroughputSettingsUpdateProperties{
-				Resource: &documentdb.ThroughputSettingsResource{
-					Throughput: common.ConvertThroughputFromResourceData(d.Get("throughput")),
-				},
-			},
-		}
-
-		throughputFuture, err := client.UpdateMongoDBCollectionThroughput(ctx, id.ResourceGroup, id.Account, id.Database, id.Name, throughputParameters)
+	if common.HasThroughputChange(d) {
+		throughputParameters := common.ExpandCosmosDBThroughputSettingsUpdateParameters(d)
+		throughputFuture, err := client.UpdateMongoDBCollectionThroughput(ctx, id.ResourceGroup, id.Account, id.Database, id.Name, *throughputParameters)
 		if err != nil {
 			if response.WasNotFound(throughputFuture.Response()) {
 				return fmt.Errorf("Error setting Throughput for Cosmos MongoDB Collection %q (Account: %q, Database: %q): %+v - "+
@@ -326,9 +333,10 @@ func resourceArmCosmosDbMongoCollectionRead(d *schema.ResourceData, meta interfa
 			return fmt.Errorf("Error reading Throughput on Cosmos Mongo Collection %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
 		} else {
 			d.Set("throughput", nil)
+			d.Set("autoscale_settings", nil)
 		}
 	} else {
-		d.Set("throughput", common.GetThroughputFromResult(throughputResp))
+		common.SetResourceDataThroughputFromResponse(throughputResp, d)
 	}
 
 	return nil

--- a/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_mongo_collection_resource.go
@@ -93,7 +93,7 @@ func resourceArmCosmosDbMongoCollection() *schema.Resource {
 				ValidateFunc: validate.CosmosThroughput,
 			},
 
-			"autoscale_settings": common.DatabaseAutoscaleSettingsSchema(),
+			"autoscale_settings": common.MongoCollectionAutoscaleSettingsSchema(),
 
 			"index": {
 				Type:     schema.TypeSet,

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_container_resource.go
@@ -85,6 +85,8 @@ func resourceArmCosmosDbSQLContainer() *schema.Resource {
 				ValidateFunc: validate.CosmosThroughput,
 			},
 
+			"autoscale_settings": common.ContainerAutoscaleSettingsSchema(),
+
 			"default_ttl": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -165,7 +167,13 @@ func resourceArmCosmosDbSQLContainerCreate(d *schema.ResourceData, meta interfac
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
-		db.SQLContainerCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		if throughput != 0 {
+			db.SQLContainerCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		}
+	}
+
+	if _, hasAutoscaleSettings := d.GetOk("autoscale_settings"); hasAutoscaleSettings {
+		db.SQLContainerCreateUpdateProperties.Options.AutoscaleSettings = common.ExpandCosmosDbAutoscaleSettings(d)
 	}
 
 	future, err := client.CreateUpdateSQLContainer(ctx, resourceGroup, account, database, name, db)
@@ -199,6 +207,11 @@ func resourceArmCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interfac
 	id, err := parse.SqlContainerID(d.Id())
 	if err != nil {
 		return err
+	}
+
+	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
+	if err != nil {
+		return fmt.Errorf("Error updating Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
 	}
 
 	partitionkeypaths := d.Get("partition_key_path").(string)
@@ -238,16 +251,9 @@ func resourceArmCosmosDbSQLContainerUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error waiting on create/update future for Cosmos SQL Container %q (Account: %q, Database: %q): %+v", id.Name, id.Account, id.Database, err)
 	}
 
-	if d.HasChange("throughput") {
-		throughputParameters := documentdb.ThroughputSettingsUpdateParameters{
-			ThroughputSettingsUpdateProperties: &documentdb.ThroughputSettingsUpdateProperties{
-				Resource: &documentdb.ThroughputSettingsResource{
-					Throughput: common.ConvertThroughputFromResourceData(d.Get("throughput")),
-				},
-			},
-		}
-
-		throughputFuture, err := client.UpdateSQLContainerThroughput(ctx, id.ResourceGroup, id.Account, id.Database, id.Name, throughputParameters)
+	if common.HasThroughputChange(d) {
+		throughputParameters := common.ExpandCosmosDBThroughputSettingsUpdateParameters(d)
+		throughputFuture, err := client.UpdateSQLContainerThroughput(ctx, id.ResourceGroup, id.Account, id.Database, id.Name, *throughputParameters)
 		if err != nil {
 			if response.WasNotFound(throughputFuture.Response()) {
 				return fmt.Errorf("Error setting Throughput for Cosmos SQL Container %q (Account: %q, Database: %q): %+v - "+
@@ -319,9 +325,10 @@ func resourceArmCosmosDbSQLContainerRead(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error reading Throughput on Cosmos SQL Container %s (Account: %q, Database: %q) ID: %v", id.Name, id.Account, id.Database, err)
 		} else {
 			d.Set("throughput", nil)
+			d.Set("autoscale_settings", nil)
 		}
 	} else {
-		d.Set("throughput", common.GetThroughputFromResult(throughputResp))
+		common.SetResourceDataThroughputFromResponse(throughputResp, d)
 	}
 
 	return nil

--- a/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_sql_database_resource.go
@@ -69,6 +69,8 @@ func resourceArmCosmosDbSQLDatabase() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validate.CosmosThroughput,
 			},
+
+			"autoscale_settings": common.DatabaseAutoscaleSettingsSchema(),
 		},
 	}
 }
@@ -105,7 +107,13 @@ func resourceArmCosmosDbSQLDatabaseCreate(d *schema.ResourceData, meta interface
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
-		db.SQLDatabaseCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		if throughput != 0 {
+			db.SQLDatabaseCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		}
+	}
+
+	if _, hasAutoscaleSettings := d.GetOk("autoscale_settings"); hasAutoscaleSettings {
+		db.SQLDatabaseCreateUpdateProperties.Options.AutoscaleSettings = common.ExpandCosmosDbAutoscaleSettings(d)
 	}
 
 	future, err := client.CreateUpdateSQLDatabase(ctx, resourceGroup, account, name, db)
@@ -141,6 +149,11 @@ func resourceArmCosmosDbSQLDatabaseUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
+	if err != nil {
+		return fmt.Errorf("Error updating Cosmos SQL Database %q (Account: %q) - %+v", id.Name, id.Account, err)
+	}
+
 	db := documentdb.SQLDatabaseCreateUpdateParameters{
 		SQLDatabaseCreateUpdateProperties: &documentdb.SQLDatabaseCreateUpdateProperties{
 			Resource: &documentdb.SQLDatabaseResource{
@@ -159,16 +172,9 @@ func resourceArmCosmosDbSQLDatabaseUpdate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error waiting on create/update future for Cosmos SQL Database %q (Account: %q): %+v", id.Name, id.Account, err)
 	}
 
-	if d.HasChange("throughput") {
-		throughputParameters := documentdb.ThroughputSettingsUpdateParameters{
-			ThroughputSettingsUpdateProperties: &documentdb.ThroughputSettingsUpdateProperties{
-				Resource: &documentdb.ThroughputSettingsResource{
-					Throughput: common.ConvertThroughputFromResourceData(d.Get("throughput")),
-				},
-			},
-		}
-
-		throughputFuture, err := client.UpdateSQLDatabaseThroughput(ctx, id.ResourceGroup, id.Account, id.Name, throughputParameters)
+	if common.HasThroughputChange(d) {
+		throughputParameters := common.ExpandCosmosDBThroughputSettingsUpdateParameters(d)
+		throughputFuture, err := client.UpdateSQLDatabaseThroughput(ctx, id.ResourceGroup, id.Account, id.Name, *throughputParameters)
 		if err != nil {
 			if response.WasNotFound(throughputFuture.Response()) {
 				return fmt.Errorf("Error setting Throughput for Cosmos SQL Database %q (Account: %q) %+v - "+
@@ -219,9 +225,10 @@ func resourceArmCosmosDbSQLDatabaseRead(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("Error reading Throughput on Cosmos SQL Database %q (Account: %q) ID: %v", id.Name, id.Account, err)
 		} else {
 			d.Set("throughput", nil)
+			d.Set("autoscale_settings", nil)
 		}
 	} else {
-		d.Set("throughput", common.GetThroughputFromResult(throughputResp))
+		common.SetResourceDataThroughputFromResponse(throughputResp, d)
 	}
 
 	return nil

--- a/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
@@ -69,6 +69,8 @@ func resourceArmCosmosDbTable() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validate.CosmosThroughput,
 			},
+
+			"autoscale_settings": common.DatabaseAutoscaleSettingsSchema(),
 		},
 	}
 }
@@ -105,7 +107,13 @@ func resourceArmCosmosDbTableCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if throughput, hasThroughput := d.GetOk("throughput"); hasThroughput {
-		db.TableCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		if throughput != 0 {
+			db.TableCreateUpdateProperties.Options.Throughput = common.ConvertThroughputFromResourceData(throughput)
+		}
+	}
+
+	if _, hasAutoscaleSettings := d.GetOk("autoscale_settings"); hasAutoscaleSettings {
+		db.TableCreateUpdateProperties.Options.AutoscaleSettings = common.ExpandCosmosDbAutoscaleSettings(d)
 	}
 
 	future, err := client.CreateUpdateTable(ctx, resourceGroup, account, name, db)
@@ -141,6 +149,11 @@ func resourceArmCosmosDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
+	if err != nil {
+		return fmt.Errorf("Error updating Cosmos Gremlin Database %q (Account: %q) - %+v", id.Name, id.Account, err)
+	}
+
 	db := documentdb.TableCreateUpdateParameters{
 		TableCreateUpdateProperties: &documentdb.TableCreateUpdateProperties{
 			Resource: &documentdb.TableResource{
@@ -159,16 +172,9 @@ func resourceArmCosmosDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error waiting on create/update future for Cosmos Table %q (Account: %q): %+v", id.Name, id.Account, err)
 	}
 
-	if d.HasChange("throughput") {
-		throughputParameters := documentdb.ThroughputSettingsUpdateParameters{
-			ThroughputSettingsUpdateProperties: &documentdb.ThroughputSettingsUpdateProperties{
-				Resource: &documentdb.ThroughputSettingsResource{
-					Throughput: common.ConvertThroughputFromResourceData(d.Get("throughput")),
-				},
-			},
-		}
-
-		throughputFuture, err := client.UpdateTableThroughput(ctx, id.ResourceGroup, id.Account, id.Name, throughputParameters)
+	if common.HasThroughputChange(d) {
+		throughputParameters := common.ExpandCosmosDBThroughputSettingsUpdateParameters(d)
+		throughputFuture, err := client.UpdateTableThroughput(ctx, id.ResourceGroup, id.Account, id.Name, *throughputParameters)
 		if err != nil {
 			if response.WasNotFound(throughputFuture.Response()) {
 				return fmt.Errorf("Error setting Throughput for Cosmos Table %q (Account: %q): %+v - "+
@@ -219,9 +225,10 @@ func resourceArmCosmosDbTableRead(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Error reading Throughput on Cosmos Table %q (Account: %q) ID: %v", id.Name, id.Account, err)
 		} else {
 			d.Set("throughput", nil)
+			d.Set("autoscale_settings", nil)
 		}
 	} else {
-		d.Set("throughput", common.GetThroughputFromResult(throughputResp))
+		common.SetResourceDataThroughputFromResponse(throughputResp, d)
 	}
 
 	return nil

--- a/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
+++ b/azurerm/internal/services/cosmos/cosmosdb_table_resource.go
@@ -151,7 +151,7 @@ func resourceArmCosmosDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 
 	err = common.CheckForChangeFromAutoscaleAndManualThroughput(d)
 	if err != nil {
-		return fmt.Errorf("Error updating Cosmos Gremlin Database %q (Account: %q) - %+v", id.Name, id.Account, err)
+		return fmt.Errorf("Error updating Cosmos Table %q (Account: %q) - %+v", id.Name, id.Account, err)
 	}
 
 	db := documentdb.TableCreateUpdateParameters{

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_cassandra_keyspace_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_cassandra_keyspace_resource_test.go
@@ -80,6 +80,42 @@ func TestAccAzureRMCosmosDbCassandraKeyspace_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbCassandraKeyspace_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_cassandra_keyspace", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbCassandraKeyspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbCassandraKeyspace_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbCassandraKeyspaceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbCassandraKeyspace_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbCassandraKeyspaceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbCassandraKeyspace_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbCassandraKeyspaceExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbCassandraKeyspaceDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.CassandraClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -160,4 +196,19 @@ resource "azurerm_cosmosdb_cassandra_keyspace" "test" {
   throughput = %[3]d
 }
 `, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableCassandra"}), data.RandomInteger, throughput)
+}
+
+func testAccAzureRMCosmosDbCassandraKeyspace_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_cassandra_keyspace" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+}
+`, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableCassandra"}), data.RandomInteger, maxThroughput)
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_gremlin_database_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_gremlin_database_resource_test.go
@@ -82,6 +82,42 @@ func TestAccAzureRMCosmosGremlinDatabase_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosGremlinDatabase_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_gremlin_database", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosGremlinDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosGremlinDatabase_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosGremlinDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosGremlinDatabase_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosGremlinDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosGremlinDatabase_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosGremlinDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosGremlinDatabaseDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.GremlinClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -173,4 +209,19 @@ resource "azurerm_cosmosdb_gremlin_database" "test" {
   throughput          = %[3]d
 }
 `, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableGremlin"}), data.RandomInteger, throughput)
+}
+
+func testAccAzureRMCosmosGremlinDatabase_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_gremlin_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+}
+`, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableGremlin"}), data.RandomInteger, maxThroughput)
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_gremlin_graph_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_gremlin_graph_resource_test.go
@@ -354,7 +354,7 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
   resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
   account_name        = azurerm_cosmosdb_account.test.name
   database_name       = azurerm_cosmosdb_gremlin_database.test.name
-  partition_key_path  = "/definition/id"
+  partition_key_path  = "/test"
 
   autoscale_settings {
     max_throughput = %[3]d

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_gremlin_graph_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_gremlin_graph_resource_test.go
@@ -119,6 +119,42 @@ func TestAccAzureRMCosmosDbGremlinGraph_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbGremlinGraph_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_gremlin_graph", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbGremlinGraphDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbGremlinGraph_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRmCosmosDbGremlinGraphExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbGremlinGraph_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRmCosmosDbGremlinGraphExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbGremlinGraph_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRmCosmosDbGremlinGraphExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbGremlinGraphDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.GremlinClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -307,4 +343,34 @@ resource "azurerm_cosmosdb_gremlin_graph" "test" {
   }
 }
 `, testAccAzureRMCosmosGremlinDatabase_basic(data), data.RandomInteger, throughput)
+}
+
+func testAccAzureRMCosmosDbGremlinGraph_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_gremlin_graph" "test" {
+  name                = "acctest-CGRPC-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_gremlin_database.test.name
+  partition_key_path  = "/definition/id"
+
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+
+  index_policy {
+    automatic      = true
+    indexing_mode  = "Consistent"
+    included_paths = ["/*"]
+    excluded_paths = ["/\"_etag\"/?"]
+  }
+
+  conflict_resolution_policy {
+    mode                     = "LastWriterWins"
+    conflict_resolution_path = "/_ts"
+  }
+}
+`, testAccAzureRMCosmosGremlinDatabase_basic(data), data.RandomInteger, maxThroughput)
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_collection_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_collection_resource_test.go
@@ -306,7 +306,6 @@ resource "azurerm_cosmosdb_mongo_collection" "test" {
   resource_group_name = azurerm_cosmosdb_mongo_database.test.resource_group_name
   account_name        = azurerm_cosmosdb_mongo_database.test.account_name
   database_name       = azurerm_cosmosdb_mongo_database.test.name
-  partition_key_path  = "/definition/id"
 
   autoscale_settings {
     max_throughput = %[3]d

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_collection_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_collection_resource_test.go
@@ -306,6 +306,7 @@ resource "azurerm_cosmosdb_mongo_collection" "test" {
   resource_group_name = azurerm_cosmosdb_mongo_database.test.resource_group_name
   account_name        = azurerm_cosmosdb_mongo_database.test.account_name
   database_name       = azurerm_cosmosdb_mongo_database.test.name
+  shard_key           = "seven"
 
   autoscale_settings {
     max_throughput = %[3]d

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_collection_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_collection_resource_test.go
@@ -143,6 +143,42 @@ func TestAccAzureRMCosmosDbMongoCollection_withIndex(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbMongoCollection_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_mongo_collection", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbMongoCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbMongoCollection_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoCollectionExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbMongoCollection_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoCollectionExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbMongoCollection_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoCollectionExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbMongoCollectionDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.MongoDbClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -259,6 +295,24 @@ resource "azurerm_cosmosdb_mongo_collection" "test" {
   throughput = %[3]d
 }
 `, testAccAzureRMCosmosDbMongoDatabase_basic(data), data.RandomInteger, throughput)
+}
+
+func testAccAzureRMCosmosDbMongoCollection_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_mongo_collection" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_mongo_database.test.resource_group_name
+  account_name        = azurerm_cosmosdb_mongo_database.test.account_name
+  database_name       = azurerm_cosmosdb_mongo_database.test.name
+  partition_key_path  = "/definition/id"
+
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+}
+`, testAccAzureRMCosmosDbMongoDatabase_basic(data), data.RandomInteger, maxThroughput)
 }
 
 func testAccAzureRMCosmosDbMongoCollection_withIndex(data acceptance.TestData) string {

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_database_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_mongo_database_resource_test.go
@@ -51,6 +51,42 @@ func TestAccAzureRMCosmosDbMongoDatabase_complete(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbMongoDatabase_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_mongo_database", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbMongoDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbMongoDatabase_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbMongoDatabase_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbMongoDatabase_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbMongoDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbMongoDatabaseDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.MongoDbClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -130,4 +166,19 @@ resource "azurerm_cosmosdb_mongo_database" "test" {
   throughput          = 700
 }
 `, testAccAzureRMCosmosDBAccount_basic(data, documentdb.MongoDB, documentdb.Strong), data.RandomInteger)
+}
+
+func testAccAzureRMCosmosDbMongoDatabase_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_mongo_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+}
+`, testAccAzureRMCosmosDBAccount_basic(data, documentdb.MongoDB, documentdb.Strong), data.RandomInteger, maxThroughput)
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_sql_container_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_sql_container_resource_test.go
@@ -84,6 +84,45 @@ func TestAccAzureRMCosmosDbSqlContainer_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbSqlContainer_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_container", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbSqlContainerDestroy,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+
+				Config: testAccAzureRMCosmosDbSqlContainer_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlContainerExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbSqlContainerDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.SqlClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -191,4 +230,22 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   throughput  = 400
 }
 `, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger)
+}
+
+func testAccAzureRMCosmosDbSqlContainer_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctest-CSQLC-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path  = "/definition/id"
+
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+}
+`, testAccAzureRMCosmosDbSqlDatabase_basic(data), data.RandomInteger, maxThroughput)
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_sql_database_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_sql_database_resource_test.go
@@ -191,7 +191,7 @@ resource "azurerm_cosmosdb_sql_database" "test" {
   account_name        = azurerm_cosmosdb_account.test.name
   autoscale_settings {
     max_throughput = %[3]d
-  } 
+  }
 }
 `, testAccAzureRMCosmosDBAccount_basic(data, documentdb.GlobalDocumentDB, documentdb.Strong), data.RandomInteger, maxThroughput)
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_sql_database_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_sql_database_resource_test.go
@@ -62,6 +62,44 @@ func TestAccAzureRMCosmosDbSqlDatabase_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbSqlDatabase_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_sql_database", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbSqlDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbSqlDatabase_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+
+				Config: testAccAzureRMCosmosDbSqlDatabase_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+
+				Config: testAccAzureRMCosmosDbSqlDatabase_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbSqlDatabaseExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbSqlDatabaseDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.SqlClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -141,4 +179,19 @@ resource "azurerm_cosmosdb_sql_database" "test" {
   throughput          = %[3]d
 }
 `, testAccAzureRMCosmosDBAccount_basic(data, documentdb.GlobalDocumentDB, documentdb.Strong), data.RandomInteger, throughput)
+}
+
+func testAccAzureRMCosmosDbSqlDatabase_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  autoscale_settings {
+    max_throughput = %[3]d
+  } 
+}
+`, testAccAzureRMCosmosDBAccount_basic(data, documentdb.GlobalDocumentDB, documentdb.Strong), data.RandomInteger, maxThroughput)
 }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_table_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_table_resource_test.go
@@ -187,7 +187,6 @@ resource "azurerm_cosmosdb_table" "test" {
   name                = "acctest-%[2]d"
   resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
   account_name        = azurerm_cosmosdb_account.test.name
-  partition_key_path  = "/definition/id"
   autoscale_settings {
     max_throughput = %[3]d
   }

--- a/azurerm/internal/services/cosmos/tests/cosmosdb_table_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_table_resource_test.go
@@ -62,6 +62,42 @@ func TestAccAzureRMCosmosDbTable_update(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMCosmosDbTable_autoscale(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_table", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMCosmosDbTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMCosmosDbTable_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbTableExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbTable_autoscale(data, 5000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbTableExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "5000"),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMCosmosDbTable_autoscale(data, 4000),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckAzureRMCosmosDbTableExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "autoscale_settings.0.max_throughput", "4000"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMCosmosDbTableDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Cosmos.TableClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -141,4 +177,20 @@ resource "azurerm_cosmosdb_table" "test" {
   throughput          = %[3]d
 }
 `, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableTable"}), data.RandomInteger, throughput)
+}
+
+func testAccAzureRMCosmosDbTable_autoscale(data acceptance.TestData, maxThroughput int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_table" "test" {
+  name                = "acctest-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  partition_key_path  = "/definition/id"
+  autoscale_settings {
+    max_throughput = %[3]d
+  }
+}
+`, testAccAzureRMCosmosDBAccount_capabilities(data, documentdb.GlobalDocumentDB, []string{"EnableTable"}), data.RandomInteger, maxThroughput)
 }

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 ---
 

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 ---
 
 An `autoscale_settings` block supports the following:

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 ---
 

--- a/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_keyspace.html.markdown
@@ -55,7 +55,15 @@ The following arguments are supported:
 
 * `account_name` - (Required) The name of the Cosmos DB Cassandra KeySpace to create the table within. Changing this forces a new resource to be created.
 
-* `throughput` - (Optional) The throughput of Cassandra keyspace (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+* `throughput` - (Optional) The throughput of Cassandra KeySpace (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the Cassandra KeySpace (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
 
 ## Attributes Reference

--- a/website/docs/r/cosmosdb_gremlin_database.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_database.html.markdown
@@ -38,6 +38,14 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of the Gremlin database (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the Gremlin database (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
+
 
 ## Attributes Reference
 

--- a/website/docs/r/cosmosdb_gremlin_database.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_database.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 ---
 
 An `autoscale_settings` block supports the following:

--- a/website/docs/r/cosmosdb_gremlin_database.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_database.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 ---
 

--- a/website/docs/r/cosmosdb_gremlin_database.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_database.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 ---
 

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -70,6 +70,8 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 * `index_policy` - (Required) The configuration of the indexing policy. One or more `index_policy` blocks as defined below. Changing this forces a new resource to be created.
 
 * `conflict_resolution_policy` - (Required) The conflict resolution policy for the graph. One or more `conflict_resolution_policy` blocks as defined below. Changing this forces a new resource to be created.

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -66,13 +66,21 @@ The following arguments are supported:
 
 * `partition_key_path` - (Optional) Define a partition key. Changing this forces a new resource to be created.
 
-* `throughput` - (Optional) The throughput of the Gremlin database (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+* `throughput` - (Optional) The throughput of the Gremlin graph (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
 * `index_policy` - (Required) The configuration of the indexing policy. One or more `index_policy` blocks as defined below. Changing this forces a new resource to be created.
 
 * `conflict_resolution_policy` - (Required) The conflict resolution policy for the graph. One or more `conflict_resolution_policy` blocks as defined below. Changing this forces a new resource to be created.
 
 * `unique_key` (Optional) One or more `unique_key` blocks as defined below. Changing this forces a new resource to be created.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the Gremlin graph (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
 ---
 

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 * `index_policy` - (Required) The configuration of the indexing policy. One or more `index_policy` blocks as defined below. Changing this forces a new resource to be created.
 

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 * `index_policy` - (Required) The configuration of the indexing policy. One or more `index_policy` blocks as defined below. Changing this forces a new resource to be created.
 

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `shard_key` to be set.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 ---
 
 An `autoscale_settings` block supports the following:

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -47,6 +47,13 @@ The following arguments are supported:
 * `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys.
 * `index` - (Optional) One or more `index` blocks as defined below.
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `shard_key` to be set.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the MongoDB collection (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
 ---
 

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `shard_key` to be set.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 ---
 

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `shard_key` to be set.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 ---
 

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -36,8 +36,15 @@ The following arguments are supported:
 
 * `account_name` - (Required) The name of the Cosmos DB Mongo Database to create the table within. Changing this forces a new resource to be created.
 
-* `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+* `throughput` - (Optional) The throughput of the MongoDB database (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the MongoDB database (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
 ## Attributes Reference
 

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 ---
 
 An `autoscale_settings` block supports the following:

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 ---
 

--- a/website/docs/r/cosmosdb_mongo_database.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_database.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 ---
 

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -47,6 +47,8 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 
 ---

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -45,7 +45,15 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of SQL container (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon container creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
+
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the SQL container (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
 
 ---
 A `unique_key` block supports the following:

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply. Requires `partition_key_path` to be set.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 * `default_ttl` - (Optional) The default time to live of SQL container. If missing, items are not expired automatically. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -38,6 +38,14 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of SQL database (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the SQL database (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
+
 
 ## Attributes Reference
 

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 ---
 
 An `autoscale_settings` block supports the following:

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 ---
 

--- a/website/docs/r/cosmosdb_sql_database.html.markdown
+++ b/website/docs/r/cosmosdb_sql_database.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 ---
 

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+
 ---
 
 An `autoscale_settings` block supports the following:

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
 
 ---
 

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
-~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and imported. 
+~> **Note:** Switching between autoscale and manual throughput is not supported via Terraform and must be completed via the Azure Portal and refreshed. 
 
 ---
 

--- a/website/docs/r/cosmosdb_table.html.markdown
+++ b/website/docs/r/cosmosdb_table.html.markdown
@@ -38,6 +38,14 @@ The following arguments are supported:
 
 * `throughput` - (Optional) The throughput of Table (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
 
+* `autoscale_settings` - (Optional) An `autoscale_settings` block as defined below. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.
+
+---
+
+An `autoscale_settings` block supports the following:
+
+* `max_throughput` - (Optional) The maximum throughput of the Table (RU/s). Must be between `4,000` and `1,000,000`. Must be set in increments of `1,000`. Conflicts with `throughput`.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds support for enabling autoscaling Cosmos DB databases and containers

Depends on fix for issue #7825 for testing
Depends on #7597 (merged in v2.20.0)
Closes #6164 
Closes #7315

### Example Usage

```tf
resource "azurerm_cosmosdb_sql_database" "autoscale" {
  account_name        = "myaccount"
  name                = "mydb"
  resource_group_name = "myrg"

  autoscale_settings {
    max_throughput = 4000
  }
}
```

### Test Status

Run with commit https://github.com/terraform-providers/terraform-provider-azurerm/pull/7773/commits/324d259c45a92912ac301d60927e992f7c2030a7

#### Passing
```
--- PASS: TestAccAzureRMCosmosDbCassandraKeyspace_basic (1330.26s)
--- PASS: TestAccAzureRMCosmosDbCassandraKeyspace_complete (1525.71s)
--- PASS: TestAccAzureRMCosmosDbCassandraKeyspace_update (1582.38s)
--- PASS: TestAccAzureRMCosmosDbCassandraKeyspace_autoscale (1778.28s)
--- PASS: TestAccAzureRMCosmosGremlinDatabase_requiresImport (1376.95s)
--- PASS: TestAccAzureRMCosmosGremlinDatabase_basic (1422.04s)
--- PASS: TestAccAzureRMCosmosGremlinDatabase_complete (1563.30s)
--- PASS: TestAccAzureRMCosmosGremlinDatabase_autoscale (1735.37s)
--- PASS: TestAccAzureRMCosmosDbGremlinGraph_requiresImport (1466.30s)
--- PASS: TestAccAzureRMCosmosDbGremlinGraph_customConflictResolutionPolicy (1498.55s)
--- PASS: TestAccAzureRMCosmosDbGremlinGraph_basic (1548.04s)
--- PASS: TestAccAzureRMCosmosDbGremlinGraph_indexPolicy (1610.39s)
--- PASS: TestAccAzureRMCosmosDbGremlinGraph_autoscale (1739.45s)
--- PASS: TestAccAzureRMCosmosDbGremlinGraph_update (1777.58s)
--- PASS: TestAccAzureRMCosmosDbMongoCollection_basic (1413.85s)
--- PASS: TestAccAzureRMCosmosDbMongoCollection_throughput (1624.28s)
--- PASS: TestAccAzureRMCosmosDbMongoCollection_autoscale (1744.72s)
--- PASS: TestAccAzureRMCosmosDbMongoDatabase_complete (1302.42s)
--- PASS: TestAccAzureRMCosmosDbMongoDatabase_basic (1307.51s)
--- PASS: TestAccAzureRMCosmosDbMongoDatabase_autoscale (1618.07s)
--- PASS: TestAccAzureRMCosmosDbSqlDatabase_basic (1350.69s)
--- PASS: TestAccAzureRMCosmosDbSqlDatabase_update (1500.18s)
--- PASS: TestAccAzureRMCosmosDbSqlDatabase_autoscale (1728.33s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_complete (1426.93s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_basic (1427.35s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_update (1572.95s)
--- PASS: TestAccAzureRMCosmosDbSqlContainer_autoscale (1734.78s)
--- PASS: TestAccAzureRMCosmosDbTable_basic (1380.36s)
--- PASS: TestAccAzureRMCosmosDbTable_autoscale (1788.62s)
--- PASS: TestAccAzureRMCosmosDbTable_update (1918.18s)
```

#### Failing

These failing tests are related to #7825 

```
--- FAIL: TestAccAzureRMCosmosDbMongoCollection_complete (1459.93s)
--- FAIL: TestAccAzureRMCosmosDbMongoCollection_withIndex (1502.19s)
--- FAIL: TestAccAzureRMCosmosDbMongoCollection_update (1639.81s)
```
