### PR TITLE
`azurerm_api_management_subscription` fix test `requiresImport`

### DIFF
--- a/azurerm/internal/services/apimanagement/tests/api_management_subscription_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_subscription_resource_test.go
@@ -192,6 +192,7 @@ func testAccAzureRMAPIManagementSubscription_requiresImport(data acceptance.Test
 %s
 
 resource "azurerm_api_management_subscription" "import" {
+  subscription_id     = azurerm_api_management_subscription.test.subscription_id
   resource_group_name = azurerm_api_management_subscription.test.resource_group_name
   api_management_name = azurerm_api_management_subscription.test.api_management_name
   user_id             = azurerm_api_management_subscription.test.user_id


### PR DESCRIPTION
=== RUN   TestAccAzureRMAPIManagementSubscription_requiresImport
=== PAUSE TestAccAzureRMAPIManagementSubscription_requiresImport
=== CONT  TestAccAzureRMAPIManagementSubscription_requiresImport
--- PASS: TestAccAzureRMAPIManagementSubscription_requiresImport (2550.16s)