### PR TITLE
azurerm_web_application_firewall_policy  - Corrected exclusion "match_variable"

### DIFF
--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -186,7 +186,7 @@ The `managed_rules` block supports the following:
 
 The `exclusion` block supports the following:
 
-* `match_variables` - (Required) The name of the Match Variable. Possible values: `RequestArgNames`, `RequestCookieNames`, `RequestHeaderNames`.
+* `match_variable` - (Required) The name of the Match Variable. Possible values: `RequestArgNames`, `RequestCookieNames`, `RequestHeaderNames`.
 
 * `selector` - (Optional) Describes field of the matchVariable collection.
 


### PR DESCRIPTION
The implementation does not require the 's' character.

![image](https://user-images.githubusercontent.com/27847622/88136805-706ce200-cc2d-11ea-9222-ec8f7a649e46.png)
