### PR TITLE
azurerm_storage_account default allow_blob_public_access to false

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -149,7 +149,7 @@ func resourceArmStorageAccount() *schema.Resource {
 			"allow_blob_public_access": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 
 			"network_rules": {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
@@ -243,6 +243,14 @@ func TestAccAzureRMStorageAccount_allowBlobPublicAccess(t *testing.T) {
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccAzureRMStorageAccount_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "allow_blob_public_access", "false"),
+				),
+			},
+			data.ImportStep(),
+			{
 				Config: testAccAzureRMStorageAccount_allowBlobPublicAccess(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(data.ResourceName),

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 * `enable_https_traffic_only` - (Optional) Boolean flag which forces HTTPS if enabled, see [here](https://docs.microsoft.com/en-us/azure/storage/storage-require-secure-transfer/)
     for more information. Defaults to `true`.
 
-* `allow_blob_public_access` - Allow or disallow public access to all blobs or containers in the storage account. Defaults to `true`.
+* `allow_blob_public_access` - Allow or disallow public access to all blobs or containers in the storage account. Defaults to `false`.
 
 * `is_hns_enabled` - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created. 
 


### PR DESCRIPTION
For `azurerm_storage_account` resources, default `allow_blob_public_access` to `false` to align with behavior prior to 2.19

Closes #7781 

```
TF_ACC=1 go test -v ./azurerm/internal/services/storage/tests/ -run=TestAccAzureRMStorageAccount_allowBlobPublicAccess -timeout 60m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMStorageAccount_allowBlobPublicAccess
=== PAUSE TestAccAzureRMStorageAccount_allowBlobPublicAccess
=== CONT  TestAccAzureRMStorageAccount_allowBlobPublicAccess
--- PASS: TestAccAzureRMStorageAccount_allowBlobPublicAccess (150.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/tests 150.313s
```