### PR TITLE
`azurerm_api_management_user` fix test `complete`

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_user_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_user_resource.go
@@ -26,10 +26,10 @@ func resourceArmApiManagementUser() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(45 * time.Minute),
 			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(45 * time.Minute),
+			Delete: schema.DefaultTimeout(45 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/website/docs/r/api_management_user.html.markdown
+++ b/website/docs/r/api_management_user.html.markdown
@@ -78,10 +78,10 @@ In addition to all arguments above, the following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the API Management User.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management User.
+* `create` - (Defaults to 45 minutes) Used when creating the API Management User.
+* `update` - (Defaults to 45 minutes) Used when updating the API Management User.
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management User.
-* `delete` - (Defaults to 30 minutes) Used when deleting the API Management User.
+* `delete` - (Defaults to 45 minutes) Used when deleting the API Management User.
 
 ## Import
 


### PR DESCRIPTION
=== RUN   TestAccAzureRMApiManagementUser_complete
=== PAUSE TestAccAzureRMApiManagementUser_complete
=== CONT  TestAccAzureRMApiManagementUser_complete
--- PASS: TestAccAzureRMApiManagementUser_complete (2521.63s)