### PR TITLE
New resource `azurerm_mssql_database_extended_auditing_policy`

### DIFF
--- a/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
@@ -19,7 +19,7 @@ func ExtendedAuditingSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"storage_account_access_key": {
 					Type:         schema.TypeString,
-					Optional:     true,
+					Required:     true,
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},

--- a/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
@@ -12,7 +12,7 @@ func ExtendedAuditingSchema() *schema.Schema {
 		Type:       schema.TypeList,
 		Optional:   true,
 		Computed:   true,
-		Deprecated: "all `extended_auditing_policy` properties have been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.",
+		Deprecated: "the `extended_auditing_policy` block has been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.",
 		ConfigMode: schema.SchemaConfigModeAttr,
 		MaxItems:   1,
 		Elem: &schema.Resource{

--- a/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/mssql/helper/sql_extended_auditing.go
@@ -9,14 +9,17 @@ import (
 
 func ExtendedAuditingSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Type:       schema.TypeList,
+		Optional:   true,
+		Computed:   true,
+		Deprecated: "all `extended_auditing_policy` properties have been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.",
+		ConfigMode: schema.SchemaConfigModeAttr,
+		MaxItems:   1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"storage_account_access_key": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -22,6 +22,7 @@ func resourceArmMsSqlDatabaseExtendedAuditingPolicy() *schema.Resource {
 		Read:   resourceArmMsSqlDatabaseExtendedAuditingPolicyRead,
 		Update: resourceArmMsSqlDatabaseExtendedAuditingPolicyCreateUpdate,
 		Delete: resourceArmMsSqlDatabaseExtendedAuditingPolicyDelete,
+
 		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
 			_, err := parse.MssqlDatabaseExtendedAuditingPolicyID(id)
 			return err

--- a/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
+++ b/azurerm/internal/services/mssql/mssql_database_extended_auditing_policy_resource.go
@@ -1,0 +1,174 @@
+package mssql
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mssql/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mssql/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmMsSqlDatabaseExtendedAuditingPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmMsSqlDatabaseExtendedAuditingPolicyCreateUpdate,
+		Read:   resourceArmMsSqlDatabaseExtendedAuditingPolicyRead,
+		Update: resourceArmMsSqlDatabaseExtendedAuditingPolicyCreateUpdate,
+		Delete: resourceArmMsSqlDatabaseExtendedAuditingPolicyDelete,
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.MssqlDatabaseExtendedAuditingPolicyID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"database_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.MsSqlDatabaseID,
+			},
+
+			"storage_endpoint": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsURLWithHTTPS,
+			},
+
+			"storage_account_access_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"storage_account_access_key_is_secondary": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"retention_in_days": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				ValidateFunc: validation.IntBetween(0, 3285),
+			},
+		},
+	}
+}
+
+func resourceArmMsSqlDatabaseExtendedAuditingPolicyCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.DatabaseExtendedBlobAuditingPoliciesClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for MsSql Database Extended Auditing Policy creation.")
+
+	dbId, err := parse.MsSqlDatabaseID(d.Get("database_id").(string))
+	if err != nil {
+		return err
+	}
+
+	params := sql.ExtendedDatabaseBlobAuditingPolicy{
+		ExtendedDatabaseBlobAuditingPolicyProperties: &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
+			State:                      sql.BlobAuditingPolicyStateEnabled,
+			StorageEndpoint:            utils.String(d.Get("storage_endpoint").(string)),
+			IsStorageSecondaryKeyInUse: utils.Bool(d.Get("storage_account_access_key_is_secondary").(bool)),
+			RetentionDays:              utils.Int32(int32(d.Get("retention_in_days").(int))),
+		},
+	}
+
+	if v, ok := d.GetOk("storage_account_access_key"); ok {
+		params.ExtendedDatabaseBlobAuditingPolicyProperties.StorageAccountAccessKey = utils.String(v.(string))
+	}
+
+	if _, err = client.CreateOrUpdate(ctx, dbId.ResourceGroup, dbId.MsSqlServer, dbId.Name, params); err != nil {
+		return fmt.Errorf("creating MsSql Database %q Extended Auditing Policy (Sql Server %q / Resource Group %q): %+v", dbId.Name, dbId.MsSqlServer, dbId.ResourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, dbId.ResourceGroup, dbId.MsSqlServer, dbId.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving MsSql Database %q Extended Auditing Policy (MsSql Server Name %q / Resource Group %q): %+v", dbId.Name, dbId.MsSqlServer, dbId.ResourceGroup, err)
+	}
+
+	if read.ID == nil || *read.ID == "" {
+		return fmt.Errorf("reading MsSql Database %q Extended Auditing Policy (MsSql Server Name %q / Resource Group %q) ID is empty or nil", dbId.Name, dbId.MsSqlServer, dbId.ResourceGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmMsSqlDatabaseExtendedAuditingPolicyRead(d, meta)
+}
+
+func resourceArmMsSqlDatabaseExtendedAuditingPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.DatabaseExtendedBlobAuditingPoliciesClient
+	dbClient := meta.(*clients.Client).MSSQL.DatabasesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.MssqlDatabaseExtendedAuditingPolicyID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.MsSqlServer, id.MsDBName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("reading MsSql Database %s Extended Auditing Policy (MsSql Server Name %q / Resource Group %q): %s", id.MsDBName, id.MsSqlServer, id.ResourceGroup, err)
+	}
+
+	dbResp, err := dbClient.Get(ctx, id.ResourceGroup, id.MsSqlServer, id.MsDBName)
+	if err != nil || *dbResp.ID == "" {
+		return fmt.Errorf("reading MsSql Database %q ID is empty or nil(Resource Group %q): %s", id.MsSqlServer, id.ResourceGroup, err)
+	}
+
+	d.Set("database_id", dbResp.ID)
+
+	if props := resp.ExtendedDatabaseBlobAuditingPolicyProperties; props != nil {
+		d.Set("storage_endpoint", props.StorageEndpoint)
+		d.Set("storage_account_access_key_is_secondary", props.IsStorageSecondaryKeyInUse)
+		d.Set("retention_in_days", props.RetentionDays)
+	}
+
+	return nil
+}
+
+func resourceArmMsSqlDatabaseExtendedAuditingPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).MSSQL.DatabaseExtendedBlobAuditingPoliciesClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.MssqlDatabaseExtendedAuditingPolicyID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	params := sql.ExtendedDatabaseBlobAuditingPolicy{
+		ExtendedDatabaseBlobAuditingPolicyProperties: &sql.ExtendedDatabaseBlobAuditingPolicyProperties{
+			State: sql.BlobAuditingPolicyStateDisabled,
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MsSqlServer, id.MsDBName, params); err != nil {
+		return fmt.Errorf("deleting MsSql Database %q Extended Auditing Policy( MsSql Server %q / Resource Group %q): %+v", id.MsDBName, id.MsSqlServer, id.ResourceGroup, err)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/mssql/parse/mssql.go
+++ b/azurerm/internal/services/mssql/parse/mssql.go
@@ -23,6 +23,12 @@ type MsSqlElasticPoolId struct {
 	ResourceGroup string
 }
 
+type MsSqlDatabaseExtendedAuditingPolicyId struct {
+	MsDBName      string
+	MsSqlServer   string
+	ResourceGroup string
+}
+
 func MsSqlDatabaseID(input string) (*MsSqlDatabaseId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
@@ -118,4 +124,33 @@ func MssqlVmID(input string) (*MssqlVmId, error) {
 	}
 
 	return &sqlvm, nil
+}
+
+func MssqlDatabaseExtendedAuditingPolicyID(input string) (*MsSqlDatabaseExtendedAuditingPolicyId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] Unable to parse Microsoft Sql Database Extended Auditing Policy %q: %+v", input, err)
+	}
+
+	sqlDatabaseExtendedAuditingPolicyId := MsSqlDatabaseExtendedAuditingPolicyId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if sqlDatabaseExtendedAuditingPolicyId.MsSqlServer, err = id.PopSegment("servers"); err != nil {
+		return nil, err
+	}
+
+	if sqlDatabaseExtendedAuditingPolicyId.MsDBName, err = id.PopSegment("databases"); err != nil {
+		return nil, err
+	}
+
+	if _, err = id.PopSegment("extendedAuditingSettings"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &sqlDatabaseExtendedAuditingPolicyId, nil
 }

--- a/azurerm/internal/services/mssql/parse/mssql_test.go
+++ b/azurerm/internal/services/mssql/parse/mssql_test.go
@@ -222,3 +222,96 @@ func TestMsSqlVmID(t *testing.T) {
 		}
 	}
 }
