### PR TITLE
Updates azurerm_storage_blob on content_md5 changes

### DIFF
--- a/azurerm/internal/services/storage/blobs.go
+++ b/azurerm/internal/services/storage/blobs.go
@@ -114,7 +114,7 @@ func (sbu BlobUpload) createEmptyAppendBlob(ctx context.Context) error {
 
 func (sbu BlobUpload) createEmptyBlockBlob(ctx context.Context) error {
 	if sbu.ContentMD5 != "" {
-		return fmt.Errorf("`content_md5` cannot be specified if for empty blobs")
+		return fmt.Errorf("`content_md5` cannot be specified for empty Block blobs")
 	}
 
 	input := blobs.PutBlockBlobInput{
@@ -153,8 +153,10 @@ func (sbu BlobUpload) uploadBlockBlob(ctx context.Context) error {
 
 	input := blobs.PutBlockBlobInput{
 		ContentType: utils.String(sbu.ContentType),
-		ContentMD5:  utils.String(sbu.ContentMD5),
 		MetaData:    sbu.MetaData,
+	}
+	if sbu.ContentMD5 != "" {
+		input.ContentMD5 = utils.String(sbu.ContentMD5)
 	}
 	if err := sbu.Client.PutBlockBlobFromFile(ctx, sbu.AccountName, sbu.ContainerName, sbu.BlobName, file, input); err != nil {
 		return fmt.Errorf("Error PutBlockBlobFromFile: %s", err)
@@ -365,7 +367,7 @@ func (sbu BlobUpload) blobPageUploadWorker(ctx context.Context, uploadCtx blobPa
 func convertHexToBase64Encoding(str string) (string, error) {
 	data, err := hex.DecodeString(str)
 	if err != nil {
-		return "", fmt.Errorf("%s", err)
+		return "", fmt.Errorf("converting %q from Hex to Base64 Encoding: %+v", str, err)
 	}
 
 	return base64.StdEncoding.EncodeToString(data), nil
@@ -374,7 +376,7 @@ func convertHexToBase64Encoding(str string) (string, error) {
 func convertBase64ToHexEncoding(str string) (string, error) {
 	data, err := base64.StdEncoding.DecodeString(str)
 	if err != nil {
-		return "", fmt.Errorf("%s", err)
+		return "", fmt.Errorf("converting %q from Base64 to Hex Encoding: %+v", str, err)
 	}
 
 	return hex.EncodeToString(data), nil

--- a/azurerm/internal/services/storage/blobs.go
+++ b/azurerm/internal/services/storage/blobs.go
@@ -114,7 +114,7 @@ func (sbu BlobUpload) createEmptyAppendBlob(ctx context.Context) error {
 
 func (sbu BlobUpload) createEmptyBlockBlob(ctx context.Context) error {
 	if sbu.ContentMD5 != "" {
-		return fmt.Errorf("`content_md5` cannot be specified if no source is specified")
+		return fmt.Errorf("`content_md5` cannot be specified if for empty blobs")
 	}
 
 	input := blobs.PutBlockBlobInput{
@@ -367,6 +367,7 @@ func convertHexToBase64Encoding(str string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("%s", err)
 	}
+
 	return base64.StdEncoding.EncodeToString(data), nil
 }
 

--- a/azurerm/internal/services/storage/resource_arm_storage_blob.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_blob.go
@@ -118,7 +118,6 @@ func resourceArmStorageBlob() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				Computed:      true,
 				ConflictsWith: []string{"source_uri"},
 			},
 

--- a/azurerm/internal/services/storage/resource_arm_storage_blob.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_blob.go
@@ -251,10 +251,6 @@ func resourceArmStorageBlobUpdate(d *schema.ResourceData, meta interface{}) erro
 		log.Printf("[DEBUG] Updating Properties for Blob %q (Container %q / Account %q)...", id.BlobName, id.ContainerName, id.AccountName)
 
 		contentMD5 := d.Get("content_md5").(string)
-		if d.Get("source").(string) == "" && d.Get("source_content").(string) == "" {
-			contentMD5 = ""
-		}
-
 		if contentMD5 != "" {
 			data, err := convertHexToBase64Encoding(contentMD5)
 			if err != nil {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
@@ -323,46 +323,6 @@ func TestAccAzureRMStorageBlob_blockFromLocalFile(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMStorageBlob_updateBlockFromInlineContent(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_storage_blob", "test")
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMStorageBlob_contentMd5ForInlineContent(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageBlobExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "name", "example.vhd"),
-					resource.TestCheckResourceAttr(data.ResourceName, "source_content", "Wubba Lubba Dub Dub"),
-				),
-			},
-			{
-				ResourceName:            data.ResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"parallelism", "size", "type"},
-			},
-			{
-				Config: testAccAzureRMStorageBlob_contentMd5ForInlineContentUpdated(data),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMStorageBlobExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "name", "example.vhd"),
-					resource.TestCheckResourceAttr(data.ResourceName, "source_content", "Wubba Lubba Dub Dub Updated"),
-				),
-			},
-			{
-				ResourceName:            data.ResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"parallelism", "size", "type"},
-			},
-		},
-	})
-}
-
 func TestAccAzureRMStorageBlob_blockFromLocalFileWithContentMd5(t *testing.T) {
 	sourceBlob, err := ioutil.TempFile("", "")
 	if err != nil {
@@ -387,12 +347,7 @@ func TestAccAzureRMStorageBlob_blockFromLocalFileWithContentMd5(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "source", sourceBlob.Name()),
 				),
 			},
-			{
-				ResourceName:            data.ResourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"parallelism", "size", "source", "type"},
-			},
+			data.ImportStep("parallelism", "size", "source", "type"),
 		},
 	})
 }
