### PR TITLE
add `soft_delete_retention_days` support for `azurerm_key_vault`

### DIFF
--- a/azurerm/helpers/azure/key_vault.go
+++ b/azurerm/helpers/azure/key_vault.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 

--- a/azurerm/helpers/azure/key_vault_access_policy.go
+++ b/azurerm/helpers/azure/key_vault_access_policy.go
@@ -1,7 +1,7 @@
 package azure
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	uuid "github.com/satori/go.uuid"

--- a/azurerm/internal/services/compute/disk_encryption_set_resource.go
+++ b/azurerm/internal/services/compute/disk_encryption_set_resource.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/keyvault/client/client.go
+++ b/azurerm/internal/services/keyvault/client/client.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	keyvaultmgmt "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/common"
 )
 

--- a/azurerm/internal/services/keyvault/key_vault_access_policy_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_access_policy_data_source.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )

--- a/azurerm/internal/services/keyvault/key_vault_access_policy_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_access_policy_resource.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	uuid "github.com/satori/go.uuid"

--- a/azurerm/internal/services/keyvault/key_vault_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_data_source.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/set"

--- a/azurerm/internal/services/keyvault/key_vault_migration_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_migration_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -10,7 +10,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network"
 
-	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -176,6 +176,13 @@ func resourceArmKeyVault() *schema.Resource {
 				Optional: true,
 			},
 
+			"soft_delete_retention_days": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				//Computed:     true,
+				ValidateFunc: validation.IntBetween(7, 90),
+			},
+
 			"tags": tags.Schema(),
 
 			// Computed
