### PR TITLE
New resource "azurerm_api_management_identity_provider_aadb2c"

### DIFF
--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -19,6 +19,14 @@ func SchemaApiManagementName() *schema.Schema {
 	}
 }
 
+func SchemaApiManagementNameDeprecated() (s *schema.Schema) {
+	s = SchemaApiManagementName()
+	s.Deprecated = "This property has been deprecated and will be removed in v3.0 of the provider. Please use the `api_management_id` property that replaces it."
+	s.Required = false
+	s.Optional = true
+	return
+}
+
 func SchemaApiManagementDataSourceName() *schema.Schema {
 	return &schema.Schema{
 		Type:         schema.TypeString,

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aad_resource.go
@@ -8,9 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -33,9 +35,17 @@ func resourceArmApiManagementIdentityProviderAAD() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(), // TODO remove in v3.0
 
-			"api_management_name": azure.SchemaApiManagementName(),
+			"api_management_name": azure.SchemaApiManagementNameDeprecated(), // TODO remove in v3.0
+
+			"api_management_id": {
+				Type:         schema.TypeString,
+				Optional:     true, // TODO change to required in v3.0
+				Computed:     true, // TODO remove in v3.0
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
 
 			"client_id": {
 				Type:         schema.TypeString,
@@ -72,8 +82,23 @@ func resourceArmApiManagementIdentityProviderAADCreateUpdate(d *schema.ResourceD
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	serviceName := d.Get("api_management_name").(string)
+	var resourceGroup, serviceName string
+	if apiManagementId, ok := d.GetOk("api_management_id"); ok && apiManagementId.(string) != "" {
+		id, err := parse.ApiManagementID(apiManagementId.(string))
+		if err != nil {
+			return err
+		}
+		resourceGroup = id.ResourceGroup
+		serviceName = id.ServiceName
+	} else {
+		resourceGroup = d.Get("resource_group_name").(string)
+		serviceName = d.Get("api_management_name").(string)
+	}
+
+	if resourceGroup == "" || serviceName == "" {
+		return fmt.Errorf("could not determine resource group or API management service, please specify `api_management_id`")
+	}
+
 	clientID := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
 	allowedTenants := d.Get("allowed_tenants").([]interface{})
@@ -119,17 +144,18 @@ func resourceArmApiManagementIdentityProviderAADCreateUpdate(d *schema.ResourceD
 }
 
 func resourceArmApiManagementIdentityProviderAADRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ApiManagementIdentityProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
+	serviceName := id.ServiceName
+	identityProviderName := id.ProviderName
 
 	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
 	if err != nil {
@@ -142,8 +168,7 @@ func resourceArmApiManagementIdentityProviderAADRead(d *schema.ResourceData, met
 		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
 	}
 
-	d.Set("resource_group_name", resourceGroup)
-	d.Set("api_management_name", serviceName)
+	d.Set("api_management_id", id.ApiManagementID(subscriptionId))
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -48,6 +48,14 @@ func resourceArmApiManagementIdentityProviderAADB2C() *schema.Resource {
 				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+			"allowed_tenants": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsUUID,
+				},
+			},
 			"signin_tenant": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -91,6 +99,8 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.Resour
 	serviceName := d.Get("api_management_name").(string)
 	clientID := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
+	allowedTenants := d.Get("allowed_tenants").([]interface{})
+
 	signinTenant := d.Get("signin_tenant").(string)
 	authority := d.Get("authority").(string)
 	signupPolicy := d.Get("signup_policy").(string)
@@ -116,6 +126,7 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.Resour
 		IdentityProviderCreateContractProperties: &apimanagement.IdentityProviderCreateContractProperties{
 			ClientID:                 utils.String(clientID),
 			ClientSecret:             utils.String(clientSecret),
+			AllowedTenants:           utils.ExpandStringSlice(allowedTenants),
 			Type:                     apimanagement.AadB2C,
 			SigninTenant:             utils.String(signinTenant),
 			Authority:                utils.String(authority),
@@ -172,6 +183,7 @@ func resourceArmApiManagementIdentityProviderAADB2CRead(d *schema.ResourceData, 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
 		d.Set("client_secret", props.ClientSecret)
+		d.Set("allowed_tenants", props.AllowedTenants)
 		d.Set("signin_tenant", props.SigninTenant)
 		d.Set("authority", props.Authority)
 		d.Set("signup_policy", props.SignupPolicyName)

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -1,0 +1,206 @@
+package apimanagement
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementIdentityProviderAADB2C() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementIdentityProviderAADB2CCreateUpdate,
+		Read:   resourceArmApiManagementIdentityProviderAADB2CRead,
+		Update: resourceArmApiManagementIdentityProviderAADB2CCreateUpdate,
+		Delete: resourceArmApiManagementIdentityProviderAADB2CDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"client_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"client_secret": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"signin_tenant": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+			"authority": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"signup_policy": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"signin_policy": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"profile_editing_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+			"password_reset_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	clientID := d.Get("client_id").(string)
+	clientSecret := d.Get("client_secret").(string)
+	signinTenant := d.Get("signin_tenant").(string)
+	authority := d.Get("authority").(string)
+	signupPolicy := d.Get("signup_policy").(string)
+
+	signinPolicy := d.Get("signin_policy").(string)
+	profileEditingPolicy := d.Get("profile_editing_policy").(string)
+	passwordResetPolicy := d.Get("password_reset_policy").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Identity Provider %q (API Management Service %q / Resource Group %q): %s", apimanagement.AadB2C, serviceName, resourceGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management_identity_provider_aadb2c", *existing.ID)
+		}
+	}
+
+	parameters := apimanagement.IdentityProviderCreateContract{
+		IdentityProviderCreateContractProperties: &apimanagement.IdentityProviderCreateContractProperties{
+			ClientID:                 utils.String(clientID),
+			ClientSecret:             utils.String(clientSecret),
+			Type:                     apimanagement.AadB2C,
+			SigninTenant:             utils.String(signinTenant),
+			Authority:                utils.String(authority),
+			SignupPolicyName:         utils.String(signupPolicy),
+			SigninPolicyName:         utils.String(signinPolicy),
+			ProfileEditingPolicyName: utils.String(profileEditingPolicy),
+			PasswordResetPolicyName:  utils.String(passwordResetPolicy),
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, apimanagement.AadB2C, parameters, ""); err != nil {
+		return fmt.Errorf("creating or updating Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.AadB2C, resourceGroup, serviceName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
+	if err != nil {
+		return fmt.Errorf("retrieving Identity Provider %q (Resource Group %q / API Management Service %q): %+v", apimanagement.AadB2C, resourceGroup, serviceName, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read ID for Identity Provider %q (Resource Group %q / API Management Service %q)", apimanagement.AadB2C, resourceGroup, serviceName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmApiManagementIdentityProviderAADB2CRead(d, meta)
+}
+
+func resourceArmApiManagementIdentityProviderAADB2CRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	identityProviderName := id.Path["identityProviders"]
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Identity Provider %q (Resource Group %q / API Management Service %q) was not found - removing from state!", identityProviderName, resourceGroup, serviceName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+	}
+
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("api_management_name", serviceName)
+
+	if props := resp.IdentityProviderContractProperties; props != nil {
+		d.Set("client_id", props.ClientID)
+		d.Set("client_secret", props.ClientSecret)
+		d.Set("signin_tenant", props.SigninTenant)
+		d.Set("authority", props.Authority)
+		d.Set("signup_policy", props.SignupPolicyName)
+		d.Set("signin_policy", props.SigninPolicyName)
+		d.Set("profile_editing_policy", props.ProfileEditingPolicyName)
+		d.Set("password_reset_policy", props.PasswordResetPolicyName)
+	}
+
+	return nil
+}
+
+func resourceArmApiManagementIdentityProviderAADB2CDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.Path["service"]
+	identityProviderName := id.Path["identityProviders"]
+
+	if resp, err := client.Delete(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName), ""); err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("deleting Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_aadb2c_resource.go
@@ -8,9 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -33,9 +35,12 @@ func resourceArmApiManagementIdentityProviderAADB2C() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"api_management_name": azure.SchemaApiManagementName(),
+			"api_management_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
 
 			"client_id": {
 				Type:         schema.TypeString,
@@ -48,22 +53,22 @@ func resourceArmApiManagementIdentityProviderAADB2C() *schema.Resource {
 				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
-			"allowed_tenants": {
-				Type:     schema.TypeList,
-				Required: true,
-				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.IsUUID,
-				},
+			// For AADB2C identity providers, `allowed_tenants` must specify exactly one tenant
+			"allowed_tenant": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"signin_tenant": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.IsUUID,
+				Type:     schema.TypeString,
+				Required: true,
+				// B2C tenant domains can be customized, and GUIDs might work here too
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"authority": {
-				Type:         schema.TypeString,
-				Required:     true,
+				Type:     schema.TypeString,
+				Required: true,
+				// B2C login domains can be customized and don't necessarily end in b2clogin.com
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"signup_policy": {
@@ -95,12 +100,18 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.Resour
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	serviceName := d.Get("api_management_name").(string)
+	apiManagementID := d.Get("api_management_id").(string)
+	id, err := parse.ApiManagementID(apiManagementID)
+	if err != nil {
+		return err
+	}
+	resourceGroup := id.ResourceGroup
+	serviceName := id.ServiceName
+
 	clientID := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
-	allowedTenants := d.Get("allowed_tenants").([]interface{})
 
+	allowedTenant := d.Get("allowed_tenant").(string)
 	signinTenant := d.Get("signin_tenant").(string)
 	authority := d.Get("authority").(string)
 	signupPolicy := d.Get("signup_policy").(string)
@@ -126,8 +137,8 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.Resour
 		IdentityProviderCreateContractProperties: &apimanagement.IdentityProviderCreateContractProperties{
 			ClientID:                 utils.String(clientID),
 			ClientSecret:             utils.String(clientSecret),
-			AllowedTenants:           utils.ExpandStringSlice(allowedTenants),
 			Type:                     apimanagement.AadB2C,
+			AllowedTenants:           utils.ExpandStringSlice([]interface{}{allowedTenant}),
 			SigninTenant:             utils.String(signinTenant),
 			Authority:                utils.String(authority),
 			SignupPolicyName:         utils.String(signupPolicy),
@@ -154,17 +165,18 @@ func resourceArmApiManagementIdentityProviderAADB2CCreateUpdate(d *schema.Resour
 }
 
 func resourceArmApiManagementIdentityProviderAADB2CRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ApiManagementIdentityProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
+	serviceName := id.ServiceName
+	identityProviderName := id.ProviderName
 
 	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
 	if err != nil {
@@ -177,19 +189,23 @@ func resourceArmApiManagementIdentityProviderAADB2CRead(d *schema.ResourceData, 
 		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
 	}
 
-	d.Set("resource_group_name", resourceGroup)
-	d.Set("api_management_name", serviceName)
+	d.Set("api_management_id", id.ApiManagementID(subscriptionId))
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)
-		d.Set("client_secret", props.ClientSecret)
-		d.Set("allowed_tenants", props.AllowedTenants)
 		d.Set("signin_tenant", props.SigninTenant)
 		d.Set("authority", props.Authority)
 		d.Set("signup_policy", props.SignupPolicyName)
 		d.Set("signin_policy", props.SigninPolicyName)
 		d.Set("profile_editing_policy", props.ProfileEditingPolicyName)
 		d.Set("password_reset_policy", props.PasswordResetPolicyName)
+
+		allowedTenant := ""
+		if allowedTenants := props.AllowedTenants; allowedTenants != nil && len(*allowedTenants) > 0 {
+			t := *allowedTenants
+			allowedTenant = t[0]
+		}
+		d.Set("allowed_tenant", allowedTenant)
 	}
 
 	return nil

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_facebook_resource.go
@@ -8,9 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -33,9 +35,17 @@ func resourceArmApiManagementIdentityProviderFacebook() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(), // TODO remove in v3.0
 
-			"api_management_name": azure.SchemaApiManagementName(),
+			"api_management_name": azure.SchemaApiManagementNameDeprecated(), // TODO remove in v3.0
+
+			"api_management_id": {
+				Type:         schema.TypeString,
+				Optional:     true, // TODO change to required in v3.0
+				Computed:     true, // TODO remove in v3.0
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
 
 			"app_id": {
 				Type:         schema.TypeString,
@@ -58,8 +68,23 @@ func resourceArmApiManagementIdentityProviderFacebookCreateUpdate(d *schema.Reso
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	serviceName := d.Get("api_management_name").(string)
+	var resourceGroup, serviceName string
+	if apiManagementId, ok := d.GetOk("api_management_id"); ok && apiManagementId.(string) != "" {
+		id, err := parse.ApiManagementID(apiManagementId.(string))
+		if err != nil {
+			return err
+		}
+		resourceGroup = id.ResourceGroup
+		serviceName = id.ServiceName
+	} else {
+		resourceGroup = d.Get("resource_group_name").(string)
+		serviceName = d.Get("api_management_name").(string)
+	}
+
+	if resourceGroup == "" || serviceName == "" {
+		return fmt.Errorf("could not determine resource group or API management service, please specify `api_management_id`")
+	}
+
 	clientID := d.Get("app_id").(string)
 	clientSecret := d.Get("app_secret").(string)
 
@@ -101,17 +126,18 @@ func resourceArmApiManagementIdentityProviderFacebookCreateUpdate(d *schema.Reso
 }
 
 func resourceArmApiManagementIdentityProviderFacebookRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ApiManagementIdentityProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
+	serviceName := id.ServiceName
+	identityProviderName := id.ProviderName
 
 	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
 	if err != nil {
@@ -124,8 +150,7 @@ func resourceArmApiManagementIdentityProviderFacebookRead(d *schema.ResourceData
 		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
 	}
 
-	d.Set("resource_group_name", resourceGroup)
-	d.Set("api_management_name", serviceName)
+	d.Set("api_management_id", id.ApiManagementID(subscriptionId))
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("app_id", props.ClientID)

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_google_resource.go
@@ -8,10 +8,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -34,9 +36,17 @@ func resourceArmApiManagementIdentityProviderGoogle() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(), // TODO remove in v3.0
 
-			"api_management_name": azure.SchemaApiManagementName(),
+			"api_management_name": azure.SchemaApiManagementNameDeprecated(), // TODO remove in v3.0
+
+			"api_management_id": {
+				Type:         schema.TypeString,
+				Optional:     true, // TODO change to required in v3.0
+				Computed:     true, // TODO remove in v3.0
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
 
 			"client_id": {
 				Type:         schema.TypeString,
@@ -59,8 +69,23 @@ func resourceArmApiManagementIdentityProviderGoogleCreateUpdate(d *schema.Resour
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	serviceName := d.Get("api_management_name").(string)
+	var resourceGroup, serviceName string
+	if apiManagementId, ok := d.GetOk("api_management_id"); ok && apiManagementId.(string) != "" {
+		id, err := parse.ApiManagementID(apiManagementId.(string))
+		if err != nil {
+			return err
+		}
+		resourceGroup = id.ResourceGroup
+		serviceName = id.ServiceName
+	} else {
+		resourceGroup = d.Get("resource_group_name").(string)
+		serviceName = d.Get("api_management_name").(string)
+	}
+
+	if resourceGroup == "" || serviceName == "" {
+		return fmt.Errorf("could not determine resource group or API management service, please specify `api_management_id`")
+	}
+
 	clientID := d.Get("client_id").(string)
 	clientSecret := d.Get("client_secret").(string)
 
@@ -102,17 +127,18 @@ func resourceArmApiManagementIdentityProviderGoogleCreateUpdate(d *schema.Resour
 }
 
 func resourceArmApiManagementIdentityProviderGoogleRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ApiManagementIdentityProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
+	serviceName := id.ServiceName
+	identityProviderName := id.ProviderName
 
 	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
 	if err != nil {
@@ -125,8 +151,7 @@ func resourceArmApiManagementIdentityProviderGoogleRead(d *schema.ResourceData, 
 		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
 	}
 
-	d.Set("resource_group_name", resourceGroup)
-	d.Set("api_management_name", serviceName)
+	d.Set("api_management_id", id.ApiManagementID(subscriptionId))
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("client_id", props.ClientID)

--- a/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
@@ -8,9 +8,11 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -33,9 +35,17 @@ func resourceArmApiManagementIdentityProviderTwitter() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"resource_group_name": azure.SchemaResourceGroupName(),
+			"resource_group_name": azure.SchemaResourceGroupNameDeprecated(), // TODO remove in v3.0
 
-			"api_management_name": azure.SchemaApiManagementName(),
+			"api_management_name": azure.SchemaApiManagementNameDeprecated(), // TODO remove in v3.0
+
+			"api_management_id": {
+				Type:         schema.TypeString,
+				Optional:     true, // TODO change to required in v3.0
+				Computed:     true, // TODO remove in v3.0
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
 
 			"api_key": {
 				Type:         schema.TypeString,
@@ -58,8 +68,23 @@ func resourceArmApiManagementIdentityProviderTwitterCreateUpdate(d *schema.Resou
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resourceGroup := d.Get("resource_group_name").(string)
-	serviceName := d.Get("api_management_name").(string)
+	var resourceGroup, serviceName string
+	if apiManagementId, ok := d.GetOk("api_management_id"); ok && apiManagementId.(string) != "" {
+		id, err := parse.ApiManagementID(apiManagementId.(string))
+		if err != nil {
+			return err
+		}
+		resourceGroup = id.ResourceGroup
+		serviceName = id.ServiceName
+	} else {
+		resourceGroup = d.Get("resource_group_name").(string)
+		serviceName = d.Get("api_management_name").(string)
+	}
+
+	if resourceGroup == "" || serviceName == "" {
+		return fmt.Errorf("could not determine resource group or API management service, please specify `api_management_id`")
+	}
+
 	clientID := d.Get("api_key").(string)
 	clientSecret := d.Get("api_secret_key").(string)
 
@@ -101,17 +126,18 @@ func resourceArmApiManagementIdentityProviderTwitterCreateUpdate(d *schema.Resou
 }
 
 func resourceArmApiManagementIdentityProviderTwitterRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).ApiManagement.IdentityProviderClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ApiManagementIdentityProviderID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
-	identityProviderName := id.Path["identityProviders"]
+	serviceName := id.ServiceName
+	identityProviderName := id.ProviderName
 
 	resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.IdentityProviderType(identityProviderName))
 	if err != nil {
@@ -124,8 +150,7 @@ func resourceArmApiManagementIdentityProviderTwitterRead(d *schema.ResourceData,
 		return fmt.Errorf("making Read request for Identity Provider %q (Resource Group %q / API Management Service %q): %+v", identityProviderName, resourceGroup, serviceName, err)
 	}
 
-	d.Set("resource_group_name", resourceGroup)
-	d.Set("api_management_name", serviceName)
+	d.Set("api_management_id", id.ApiManagementID(subscriptionId))
 
 	if props := resp.IdentityProviderContractProperties; props != nil {
 		d.Set("api_key", props.ClientID)

--- a/azurerm/internal/services/apimanagement/parse/api_management_id.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management_id.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"fmt"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 

--- a/azurerm/internal/services/apimanagement/parse/api_management_id.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management_id.go
@@ -1,12 +1,19 @@
 package parse
 
 import (
+	"fmt"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
 type ApiManagementId struct {
 	ResourceGroup string
 	ServiceName   string
+}
+
+func (a *ApiManagementId) ID(subscriptionId string) (id string) {
+	id = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s",
+		subscriptionId, a.ResourceGroup, a.ServiceName)
+	return
 }
 
 func ApiManagementID(input string) (*ApiManagementId, error) {

--- a/azurerm/internal/services/apimanagement/parse/api_management_identity_provider.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management_identity_provider.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"fmt"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 

--- a/azurerm/internal/services/apimanagement/parse/api_management_identity_provider.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management_identity_provider.go
@@ -1,0 +1,50 @@
+package parse
+
+import (
+	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ApiManagementIdentityProviderId struct {
+	ResourceGroup string
+	ServiceName   string
+	ProviderName  string
+}
+
+func (a *ApiManagementIdentityProviderId) ID(subscriptionId string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ApiManagement/service/%s/identityProviders/%s",
+		subscriptionId, a.ResourceGroup, a.ServiceName, a.ProviderName)
+}
+
+func (a *ApiManagementIdentityProviderId) ApiManagementID(subscriptionId string) string {
+	id := ApiManagementId{
+		ResourceGroup: a.ResourceGroup,
+		ServiceName:   a.ServiceName,
+	}
+	return id.ID(subscriptionId)
+}
+
+func ApiManagementIdentityProviderID(input string) (*ApiManagementIdentityProviderId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	apiManagementIdentityProvider := ApiManagementIdentityProviderId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if apiManagementIdentityProvider.ServiceName, err = id.PopSegment("service"); err != nil {
+		return nil, err
+	}
+
+	if apiManagementIdentityProvider.ProviderName, err = id.PopSegment("identityProviders"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &apiManagementIdentityProvider, nil
+}

--- a/azurerm/internal/services/apimanagement/parse/api_management_identity_provider_id_test.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management_identity_provider_id_test.go
@@ -1,0 +1,81 @@
+package parse
+
+import "testing"
+
+func TestApiManagementIdentityProviderID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *ApiManagementIdentityProviderId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Service Name",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Provider Name",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/identityProviders/",
+			Expected: nil,
+		},
+		{
+			Name:  "Valid",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/identityProviders/providerA",
+			Expected: &ApiManagementIdentityProviderId{
+				ResourceGroup: "resGroup1",
+				ServiceName:   "service1",
+				ProviderName:  "providerA",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/Service/service1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ApiManagementIdentityProviderID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.ProviderName != v.Expected.ProviderName {
+			t.Fatalf("Expected %q but got %q for Provider Name", v.Expected.ProviderName, actual.ProviderName)
+		}
+
+		if actual.ServiceName != v.Expected.ServiceName {
+			t.Fatalf("Expected %q but got %q for Service Name", v.Expected.ServiceName, actual.ServiceName)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/apimanagement/registration.go
+++ b/azurerm/internal/services/apimanagement/registration.go
@@ -49,6 +49,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_api_management_group":                       resourceArmApiManagementGroup(),
 		"azurerm_api_management_group_user":                  resourceArmApiManagementGroupUser(),
 		"azurerm_api_management_identity_provider_aad":       resourceArmApiManagementIdentityProviderAAD(),
+		"azurerm_api_management_identity_provider_aadb2c":    resourceArmApiManagementIdentityProviderAADB2C(),
 		"azurerm_api_management_identity_provider_facebook":  resourceArmApiManagementIdentityProviderFacebook(),
 		"azurerm_api_management_identity_provider_google":    resourceArmApiManagementIdentityProviderGoogle(),
 		"azurerm_api_management_identity_provider_microsoft": resourceArmApiManagementIdentityProviderMicrosoft(),

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aad_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aad_resource_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -27,6 +29,25 @@ func TestAccAzureRMApiManagementIdentityProviderAAD_basic(t *testing.T) {
 				),
 			},
 			data.ImportStep("client_secret"),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderAAD_basicDeprecated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aad", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderAADDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderAAD_basicDeprecated(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderAADExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("client_secret", "api_management_name", "resource_group_name"),
 		},
 	})
 }
@@ -93,10 +114,14 @@ func testCheckAzureRMApiManagementIdentityProviderAADDestroy(s *terraform.State)
 			continue
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Aad)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Aad)
+
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return err
@@ -118,13 +143,16 @@ func testCheckAzureRMApiManagementIdentityProviderAADExists(resourceName string)
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Aad)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Aad)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Aad, resourceGroup, serviceName)
+				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Aad, id.ResourceGroup, id.ServiceName)
 			}
 			return fmt.Errorf("Bad: Get on apiManagementIdentityProviderClient: %+v", err)
 		}
@@ -140,12 +168,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -154,14 +182,44 @@ resource "azurerm_api_management" "test" {
 }
 
 resource "azurerm_api_management_identity_provider_aad" "test" {
+  api_management_id = azurerm_api_management.test.id
+  client_id         = "00000000-0000-0000-0000-000000000000"
+  client_secret     = "00000000000000000000000000000000"
+  signin_tenant     = "00000000-0000-0000-0000-000000000000"
+  allowed_tenants   = ["%[3]s"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.Client().TenantID)
+}
+
+func testAccAzureRMApiManagementIdentityProviderAAD_basicDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[1]d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_aad" "test" {
+  resource_group_name = azurerm_api_management.test.resource_group_name
   api_management_name = azurerm_api_management.test.name
   client_id           = "00000000-0000-0000-0000-000000000000"
   client_secret       = "00000000000000000000000000000000"
   signin_tenant       = "00000000-0000-0000-0000-000000000000"
-  allowed_tenants     = ["%s"]
+  allowed_tenants     = ["%[3]s"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
+`, data.RandomInteger, data.Locations.Primary, data.Client().TenantID)
 }
 
 func testAccAzureRMApiManagementIdentityProviderAAD_update(data acceptance.TestData) string {
@@ -171,12 +229,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -185,13 +243,12 @@ resource "azurerm_api_management" "test" {
 }
 
 resource "azurerm_api_management_identity_provider_aad" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  api_management_name = azurerm_api_management.test.name
-  client_id           = "11111111-1111-1111-1111-111111111111"
-  client_secret       = "11111111111111111111111111111111"
-  allowed_tenants     = ["%s", "%s"]
+  api_management_id = azurerm_api_management.test.id
+  client_id         = "11111111-1111-1111-1111-111111111111"
+  client_secret     = "11111111111111111111111111111111"
+  allowed_tenants   = ["%[3]s", "%[3]s"]
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID, data.Client().TenantID)
+`, data.RandomInteger, data.Locations.Primary, data.Client().TenantID)
 }
 
 func testAccAzureRMApiManagementIdentityProviderAAD_requiresImport(data acceptance.TestData) string {
@@ -200,11 +257,10 @@ func testAccAzureRMApiManagementIdentityProviderAAD_requiresImport(data acceptan
 %s
 
 resource "azurerm_api_management_identity_provider_aad" "import" {
-  resource_group_name = azurerm_api_management_identity_provider_aad.test.resource_group_name
-  api_management_name = azurerm_api_management_identity_provider_aad.test.api_management_name
-  client_id           = azurerm_api_management_identity_provider_aad.test.client_id
-  client_secret       = azurerm_api_management_identity_provider_aad.test.client_secret
-  allowed_tenants     = azurerm_api_management_identity_provider_aad.test.allowed_tenants
+  api_management_id = azurerm_api_management_identity_provider_aad.test.api_management_id
+  client_id         = azurerm_api_management_identity_provider_aad.test.client_id
+  client_secret     = azurerm_api_management_identity_provider_aad.test.client_secret
+  allowed_tenants   = azurerm_api_management_identity_provider_aad.test.allowed_tenants
 }
 `, template)
 }

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
@@ -73,7 +73,12 @@ func testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t *testing.T
 			config[k] = v
 			continue
 		}
-		t.Fatalf("`%s` must be set for acceptance tests for resource `azurerm_api_management_identity_provider_aadb2c`!", e)
+		vars := make([]string, 0, len(config))
+		for k := range config {
+			v := fmt.Sprintf("ARM_TEST_B2C_%s", strings.ToUpper(k))
+			vars = append(vars, v)
+		}
+		t.Skip(fmt.Sprintf("Acceptance tests for resource `azurerm_api_management_identity_provider_aadb2c` skipped unless environment variables set: %s", strings.Join(vars, ", ")))
 	}
 
 	return config

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
@@ -45,8 +45,11 @@ func TestAccAzureRMApiManagementIdentityProviderAADB2C_update(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "00000000-0000-0000-0000-000000000000"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "00000000000000000000000000000000"),
-					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.0", data.Client().TenantID),
+
+					resource.TestCheckResourceAttr(data.ResourceName, "signin_tenant", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr(data.ResourceName, "authority", "ExampleAuthority"),
+					resource.TestCheckResourceAttr(data.ResourceName, "signup_policy", "ExampleSignupPolicy"),
+					resource.TestCheckResourceAttr(data.ResourceName, "signin_policy", "ExampleSigninPolicy"),
 				),
 			},
 			{
@@ -79,7 +82,7 @@ func TestAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport(t *testing
 					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMApiManagementIdentityProviderAAD_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport),
 		},
 	})
 }
@@ -158,7 +161,11 @@ resource "azurerm_api_management_identity_provider_aadb2c" "test" {
   resource_group_name = azurerm_resource_group.test.name
   api_management_name = azurerm_api_management.test.name
   client_id           = "00000000-0000-0000-0000-000000000000"
-  client_secret       = "00000000000000000000000000000000"
+		client_secret       = "00000000000000000000000000000000"
+		signin_tenant       = "%s"
+		authority           = "ExampleAuthority"
+		signup_policy       = "ExampleSignupPolicy"
+		signin_policy       = "ExampleSigninPolicy"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
 }
@@ -186,11 +193,14 @@ resource "azurerm_api_management" "test" {
 resource "azurerm_api_management_identity_provider_aadb2c" "test" {
   resource_group_name = azurerm_resource_group.test.name
   api_management_name = azurerm_api_management.test.name
-  client_id           = "11111111-1111-1111-1111-111111111111"
-  client_secret       = "11111111111111111111111111111111"
-  allowed_tenants     = ["%s", "%s"]
+		client_id           = "22222222-2222-2222-2222-222222222222"
+		client_secret       = "22222222222222222222222222222222"
+		signin_tenant       = "%s"
+		authority           = "ExampleAuthority"
+		signup_policy       = "ExampleSignupPolicy"
+		signin_policy       = "ExampleSigninPolicy"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID, data.Client().TenantID)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
 }
 
 func testAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport(data acceptance.TestData) string {
@@ -202,8 +212,11 @@ resource "azurerm_api_management_identity_provider_aadb2c" "import" {
   resource_group_name = azurerm_api_management_identity_provider_aadb2c.test.resource_group_name
   api_management_name = azurerm_api_management_identity_provider_aadb2c.test.api_management_name
   client_id           = azurerm_api_management_identity_provider_aadb2c.test.client_id
-  client_secret       = azurerm_api_management_identity_provider_aadb2c.test.client_secret
-  allowed_tenants     = azurerm_api_management_identity_provider_aadb2c.test.allowed_tenants
+		client_secret       = azurerm_api_management_identity_provider_aadb2c.test.client_secret
+		signin_tenant       = azurerm_api_management_identity_provider_aadb2c.test.signin_tenant
+		authority           = azurerm_api_management_identity_provider_aadb2c.test.authority
+		signup_policy       = azurerm_api_management_identity_provider_aadb2c.test.signup_policy
+		signin_policy       = azurerm_api_management_identity_provider_aadb2c.test.signin_policy
 }
 `, template)
 }

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
@@ -67,7 +67,7 @@ func testAccAzureRMApiManagementIdentityProviderAADB2C_getB2CConfig(t *testing.T
 		"client_secret": "",
 	}
 
-	for k, _ := range config {
+	for k := range config {
 		e := fmt.Sprintf("ARM_TEST_B2C_%s", strings.ToUpper(k))
 		if v := os.Getenv(e); v != "" {
 			config[k] = v

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
@@ -46,7 +46,7 @@ func TestAccAzureRMApiManagementIdentityProviderAADB2C_update(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "00000000-0000-0000-0000-000000000000"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "00000000000000000000000000000000"),
 
-					resource.TestCheckResourceAttr(data.ResourceName, "signin_tenant", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr(data.ResourceName, "signin_tenant", "11111111-1111-1111-1111-111111111111"),
 					resource.TestCheckResourceAttr(data.ResourceName, "authority", "ExampleAuthority"),
 					resource.TestCheckResourceAttr(data.ResourceName, "signup_policy", "ExampleSignupPolicy"),
 					resource.TestCheckResourceAttr(data.ResourceName, "signin_policy", "ExampleSigninPolicy"),
@@ -56,12 +56,12 @@ func TestAccAzureRMApiManagementIdentityProviderAADB2C_update(t *testing.T) {
 				Config: testAccAzureRMApiManagementIdentityProviderAADB2C_update(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "11111111-1111-1111-1111-111111111111"),
-					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "11111111111111111111111111111111"),
-					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.#", "2"),
-					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.0", data.Client().TenantID),
-					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.1", data.Client().TenantID),
-				),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "22222222-2222-2222-2222-222222222222"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "22222222222222222222222222222222"),
+					resource.TestCheckResourceAttr(data.ResourceName, "signin_tenant", "11111111-1111-1111-1111-111111111111"),
+					resource.TestCheckResourceAttr(data.ResourceName, "authority", "ExampleAuthority"),
+					resource.TestCheckResourceAttr(data.ResourceName, "signup_policy", "ExampleSignupPolicy"),
+					resource.TestCheckResourceAttr(data.ResourceName, "signin_policy", "ExampleSigninPolicy")),
 			},
 			data.ImportStep(),
 		},
@@ -161,11 +161,11 @@ resource "azurerm_api_management_identity_provider_aadb2c" "test" {
   resource_group_name = azurerm_resource_group.test.name
   api_management_name = azurerm_api_management.test.name
   client_id           = "00000000-0000-0000-0000-000000000000"
-		client_secret       = "00000000000000000000000000000000"
-		signin_tenant       = "%s"
-		authority           = "ExampleAuthority"
-		signup_policy       = "ExampleSignupPolicy"
-		signin_policy       = "ExampleSigninPolicy"
+  client_secret       = "00000000000000000000000000000000"
+  signin_tenant       = "%s"
+  authority           = "ExampleAuthority"
+  signup_policy       = "ExampleSignupPolicy"
+  signin_policy       = "ExampleSigninPolicy"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
 }
@@ -193,12 +193,12 @@ resource "azurerm_api_management" "test" {
 resource "azurerm_api_management_identity_provider_aadb2c" "test" {
   resource_group_name = azurerm_resource_group.test.name
   api_management_name = azurerm_api_management.test.name
-		client_id           = "22222222-2222-2222-2222-222222222222"
-		client_secret       = "22222222222222222222222222222222"
-		signin_tenant       = "%s"
-		authority           = "ExampleAuthority"
-		signup_policy       = "ExampleSignupPolicy"
-		signin_policy       = "ExampleSigninPolicy"
+  client_id           = "22222222-2222-2222-2222-222222222222"
+  client_secret       = "22222222222222222222222222222222"
+  signin_tenant       = "%s"
+  authority           = "ExampleAuthority"
+  signup_policy       = "ExampleSignupPolicy"
+  signin_policy       = "ExampleSigninPolicy"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
 }
@@ -212,11 +212,11 @@ resource "azurerm_api_management_identity_provider_aadb2c" "import" {
   resource_group_name = azurerm_api_management_identity_provider_aadb2c.test.resource_group_name
   api_management_name = azurerm_api_management_identity_provider_aadb2c.test.api_management_name
   client_id           = azurerm_api_management_identity_provider_aadb2c.test.client_id
-		client_secret       = azurerm_api_management_identity_provider_aadb2c.test.client_secret
-		signin_tenant       = azurerm_api_management_identity_provider_aadb2c.test.signin_tenant
-		authority           = azurerm_api_management_identity_provider_aadb2c.test.authority
-		signup_policy       = azurerm_api_management_identity_provider_aadb2c.test.signup_policy
-		signin_policy       = azurerm_api_management_identity_provider_aadb2c.test.signin_policy
+  client_secret       = azurerm_api_management_identity_provider_aadb2c.test.client_secret
+  signin_tenant       = azurerm_api_management_identity_provider_aadb2c.test.signin_tenant
+  authority           = azurerm_api_management_identity_provider_aadb2c.test.authority
+  signup_policy       = azurerm_api_management_identity_provider_aadb2c.test.signup_policy
+  signin_policy       = azurerm_api_management_identity_provider_aadb2c.test.signin_policy
 }
 `, template)
 }

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
@@ -1,0 +1,209 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMApiManagementIdentityProviderAADB2C_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderAADB2CDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderAADB2C_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderAADB2C_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderAADB2CDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderAADB2C_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "00000000000000000000000000000000"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.0", data.Client().TenantID),
+				),
+			},
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderAADB2C_update(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "11111111-1111-1111-1111-111111111111"),
+					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "11111111111111111111111111111111"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.#", "2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.0", data.Client().TenantID),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.1", data.Client().TenantID),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_aadb2c", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderAADB2CDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderAADB2C_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementIdentityProviderAAD_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementIdentityProviderAADB2CDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_identity_provider_aadb2c" {
+			continue
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
+
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+	return nil
+}
+
+func testCheckAzureRMApiManagementIdentityProviderAADB2CExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+		serviceName := rs.Primary.Attributes["api_management_name"]
+
+		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.AadB2C)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.AadB2C, resourceGroup, serviceName)
+			}
+			return fmt.Errorf("Bad: Get on apiManagementIdentityProviderClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApiManagementIdentityProviderAADB2C_basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_aadb2c" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  client_id           = "00000000-0000-0000-0000-000000000000"
+  client_secret       = "00000000000000000000000000000000"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
+}
+
+func testAccAzureRMApiManagementIdentityProviderAADB2C_update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_aadb2c" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  client_id           = "11111111-1111-1111-1111-111111111111"
+  client_secret       = "11111111111111111111111111111111"
+  allowed_tenants     = ["%s", "%s"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID, data.Client().TenantID)
+}
+
+func testAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementIdentityProviderAADB2C_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_identity_provider_aadb2c" "import" {
+  resource_group_name = azurerm_api_management_identity_provider_aadb2c.test.resource_group_name
+  api_management_name = azurerm_api_management_identity_provider_aadb2c.test.api_management_name
+  client_id           = azurerm_api_management_identity_provider_aadb2c.test.client_id
+  client_secret       = azurerm_api_management_identity_provider_aadb2c.test.client_secret
+  allowed_tenants     = azurerm_api_management_identity_provider_aadb2c.test.allowed_tenants
+}
+`, template)
+}

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_aadb2c_resource_test.go
@@ -45,6 +45,8 @@ func TestAccAzureRMApiManagementIdentityProviderAADB2C_update(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "00000000-0000-0000-0000-000000000000"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "00000000000000000000000000000000"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.0", data.Client().TenantID),
 
 					resource.TestCheckResourceAttr(data.ResourceName, "signin_tenant", "11111111-1111-1111-1111-111111111111"),
 					resource.TestCheckResourceAttr(data.ResourceName, "authority", "ExampleAuthority"),
@@ -58,6 +60,8 @@ func TestAccAzureRMApiManagementIdentityProviderAADB2C_update(t *testing.T) {
 					testCheckAzureRMApiManagementIdentityProviderAADB2CExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_id", "22222222-2222-2222-2222-222222222222"),
 					resource.TestCheckResourceAttr(data.ResourceName, "client_secret", "22222222222222222222222222222222"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "allowed_tenants.0", data.Client().TenantID),
 					resource.TestCheckResourceAttr(data.ResourceName, "signin_tenant", "11111111-1111-1111-1111-111111111111"),
 					resource.TestCheckResourceAttr(data.ResourceName, "authority", "ExampleAuthority"),
 					resource.TestCheckResourceAttr(data.ResourceName, "signup_policy", "ExampleSignupPolicy"),
@@ -162,12 +166,13 @@ resource "azurerm_api_management_identity_provider_aadb2c" "test" {
   api_management_name = azurerm_api_management.test.name
   client_id           = "00000000-0000-0000-0000-000000000000"
   client_secret       = "00000000000000000000000000000000"
+  allowed_tenants     = ["%s"]
   signin_tenant       = "%s"
-  authority           = "ExampleAuthority"
+  authority           = "${azurerm_api_management.test.name}.b2clogin.com"
   signup_policy       = "ExampleSignupPolicy"
   signin_policy       = "ExampleSigninPolicy"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID, data.Client().TenantID)
 }
 
 func testAccAzureRMApiManagementIdentityProviderAADB2C_update(data acceptance.TestData) string {
@@ -195,12 +200,13 @@ resource "azurerm_api_management_identity_provider_aadb2c" "test" {
   api_management_name = azurerm_api_management.test.name
   client_id           = "22222222-2222-2222-2222-222222222222"
   client_secret       = "22222222222222222222222222222222"
+  allowed_tenants     = ["%s"]
   signin_tenant       = "%s"
   authority           = "ExampleAuthority"
   signup_policy       = "ExampleSignupPolicy"
   signin_policy       = "ExampleSigninPolicy"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Client().TenantID, data.Client().TenantID)
 }
 
 func testAccAzureRMApiManagementIdentityProviderAADB2C_requiresImport(data acceptance.TestData) string {
@@ -213,6 +219,7 @@ resource "azurerm_api_management_identity_provider_aadb2c" "import" {
   api_management_name = azurerm_api_management_identity_provider_aadb2c.test.api_management_name
   client_id           = azurerm_api_management_identity_provider_aadb2c.test.client_id
   client_secret       = azurerm_api_management_identity_provider_aadb2c.test.client_secret
+  allowed_tenants     = azurerm_api_management_identity_provider_aadb2c.test.allowed_tenants
   signin_tenant       = azurerm_api_management_identity_provider_aadb2c.test.signin_tenant
   authority           = azurerm_api_management_identity_provider_aadb2c.test.authority
   signup_policy       = azurerm_api_management_identity_provider_aadb2c.test.signup_policy

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_facebook_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_facebook_resource_test.go
@@ -7,14 +7,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMApiManagementIdentityProviderFacebook_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_facebook", "test")
-	config := testAccAzureRMApiManagementIdentityProviderFacebook_basic(data)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccAzureRMApiManagementIdentityProviderFacebook_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderFacebookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAzureRMApiManagementIdentityProviderFacebook_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderFacebookExists(data.ResourceName),
 				),
@@ -32,10 +33,8 @@ func TestAccAzureRMApiManagementIdentityProviderFacebook_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMApiManagementIdentityProviderFacebook_update(t *testing.T) {
+func TestAccAzureRMApiManagementIdentityProviderFacebook_basicDeprecated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_facebook", "test")
-	config := testAccAzureRMApiManagementIdentityProviderFacebook_basic(data)
-	updateConfig := testAccAzureRMApiManagementIdentityProviderFacebook_update(data)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -43,7 +42,26 @@ func TestAccAzureRMApiManagementIdentityProviderFacebook_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderFacebookDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAzureRMApiManagementIdentityProviderFacebook_basicDeprecated(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderFacebookExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("app_secret", "api_management_name", "resource_group_name"),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderFacebook_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_facebook", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderFacebookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderFacebook_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderFacebookExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "app_id", "00000000000000000000000000000000"),
@@ -51,7 +69,7 @@ func TestAccAzureRMApiManagementIdentityProviderFacebook_update(t *testing.T) {
 			},
 			data.ImportStep("app_secret"),
 			{
-				Config: updateConfig,
+				Config: testAccAzureRMApiManagementIdentityProviderFacebook_update(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderFacebookExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "app_id", "11111111111111111111111111111111"),
@@ -83,16 +101,21 @@ func TestAccAzureRMApiManagementIdentityProviderFacebook_requiresImport(t *testi
 
 func testCheckAzureRMApiManagementIdentityProviderFacebookDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_identity_provider_facebook" {
 			continue
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Facebook)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Facebook)
+
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return err
@@ -106,20 +129,24 @@ func testCheckAzureRMApiManagementIdentityProviderFacebookDestroy(s *terraform.S
 
 func testCheckAzureRMApiManagementIdentityProviderFacebookExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Facebook)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Facebook)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Facebook, resourceGroup, serviceName)
+				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Facebook, id.ResourceGroup, id.ServiceName)
 			}
 			return fmt.Errorf("Bad: Get on apiManagementIdentityProviderClient: %+v", err)
 		}
@@ -135,12 +162,40 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_facebook" "test" {
+  api_management_id = azurerm_api_management.test.id
+  app_id            = "00000000000000000000000000000000"
+  app_secret        = "00000000000000000000000000000000"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAccAzureRMApiManagementIdentityProviderFacebook_basicDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -154,7 +209,7 @@ resource "azurerm_api_management_identity_provider_facebook" "test" {
   app_id              = "00000000000000000000000000000000"
   app_secret          = "00000000000000000000000000000000"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func testAccAzureRMApiManagementIdentityProviderFacebook_update(data acceptance.TestData) string {
@@ -164,12 +219,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -178,12 +233,11 @@ resource "azurerm_api_management" "test" {
 }
 
 resource "azurerm_api_management_identity_provider_facebook" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  api_management_name = azurerm_api_management.test.name
-  app_id              = "11111111111111111111111111111111"
-  app_secret          = "11111111111111111111111111111111"
+  api_management_id = azurerm_api_management.test.id
+  app_id            = "11111111111111111111111111111111"
+  app_secret        = "11111111111111111111111111111111"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func testAccAzureRMApiManagementIdentityProviderFacebook_requiresImport(data acceptance.TestData) string {
@@ -192,10 +246,9 @@ func testAccAzureRMApiManagementIdentityProviderFacebook_requiresImport(data acc
 %s
 
 resource "azurerm_api_management_identity_provider_facebook" "import" {
-  resource_group_name = azurerm_api_management_identity_provider_facebook.test.resource_group_name
-  api_management_name = azurerm_api_management_identity_provider_facebook.test.api_management_name
-  app_id              = azurerm_api_management_identity_provider_facebook.test.app_id
-  app_secret          = azurerm_api_management_identity_provider_facebook.test.app_secret
+  api_management_id = azurerm_api_management_identity_provider_facebook.test.api_management_id
+  app_id            = azurerm_api_management_identity_provider_facebook.test.app_id
+  app_secret        = azurerm_api_management_identity_provider_facebook.test.app_secret
 }
 `, template)
 }

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_google_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_google_resource_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
@@ -27,6 +29,25 @@ func TestAccAzureRMApiManagementIdentityProviderGoogle_basic(t *testing.T) {
 				),
 			},
 			data.ImportStep("client_secret"),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderGoogle_basicDeprecated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_google", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderGoogleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderGoogle_basicDeprecated(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderGoogleExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("client_secret", "api_management_name", "resource_group_name"),
 		},
 	})
 }
@@ -87,10 +108,14 @@ func testCheckAzureRMApiManagementIdentityProviderGoogleDestroy(s *terraform.Sta
 			continue
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Google)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Google)
+
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return err
@@ -112,13 +137,16 @@ func testCheckAzureRMApiManagementIdentityProviderGoogleExists(resourceName stri
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Google)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Google)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Google, resourceGroup, serviceName)
+				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Google, id.ResourceGroup, id.ServiceName)
 			}
 			return fmt.Errorf("Bad: Get on apiManagementIdentityProviderClient: %+v", err)
 		}
@@ -134,12 +162,40 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_google" "test" {
+  api_management_id = azurerm_api_management.test.id
+  client_id         = "00000000.apps.googleusercontent.com"
+  client_secret     = "00000000000000000000000000000000"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAccAzureRMApiManagementIdentityProviderGoogle_basicDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -153,7 +209,7 @@ resource "azurerm_api_management_identity_provider_google" "test" {
   client_id           = "00000000.apps.googleusercontent.com"
   client_secret       = "00000000000000000000000000000000"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func testAccAzureRMApiManagementIdentityProviderGoogle_update(data acceptance.TestData) string {
@@ -163,12 +219,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -177,12 +233,11 @@ resource "azurerm_api_management" "test" {
 }
 
 resource "azurerm_api_management_identity_provider_google" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  api_management_name = azurerm_api_management.test.name
-  client_id           = "11111111.apps.googleusercontent.com"
-  client_secret       = "11111111111111111111111111111111"
+  api_management_id = azurerm_api_management.test.id
+  client_id         = "11111111.apps.googleusercontent.com"
+  client_secret     = "11111111111111111111111111111111"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func testAccAzureRMApiManagementIdentityProviderGoogle_requiresImport(data acceptance.TestData) string {
@@ -191,10 +246,9 @@ func testAccAzureRMApiManagementIdentityProviderGoogle_requiresImport(data accep
 %s
 
 resource "azurerm_api_management_identity_provider_google" "import" {
-  resource_group_name = azurerm_api_management_identity_provider_google.test.resource_group_name
-  api_management_name = azurerm_api_management_identity_provider_google.test.api_management_name
-  client_id           = azurerm_api_management_identity_provider_google.test.client_id
-  client_secret       = azurerm_api_management_identity_provider_google.test.client_secret
+  api_management_id = azurerm_api_management_identity_provider_google.test.api_management_id
+  client_id         = azurerm_api_management_identity_provider_google.test.client_id
+  client_secret     = azurerm_api_management_identity_provider_google.test.client_secret
 }
 `, template)
 }

--- a/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_twitter_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_identity_provider_twitter_resource_test.go
@@ -7,14 +7,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
 func TestAccAzureRMApiManagementIdentityProviderTwitter_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_twitter", "test")
-	config := testAccAzureRMApiManagementIdentityProviderTwitter_basic(data)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -22,7 +23,7 @@ func TestAccAzureRMApiManagementIdentityProviderTwitter_basic(t *testing.T) {
 		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderTwitterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAzureRMApiManagementIdentityProviderTwitter_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderTwtterExists(data.ResourceName),
 				),
@@ -32,10 +33,8 @@ func TestAccAzureRMApiManagementIdentityProviderTwitter_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMApiManagementIdentityProviderTwitter_update(t *testing.T) {
+func TestAccAzureRMApiManagementIdentityProviderTwitter_basicDeprecated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_twitter", "test")
-	config := testAccAzureRMApiManagementIdentityProviderTwitter_basic(data)
-	updateConfig := testAccAzureRMApiManagementIdentityProviderTwitter_update(data)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
@@ -43,7 +42,26 @@ func TestAccAzureRMApiManagementIdentityProviderTwitter_update(t *testing.T) {
 		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderTwitterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: config,
+				Config: testAccAzureRMApiManagementIdentityProviderTwitter_basicDeprecated(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementIdentityProviderTwtterExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("api_secret_key", "api_management_name", "resource_group_name"),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementIdentityProviderTwitter_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_identity_provider_twitter", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementIdentityProviderTwitterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementIdentityProviderTwitter_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderTwtterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "api_key", "00000000000000000000000000000000"),
@@ -51,7 +69,7 @@ func TestAccAzureRMApiManagementIdentityProviderTwitter_update(t *testing.T) {
 			},
 			data.ImportStep("api_secret_key"),
 			{
-				Config: updateConfig,
+				Config: testAccAzureRMApiManagementIdentityProviderTwitter_update(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMApiManagementIdentityProviderTwtterExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "api_key", "11111111111111111111111111111111"),
@@ -83,16 +101,21 @@ func TestAccAzureRMApiManagementIdentityProviderTwitter_requiresImport(t *testin
 
 func testCheckAzureRMApiManagementIdentityProviderTwitterDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "azurerm_api_management_identity_provider_twitter" {
 			continue
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Twitter)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Twitter)
+
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return err
@@ -106,20 +129,24 @@ func testCheckAzureRMApiManagementIdentityProviderTwitterDestroy(s *terraform.St
 
 func testCheckAzureRMApiManagementIdentityProviderTwtterExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		resourceGroup := rs.Primary.Attributes["resource_group_name"]
-		serviceName := rs.Primary.Attributes["api_management_name"]
+		apiManagementId := rs.Primary.Attributes["api_management_id"]
+		id, err := parse.ApiManagementID(apiManagementId)
+		if err != nil {
+			return fmt.Errorf("Error parsing API Management ID %q: %+v", apiManagementId, err)
+		}
 
-		client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.IdentityProviderClient
-		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
-		resp, err := client.Get(ctx, resourceGroup, serviceName, apimanagement.Twitter)
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ServiceName, apimanagement.Twitter)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Twitter, resourceGroup, serviceName)
+				return fmt.Errorf("Bad: API Management Identity Provider %q (Resource Group %q / API Management Service %q) does not exist", apimanagement.Twitter, id.ResourceGroup, id.ServiceName)
 			}
 			return fmt.Errorf("Bad: Get on apiManagementIdentityProviderClient: %+v", err)
 		}
@@ -135,12 +162,40 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_twitter" "test" {
+  api_management_id = azurerm_api_management.test.id
+  api_key           = "00000000000000000000000000000000"
+  api_secret_key    = "00000000000000000000000000000000"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAccAzureRMApiManagementIdentityProviderTwitter_basicDeprecated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -154,7 +209,7 @@ resource "azurerm_api_management_identity_provider_twitter" "test" {
   api_key             = "00000000000000000000000000000000"
   api_secret_key      = "00000000000000000000000000000000"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func testAccAzureRMApiManagementIdentityProviderTwitter_update(data acceptance.TestData) string {
@@ -164,12 +219,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-api-%d"
-  location = "%s"
+  name     = "acctestRG-api-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_api_management" "test" {
-  name                = "acctestAM-%d"
+  name                = "acctestAM-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   publisher_name      = "pub1"
@@ -178,12 +233,11 @@ resource "azurerm_api_management" "test" {
 }
 
 resource "azurerm_api_management_identity_provider_twitter" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  api_management_name = azurerm_api_management.test.name
-  api_key             = "11111111111111111111111111111111"
-  api_secret_key      = "11111111111111111111111111111111"
+  api_management_id = azurerm_api_management.test.id
+  api_key           = "11111111111111111111111111111111"
+  api_secret_key    = "11111111111111111111111111111111"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func testAccAzureRMApiManagementIdentityProviderTwitter_requiresImport(data acceptance.TestData) string {
@@ -192,10 +246,9 @@ func testAccAzureRMApiManagementIdentityProviderTwitter_requiresImport(data acce
 %s
 
 resource "azurerm_api_management_identity_provider_twitter" "import" {
-  resource_group_name = azurerm_api_management_identity_provider_twitter.test.resource_group_name
-  api_management_name = azurerm_api_management_identity_provider_twitter.test.api_management_name
-  api_key             = azurerm_api_management_identity_provider_twitter.test.api_key
-  api_secret_key      = azurerm_api_management_identity_provider_twitter.test.api_secret_key
+  api_management_id = azurerm_api_management_identity_provider_twitter.test.api_management_id
+  api_key           = azurerm_api_management_identity_provider_twitter.test.api_key
+  api_secret_key    = azurerm_api_management_identity_provider_twitter.test.api_secret_key
 }
 `, template)
 }

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -784,6 +784,10 @@
                 </li>
 
                 <li>
+                <a href="/docs/providers/azurerm/r/api_management_identity_provider_aadb2c.html">azurerm_api_management_identity_provider_aadb2c</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_identity_provider_facebook.html">azurerm_api_management_identity_provider_facebook</a>
                 </li>
 

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -3,12 +3,12 @@ subcategory: "API Management"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_aadb2c"
 description: |-
-  Manages a API Management Resources.
+  Manages an API Management AADB2C Identity Provider.
 ---
 
 # azurerm_api_management_identity_provider_aadb2c
 
-Manages a API Management Resources.
+Manages an API Management AADB2C Identity Provider.
 
 ## Example Usage
 
@@ -27,15 +27,29 @@ resource "azurerm_api_management" "example" {
   sku_name            = "Developer_1"
 }
 
+resource "azuread_application" "example" {
+  name                       = "acctestAM-%[5]d"
+  oauth2_allow_implicit_flow = true
+  reply_urls                 = ["https://${azurerm_api_management.test.name}.developer.azure-api.net/signin"]
+}
+
+resource "azuread_application_password" "example" {
+  application_object_id = azuread_application.test.object_id
+  end_date_relative     = "36h"
+  value                 = "P@55w0rD!%[7]s"
+}
+
 resource "azurerm_api_management_identity_provider_aadb2c" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  api_management_name = azurerm_api_management.example.name
-  client_id           = "00000000-0000-0000-0000-000000000000"
-  client_secret       = "00000000000000000000000000000000"
-  signin_tenant       = "00000000-0000-0000-0000-000000000000"
-  authority           = "ExampleAuthority"
-  signin_policy       = "ExampleSigninPolicy"
-  signup_policy       = "ExampleSignupPolicy"
+  api_management_id = azurerm_api_management.example.id
+  client_id         = azuread_application.example.application_id
+  client_secret     = "P@55w0rD!%[7]s"
+  allowed_tenant    = "myb2ctenant.onmicrosoft.com"
+  signin_tenant     = "myb2ctenant.onmicrosoft.com"
+  authority         = "myb2ctenant.b2clogin.com"
+  signin_policy     = "B2C_1_Login"
+  signup_policy     = "B2C_1_Signup"
+
+  depends_on = [azuread_application_password.example]
 }
 ```
 
@@ -43,19 +57,17 @@ resource "azurerm_api_management_identity_provider_aadb2c" "example" {
 
 The following arguments are supported:
 
-* `api_management_name` - (Required) The Name of the API Management Service where this AADB2C Identity Provider should be created. Changing this forces a new resource to be created.
+* `api_management_id` - (Required) The ID of the API Management Service where this AADB2C Identity Provider should be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+* `client_id` - (Required) Client ID of the Application in your B2C tenant.
 
-* `client_id` - (Required) Client Id of the Application in the AADB2C Identity Provider.
-
-* `client_secret` - (Required) Client secret of the Application in the AADB2C Identity Provider.
+* `client_secret` - (Required) Client secret of the Application in your B2C tenant.
  
-* `signin_tenant` - (Required) The TenantId to use instead of Common when logging into Active Directory.
+* `allowed_tenant` - (Required) The allowed AAD tenant, usually your B2C tenant domain.
 
-* `allowed_tenants` - (Required) List of allowed AAD Tenants.
+* `signin_tenant` - (Required) The tenant to use instead of Common when logging into Active Directory, usually your B2C tenant domain.
 
-* `authority` - (Required) OpenID Connect discovery endpoint hostname.
+* `authority` - (Required) OpenID Connect discovery endpoint hostname, usually your b2clogin.com domain.
 
 * `signin_policy` - (Required) Signup Policy Name.
 
@@ -63,15 +75,15 @@ The following arguments are supported:
 
 ---
 
-* `password_reset_policy` - (Optional) TODO.
+* `password_reset_policy` - (Optional) Password reset Policy Name.
 
-* `profile_editing_policy` - (Optional) TODO.
+* `profile_editing_policy` - (Optional) Profile editing Policy Name.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the API Management Resources.
+* `id` - The ID of the API Management Identity Provider Resource.
 
 ## Timeouts
 
@@ -87,5 +99,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 API Management Resourcess can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_identity_provider_aadb2c.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/aadb2c
+terraform import azurerm_api_management_identity_provider_aadb2c.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service1/identityProviders/AadB2C
 ```

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -32,10 +32,10 @@ resource "azurerm_api_management_identity_provider_aadb2c" "example" {
   api_management_name = azurerm_api_management.example.name
   client_id           = "00000000-0000-0000-0000-000000000000"
   client_secret       = "00000000000000000000000000000000"
-  signin_tenant = "00000000-0000-0000-0000-000000000000"
-  authority = "ExampleAuthority"
-  signin_policy = "ExampleSigninPolicy"
-  signup_policy = "ExampleSignupPolicy"
+  signin_tenant       = "00000000-0000-0000-0000-000000000000"
+  authority           = "ExampleAuthority"
+  signin_policy       = "ExampleSigninPolicy"
+  signup_policy       = "ExampleSignupPolicy"
 }
 ```
 
@@ -50,6 +50,8 @@ The following arguments are supported:
 * `client_id` - (Required) Client Id of the Application in the AADB2C Identity Provider.
 
 * `client_secret` - (Required) Client secret of the Application in the AADB2C Identity Provider.
+
+* `allowed_tenants` - (Required) List of allowed AAD Tenants.
 
 * `authority` - (Required) TODO.
 

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -50,16 +50,16 @@ The following arguments are supported:
 * `client_id` - (Required) Client Id of the Application in the AADB2C Identity Provider.
 
 * `client_secret` - (Required) Client secret of the Application in the AADB2C Identity Provider.
+ 
+* `signin_tenant` - (Required) The TenantId to use instead of Common when logging into Active Directory.
 
 * `allowed_tenants` - (Required) List of allowed AAD Tenants.
 
-* `authority` - (Required) TODO.
+* `authority` - (Required) OpenID Connect discovery endpoint hostname.
 
-* `signin_policy` - (Required) TODO.
+* `signin_policy` - (Required) Signup Policy Name.
 
-* `signin_tenant` - (Required) TODO.
-
-* `signup_policy` - (Required) TODO.
+* `signup_policy` - (Required) Signin Policy Name.
 
 ---
 

--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -1,0 +1,89 @@
+---
+subcategory: "API Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_identity_provider_aadb2c"
+description: |-
+  Manages a API Management Resources.
+---
+
+# azurerm_api_management_identity_provider_aadb2c
+
+Manages a API Management Resources.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_api_management" "example" {
+  name                = "example-apim"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_identity_provider_aadb2c" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  api_management_name = azurerm_api_management.example.name
+  client_id           = "00000000-0000-0000-0000-000000000000"
+  client_secret       = "00000000000000000000000000000000"
+  signin_tenant = "00000000-0000-0000-0000-000000000000"
+  authority = "ExampleAuthority"
+  signin_policy = "ExampleSigninPolicy"
+  signup_policy = "ExampleSignupPolicy"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `api_management_name` - (Required) The Name of the API Management Service where this AADB2C Identity Provider should be created. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+
+* `client_id` - (Required) Client Id of the Application in the AADB2C Identity Provider.
+
+* `client_secret` - (Required) Client secret of the Application in the AADB2C Identity Provider.
+
+* `authority` - (Required) TODO.
+
+* `signin_policy` - (Required) TODO.
+
+* `signin_tenant` - (Required) TODO.
+
+* `signup_policy` - (Required) TODO.
+
+---
+
+* `password_reset_policy` - (Optional) TODO.
+
+* `profile_editing_policy` - (Optional) TODO.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the API Management Resources.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Management Resources.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Management Resources.
+* `update` - (Defaults to 30 minutes) Used when updating the API Management Resources.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Resources.
+
+## Import
+
+API Management Resourcess can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_identity_provider_aadb2c.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/aadb2c
+```

--- a/website/docs/r/api_management_identity_provider_facebook.html.markdown
+++ b/website/docs/r/api_management_identity_provider_facebook.html.markdown
@@ -28,10 +28,9 @@ resource "azurerm_api_management" "example" {
 }
 
 resource "azurerm_api_management_identity_provider_facebook" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  api_management_name = azurerm_api_management.example.name
-  app_id              = "00000000000000000000000000000000"
-  app_secret          = "00000000000000000000000000000000"
+  api_management_id = azurerm_api_management.example.id
+  app_id            = "00000000000000000000000000000000"
+  app_secret        = "00000000000000000000000000000000"
 }
 ```
 
@@ -39,9 +38,11 @@ resource "azurerm_api_management_identity_provider_facebook" "example" {
 
 The following arguments are supported:
 
-* `api_management_name` - (Required) The Name of the API Management Service where this Facebook Identity Provider should be created. Changing this forces a new resource to be created.
+* `api_management_id` - (Required) The ID of the API Management Service where this Facebook Identity Provider should be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+* `api_management_name` - (Optional, Deprecated) The Name of the API Management Service where this Facebook Identity Provider should be created. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Optional, Deprecated) The Name of the Resource Group where the API Management Service exists. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
 
 * `app_id` - (Required) App ID for Facebook.
 
@@ -69,5 +70,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 API Management Facebook Identity Provider can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_identity_provider_facebook.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/facebook
+terraform import azurerm_api_management_identity_provider_facebook.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service1/identityProviders/Facebook
 ```

--- a/website/docs/r/api_management_identity_provider_google.html.markdown
+++ b/website/docs/r/api_management_identity_provider_google.html.markdown
@@ -28,10 +28,9 @@ resource "azurerm_api_management" "example" {
 }
 
 resource "azurerm_api_management_identity_provider_google" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  api_management_name = azurerm_api_management.example.name
-  client_id           = "00000000.apps.googleusercontent.com"
-  client_secret       = "00000000000000000000000000000000"
+  api_management_id = azurerm_api_management.example.id
+  client_id         = "00000000.apps.googleusercontent.com"
+  client_secret     = "00000000000000000000000000000000"
 }
 ```
 
@@ -39,9 +38,11 @@ resource "azurerm_api_management_identity_provider_google" "example" {
 
 The following arguments are supported:
 
-* `api_management_name` - (Required) The Name of the API Management Service where this Google Identity Provider should be created. Changing this forces a new resource to be created.
+* `api_management_id` - (Required) The ID of the API Management Service where this Google Identity Provider should be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+* `api_management_name` - (Optional, Deprecated) The Name of the API Management Service where this Google Identity Provider should be created. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Optional, Deprecated) The Name of the Resource Group where the API Management Service exists. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
 
 * `client_id` - (Required) Client Id for Google Sign-in.
 
@@ -69,5 +70,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 API Management Google Identity Provider can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_identity_provider_google.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/google
+terraform import azurerm_api_management_identity_provider_google.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service1/identityProviders/Google
 ```

--- a/website/docs/r/api_management_identity_provider_microsoft.html.markdown
+++ b/website/docs/r/api_management_identity_provider_microsoft.html.markdown
@@ -28,10 +28,9 @@ resource "azurerm_api_management" "example" {
 }
 
 resource "azurerm_api_management_identity_provider_microsoft" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  api_management_name = azurerm_api_management.example.name
-  client_id           = "00000000-0000-0000-0000-000000000000"
-  client_secret       = "00000000000000000000000000000000"
+  api_management_id = azurerm_api_management.example.id
+  client_id         = "00000000-0000-0000-0000-000000000000"
+  client_secret     = "00000000000000000000000000000000"
 }
 ```
 
@@ -39,9 +38,11 @@ resource "azurerm_api_management_identity_provider_microsoft" "example" {
 
 The following arguments are supported:
 
-* `api_management_name` - (Required) The Name of the API Management Service where this Microsoft Identity Provider should be created. Changing this forces a new resource to be created.
+* `api_management_id` - (Required) The ID of the API Management Service where this Microsoft Identity Provider should be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+* `api_management_name` - (Optional, Deprecated) The Name of the API Management Service where this Microsoft Identity Provider should be created. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Optional, Deprecated) The Name of the Resource Group where the API Management Service exists. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
 
 * `client_id` - (Required) Client Id of the Azure AD Application.
 
@@ -69,5 +70,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 API Management Microsoft Identity Provider can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_identity_provider_microsoft.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/microsoft
+terraform import azurerm_api_management_identity_provider_microsoft.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service1/identityProviders/Microsoft
 ```

--- a/website/docs/r/api_management_identity_provider_twitter.html.markdown
+++ b/website/docs/r/api_management_identity_provider_twitter.html.markdown
@@ -28,10 +28,9 @@ resource "azurerm_api_management" "example" {
 }
 
 resource "azurerm_api_management_identity_provider_twitter" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  api_management_name = azurerm_api_management.example.name
-  api_key             = "00000000000000000000000000000000"
-  api_secret_key      = "00000000000000000000000000000000"
+  api_management_id = azurerm_api_management.example.id
+  api_key           = "00000000000000000000000000000000"
+  api_secret_key    = "00000000000000000000000000000000"
 }
 ```
 
@@ -39,9 +38,11 @@ resource "azurerm_api_management_identity_provider_twitter" "example" {
 
 The following arguments are supported:
 
-* `api_management_name` - (Required) The Name of the API Management Service where this Twitter Identity Provider should be created. Changing this forces a new resource to be created.
+* `api_management_id` - (Required) The ID of the API Management Service where this Twitter Identity Provider should be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The Name of the Resource Group where the API Management Service exists. Changing this forces a new resource to be created.
+* `api_management_name` - (Optional, Deprecated) The Name of the API Management Service where this Twitter Identity Provider should be created. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
+
+* `resource_group_name` - (Optional, Deprecated) The Name of the Resource Group where the API Management Service exists. This property is deprecated and will be removed in version 3.0 of the provider. Use the `api_management_id` property instead. Changing this forces a new resource to be created.
 
 * `api_key` - (Required) App Consumer API key for Twitter.
 
@@ -69,5 +70,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 API Management Twitter Identity Provider can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_identity_provider_twitter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1/identityProviders/twitter
+terraform import azurerm_api_management_identity_provider_twitter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service1/identityProviders/Twitter
 ```


### PR DESCRIPTION
Added a new resource. needs some work on integration tests

---

EDIT: @manicminer 

Additional changes include deprecating `api_management_name` / `resource_group_name` in all API management identity provider resources and replacing with `api_management_id`

NOTE: Because a real B2C tenant (and an app registered in that tenant) are required for the API to work, acceptance tests for this resource require additional environment variables set:

- ARM_TEST_B2C_TENANT_ID
- ARM_TEST_B2C_TENANT_SLUG
- ARM_TEST_B2C_CLIENT_ID
- ARM_TEST_B2C_CLIENT_SECRET

Any B2C tenant can be used, using the basic configuration described at https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-aad-b2c