### PR TITLE
azurerm_eventgrid_event_subscription - deprecate topic_name

### DIFF
--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
@@ -90,7 +90,7 @@ func resourceArmEventGridEventSubscription() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				Computed:   true,
-				Deprecated: "This field has been updated to readonly field since Apr 25, 2019. So remove this unnecessary field.",
+				Deprecated: "This field has been updated to readonly field since Apr 25, 2019 so no longer has any affect and will be removed in version 3.0 of the provider.",
 			},
 
 			"azure_function_endpoint": {

--- a/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
+++ b/azurerm/internal/services/eventgrid/eventgrid_event_subscription_resource.go
@@ -87,9 +87,10 @@ func resourceArmEventGridEventSubscription() *schema.Resource {
 			},
 
 			"topic_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "This field has been updated to readonly field since Apr 25, 2019. So remove this unnecessary field.",
 			},
 
 			"azure_function_endpoint": {
@@ -672,10 +673,6 @@ func resourceArmEventGridEventSubscriptionRead(d *schema.ResourceData, meta inte
 		}
 
 		d.Set("event_delivery_schema", string(props.EventDeliverySchema))
-
-		if props.Topic != nil && *props.Topic != "" {
-			d.Set("topic_name", props.Topic)
-		}
 
 		if azureFunctionEndpoint, ok := props.Destination.AsAzureFunctionEventSubscriptionDestination(); ok {
 			if err := d.Set("azure_function_endpoint", flattenEventGridEventSubscriptionAzureFunctionEndpoint(azureFunctionEndpoint)); err != nil {

--- a/examples/eventgrid/event-subscription/main.tf
+++ b/examples/eventgrid/event-subscription/main.tf
@@ -1,0 +1,59 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "${var.prefix}sa"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_queue" "example" {
+  name                 = "${var.prefix}-sq"
+  storage_account_name = azurerm_storage_account.example.name
+}
+
+resource "azurerm_storage_container" "example" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.example.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_blob" "example" {
+  name = "herpderp1.vhd"
+
+  storage_account_name   = azurerm_storage_account.example.name
+  storage_container_name = azurerm_storage_container.example.name
+
+  type = "Page"
+  size = 5120
+}
+
+resource "azurerm_eventgrid_event_subscription" "example" {
+  name  = "${var.prefix}-eventsubs"
+  scope = azurerm_resource_group.example.id
+
+  storage_queue_endpoint {
+    storage_account_id = azurerm_storage_account.example.id
+    queue_name         = azurerm_storage_queue.example.name
+  }
+
+  storage_blob_dead_letter_destination {
+    storage_account_id          = azurerm_storage_account.example.id
+    storage_blob_container_name = azurerm_storage_container.example.name
+  }
+
+  retry_policy {
+    event_time_to_live    = 11
+    max_delivery_attempts = 11
+  }
+
+  labels = ["test", "test1", "test2"]
+}

--- a/examples/eventgrid/event-subscription/variables.tf
+++ b/examples/eventgrid/event-subscription/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The Prefix used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created."
+}

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -198,7 +198,7 @@ The following attributes are exported:
 
 * `id` - The ID of the EventGrid Event Subscription.
 
-* `topic_name` - (Optional) Specifies the name of the topic to associate with the event subscription.
+* `topic_name` - (Optional/ **Deprecated) Specifies the name of the topic to associate with the event subscription.
 
 ## Timeouts
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/3305

According by the [PR](https://github.com/Azure/azure-sdk-for-go/commit/119eb84dcd476135fd9fc0b36a27b1276ba87c6f), topic_name has been changed to readonly field. So I remove this unnecessary field.

--- PASS: TestAccAzureRMEventGridEventSubscription_advancedFilter (307.33s)
--- PASS: TestAccAzureRMEventGridEventSubscription_filter (372.90s)
--- PASS: TestAccAzureRMEventGridEventSubscription_requiresImport (383.96s)
--- PASS: TestAccAzureRMEventGridEventSubscription_basic (401.60s)
--- PASS: TestAccAzureRMEventGridEventSubscription_serviceBusQueueID (430.50s)
--- PASS: TestAccAzureRMEventGridEventSubscription_serviceBusTopicID (522.11s)
--- PASS: TestAccAzureRMEventGridEventSubscription_eventHubID (531.38s)
--- PASS: TestAccAzureRMEventGridEventSubscription_update (647.02s)
PASS