@@ -269,8 +276,15 @@ func resourceArmKeyVaultCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// This settings can only be set if it is true, if set when value is false API returns errors
-	if softDeleteEnabled := d.Get("soft_delete_enabled").(bool); softDeleteEnabled {
-		parameters.Properties.EnableSoftDelete = utils.Bool(softDeleteEnabled)
+	softDeleteEnabled := d.Get("soft_delete_enabled").(bool)
+	if softDeleteEnabled {
+		parameters.Properties.EnableSoftDelete = utils.Bool(true)
+
+		if softDeleteRetentionInDays := d.Get("soft_delete_retention_days").(int); softDeleteRetentionInDays != 0 {
+			parameters.Properties.SoftDeleteRetentionInDays = utils.Int32(int32(softDeleteRetentionInDays))
+		}
+	} else {
+		parameters.Properties.EnableSoftDelete = utils.Bool(false)
 	}
 	if purgeProtectionEnabled := d.Get("purge_protection_enabled").(bool); purgeProtectionEnabled {
 		parameters.Properties.EnablePurgeProtection = utils.Bool(purgeProtectionEnabled)
@@ -483,6 +497,26 @@ func resourceArmKeyVaultUpdate(d *schema.ResourceData, meta interface{}) error {
 		update.Properties.EnableSoftDelete = utils.Bool(newValue)
 	}
 
+	if d.HasChange("soft_delete_retention_days") {
+		if update.Properties == nil {
+			update.Properties = &keyvault.VaultPatchProperties{}
+		}
+
+		// existing.Properties guaranteed non-nil above
+		var oldValue int32 = 0
+		if existing.Properties.SoftDeleteRetentionInDays != nil {
+			oldValue = *existing.Properties.SoftDeleteRetentionInDays
+		}
+
+		// whilst this should have got caught in the customizeDiff this won't work if that fields interpolated
+		// hence the double-checking here
+		if oldValue != 0 {
+			return fmt.Errorf("updating Key Vault %q (Resource Group %q): once Soft Delete has been Enabled it's not possible to change `soft_delete_retention_days`", name, resourceGroup)
+		}
+
+		update.Properties.SoftDeleteRetentionInDays = utils.Int32(int32(d.Get("soft_delete_retention_days").(int)))
+	}
+
 	if d.HasChange("tenant_id") {
 		if update.Properties == nil {
 			update.Properties = &keyvault.VaultPatchProperties{}
@@ -540,6 +574,7 @@ func resourceArmKeyVaultRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("enabled_for_disk_encryption", props.EnabledForDiskEncryption)
 		d.Set("enabled_for_template_deployment", props.EnabledForTemplateDeployment)
 		d.Set("soft_delete_enabled", props.EnableSoftDelete)
+		d.Set("soft_delete_retention_days", props.SoftDeleteRetentionInDays)
 		d.Set("purge_protection_enabled", props.EnablePurgeProtection)
 		d.Set("vault_uri", props.VaultURI)
 

--- a/azurerm/internal/services/keyvault/key_vault_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_resource.go
@@ -177,9 +177,8 @@ func resourceArmKeyVault() *schema.Resource {
 			},
 
 			"soft_delete_retention_days": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				//Computed:     true,
+				Type:         schema.TypeInt,
+				Optional:     true,
 				ValidateFunc: validation.IntBetween(7, 90),
 			},
 

--- a/azurerm/internal/services/keyvault/tests/key_vault_resource_test.go
+++ b/azurerm/internal/services/keyvault/tests/key_vault_resource_test.go
@@ -1153,12 +1153,13 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "vault%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  tenant_id           = data.azurerm_client_config.current.tenant_id
-  sku_name            = "premium"
-  soft_delete_enabled = true
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -1177,13 +1178,15 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                     = "vault%d"
-  location                 = azurerm_resource_group.test.location
-  resource_group_name      = azurerm_resource_group.test.name
-  tenant_id                = data.azurerm_client_config.current.tenant_id
-  sku_name                 = "premium"
-  soft_delete_enabled      = true
-  purge_protection_enabled = true
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_enabled        = true
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = true
+
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/client.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/client.go
@@ -1,4 +1,4 @@
-// Package keyvault implements the Azure ARM Keyvault service API version 2018-02-14.
+// Package keyvault implements the Azure ARM Keyvault service API version 2019-09-01.
 //
 // The Azure management API provides a RESTful set of web services that interact with Azure Key Vault.
 package keyvault

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/models.go
@@ -30,7 +30,7 @@ import (
 )
 
 // The package's fully qualified name.
-const fqdn = "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
+const fqdn = "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault"
 
 // AccessPolicyUpdateKind enumerates the values for access policy update kind.
 type AccessPolicyUpdateKind string
@@ -1568,8 +1568,12 @@ type VaultPatchProperties struct {
 	EnabledForDiskEncryption *bool `json:"enabledForDiskEncryption,omitempty"`
 	// EnabledForTemplateDeployment - Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault.
 	EnabledForTemplateDeployment *bool `json:"enabledForTemplateDeployment,omitempty"`
-	// EnableSoftDelete - Property to specify whether the 'soft delete' functionality is enabled for this key vault. It does not accept false value.
+	// EnableSoftDelete - Property to specify whether the 'soft delete' functionality is enabled for this key vault. Once set to true, it cannot be reverted to false.
 	EnableSoftDelete *bool `json:"enableSoftDelete,omitempty"`
+	// EnableRbacAuthorization - Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored (warning: this is a preview feature). When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. If null or not specified, the value of this property will not change.
+	EnableRbacAuthorization *bool `json:"enableRbacAuthorization,omitempty"`
+	// SoftDeleteRetentionInDays - softDelete data retention days. It accepts >=7 and <=90.
+	SoftDeleteRetentionInDays *int32 `json:"softDeleteRetentionInDays,omitempty"`
 	// CreateMode - The vault's create mode to indicate whether the vault need to be recovered or not. Possible values include: 'CreateModeRecover', 'CreateModeDefault'
 	CreateMode CreateMode `json:"createMode,omitempty"`
 	// EnablePurgeProtection - Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. The setting is effective only if soft delete is also enabled. Enabling this functionality is irreversible - that is, the property does not accept false as its value.
@@ -1594,8 +1598,12 @@ type VaultProperties struct {
 	EnabledForDiskEncryption *bool `json:"enabledForDiskEncryption,omitempty"`
 	// EnabledForTemplateDeployment - Property to specify whether Azure Resource Manager is permitted to retrieve secrets from the key vault.
 	EnabledForTemplateDeployment *bool `json:"enabledForTemplateDeployment,omitempty"`
-	// EnableSoftDelete - Property to specify whether the 'soft delete' functionality is enabled for this key vault. It does not accept false value.
+	// EnableSoftDelete - Property to specify whether the 'soft delete' functionality is enabled for this key vault. If it's not set to any value(true or false) when creating new key vault, it will be set to true by default. Once set to true, it cannot be reverted to false.
 	EnableSoftDelete *bool `json:"enableSoftDelete,omitempty"`
+	// SoftDeleteRetentionInDays - softDelete data retention days. It accepts >=7 and <=90.
+	SoftDeleteRetentionInDays *int32 `json:"softDeleteRetentionInDays,omitempty"`
+	// EnableRbacAuthorization - Property that controls how data actions are authorized. When true, the key vault will use Role Based Access Control (RBAC) for authorization of data actions, and the access policies specified in vault properties will be  ignored (warning: this is a preview feature). When false, the key vault will use the access policies specified in vault properties, and any policy stored on Azure Resource Manager will be ignored. If null or not specified, the vault is created with the default value of false. Note that management actions are always authorized with RBAC.
+	EnableRbacAuthorization *bool `json:"enableRbacAuthorization,omitempty"`
 	// CreateMode - The vault's create mode to indicate whether the vault need to be recovered or not. Possible values include: 'CreateModeRecover', 'CreateModeDefault'
 	CreateMode CreateMode `json:"createMode,omitempty"`
 	// EnablePurgeProtection - Property specifying whether protection against purge is enabled for this vault. Setting this property to true activates protection against purge for this vault and its content - only the Key Vault service may initiate a hard, irrecoverable deletion. The setting is effective only if soft delete is also enabled. Enabling this functionality is irreversible - that is, the property does not accept false as its value.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/operations.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/operations.go
@@ -78,7 +78,7 @@ func (client OperationsClient) List(ctx context.Context) (result OperationListRe
 
 // ListPreparer prepares the List request.
 func (client OperationsClient) ListPreparer(ctx context.Context) (*http.Request, error) {
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/privateendpointconnections.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/privateendpointconnections.go
@@ -90,7 +90,7 @@ func (client PrivateEndpointConnectionsClient) DeletePreparer(ctx context.Contex
 		"vaultName":                     autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -179,7 +179,7 @@ func (client PrivateEndpointConnectionsClient) GetPreparer(ctx context.Context, 
 		"vaultName":                     autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -263,7 +263,7 @@ func (client PrivateEndpointConnectionsClient) PutPreparer(ctx context.Context, 
 		"vaultName":                     autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/privatelinkresources.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/privatelinkresources.go
@@ -94,7 +94,7 @@ func (client PrivateLinkResourcesClient) ListByVaultPreparer(ctx context.Context
 		"vaultName":         autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/vaults.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/vaults.go
@@ -91,7 +91,7 @@ func (client VaultsClient) CheckNameAvailabilityPreparer(ctx context.Context, va
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -176,7 +176,7 @@ func (client VaultsClient) CreateOrUpdatePreparer(ctx context.Context, resourceG
 		"vaultName":         autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -259,7 +259,7 @@ func (client VaultsClient) DeletePreparer(ctx context.Context, resourceGroupName
 		"vaultName":         autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -333,7 +333,7 @@ func (client VaultsClient) GetPreparer(ctx context.Context, resourceGroupName st
 		"vaultName":         autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -408,7 +408,7 @@ func (client VaultsClient) GetDeletedPreparer(ctx context.Context, vaultName str
 		"vaultName":      autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -598,7 +598,7 @@ func (client VaultsClient) ListByResourceGroupPreparer(ctx context.Context, reso
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -711,7 +711,7 @@ func (client VaultsClient) ListBySubscriptionPreparer(ctx context.Context, top *
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -822,7 +822,7 @@ func (client VaultsClient) ListDeletedPreparer(ctx context.Context) (*http.Reque
 		"subscriptionId": autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -928,7 +928,7 @@ func (client VaultsClient) PurgeDeletedPreparer(ctx context.Context, vaultName s
 		"vaultName":      autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1015,7 +1015,7 @@ func (client VaultsClient) UpdatePreparer(ctx context.Context, resourceGroupName
 		"vaultName":         autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -1104,7 +1104,7 @@ func (client VaultsClient) UpdateAccessPolicyPreparer(ctx context.Context, resou
 		"vaultName":         autorest.Encode("path", vaultName),
 	}
 
-	const APIVersion = "2018-02-14"
+	const APIVersion = "2019-09-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault/version.go
@@ -21,7 +21,7 @@ import "github.com/Azure/azure-sdk-for-go/version"
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-	return "Azure-SDK-For-Go/" + Version() + " keyvault/2018-02-14"
+	return "Azure-SDK-For-Go/" + Version() + " keyvault/2019-09-01"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -38,7 +38,7 @@ github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac
 github.com/Azure/azure-sdk-for-go/services/healthcareapis/mgmt/2019-09-16/healthcareapis
 github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral
 github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault
-github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault
+github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2019-09-01/keyvault
 github.com/Azure/azure-sdk-for-go/services/kusto/mgmt/2020-02-15/kusto
 github.com/Azure/azure-sdk-for-go/services/logic/mgmt/2019-05-01/logic
 github.com/Azure/azure-sdk-for-go/services/machinelearningservices/mgmt/2020-04-01/machinelearningservices

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -112,9 +112,9 @@ The following arguments are supported:
 
 ~> **Note:** Terraform will check when creating a Key Vault for a previous soft-deleted Key Vault and recover it if one exists. You can configure this behaviour using the `features` block within the `provider` block.  
 
-* `soft_delete_retention_days` - (Optional) The key Vault retention days when enable soft delete.
+* `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted.
 
-!> **Note:** Once Soft Delete has been Enabled it's not possible to update it.
+~> **Note:** This field can only be set once Soft Delete is Enabled and cannot be updated.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -111,6 +111,10 @@ The following arguments are supported:
 
 ~> **Note:** Terraform will check when creating a Key Vault for a previous soft-deleted Key Vault and recover it if one exists. You can configure this behaviour using the `features` block within the `provider` block.  
 
+* `soft_delete_retention_days` - (Optional) The key Vault retention days when enable soft delete.
+
+!> **Note:** Once Soft Delete has been Enabled it's not possible to update it.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -41,6 +41,7 @@ resource "azurerm_key_vault" "example" {
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   soft_delete_enabled         = true
+  soft_delete_retention_days  = 7
   purge_protection_enabled    = false
 
   sku_name = "standard"


### PR DESCRIPTION
fix #6665 
fix #7178

this is a new field in api-version: 2019-09-01
once `soft_delete_retention_days` is set, it could not be updated

if `soft_delete_enabled` is true, and not set `soft_delete_retention_days`, the resp `softDeleteRetentionInDays`  is also nil, so no influence to existing test case.