### PR TITLE
add cache for key vault for larger terraform configurations

### DIFF
--- a/azurerm/internal/services/compute/disk_encryption_set_resource.go
+++ b/azurerm/internal/services/compute/disk_encryption_set_resource.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
@@ -264,36 +263,26 @@ type diskEncryptionSetKeyVault struct {
 	softDeleteEnabled      bool
 }
 
-func diskEncryptionSetRetrieveKeyVault(ctx context.Context, client *keyvault.VaultsClient, id string) (*diskEncryptionSetKeyVault, error) {
+func diskEncryptionSetRetrieveKeyVault(ctx context.Context, meta interface{}, id string) (*diskEncryptionSetKeyVault, error) {
+	vaultClient := meta.(*clients.Client).KeyVault
+
 	keyVaultKeyId, err := azure.ParseKeyVaultChildID(id)
 	if err != nil {
 		return nil, err
 	}
-	keyVaultID, err := azure.GetKeyVaultIDFromBaseUrl(ctx, client, keyVaultKeyId.KeyVaultBaseUrl)
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", keyVaultKeyId.KeyVaultBaseUrl, err)
-	}
-	if keyVaultID == nil {
-		return nil, fmt.Errorf("Unable to determine the Resource ID for the Key Vault at URL %q", keyVaultKeyId.KeyVaultBaseUrl)
-	}
 
-	// TODO: use keyvault's custom ID parse function when implemented
-	parsedKeyVaultID, err := azure.ParseAzureResourceID(*keyVaultID)
+	vault, err := vaultClient.FindKeyVault(ctx, keyVaultKeyId.KeyVaultBaseUrl)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing ID for keyvault in Disk Encryption Set: %+v", err)
+		return nil, fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", keyVaultKeyId.KeyVaultBaseUrl, err)
 	}