@@ -1076,46 +1031,6 @@ resource "azurerm_storage_blob" "test" {
   content_md5            = "${filemd5("%s")}"
 }
 `, template, fileName, fileName)
-}
-
-func testAccAzureRMStorageBlob_contentMd5ForInlineContent(data acceptance.TestData) string {
-	template := testAccAzureRMStorageBlob_template(data, "blob")
-	return fmt.Sprintf(`
-%s
-
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_storage_blob" "test" {
-  name                   = "example.vhd"
-  storage_account_name   = azurerm_storage_account.test.name
-  storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "Wubba Lubba Dub Dub"
-  content_md5            = "${md5("Wubba Lubba Dub Dub")}"
-}
-`, template)
-}
-
-func testAccAzureRMStorageBlob_contentMd5ForInlineContentUpdated(data acceptance.TestData) string {
-	template := testAccAzureRMStorageBlob_template(data, "blob")
-	return fmt.Sprintf(`
-%s
-
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_storage_blob" "test" {
-  name                   = "example.vhd"
-  storage_account_name   = azurerm_storage_account.test.name
-  storage_container_name = azurerm_storage_container.test.name
-  type                   = "Block"
-  source_content         = "Wubba Lubba Dub Dub Updated"
-  content_md5            = "${md5("Wubba Lubba Dub Dub Updated")}"
-}
-`, template)
 }
 
 func testAccAzureRMStorageBlob_contentType(data acceptance.TestData) string {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
@@ -335,6 +335,7 @@ func TestAccAzureRMStorageBlob_updateBlockFromInlineContent(t *testing.T) {
 				Config: testAccAzureRMStorageBlob_contentMd5ForInlineContent(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "name", "example.vhd"),
 					resource.TestCheckResourceAttr(data.ResourceName, "source_content", "Wubba Lubba Dub Dub"),
 				),
 			},
@@ -348,6 +349,7 @@ func TestAccAzureRMStorageBlob_updateBlockFromInlineContent(t *testing.T) {
 				Config: testAccAzureRMStorageBlob_contentMd5ForInlineContentUpdated(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "name", "example.vhd"),
 					resource.TestCheckResourceAttr(data.ResourceName, "source_content", "Wubba Lubba Dub Dub Updated"),
 				),
 			},
@@ -390,6 +392,7 @@ func TestAccAzureRMStorageBlob_BlockFromLocalFileWithContentMd5(t *testing.T) {
 				Config: testAccAzureRMStorageBlob_contentMd5ForLocalFile(data, tmpfile.Name()),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageBlobExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "name", "example.vhd"),
 					resource.TestCheckResourceAttr(data.ResourceName, "source", tmpfile.Name()),
 				),
 			},
@@ -1079,7 +1082,7 @@ resource "azurerm_storage_blob" "test" {
   storage_container_name = azurerm_storage_container.test.name
   type                   = "Block"
   source                 = "%s"
-  content_md5			 = "${filemd5("%s")}"
+  content_md5            = "${filemd5("%s")}"
 }
 `, template, fileName, fileName)
 }
@@ -1094,12 +1097,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_storage_blob" "test" {
-  name                   = "rick.morty"
+  name                   = "example.vhd"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
   type                   = "Block"
   source_content         = "Wubba Lubba Dub Dub"
