### PR TITLE
`azurerm_function_app_slot.site_config` - support for `auto_swap_slot_name`

### DIFF
--- a/azurerm/internal/services/web/resource_arm_function_app_slot.go
+++ b/azurerm/internal/services/web/resource_arm_function_app_slot.go
@@ -270,6 +270,10 @@ func resourceArmFunctionAppSlot() *schema.Resource {
 							ValidateFunc: validation.IntBetween(0, 10),
 						},
 						"cors": azure.SchemaWebCorsSettings(),
+						"auto_swap_slot_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -832,6 +836,10 @@ func expandFunctionAppSlotSiteConfig(d *schema.ResourceData) (web.SiteConfig, er
 		siteConfig.PreWarmedInstanceCount = utils.Int32(int32(v.(int)))
 	}
 
+	if v, ok := config["auto_swap_slot_name"]; ok {
+		siteConfig.AutoSwapSlotName = utils.String(v.(string))
+	}
+
 	return siteConfig, nil
 }
 
@@ -874,6 +882,10 @@ func flattenFunctionAppSlotSiteConfig(input *web.SiteConfig) []interface{} {
 	result["ftps_state"] = string(input.FtpsState)
 
 	result["cors"] = azure.FlattenWebCorsSettings(input.Cors)
+
+	if input.AutoSwapSlotName != nil {
+		result["auto_swap_slot_name"] = *input.AutoSwapSlotName
+	}
 
 	results = append(results, result)
 	return results

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -232,7 +232,7 @@ The following arguments are supported:
 
 * `websockets_enabled` - (Optional) Should WebSockets be enabled?
 
-* `auto_swap_slot_name` - (Optional) The name of the swap to automatically swap to during deployment
+* `auto_swap_slot_name` - (Optional) The name of the slot to automatically swap to during deployment
 
 ---
 

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -70,6 +70,8 @@ The following arguments are supported:
 
 * `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Function App Slot.
 
+* `function_app_name` - (Required) The name of the Function App within which to create the Function App Slot. Changing this forces a new resource to be created.
+
 * `storage_account_name` - (Required) The backend storage account name which will be used by the Function App (such as the dashboard, logs).
 
 * `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Function App.
@@ -139,6 +141,8 @@ The following arguments are supported:
 * `cors` - (Optional) A `cors` block as defined below.
 
 * `ip_restriction` - (Optional) A [List of objects](/docs/configuration/attr-as-blocks.html) representing ip restrictions as defined below.
+
+* `auto_swap_slot_name` - (Optional) The name of the slot to automatically swap to during deployment
 
 ---
 


### PR DESCRIPTION
Add `auto_swap_slot_name` to the `azurerm_function_app_slot` resource's `site_config`. This attribute enables auto-swapping to another slot (e.g. the production slot) during deployment.

Fix typo in `azurerm_app_service_slot.site_config.auto_swap_slot_name` documentation.

Add missing required `azurerm_function_app_slot.function_app_name` parameter to documentation.