-	resourceGroup := parsedKeyVaultID.ResourceGroup
-	vaultName := parsedKeyVaultID.Path["vaults"]
-
-	resp, err := client.Get(ctx, resourceGroup, vaultName)
-	if err != nil {
-		return nil, fmt.Errorf("Error retrieving KeyVault %q (Resource Group %q): %+v", vaultName, resourceGroup, err)
+	if vault == nil {
+		return nil, fmt.Errorf("retrieving key vault %q", keyVaultKeyId.KeyVaultBaseUrl)
 	}
 
 	purgeProtectionEnabled := false
 	softDeleteEnabled := false
 
-	if props := resp.Properties; props != nil {
+	if props := vault.Properties; props != nil {
 		if props.EnableSoftDelete != nil {
 			softDeleteEnabled = *props.EnableSoftDelete
 		}
@@ -304,9 +293,9 @@ func diskEncryptionSetRetrieveKeyVault(ctx context.Context, client *keyvault.Vau
 	}
 
 	return &diskEncryptionSetKeyVault{
-		keyVaultId:             *keyVaultID,
-		resourceGroupName:      resourceGroup,
-		keyVaultName:           vaultName,
+		keyVaultId:             vault.ID,
+		resourceGroupName:      vault.ResourceGroup,
+		keyVaultName:           vault.Name,
 		purgeProtectionEnabled: purgeProtectionEnabled,
 		softDeleteEnabled:      softDeleteEnabled,
 	}, nil

--- a/azurerm/internal/services/datafactory/data_factory_linked_service_key_vault_resource.go
+++ b/azurerm/internal/services/datafactory/data_factory_linked_service_key_vault_resource.go
@@ -183,7 +183,7 @@ func resourceArmDataFactoryLinkedServiceKeyVaultCreateUpdate(d *schema.ResourceD
 
 func resourceArmDataFactoryLinkedServiceKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).DataFactory.LinkedServiceClient
-	vaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	vaultClient := meta.(*clients.Client).KeyVault
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -245,12 +245,15 @@ func resourceArmDataFactoryLinkedServiceKeyVaultRead(d *schema.ResourceData, met
 		}
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultClient, baseUrl)
+	vault, err := vaultClient.FindKeyVault(ctx, baseUrl)
 	if err != nil {
-		return fmt.Errorf("Error looking up Key Vault id from url %q: %+v", baseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", baseUrl, err)
+	}
+	if vault == nil {
+		return fmt.Errorf("retrieving key vault %q", baseUrl)
 	}
 
-	d.Set("key_vault_id", keyVaultId)
+	d.Set("key_vault_id", vault.ID)
 
 	return nil
 }

--- a/azurerm/internal/services/keyvault/client/helper.go
+++ b/azurerm/internal/services/keyvault/client/helper.go
@@ -85,25 +85,25 @@ func (client Client) FindKeyVault(ctx context.Context, keyVaultUrl string) (*key
 	return nil, nil
 }
 
-func populateKeyVaultDetails(props keyvault.Vault) (*keyVaultDetails, error) {
-	if props.ID == nil || *props.ID == "" {
-		return nil, fmt.Errorf("`id` was nil or empty for Account %q", props.Name)
+func populateKeyVaultDetails(vault keyvault.Vault) (*keyVaultDetails, error) {
+	if vault.ID == nil || *vault.ID == "" {
+		return nil, fmt.Errorf("`id` was nil or empty for Account %+v", vault)
 	}
 
-	id, err := parse.KeyVaultID(*props.ID)
+	id, err := parse.KeyVaultID(*vault.ID)
 	if err != nil {
-		return nil, fmt.Errorf("parsing %q as key vault ID: %+v", *props.ID, err)
+		return nil, fmt.Errorf("parsing %q as key vault ID: %+v", *vault.ID, err)
 	}
 
-	if props.Properties == nil || props.Properties.VaultURI == nil {
+	if vault.Properties == nil || vault.Properties.VaultURI == nil {
 		return nil, fmt.Errorf("KeyVault %q (Resource Group %q) has nil ID, properties or vault URI", id.Name, id.ResourceGroup)
 	}
 
 	return &keyVaultDetails{
-		ID:            *props.ID,
+		ID:            *vault.ID,
 		Name:          id.Name,
 		ResourceGroup: id.ResourceGroup,
-		Properties:    props.Properties,
-		Tags:          props.Tags,
+		Properties:    vault.Properties,
+		Tags:          vault.Tags,
 	}, nil
 }

--- a/azurerm/internal/services/keyvault/client/helper.go
+++ b/azurerm/internal/services/keyvault/client/helper.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )

--- a/azurerm/internal/services/keyvault/client/helper.go
+++ b/azurerm/internal/services/keyvault/client/helper.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+var (
+	keyVaultsCache = map[string]*keyVaultDetails{}
+	KeyVaultLock   = sync.RWMutex{}
+)
+
+type keyVaultDetails struct {
+	ID            string
+	ResourceGroup string
+	Name          string
+	Properties    *keyvault.VaultProperties
+	Tags          map[string]*string
+}
+
+func (client Client) RemoveKeyVaultFromCache(keyVaultUrl string) {
+	KeyVaultLock.Lock()
+	delete(keyVaultsCache, keyVaultUrl)
+	KeyVaultLock.Unlock()
+}
+
+func (client Client) FindKeyVault(ctx context.Context, keyVaultUrl string) (*keyVaultDetails, error) {
+	KeyVaultLock.Lock()
+	defer KeyVaultLock.Unlock()
+
+	if existing, ok := keyVaultsCache[keyVaultUrl]; ok {
+		return existing, nil
+	}
+
+	list, err := client.VaultsClient.ListComplete(ctx, utils.Int32(1000))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Key Vaults %v", err)
+	}
+
+	for list.NotDone() {
+		v := list.Value()
+
+		if v.ID == nil || *v.ID == "" {
+			return nil, fmt.Errorf("v.ID was nil")
+		}
+
+		id, err := parse.KeyVaultID(*v.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ID for Key Vault URI %q: %s", *v.ID, err)
+		}
+
+		// resp does not appear to contain the vault properties, so lets fetch them
+		vault, err := client.VaultsClient.Get(ctx, id.ResourceGroup, id.Name)
+		if err != nil {
+			if utils.ResponseWasNotFound(vault.Response) {
+				if e := list.NextWithContext(ctx); e != nil {
+					return nil, fmt.Errorf("failed to get next vault on KeyVault url %q : %+v", keyVaultUrl, err)
+				}
+				continue
+			}
+			return nil, fmt.Errorf("failed to make Read request on KeyVault %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
+		}
+
+		vaultDetails, err := populateKeyVaultDetails(vault)
+		if err != nil {
+			return nil, err
+		}
+
+		keyVaultsCache[*vault.Properties.VaultURI] = vaultDetails
+
+		if e := list.NextWithContext(ctx); e != nil {
+			return nil, fmt.Errorf("failed to get next vault on KeyVault url %q : %+v", keyVaultUrl, err)
+		}
+	}
+
+	if existing, ok := keyVaultsCache[keyVaultUrl]; ok {
+		return existing, nil
+	}
+
+	return nil, nil
+}
+
+func populateKeyVaultDetails(props keyvault.Vault) (*keyVaultDetails, error) {
+	if props.ID == nil || *props.ID == "" {
+		return nil, fmt.Errorf("`id` was nil or empty for Account %q", props.Name)
+	}
+
+	id, err := parse.KeyVaultID(*props.ID)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as key vault ID: %+v", *props.ID, err)
+	}
+
+	if props.Properties == nil || props.Properties.VaultURI == nil {
+		return nil, fmt.Errorf("KeyVault %q (Resource Group %q) has nil ID, properties or vault URI", id.Name, id.ResourceGroup)
+	}
+
+	return &keyVaultDetails{
+		ID:            *props.ID,
+		Name:          id.Name,
+		ResourceGroup: id.ResourceGroup,
+		Properties:    props.Properties,
+		Tags:          props.Tags,
+	}, nil
+}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_issuer_resource.go
@@ -175,7 +175,7 @@ func resourceArmKeyVaultCertificateIssuerCreateOrUpdate(d *schema.ResourceData, 
 }
 
 func resourceArmKeyVaultCertificateIssuerRead(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -185,22 +185,12 @@ func resourceArmKeyVaultCertificateIssuerRead(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
+	if vault == nil {
 		log.Printf("[DEBUG] Unable to determine the Resource ID for the Key Vault at URL %q - removing from state!", id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}
@@ -238,7 +228,7 @@ func resourceArmKeyVaultCertificateIssuerRead(d *schema.ResourceData, meta inter
 
 func resourceArmKeyVaultCertificateIssuerDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).KeyVault.ManagementClient
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -247,19 +237,12 @@ func resourceArmKeyVaultCertificateIssuerDelete(d *schema.ResourceData, meta int
 		return err
 	}
 
-	// we verify it exists
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Issuer %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-
-	if !ok {
-		log.Printf("[DEBUG] Issuer %q (Key Vault %q) was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Issuer %q (Key Vault %q) was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource.go
@@ -25,7 +25,7 @@ import (
 
 // todo refactor and find a home for this wayward func
 func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	client := meta.(*clients.Client).KeyVault.VaultsClient
+	client := meta.(*clients.Client).KeyVault
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -34,12 +34,15 @@ func resourceArmKeyVaultChildResourceImporter(d *schema.ResourceData, meta inter
 		return []*schema.ResourceData{d}, fmt.Errorf("Error Unable to parse ID (%s) for Key Vault Child import: %v", d.Id(), err)
 	}
 
-	kvid, err := azure.GetKeyVaultIDFromBaseUrl(ctx, client, id.KeyVaultBaseUrl)
+	vault, err := client.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
 		return []*schema.ResourceData{d}, fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
+	if vault == nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+	}
 
-	d.Set("key_vault_id", kvid)
+	d.Set("key_vault_id", vault.ID)
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -495,7 +498,7 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 }
 
 func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -505,22 +508,12 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
-		log.Printf("[DEBUG] Unable to determine the Resource ID for the Key Vault at URL %q - removing from state!", id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}
@@ -572,7 +565,7 @@ func resourceArmKeyVaultCertificateRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmKeyVaultCertificateDelete(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -582,20 +575,12 @@ func resourceArmKeyVaultCertificateDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
-		return fmt.Errorf("Unable to determine the Resource ID for the Key Vault at URL %q", id.KeyVaultBaseUrl)
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Certificate %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Certificate %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}

--- a/azurerm/internal/services/keyvault/key_vault_key_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_key_resource.go
@@ -259,7 +259,7 @@ func resourceArmKeyVaultKeyCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	vaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	vaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -269,20 +269,12 @@ func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultClient, id.KeyVaultBaseUrl)
+	vault, err := vaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
-		return fmt.Errorf("Unable to determine the Resource ID for the Key Vault at URL %q", id.KeyVaultBaseUrl)
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, vaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}
@@ -318,7 +310,7 @@ func resourceArmKeyVaultKeyUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -328,22 +320,12 @@ func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
+	if vault == nil {
 		log.Printf("[DEBUG] Unable to determine the Resource ID for the Key Vault at URL %q - removing from state!", id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}
@@ -401,7 +383,7 @@ func resourceArmKeyVaultKeyRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceArmKeyVaultKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -411,20 +393,12 @@ func resourceArmKeyVaultKeyDelete(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
-		return fmt.Errorf("Unable to determine the Resource ID for the Key Vault at URL %q", id.KeyVaultBaseUrl)
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Key %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Key %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -685,6 +685,7 @@ func resourceArmKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceArmKeyVaultDelete(d *schema.ResourceData, meta interface{}) error {
+	vaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.VaultsClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -788,6 +789,10 @@ func resourceArmKeyVaultDelete(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error purging Key Vault %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 		log.Printf("[DEBUG] Purged KeyVault %q.", name)
+
+		if read.Properties != nil && read.Properties.VaultURI != nil {
+			vaultClient.RemoveKeyVaultFromCache(*read.Properties.VaultURI)
+		}
 	}
 
 	return nil

--- a/azurerm/internal/services/keyvault/key_vault_secret_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource.go
@@ -182,7 +182,7 @@ func resourceArmKeyVaultSecretCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -193,20 +193,12 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
-		return fmt.Errorf("Unable to determine the Resource ID for the Key Vault at URL %q", id.KeyVaultBaseUrl)
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}
@@ -270,7 +262,7 @@ func resourceArmKeyVaultSecretUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -280,22 +272,12 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
-		log.Printf("[DEBUG] Unable to determine the Resource ID for the Key Vault at URL %q - removing from state!", id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}
@@ -336,7 +318,7 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceArmKeyVaultSecretDelete(d *schema.ResourceData, meta interface{}) error {
-	keyVaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	keyVaultClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -346,20 +328,12 @@ func resourceArmKeyVaultSecretDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	keyVaultId, err := azure.GetKeyVaultIDFromBaseUrl(ctx, keyVaultClient, id.KeyVaultBaseUrl)
+	vault, err := keyVaultClient.FindKeyVault(ctx, id.KeyVaultBaseUrl)
 	if err != nil {
-		return fmt.Errorf("Error retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
+		return fmt.Errorf("retrieving the Resource ID for the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)
 	}
-	if keyVaultId == nil {
-		return fmt.Errorf("Unable to determine the Resource ID for the Key Vault at URL %q", id.KeyVaultBaseUrl)
-	}
-
-	ok, err := azure.KeyVaultExists(ctx, keyVaultClient, *keyVaultId)
-	if err != nil {
-		return fmt.Errorf("Error checking if key vault %q for Secret %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+	if vault == nil {
+		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, vault.ID, id.KeyVaultBaseUrl)
 		d.SetId("")
 		return nil
 	}

--- a/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
@@ -168,7 +168,7 @@ func resourceArmStorageAccountCustomerManagedKeyCreateUpdate(d *schema.ResourceD
 
 func resourceArmStorageAccountCustomerManagedKeyRead(d *schema.ResourceData, meta interface{}) error {
 	storageClient := meta.(*clients.Client).Storage.AccountsClient
-	vaultsClient := meta.(*clients.Client).KeyVault.VaultsClient
+	vaultsClient := meta.(*clients.Client).KeyVault
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -217,15 +217,18 @@ func resourceArmStorageAccountCustomerManagedKeyRead(d *schema.ResourceData, met
 		return fmt.Errorf("Error retrieving Storage Account %q (Resource Group %q): `properties.encryption.keyVaultProperties.keyVaultURI` was nil", storageAccountID.Name, storageAccountID.ResourceGroup)
 	}
 
-	keyVaultID, err := azure.GetKeyVaultIDFromBaseUrl(ctx, vaultsClient, keyVaultURI)
+	vault, err := vaultsClient.FindKeyVault(ctx, keyVaultURI)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Key Vault ID from the Base URI %q: %+v", keyVaultURI, err)
+		return fmt.Errorf("retrieving the Key Vault ID from the Key Vault at URL %q: %s", keyVaultURI, err)
+	}
+	if vault == nil {
+		return fmt.Errorf("retrieving key vault %q", keyVaultURI)
 	}
 
 	// now we have the key vault uri we can look up the ID
 
 	d.Set("storage_account_id", d.Id())
-	d.Set("key_vault_id", keyVaultID)
+	d.Set("key_vault_id", vault.ID)
 	d.Set("key_name", keyName)
 	d.Set("key_version", keyVersion)
 


### PR DESCRIPTION
fix #6196 

every key vault child resources will list all key vaults and then get one by one. When they are many child resources, it tends to appear `context deadline exceed`.

so add cache for key vault.

Hi Hashicorp reviewer: 

something may be improved further: because key vault name are global unique, we could get name directly from key vault base url. in this way, we could only by listing all key vaults and compare by name. No need to get one by one.
If you think this is better, I will do it