-  content_md5 			 = "${md5("Wubba Lubba Dub Dub")}"
+  content_md5            = "${md5("Wubba Lubba Dub Dub")}"
 }
 `, template)
 }
@@ -1114,12 +1117,12 @@ provider "azurerm" {
 }
 
 resource "azurerm_storage_blob" "test" {
-  name                   = "rick.morty"
+  name                   = "example.vhd"
   storage_account_name   = azurerm_storage_account.test.name
   storage_container_name = azurerm_storage_container.test.name
   type                   = "Block"
   source_content         = "Wubba Lubba Dub Dub Updated"
-  content_md5 			 = "${md5("Wubba Lubba Dub Dub Updated")}"
+  content_md5            = "${md5("Wubba Lubba Dub Dub Updated")}"
 }
 `, template)
 }

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
@@ -1309,6 +1309,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  allow_blob_public_access = true
 }
 
 resource "azurerm_storage_container" "test" {
@@ -1333,6 +1334,7 @@ resource "azurerm_storage_account" "test" {
   account_kind             = "StorageV2"
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  allow_blob_public_access = true
 }
 
 resource "azurerm_storage_container" "test" {
@@ -1356,6 +1358,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Premium"
   account_replication_type = "LRS"
+  allow_blob_public_access = true
 }
 
 resource "azurerm_storage_container" "test" {

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_blob_test.go
@@ -363,7 +363,7 @@ func TestAccAzureRMStorageBlob_updateBlockFromInlineContent(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMStorageBlob_BlockFromLocalFileWithContentMd5(t *testing.T) {
+func TestAccAzureRMStorageBlob_blockFromLocalFileWithContentMd5(t *testing.T) {
 	sourceBlob, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Fatalf("Failed to create local source blob file")
@@ -1059,7 +1059,7 @@ resource "azurerm_storage_blob" "test" {
 }
 
 func testAccAzureRMStorageBlob_contentMd5ForLocalFile(data acceptance.TestData, fileName string) string {
-	template := testAccAzureRMStorageBlob_template(data, "private")
+	template := testAccAzureRMStorageBlob_template(data, "blob")
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
 
-* `content_md5` - (Optional) The MD% sum of the blob contents. Cannot be defined if `source_uri` is defined, or if blob type is Append or Page. Changing this forces a new resource to be created.   
+* `content_md5` - (Optional) The MD5 sum of the blob contents. Cannot be defined if `source_uri` is defined, or if blob type is Append or Page. Changing this forces a new resource to be created.   
 
 ~> **NOTE:** This property is intended to be used with the Terraform internal [filemd5](https://www.terraform.io/docs/configuration/functions/filemd5.html) and [md5](https://www.terraform.io/docs/configuration/functions/md5.html) functions when `source` or `source_content`, respectively, are defined. 
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -62,7 +62,9 @@ The following arguments are supported:
 
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
 
-* `content_md5` - (Optional) Used to trigger blob updates. This field cannot be specified if `source_uri` is specified or if blob type is Append or Page. The only meaningful value is ${filemd5("path/to/file")} if source is defined or "${md5("Sample blob content")}" if source_content is defined. Changing this forces a new resource to be created.
+* `content_md5` - (Optional) The MD% sum of the blob contents. Cannot be defined if `source_uri` is defined, or if blob type is Append or Page. Changing this forces a new resource to be created.   
+
+~> **NOTE:** This property is intended to be used with the Terraform internal [filemd5](https://www.terraform.io/docs/configuration/functions/filemd5.html) and [md5](https://www.terraform.io/docs/configuration/functions/md5.html) functions when `source` or `source_content`, respectively, are defined. 
 
 * `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified.
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
 
-* `content_md5` - (Optional) Used to trigger blob updates. The only meaningful value is ${filemd5("path/to/file")} if source is defined or "${md5("Sample blob content")}" if source_content is defined. This field cannot be specified if `source_uri` is specified. Changing this forces a new resource to be created.
+* `content_md5` - (Optional) Used to trigger blob updates. This field cannot be specified if `source_uri` is specified or if blob type is Append or Page. The only meaningful value is ${filemd5("path/to/file")} if source is defined or "${md5("Sample blob content")}" if source_content is defined. Changing this forces a new resource to be created.
 
 * `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified.
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -54,13 +54,15 @@ The following arguments are supported:
 
 * `type` - (Required) The type of the storage blob to be created. Possible values are `Append`, `Block` or `Page`. Changing this forces a new resource to be created.
 
-* `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0. 
+* `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0.
 
 ~> **Note:** `size` is required if `source_uri` is not set.
 
 * `access_tier` - (Optional) The access tier of the storage blob. Possible values are `Archive`, `Cool` and `Hot`.
 
 * `content_type` - (Optional) The content type of the storage blob. Cannot be defined if `source_uri` is defined. Defaults to `application/octet-stream`.
+
+* `content_md5` - (Optional) Used to trigger blob updates. The only meaningful value is ${filemd5("path/to/file")} if source is defined or "${md5("Sample blob content")}" if source_content is defined. This field cannot be specified if `source_uri` is specified. Changing this forces a new resource to be created.
 
 * `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified.
 


### PR DESCRIPTION
Implementing feature mentioned in the feature request: #1990

Problem statement: Currently in order to update the blob, user has to change the blob name to trigger the update.

This PR adds new field content_md5 to have azurerm_storage_blob update on content_md5 changes. It forces a new deployment if the value for content_md5 is changed. This is only supported for blob type Block.

(fixes #1990)