### PR TITLE
Add basic azurerm_servicebus_subscription_rule sql_filter validation

### DIFF
--- a/azurerm/internal/services/servicebus/resource_arm_servicebus_subscription_rule.go
+++ b/azurerm/internal/services/servicebus/resource_arm_servicebus_subscription_rule.go
@@ -83,8 +83,9 @@ func resourceArmServiceBusSubscriptionRule() *schema.Resource {
 			},
 
 			"sql_filter": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validate.SqlFilter,
 			},
 
 			"correlation_filter": {

--- a/azurerm/internal/services/servicebus/validate/sql_filter.go
+++ b/azurerm/internal/services/servicebus/validate/sql_filter.go
@@ -1,0 +1,27 @@
+package validate
+
+import (
+	"fmt"
+)
+
+func SqlFilter(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	// SqlFilters can not be empty
+	if len(v) == 0 {
+		errors = append(errors, fmt.Errorf("%q cannot be an empty string: %q", k, v))
+		return warnings, errors
+	}
+
+	// SqlFilters have a maximum length of 1024
+	if len(v) > 1024 {
+		errors = append(errors, fmt.Errorf("%q is of length %d, which exceeds the maximum length of 1024", k, len(v)))
+		return
+	}
+
+	return warnings, errors
+}

--- a/azurerm/internal/services/servicebus/validate/sql_filter_test.go
+++ b/azurerm/internal/services/servicebus/validate/sql_filter_test.go
@@ -1,0 +1,39 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSqlFilterValidateFunc(t *testing.T) {
+	cases := []struct {
+		Value       string
+		ShouldError bool
+	}{
+		{
+			Value:       "to='terraform'",
+			ShouldError: false,
+		},
+		{
+			Value:       "",
+			ShouldError: true,
+		},
+		{
+			Value:       strings.Repeat("user.foo='bar' AND ", 55)[:1040],
+			ShouldError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := SqlFilter(tc.Value, "sql_filter")
+
+		hasErrors := len(errors) > 0
+		if hasErrors && !tc.ShouldError {
+			t.Fatalf("Expected no errors but got %d for %q", errors[0], tc.Value)
+		}
+
+		if !hasErrors && tc.ShouldError {
+			t.Fatalf("Expected no errors but got %d for %q", len(errors), tc.Value)
+		}
+	}
+}


### PR DESCRIPTION
Covers the basics of 
* Not an empty string
* Doesn't exceed the maximum length

**Existing Acceptance Tests**

```
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_basicCorrelationFilter (201.50s)
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_sqlFilterWithAction (208.46s)
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_correlationFilterWithAction (218.94s)
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_requiresImport (221.08s)
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_correlationFilterUpdated (233.27s)
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_sqlFilterUpdated (233.67s)
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_updateSqlFilterToCorrelationFilter (248.52s)
--- PASS: TestAccAzureRMServiceBusSubscriptionRule_basicSqlFilter (273.07s)
```