### PR TITLE
Copyediting: remove spurious aprostrophes in possessive "its"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ ENHANCEMENTS:
 * `azurerm_policy_assignment` - support for `metadata` property ([#7725](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7725))
 * `azurerm_policy_set_definition` - support for the `policy_definition_reference_id` property ([#7018](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7018))
 * `azurerm_storage_account` - support for configuring `allow_blob_public_access` ([#7739](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7739))
-* `azurerm_storage_container` - container creation will retry if a container of the same name has not completed it's delete operation ([#7179](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7179))
-* `azurerm_storage_share` - share creation will retry if a share of the same name has not completed it's previous delete operation ([#7179](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7179))
+* `azurerm_storage_container` - container creation will retry if a container of the same name has not completed its delete operation ([#7179](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7179))
+* `azurerm_storage_share` - share creation will retry if a share of the same name has not completed its previous delete operation ([#7179](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7179))
 * `azurerm_virtual_network_gateway_connection` - support for the `traffic_selector_policy` block ([#6586](https://github.com/terraform-providers/terraform-provider-azurerm/issues/6586))
 * `azurerm_orchestrated_virtual_machine_scale_set` - support for the `proximity_placement_group_id` property ([#7510](https://github.com/terraform-providers/terraform-provider-azurerm/issues/7510))
 

--- a/azurerm/helpers/azure/elasticpool.go
+++ b/azurerm/helpers/azure/elasticpool.go
@@ -24,7 +24,7 @@ type sku struct {
 }
 
 // getDTUMaxGB: this map holds all of the DTU to 'max_size_gb' mappings based on a DTU lookup
-//              note that the value can be below the returned value, except for 'basic' it's
+//              note that the value can be below the returned value; except for 'basic' its
 //              value must match exactly what is returned else it will be rejected by the API
 //              which will return a 'Internal Server Error'
 

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -352,7 +352,7 @@ func resourceArmKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	d.Partial(true)
 
-	// first pull the existing key vault since we need to lock on several bits of it's information
+	// first pull the existing key vault since we need to lock on several bits of its information
 	existing, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Key Vault %q (Resource Group %q): %+v", name, resourceGroup, err)

--- a/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/azurerm/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -247,7 +247,7 @@ func resourceArmKustoClusterCustomerManagedKeyDelete(d *schema.ResourceData, met
 	// Since this isn't a real object, just modifying an existing object
 	// "Delete" doesn't really make sense it should really be a "Revert to Default"
 	// So instead of the Delete func actually deleting the Kusto Cluster I am
-	// making it reset the Kusto Cluster to it's default state
+	// making it reset the Kusto cluster to its default state
 	props := kusto.ClusterUpdate{
 		ClusterProperties: &kusto.ClusterProperties{
 			KeyVaultProperties: &kusto.KeyVaultProperties{},

--- a/azurerm/internal/services/logic/logic_apps.go
+++ b/azurerm/internal/services/logic/logic_apps.go
@@ -15,7 +15,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-// NOTE: this file is not a recommended way of developing Terraform resources; this exists to work around the fact that this API is dynamic (by it's nature)
+// NOTE: this file is not a recommended way of developing Terraform resources; this exists to work around the fact that this API is dynamic (by its nature)
 func flattenLogicAppActionRunAfter(input map[string]interface{}) []interface{} {
 	if len(input) == 0 {
 		return nil

--- a/azurerm/internal/services/network/private_endpoint_resource.go
+++ b/azurerm/internal/services/network/private_endpoint_resource.go
@@ -604,7 +604,7 @@ func flattenArmPrivateDnsZoneConfigs(input *[]network.PrivateDNSZoneConfig, zone
 
 		if name := v.Name; name != nil {
 			result["name"] = *name
-			// I have to consturct this because the SDK does not expose it in it's PrivateDNSZoneConfig struct
+			// I have to consturct this because the SDK does not expose it in its PrivateDNSZoneConfig struct
 			result["id"] = fmt.Sprintf("%s/privateDnsZoneConfigs/%s", zoneGroupId, *name)
 		}
 

--- a/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_queue_test.go
+++ b/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_queue_test.go
@@ -95,7 +95,7 @@ func TestAccAzureRMServiceBusQueue_enablePartitioningStandard(t *testing.T) {
 				Config: testAccAzureRMServiceBusQueue_enablePartitioningStandard(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "enable_partitioning", "true"),
-					// Ensure size is read back in it's original value and not the x16 value returned by Azure
+					// Ensure size is read back in its original value and not the x16 value returned by Azure
 					resource.TestCheckResourceAttr(data.ResourceName, "max_size_in_megabytes", "5120"),
 				),
 			},

--- a/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_topic_test.go
+++ b/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_topic_test.go
@@ -144,7 +144,7 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 				Config: testAccAzureRMServiceBusTopic_enablePartitioningStandard(data),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "enable_partitioning", "true"),
-					// Ensure size is read back in it's original value and not the x16 value returned by Azure
+					// Ensure size is read back in its original value and not the x16 value returned by Azure
 					resource.TestCheckResourceAttr(data.ResourceName, "max_size_in_megabytes", "5120"),
 				),
 			},

--- a/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account_customer_managed_key.go
@@ -257,7 +257,7 @@ func resourceArmStorageAccountCustomerManagedKeyDelete(d *schema.ResourceData, m
 	// Since this isn't a real object, just modifying an existing object
 	// "Delete" doesn't really make sense it should really be a "Revert to Default"
 	// So instead of the Delete func actually deleting the Storage Account I am
-	// making it reset the Storage Account to it's default state
+	// making it reset the Storage Account to its default state
 	props := storage.AccountUpdateParameters{
 		AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
 			Encryption: &storage.Encryption{

--- a/examples/virtual-machines/virtual_machine/bastion-box/README.md
+++ b/examples/virtual-machines/virtual_machine/bastion-box/README.md
@@ -1,3 +1,3 @@
 ## Example: A Bastion Box
 
-This example provisions a Bastion Box, which is located in it's own Subnet with a Public IP Address - which has SSH access to the other internal subnets (in this case a placeholder `web` subnet).
+This example provisions a Bastion Box, which is located in its own Subnet with a Public IP Address - which has SSH access to the other internal subnets (in this case a placeholder `web` subnet).

--- a/examples/virtual-machines/virtual_machine/spark-and-cassandra-on-centos/variables.tf
+++ b/examples/virtual-machines/virtual_machine/spark-and-cassandra-on-centos/variables.tf
@@ -47,7 +47,7 @@ variable "vm_primary_vm_size" {
 }
 
 variable "vm_number_of_secondarys" {
-  description = "Number of VMs to create to support the secondarys.  Each secondary is created on it's own VM.  Minimum of 2 & Maximum of 200 VMs. min = 2, max = 200"
+  description = "Number of VMs to create to support the secondarys.  Each secondary is created on its own VM.  Minimum of 2 & Maximum of 200 VMs. min = 2, max = 200"
   default     = 2
 }
 

--- a/website/docs/guides/2.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/2.0-upgrade-guide.html.markdown
@@ -652,7 +652,7 @@ The `azurerm_virtual_machine` resource will be deprecated in favour of two new r
 
 Splitting the Virtual Machine resource in two allows us to both provide finer-grain validation for this resource and update the schema.
 
-The existing `azurerm_virtual_machine` Resource will continue to be available in it's current form, however it will eventually be deprecated and we recommend using the new resources going forward.
+The existing `azurerm_virtual_machine` Resource will continue to be available in its current form, however it will eventually be deprecated and we recommend using the new resources going forward.
 
 ### Resource: `azurerm_virtual_machine_extension`
 
@@ -664,7 +664,7 @@ The `azurerm_virtual_machine_scale_set` resource will be deprecated in favour of
 
 Splitting the Virtual Machine Scale Set resource in two allows us to both provide finer-grain validation for this resource and update the schema.
 
-The existing `azurerm_virtual_machine_scale_set` Resource will continue to be available in it's current form, however it will eventually be deprecated and we recommend using the new resources going forward.
+The existing `azurerm_virtual_machine_scale_set` Resource will continue to be available in its current form, however it will eventually be deprecated and we recommend using the new resources going forward.
 
 ### Resource: `azurerm_virtual_network_peering`
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -181,7 +181,7 @@ The `virtual_machine` block supports the following:
 
 * `delete_os_disk_on_deletion` - (Optional) Should the `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` resources delete the OS Disk attached to the Virtual Machine when the Virtual Machine is destroyed? Defaults to `true`.
 
-~> **Note:** This does not affect the older `azurerm_virtual_machine` resource, which has it's own flags for managing this within the resource.
+~> **Note:** This does not affect the older `azurerm_virtual_machine` resource, which has its own flags for managing this within the resource.
 
 ---
 

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The display name of the API.
 
-* `path` - (Required) The Path for this API Management API, which is a relative URL which uniquely identifies this API and all of it's resource paths within the API Management Service.
+* `path` - (Required) The Path for this API Management API, which is a relative URL which uniquely identifies this API and all of its resource paths within the API Management Service.
 
 * `protocols` - (Required) A list of protocols the operations in this API can be invoked. Possible values are `http` and `https`.
 

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created.
 
-~> **NOTE:** Once you increase your bandwidth, you will not be able to decrease it to it's previous value.
+~> **NOTE:** Once you increase your bandwidth, you will not be able to decrease it to its previous value.
 
 * `sku` - (Required) A `sku` block for the ExpressRoute circuit as documented below.
 

--- a/website/docs/r/log_analytics_solution.html.markdown
+++ b/website/docs/r/log_analytics_solution.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `solution_name` - (Required) Specifies the name of the solution to be deployed. See [here for options](https://docs.microsoft.com/en-us/azure/log-analytics/log-analytics-add-solutions).Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which the Log Analytics solution is created. Changing this forces a new resource to be created. Note: The solution and it's related workspace can only exist in the same resource group.
+* `resource_group_name` - (Required) The name of the resource group in which the Log Analytics solution is created. Changing this forces a new resource to be created. Note: The solution and its related workspace can only exist in the same resource group.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This PR changes all uses of "it's" that should be "its".
