### PR TITLE
update key vault key and secret id when reading

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_secret_resource.go
+++ b/azurerm/internal/services/keyvault/key_vault_secret_resource.go
@@ -311,11 +311,17 @@ func resourceArmKeyVaultSecretRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error making Read request on Azure KeyVault Secret %s: %+v", id.Name, err)
 	}
 
+	if resp.ID == nil || *resp.ID == "" {
+		return fmt.Errorf("empty or nil ID returned for Azure KeyVault Secret %q", id.Name)
+	}
+
 	// the version may have changed, so parse the updated id
 	respID, err := azure.ParseKeyVaultChildID(*resp.ID)
 	if err != nil {
 		return err
 	}
+	// the version may have changed, we are comparing diff with the latest version. So set the id
+	d.SetId(*resp.ID)
 
 	d.Set("name", respID.Name)
 	d.Set("value", resp.Value)


### PR DESCRIPTION
fix #6222 

the reason of this issue is:
1. user create a new version secret via the portal
2. terraform plan will read the latest secret version and find tags is missing
3. terraform update will only update the tags of `id.version`. 

Because id is not updated, so it's not updating the latest version. The next Time terraform plan it will show diff again.

I think key vault key also have such problem