+
+func TestMssqlDatabaseExtendedAuditingPolicy(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *MsSqlDatabaseExtendedAuditingPolicyId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sql Server Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sql Database",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Sql Database Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/databases",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Extended Auditing Policy",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/databases/db1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Extended Auditing Policy Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/databases/db1/extendedAuditingSettings",
+			Expected: nil,
+		},
+		{
+			Name:  "Extended Auditing Policy",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/databases/db1/extendedAuditingSettings/default",
+			Expected: &MsSqlDatabaseExtendedAuditingPolicyId{
+				ResourceGroup: "resGroup1",
+				MsSqlServer:   "sqlServer1",
+				MsDBName:      "db1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Sql/servers/sqlServer1/databases/db1/ExtendedAuditingSettings/default",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := MssqlDatabaseExtendedAuditingPolicyID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.MsDBName != v.Expected.MsDBName {
+			t.Fatalf("Expected %q but got %q for DB Name", v.Expected.MsDBName, actual.MsDBName)
+		}
+
+		if actual.MsSqlServer != v.Expected.MsSqlServer {
+			t.Fatalf("Expected %q but got %q for Server Name", v.Expected.MsSqlServer, actual.MsSqlServer)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/mssql/registration.go
+++ b/azurerm/internal/services/mssql/registration.go
@@ -29,7 +29,8 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_mssql_database": resourceArmMsSqlDatabase(),
+		"azurerm_mssql_database":                                        resourceArmMsSqlDatabase(),
+		"azurerm_mssql_database_extended_auditing_policy":               resourceArmMsSqlDatabaseExtendedAuditingPolicy(),
 		"azurerm_mssql_database_vulnerability_assessment_rule_baseline": resourceArmMssqlDatabaseVulnerabilityAssessmentRuleBaseline(),
 		"azurerm_mssql_elasticpool":                                     resourceArmMsSqlElasticPool(),
 		"azurerm_mssql_server":                                          resourceArmMsSqlServer(),

--- a/azurerm/internal/services/mssql/tests/mssql_database_extended_auditing_policy_resource_test.go
+++ b/azurerm/internal/services/mssql/tests/mssql_database_extended_auditing_policy_resource_test.go
@@ -1,0 +1,325 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/sql/mgmt/v3.0/sql"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/mssql/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+			{
+				Config: testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+			{
+				Config: testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_update(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_database_extended_auditing_policy", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_storageAccountBehindFireWall(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyExists(data.ResourceName),
+				),
+			},
+			data.ImportStep("storage_account_access_key"),
+		},
+	})
+}
+
+func testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).MSSQL.DatabaseExtendedBlobAuditingPoliciesClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id, err := parse.MssqlDatabaseExtendedAuditingPolicyID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Get(ctx, id.ResourceGroup, id.MsSqlServer, id.MsDBName)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("MsSql Database ExtendedAuditingPolicy %q (resource group: %q) does not exist", id.MsDBName, id.ResourceGroup)
+			}
+
+			return fmt.Errorf("Get on MsSql Database ExtendedAuditingPolicy Client: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMMsSqlDatabaseExtendedAuditingPolicyDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).MSSQL.DatabaseExtendedBlobAuditingPoliciesClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_mssql_database_extended_auditing_policy" {
+			continue
+		}
+
+		id, err := parse.MssqlDatabaseExtendedAuditingPolicyID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if resp, err := client.Get(ctx, id.ResourceGroup, id.MsSqlServer, id.MsDBName); err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Get on MsSql Database ExtendedAuditingPolicy Client: %+v", err)
+			}
+
+			if resp.ExtendedDatabaseBlobAuditingPolicyProperties != nil && resp.ExtendedDatabaseBlobAuditingPolicyProperties.State == sql.BlobAuditingPolicyStateEnabled {
+				return fmt.Errorf("`azurerm_mssql_database_extended_auditing_policy` is still enabled")
+			}
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest-sqlserver-%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+}
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[1]d"
+  server_id = azurerm_mssql_server.test.id
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id                = azurerm_mssql_database.test.id
+  storage_endpoint           = azurerm_storage_account.test.primary_blob_endpoint
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+}
+`, template)
+}
+
+func testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id                             = azurerm_mssql_database.test.id
+  storage_endpoint                        = azurerm_storage_account.test.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.test.primary_access_key
+  storage_account_access_key_is_secondary = false
+  retention_in_days                       = 6
+}
+`, template)
+}
+
+func testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_update(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test2" {
+  name                     = "unlikely23exst2acc2%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id                             = azurerm_mssql_database.test.id
+  storage_endpoint                        = azurerm_storage_account.test2.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.test2.primary_access_key
+  storage_account_access_key_is_secondary = true
+  retention_in_days                       = 3
+}
+`, template, data.RandomString)
+}
+
+func testAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_storageAccountBehindFireWall(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-mssql-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest-sqlserver-%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_mssql_database" "test" {
+  name      = "acctest-db-%[1]d"
+  server_id = azurerm_mssql_server.test.id
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefix       = "10.0.2.0/24"
+  service_endpoints    = ["Microsoft.Storage"]
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  network_rules {
+    default_action             = "Deny"
+    ip_rules                   = ["127.0.0.1"]
+    virtual_network_subnet_ids = [azurerm_subnet.test.id]
+  }
+}
+
+data "azuread_service_principal" "test" {
+  display_name = azurerm_mssql_server.test.name
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_storage_account.test.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = data.azuread_service_principal.test.object_id
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "test" {
+  database_id      = azurerm_mssql_database.test.id
+  storage_endpoint = azurerm_storage_account.test.primary_blob_endpoint
+
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/azurerm/internal/services/mssql/tests/mssql_database_resource_test.go
+++ b/azurerm/internal/services/mssql/tests/mssql_database_resource_test.go
@@ -371,7 +371,7 @@ func TestAccAzureRMMsSqlDatabase_withBlobAuditingPolices(t *testing.T) {
 			},
 			data.ImportStep("extended_auditing_policy.0.storage_account_access_key"),
 			{
-				Config: testAccAzureRMMsSqlDatabase_basic(data),
+				Config: testAccAzureRMMsSqlDatabase_withBlobAuditingPolicesDisabled(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMMsSqlDatabaseExists(data.ResourceName),
 				),
@@ -884,6 +884,35 @@ resource "azurerm_mssql_database" "test" {
     storage_account_access_key_is_secondary = false
     retention_in_days                       = 3
   }
+}
+`, template, data.RandomIntOfLength(15), data.RandomInteger)
+}
+
+func testAccAzureRMMsSqlDatabase_withBlobAuditingPolicesDisabled(data acceptance.TestData) string {
+	template := testAccAzureRMMsSqlDatabase_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctest%[2]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_account" "test2" {
+  name                     = "acctest2%[2]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_mssql_database" "test" {
+  name                     = "acctest-db-%[3]d"
+  server_id                = azurerm_sql_server.test.id
+  extended_auditing_policy = []
 }
 `, template, data.RandomIntOfLength(15), data.RandomInteger)
 }

--- a/azurerm/internal/services/sql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/sql/helper/sql_extended_auditing.go
@@ -19,7 +19,7 @@ func ExtendedAuditingSchema() *schema.Schema {
 			Schema: map[string]*schema.Schema{
 				"storage_account_access_key": {
 					Type:         schema.TypeString,
-					Optional:     true,
+					Required:     true,
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},

--- a/azurerm/internal/services/sql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/sql/helper/sql_extended_auditing.go
@@ -12,7 +12,7 @@ func ExtendedAuditingSchema() *schema.Schema {
 		Type:       schema.TypeList,
 		Optional:   true,
 		Computed:   true,
-		Deprecated: "all `extended_auditing_policy` properties have been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.",
+		Deprecated: "the `extended_auditing_policy` block has been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.",
 		ConfigMode: schema.SchemaConfigModeAttr,
 		MaxItems:   1,
 		Elem: &schema.Resource{

--- a/azurerm/internal/services/sql/helper/sql_extended_auditing.go
+++ b/azurerm/internal/services/sql/helper/sql_extended_auditing.go
@@ -9,14 +9,17 @@ import (
 
 func ExtendedAuditingSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Type:       schema.TypeList,
+		Optional:   true,
+		Computed:   true,
+		Deprecated: "all `extended_auditing_policy` properties have been moved to `azurerm_mssql_server_extended_auditing_policy` and `azurerm_mssql_database_extended_auditing_policy`. This block will be removed in version 3.0 of the provider.",
+		ConfigMode: schema.SchemaConfigModeAttr,
+		MaxItems:   1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"storage_account_access_key": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
 					Sensitive:    true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},

--- a/azurerm/internal/services/sql/tests/resource_arm_sql_database_test.go
+++ b/azurerm/internal/services/sql/tests/resource_arm_sql_database_test.go
@@ -425,7 +425,6 @@ func TestAccAzureRMSqlDatabase_withBlobAuditingPolices(t *testing.T) {
 				Config: testAccAzureRMSqlDatabase_basic(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlDatabaseExists(data.ResourceName),
-					resource.TestCheckNoResourceAttr(data.ResourceName, "extended_auditing_policy.#"),
 				),
 			},
 			data.ImportStep("administrator_login_password", "create_mode"),
@@ -433,17 +432,13 @@ func TestAccAzureRMSqlDatabase_withBlobAuditingPolices(t *testing.T) {
 				Config: testAccAzureRMSqlDatabase_withBlobAuditingPolices(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlDatabaseExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "extended_auditing_policy.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "extended_auditing_policy.0.storage_account_access_key_is_secondary", "true"),
-					resource.TestCheckResourceAttr(data.ResourceName, "extended_auditing_policy.0.retention_in_days", "6"),
 				),
 			},
 			data.ImportStep("administrator_login_password", "extended_auditing_policy.0.storage_account_access_key", "create_mode"),
 			{
-				Config: testAccAzureRMSqlDatabase_basic(data),
+				Config: testAccAzureRMSqlDatabase_withBlobAuditingPolicesDisabled(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSqlDatabaseExists(data.ResourceName),
-					resource.TestCheckNoResourceAttr(data.ResourceName, "extended_auditing_policy.#"),
 				),
 			},
 			data.ImportStep("administrator_login_password", "create_mode"),
@@ -1108,6 +1103,57 @@ resource "azurerm_sql_database" "test" {
     storage_account_access_key_is_secondary = false
     retention_in_days                       = 11
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(15))
+}
+
+func testAccAzureRMSqlDatabase_withBlobAuditingPolicesDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctest%[3]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_account" "test2" {
+  name                     = "acctest2%[3]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_sql_server" "test" {
+  name                         = "acctestsqlserver%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "mradministrator"
+  administrator_login_password = "thisIsDog11"
+}
+
+resource "azurerm_sql_database" "test" {
+  name                             = "acctestdb%[1]d"
+  resource_group_name              = azurerm_resource_group.test.name
+  server_name                      = azurerm_sql_server.test.name
+  location                         = azurerm_resource_group.test.location
+  edition                          = "Standard"
+  collation                        = "SQL_Latin1_General_CP1_CI_AS"
+  max_size_bytes                   = "1073741824"
+  requested_service_objective_name = "S0"
+
+  extended_auditing_policy = []
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(15))
 }

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -1352,6 +1352,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/mssql_database_extended_auditing_policy.html">azurerm_mssql_database_extended_auditing_policy</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/sql_active_directory_administrator.html">azurerm_sql_active_directory_administrator</a>
                 </li>
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -10,8 +10,7 @@ description: |-
 
 Manages a MS SQL Database.
 
-~> **NOTE on Ms Sql Database and Ms Sql Database Extended Auditing Policy:** Terraform currently provides both a standalone [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html), and allows for extended auditing policy to be defined in-line within the [mssql_database resource](mssql_database.html) and [sql_database resource](sql_database.html).
-At this time you cannot use a Sql Database with in-line Extended Auditing Policy in conjunction with any Sql Database Extended Auditing Policy resources. Doing so will cause a conflict of policy settings and will overwrite the policy.
+~> **NOTE:** The Database Extended Auditing Policy Can be set inline here as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
 ## Example Usage
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Manages a MS SQL Database.
 
+~> **NOTE on Ms Sql Database and Ms Sql Database Extended Auditing Policy:** Terraform currently provides both a standalone [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html), and allows for extended auditing policy to be defined in-line within the [mssql_database resource](mssql_database.html) and [sql_database resource](sql_database.html).
+At this time you cannot use a Sql Database with in-line Extended Auditing Policy in conjunction with any Sql Database Extended Auditing Policy resources. Doing so will cause a conflict of policy settings and will overwrite the policy.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -10,8 +10,7 @@ description: |-
 
 Manages a Ms Sql Database Extended Auditing Policy.
 
-~> **NOTE on Ms Sql Database and Ms Sql Database Extended Auditing Policy:** Terraform currently provides both a standalone [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html), and allows for extended auditing policy to be defined in-line within the [mssql_database resource](mssql_database.html) and [sql_database resource](sql_database.html).
-At this time you cannot use a Sql Database with in-line Extended Auditing Policy in conjunction with any Sql Database Extended Auditing Policy resources. Doing so will cause a conflict of policy settings and will overwrite the policy.
+~> **NOTE:** The Database Extended Auditing Policy Can be set inline here as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
 ## Example Usage
 

--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "Database"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_mssql_database_extended_auditing_policy"
+description: |-
+  Manages a Ms Sql Database Extended Auditing Policy.
+---
+
+# azurerm_mssql_database_extended_auditing_policy
+
+Manages a Ms Sql Database Extended Auditing Policy.
+
+~> **NOTE on Ms Sql Database and Ms Sql Database Extended Auditing Policy:** Terraform currently provides both a standalone [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html), and allows for extended auditing policy to be defined in-line within the [mssql_database resource](mssql_database.html) and [sql_database resource](sql_database.html).
+At this time you cannot use a Sql Database with in-line Extended Auditing Policy in conjunction with any Sql Database Extended Auditing Policy resources. Doing so will cause a conflict of policy settings and will overwrite the policy.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_mssql_server" "example" {
+  name                         = "example-sqlserver"
+  resource_group_name          = azurerm_resource_group.example.name
+  location                     = azurerm_resource_group.example.location
+  version                      = "12.0"
+  administrator_login          = "missadministrator"
+  administrator_login_password = "AdminPassword123!"
+}
+
+resource "azurerm_mssql_database" "example" {
+  name      = "example-db"
+  server_id = azurerm_mssql_server.example.id
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplesa"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_mssql_database_extended_auditing_policy" "example" {
+  database_id                             = azurerm_mssql_database.example.id
+  storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
+  storage_account_access_key              = azurerm_storage_account.example.primary_access_key
+  storage_account_access_key_is_secondary = false
+  retention_in_days                       = 6
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `database_id` - (Required) The ID of the sql database to set the extended auditing policy. Changing this forces a new resource to be created.
+
+* `storage_endpoint` - (Required) The blob storage endpoint (e.g. https://MyAccount.blob.core.windows.net). This blob storage will hold all extended auditing logs.
+
+---
+
+* `retention_in_days` - (Optional) The number of days to retain logs for in the storage account.
+
+* `storage_account_access_key` - (Optional) The access key to use for the auditing storage account.
+
+* `storage_account_access_key_is_secondary` - (Optional) Is `storage_account_access_key` value the storage's secondary key?
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Ms Sql Database Extended Auditing Policy.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Ms Sql Database Extended Auditing Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Ms Sql Database Extended Auditing Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the Ms Sql Database Extended Auditing Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Ms Sql Database Extended Auditing Policy.
+
+## Import
+
+Ms Sql Database Extended Auditing Policys can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_mssql_database_extended_auditing_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Sql/servers/sqlServer1/databases/db1/extendedAuditingSettings/default
+```

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -10,8 +10,7 @@ description: |-
 
 Allows you to manage an Azure SQL Database
 
-~> **NOTE on Ms Sql Database and Ms Sql Database Extended Auditing Policy:** Terraform currently provides both a standalone [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html), and allows for extended auditing policy to be defined in-line within the [mssql_database resource](mssql_database.html) and [sql_database resource](sql_database.html).
-At this time you cannot use a Sql Database with in-line Extended Auditing Policy in conjunction with any Sql Database Extended Auditing Policy resources. Doing so will cause a conflict of policy settings and will overwrite the policy.
+~> **NOTE:** The Database Extended Auditing Policy Can be set inline here as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
 
 ## Example Usage
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Allows you to manage an Azure SQL Database
 
+~> **NOTE on Ms Sql Database and Ms Sql Database Extended Auditing Policy:** Terraform currently provides both a standalone [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html), and allows for extended auditing policy to be defined in-line within the [mssql_database resource](mssql_database.html) and [sql_database resource](sql_database.html).
+At this time you cannot use a Sql Database with in-line Extended Auditing Policy in conjunction with any Sql Database Extended Auditing Policy resources. Doing so will cause a conflict of policy settings and will overwrite the policy.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Partial fix: https://github.com/terraform-providers/terraform-provider-azurerm/issues/7486
https://github.com/terraform-providers/terraform-provider-azurerm/issues/6906

`azurerm_mssql_server_extended_auditing_policy` will be created after this PR is merged

=== RUN   TestAccAzureRMMsSqlDatabase_withBlobAuditingPolices
=== PAUSE TestAccAzureRMMsSqlDatabase_withBlobAuditingPolices
=== CONT  TestAccAzureRMMsSqlDatabase_withBlobAuditingPolices
--- PASS: TestAccAzureRMMsSqlDatabase_withBlobAuditingPolices (456.35s)

=== RUN   TestAccAzureRMSqlDatabase_withBlobAuditingPolices
=== PAUSE TestAccAzureRMSqlDatabase_withBlobAuditingPolices
=== CONT  TestAccAzureRMSqlDatabase_withBlobAuditingPolices
--- PASS: TestAccAzureRMSqlDatabase_withBlobAuditingPolices (416.91s)

=== RUN   TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic
=== PAUSE TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic
=== CONT  TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic
--- PASS: TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_basic (299.94s)
=== RUN   TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete
=== PAUSE TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete
=== CONT  TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete
--- PASS: TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_complete (283.80s)
=== RUN   TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_update
=== PAUSE TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_update
=== CONT  TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_update
--- PASS: TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_update (427.41s)
=== RUN   TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall
=== PAUSE TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall
=== CONT  TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall
--- PASS: TestAccAzureRMMsSqlDatabaseExtendedAuditingPolicy_storageAccBehindFireWall (291.75s)