### PR TITLE
New Resource: `azurerm_api_management_api_diagnostic`

### DIFF
--- a/azurerm/helpers/azure/resourceid.go
+++ b/azurerm/helpers/azure/resourceid.go
@@ -110,5 +110,5 @@ func (id *ResourceID) ValidateNoEmptySegments(sourceId string) error {
 		return nil
 	}
 
-	return fmt.Errorf("ID contained more segments than required: %q", sourceId)
+	return fmt.Errorf("ID contained more segments than required: %q, %v", sourceId, id.Path)
 }

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -45,6 +45,7 @@ func resourceArmApiManagementApiDiagnostic() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"applicationinsights",
+					"azuremonitor",
 				}, false),
 			},
 

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -111,7 +111,7 @@ func resourceArmApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, m
 	}
 	d.SetId(*resp.ID)
 
-	return resourceArmApiManagementDiagnosticRead(d, meta)
+	return resourceArmApiManagementApiDiagnosticRead(d, meta)
 }
 
 func resourceArmApiManagementApiDiagnosticRead(d *schema.ResourceData, meta interface{}) error {

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -138,7 +138,9 @@ func resourceArmApiManagementApiDiagnosticRead(d *schema.ResourceData, meta inte
 	d.Set("identifier", resp.Name)
 	d.Set("resource_group_name", diagnosticId.ResourceGroup)
 	d.Set("api_management_name", diagnosticId.ServiceName)
-	d.Set("api_management_logger_id", resp.LoggerID)
+	if props := resp.DiagnosticContractProperties; props != nil {
+		d.Set("api_management_logger_id", props.LoggerID)
+	}
 
 	return nil
 }

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -135,6 +135,7 @@ func resourceArmApiManagementApiDiagnosticRead(d *schema.ResourceData, meta inte
 		return fmt.Errorf("making Read request for Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %+v", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, err)
 	}
 
+	d.Set("api_name", diagnosticId.ApiName)
 	d.Set("identifier", resp.Name)
 	d.Set("resource_group_name", diagnosticId.ResourceGroup)
 	d.Set("api_management_name", diagnosticId.ServiceName)

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -1,0 +1,168 @@
+package apimanagement
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	helpersvalidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/validate"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmApiManagementApiDiagnostic() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmApiManagementApiDiagnosticCreateUpdate,
+		Read:   resourceArmApiManagementApiDiagnosticRead,
+		Update: resourceArmApiManagementApiDiagnosticCreateUpdate,
+		Delete: resourceArmApiManagementApiDiagnosticDelete,
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.ApiManagementApiDiagnosticID(id)
+			return err
+		}),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"applicationinsights",
+				}, false),
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"api_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: helpersvalidate.ApiManagementApiName,
+			},
+
+			"api_management_logger_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.ApiManagementLoggerID,
+			},
+
+			"enabled": {
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Deprecated: "this property has been removed from the API and will be removed in version 3.0 of the provider",
+			},
+		},
+	}
+}
+
+func resourceArmApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.ApiDiagnosticClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	diagnosticId := d.Get("identifier").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+	serviceName := d.Get("api_management_name").(string)
+	apiName := d.Get("api_name").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, serviceName, apiName, diagnosticId)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing Diagnostic %q (API Management Service %q / Resource Group %q / API %q): %s", diagnosticId, serviceName, resourceGroup, apiName, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return tf.ImportAsExistsError("azurerm_api_management_api_diagnostic", *existing.ID)
+		}
+	}
+
+	parameters := apimanagement.DiagnosticContract{
+		DiagnosticContractProperties: &apimanagement.DiagnosticContractProperties{
+			LoggerID: utils.String(d.Get("api_management_logger_id").(string)),
+		},
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, diagnosticId, apiName, parameters, ""); err != nil {
+		return fmt.Errorf("creating or updating Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+	}
+
+	resp, err := client.Get(ctx, resourceGroup, serviceName, apiName, diagnosticId)
+	if err != nil {
+		return fmt.Errorf("retrieving Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+	}
+	if resp.ID == nil {
+		return fmt.Errorf("reading ID for Diagnostic %q (Resource Group %q / API Management Service %q): ID is empty", diagnosticId, resourceGroup, serviceName)
+	}
+	d.SetId(*resp.ID)
+
+	return resourceArmApiManagementDiagnosticRead(d, meta)
+}
+
+func resourceArmApiManagementApiDiagnosticRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.ApiDiagnosticClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	diagnosticId, err := parse.ApiManagementApiDiagnosticID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, diagnosticId.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Diagnostic %q (Resource Group %q / API Management Service %q) was not found - removing from state!", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("making Read request for Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, err)
+	}
+
+	d.Set("identifier", resp.Name)
+	d.Set("resource_group_name", diagnosticId.ResourceGroup)
+	d.Set("api_management_name", diagnosticId.ServiceName)
+	d.Set("api_management_logger_id", resp.LoggerID)
+
+	return nil
+}
+
+func resourceArmApiManagementApiDiagnosticDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.ApiDiagnosticClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	diagnosticId, err := parse.ApiManagementApiDiagnosticID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if resp, err := client.Delete(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, diagnosticId.Name, ""); err != nil {
+		if !utils.ResponseWasNotFound(resp) {
+			return fmt.Errorf("deleting Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, err)
+		}
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -65,12 +65,6 @@ func resourceArmApiManagementApiDiagnostic() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validate.ApiManagementLoggerID,
 			},
-
-			"enabled": {
-				Type:       schema.TypeBool,
-				Optional:   true,
-				Deprecated: "this property has been removed from the API and will be removed in version 3.0 of the provider",
-			},
 		},
 	}
 }
@@ -112,7 +106,7 @@ func resourceArmApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, m
 	if err != nil {
 		return fmt.Errorf("retrieving Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %+v", diagnosticId, resourceGroup, serviceName, apiName, err)
 	}
-	if resp.ID == nil {
+	if resp.ID == nil || *resp.ID == "" {
 		return fmt.Errorf("reading ID for Diagnostic %q (Resource Group %q / API Management Service %q / API %q): ID is empty", diagnosticId, resourceGroup, serviceName, apiName)
 	}
 	d.SetId(*resp.ID)

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -104,7 +104,7 @@ func resourceArmApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, m
 		},
 	}
 
-	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, diagnosticId, apiName, parameters, ""); err != nil {
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, apiName, diagnosticId, parameters, ""); err != nil {
 		return fmt.Errorf("creating or updating Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %+v", diagnosticId, resourceGroup, serviceName, apiName, err)
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -89,7 +89,7 @@ func resourceArmApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, m
 		existing, err := client.Get(ctx, resourceGroup, serviceName, apiName, diagnosticId)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing Diagnostic %q (API Management Service %q / Resource Group %q / API %q): %s", diagnosticId, serviceName, resourceGroup, apiName, err)
+				return fmt.Errorf("checking for presence of existing Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %s", diagnosticId, resourceGroup, serviceName, apiName, err)
 			}
 		}
 
@@ -105,15 +105,15 @@ func resourceArmApiManagementApiDiagnosticCreateUpdate(d *schema.ResourceData, m
 	}
 
 	if _, err := client.CreateOrUpdate(ctx, resourceGroup, serviceName, diagnosticId, apiName, parameters, ""); err != nil {
-		return fmt.Errorf("creating or updating Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+		return fmt.Errorf("creating or updating Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %+v", diagnosticId, resourceGroup, serviceName, apiName, err)
 	}
 
 	resp, err := client.Get(ctx, resourceGroup, serviceName, apiName, diagnosticId)
 	if err != nil {
-		return fmt.Errorf("retrieving Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId, resourceGroup, serviceName, err)
+		return fmt.Errorf("retrieving Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %+v", diagnosticId, resourceGroup, serviceName, apiName, err)
 	}
 	if resp.ID == nil {
-		return fmt.Errorf("reading ID for Diagnostic %q (Resource Group %q / API Management Service %q): ID is empty", diagnosticId, resourceGroup, serviceName)
+		return fmt.Errorf("reading ID for Diagnostic %q (Resource Group %q / API Management Service %q / API %q): ID is empty", diagnosticId, resourceGroup, serviceName, apiName)
 	}
 	d.SetId(*resp.ID)
 
@@ -133,12 +133,12 @@ func resourceArmApiManagementApiDiagnosticRead(d *schema.ResourceData, meta inte
 	resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, diagnosticId.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] Diagnostic %q (Resource Group %q / API Management Service %q) was not found - removing from state!", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName)
+			log.Printf("[DEBUG] Diagnostic %q (Resource Group %q / API Management Service %q / API %q) was not found - removing from state!", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName)
 			d.SetId("")
 			return nil
 		}
 
-		return fmt.Errorf("making Read request for Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, err)
+		return fmt.Errorf("making Read request for Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %+v", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, err)
 	}
 
 	d.Set("identifier", resp.Name)
@@ -161,7 +161,7 @@ func resourceArmApiManagementApiDiagnosticDelete(d *schema.ResourceData, meta in
 
 	if resp, err := client.Delete(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, diagnosticId.Name, ""); err != nil {
 		if !utils.ResponseWasNotFound(resp) {
-			return fmt.Errorf("deleting Diagnostic %q (Resource Group %q / API Management Service %q): %+v", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, err)
+			return fmt.Errorf("deleting Diagnostic %q (Resource Group %q / API Management Service %q / API %q): %+v", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, err)
 		}
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -44,6 +44,7 @@ func resourceArmApiManagementDiagnostic() *schema.Resource {
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"applicationinsights",
+					"azuremonitor",
 				}, false),
 			},
 

--- a/azurerm/internal/services/apimanagement/client/client.go
+++ b/azurerm/internal/services/apimanagement/client/client.go
@@ -39,6 +39,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	apiClient := apimanagement.NewAPIClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&apiClient.Client, o.ResourceManagerAuthorizer)
 
+	apiDiagnosticClient := apimanagement.NewDiagnosticClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&apiDiagnosticClient.Client, o.ResourceManagerAuthorizer)
+
 	apiPoliciesClient := apimanagement.NewAPIPolicyClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&apiPoliciesClient.Client, o.ResourceManagerAuthorizer)
 
@@ -116,6 +119,7 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	return &Client{
 		ApiClient:                  &apiClient,
+		ApiDiagnosticClient:        &apiDiagnosticClient,
 		ApiPoliciesClient:          &apiPoliciesClient,
 		ApiOperationsClient:        &apiOperationsClient,
 		ApiOperationPoliciesClient: &apiOperationPoliciesClient,

--- a/azurerm/internal/services/apimanagement/client/client.go
+++ b/azurerm/internal/services/apimanagement/client/client.go
@@ -39,7 +39,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	apiClient := apimanagement.NewAPIClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&apiClient.Client, o.ResourceManagerAuthorizer)
 
-	apiDiagnosticClient := apimanagement.NewDiagnosticClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	apiDiagnosticClient := apimanagement.NewAPIDiagnosticClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&apiDiagnosticClient.Client, o.ResourceManagerAuthorizer)
 
 	apiPoliciesClient := apimanagement.NewAPIPolicyClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)

--- a/azurerm/internal/services/apimanagement/client/client.go
+++ b/azurerm/internal/services/apimanagement/client/client.go
@@ -7,6 +7,7 @@ import (
 
 type Client struct {
 	ApiClient                  *apimanagement.APIClient
+	ApiDiagnosticClient        *apimanagement.APIDiagnosticClient
 	ApiPoliciesClient          *apimanagement.APIPolicyClient
 	ApiOperationsClient        *apimanagement.APIOperationClient
 	ApiOperationPoliciesClient *apimanagement.APIOperationPolicyClient

--- a/azurerm/internal/services/apimanagement/parse/api_diagnostic_id.go
+++ b/azurerm/internal/services/apimanagement/parse/api_diagnostic_id.go
@@ -1,0 +1,43 @@
+package parse
+
+import (
+	"fmt"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ApiManagementApiDiagnosticId struct {
+	ResourceGroup string
+	ServiceName   string
+	ApiName       string
+	Name          string
+}
+
+func ApiManagementApiDiagnosticID(input string) (*ApiManagementApiDiagnosticId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing Api Management Diagnostic ID %q: %+v", input, err)
+	}
+
+	diagnostic := ApiManagementApiDiagnosticId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if diagnostic.ServiceName, err = id.PopSegment("service"); err != nil {
+		return nil, err
+	}
+
+	if diagnostic.ApiName, err = id.PopSegment("apis"); err != nil {
+		return nil, err
+	}
+
+	if diagnostic.Name, err = id.PopSegment("diagnostics"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &diagnostic, nil
+}

--- a/azurerm/internal/services/apimanagement/parse/api_diagnostic_id_test.go
+++ b/azurerm/internal/services/apimanagement/parse/api_diagnostic_id_test.go
@@ -1,0 +1,101 @@
+package parse
+
+import "testing"
+
+func TestApiManagementApiDiagnosticID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *ApiManagementApiDiagnosticId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Service Name",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing APIs",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing APIs Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/apis",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Diagnostics",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/apis/api1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Diagnostics Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/apis/api1/diagnostics",
+			Expected: nil,
+		},
+		{
+			Name:  "Diagnostic ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/apis/api1/diagnostics/applicationinsights",
+			Expected: &ApiManagementApiDiagnosticId{
+				Name:          "applicationinsights",
+				ApiName:       "api1",
+				ServiceName:   "service1",
+				ResourceGroup: "resGroup1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/APIs/api1/diagnostics/applicationinsights",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ApiManagementApiDiagnosticID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.ApiName != v.Expected.ApiName {
+			t.Fatalf("Expected %q but got %q for API Name", v.Expected.ApiName, actual.ApiName)
+		}
+
+		if actual.ServiceName != v.Expected.ServiceName {
+			t.Fatalf("Expected %q but got %q for Service Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/apimanagement/parse/api_diagnostic_id_test.go
+++ b/azurerm/internal/services/apimanagement/parse/api_diagnostic_id_test.go
@@ -68,6 +68,16 @@ func TestApiManagementApiDiagnosticID(t *testing.T) {
 			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/APIs/api1/diagnostics/applicationinsights",
 			Expected: nil,
 		},
+		{
+			Name:  "From ACC test",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acctestRG-200904094049117016/providers/Microsoft.ApiManagement/service/acctestAM-200904094049117016/apis/acctestAMA-200904094049117016/diagnostics/applicationinsights",
+			Expected: &ApiManagementApiDiagnosticId{
+				Name:          "applicationinsights",
+				ApiName:       "acctestAMA-200904094049117016",
+				ServiceName:   "acctestAM-200904094049117016",
+				ResourceGroup: "acctestRG-200904094049117016",
+			},
+		},
 	}
 
 	for _, v := range testData {

--- a/azurerm/internal/services/apimanagement/registration.go
+++ b/azurerm/internal/services/apimanagement/registration.go
@@ -35,6 +35,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_api_management":                             resourceArmApiManagementService(),
 		"azurerm_api_management_api":                         resourceArmApiManagementApi(),
+		"azurerm_api_management_api_diagnostic":              resourceArmApiManagementApiDiagnostic(),
 		"azurerm_api_management_api_operation":               resourceArmApiManagementApiOperation(),
 		"azurerm_api_management_api_operation_policy":        resourceArmApiManagementApiOperationPolicy(),
 		"azurerm_api_management_api_policy":                  resourceArmApiManagementApiPolicy(),

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
@@ -89,7 +89,7 @@ func testCheckAzureRMApiManagementApiDiagnosticDestroy(s *terraform.State) error
 		if err != nil {
 			return err
 		}
-		resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.Name, diagnosticId.ApiName)
+		resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, diagnosticId.Name)
 
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
@@ -117,7 +117,7 @@ func testCheckAzureRMApiManagementApiDiagnosticExists(resourceName string) resou
 			return err
 		}
 
-		resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.Name, diagnosticId.ApiName)
+		resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName, diagnosticId.Name)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("bad: API Management Diagnostic %q (Resource Group %q / API Management Service %q / API %q) does not exist", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName)

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
@@ -63,7 +63,7 @@ func TestAccAzureRMApiManagementApiDiagnostic_requiresImport(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMApiManagementDestroy,
+		CheckDestroy: testCheckAzureRMApiManagementApiDiagnosticDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMApiManagementApiDiagnostic_basic(data),

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
@@ -220,26 +220,11 @@ resource "azurerm_api_management_logger" "test2" {
   }
 }
 
-resource "azurerm_api_management_api" "test2" {
-  name                = "acctestAMA-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  api_management_name = azurerm_api_management.test.name
-  revision            = "1"
-  display_name        = "Test API"
-  path                = "test"
-  protocols           = ["https"]
-
-  import {
-    content_format = "swagger-link-json"
-    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
-  }
-}
-
 resource "azurerm_api_management_api_diagnostic" "test" {
   identifier               = "applicationinsights"
   resource_group_name      = azurerm_resource_group.test.name
   api_management_name      = azurerm_api_management.test.name
-  api_name                 = azurerm_api_management_api.test2.name
+  api_name                 = azurerm_api_management_api.test.name
   api_management_logger_id = azurerm_api_management_logger.test2.id
 }
 `, config, data.RandomInteger)

--- a/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_api_diagnostic_resource_test.go
@@ -1,0 +1,261 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMApiManagementApiDiagnostic_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementApiDiagnosticDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementApiDiagnostic_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementApiDiagnosticExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementApiDiagnostic_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementApiDiagnosticDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementApiDiagnostic_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementApiDiagnosticExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMApiManagementApiDiagnostic_update(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementApiDiagnosticExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementApiDiagnostic_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api_diagnostic", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementApiDiagnostic_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementApiDiagnosticExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementApiDiagnostic_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementApiDiagnosticDestroy(s *terraform.State) error {
+	client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.ApiDiagnosticClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_api_diagnostic" {
+			continue
+		}
+
+		diagnosticId, err := parse.ApiManagementApiDiagnosticID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.Name, diagnosticId.ApiName)
+
+		if err != nil {
+			if !utils.ResponseWasNotFound(resp.Response) {
+				return err
+			}
+		}
+
+		return nil
+	}
+	return nil
+}
+
+func testCheckAzureRMApiManagementApiDiagnosticExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.ApiDiagnosticClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		diagnosticId, err := parse.ApiManagementApiDiagnosticID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		resp, err := client.Get(ctx, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.Name, diagnosticId.ApiName)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("bad: API Management Diagnostic %q (Resource Group %q / API Management Service %q / API %q) does not exist", diagnosticId.Name, diagnosticId.ResourceGroup, diagnosticId.ServiceName, diagnosticId.ApiName)
+			}
+			return fmt.Errorf("bad: Get on apiManagementApiDiagnosticClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApiManagementApiDiagnostic_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_logger" "test" {
+  name                = "acctestapimnglogger-%[1]d"
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  application_insights {
+    instrumentation_key = azurerm_application_insights.test.instrumentation_key
+  }
+}
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestAMA-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  revision            = "1"
+  display_name        = "Test API"
+  path                = "test"
+  protocols           = ["https"]
+
+  import {
+    content_format = "swagger-link-json"
+    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func testAccAzureRMApiManagementApiDiagnostic_basic(data acceptance.TestData) string {
+	config := testAccAzureRMApiManagementApiDiagnostic_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api_diagnostic" "test" {
+  identifier               = "applicationinsights"
+  resource_group_name      = azurerm_resource_group.test.name
+  api_management_name      = azurerm_api_management.test.name
+  api_name                 = azurerm_api_management_api.test.name
+  api_management_logger_id = azurerm_api_management_logger.test.id
+}
+`, config)
+}
+
+func testAccAzureRMApiManagementApiDiagnostic_update(data acceptance.TestData) string {
+	config := testAccAzureRMApiManagementApiDiagnostic_template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_application_insights" "test2" {
+  name                = "acctestappinsightsUpdate-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_api_management_logger" "test2" {
+  name                = "acctestapimngloggerUpdate-%[2]d"
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+
+  application_insights {
+    instrumentation_key = azurerm_application_insights.test2.instrumentation_key
+  }
+}
+
+resource "azurerm_api_management_api" "test2" {
+  name                = "acctestAMA-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  revision            = "1"
+  display_name        = "Test API"
+  path                = "test"
+  protocols           = ["https"]
+
+  import {
+    content_format = "swagger-link-json"
+    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
+  }
+}
+
+resource "azurerm_api_management_api_diagnostic" "test" {
+  identifier               = "applicationinsights"
+  resource_group_name      = azurerm_resource_group.test.name
+  api_management_name      = azurerm_api_management.test.name
+  api_name                 = azurerm_api_management_api.test2.name
+  api_management_logger_id = azurerm_api_management_logger.test2.id
+}
+`, config, data.RandomInteger)
+}
+
+func testAccAzureRMApiManagementApiDiagnostic_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementApiDiagnostic_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api_diagnostic" "import" {
+  identifier               = azurerm_api_management_api_diagnostic.test.identifier
+  resource_group_name      = azurerm_api_management_api_diagnostic.test.resource_group_name
+  api_management_name      = azurerm_api_management_api_diagnostic.test.api_management_name
+  api_name                 = azurerm_api_management_api.test.name
+  api_management_logger_id = azurerm_api_management_api_diagnostic.test.api_management_logger_id
+}
+`, template)
+}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -688,7 +688,7 @@
                 </li>
 
                 <li>
-                  <a href="/docs/providers/azurerm/r/api_management_diagnostic.html">azurerm_api_management_api_diagnostic</a>
+                  <a href="/docs/providers/azurerm/r/api_management_api_diagnostic.html">azurerm_api_management_api_diagnostic</a>
                 </li>
 
                 <li>

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -688,6 +688,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/r/api_management_diagnostic.html">azurerm_api_management_api_diagnostic</a>
+                </li>
+
+                <li>
                   <a href="/docs/providers/azurerm/r/api_management_api_operation.html">azurerm_api_management_api_operation</a>
                 </li>
 

--- a/website/docs/r/api_management_api_diagnostic.html.markdown
+++ b/website/docs/r/api_management_api_diagnostic.html.markdown
@@ -64,7 +64,6 @@ resource "azurerm_api_management_logger" "example" {
 }
 
 resource "azurerm_api_management_api_diagnostic" "example" {
-  resource_group_name      = "example"
   resource_group_name      = azurerm_resource_group.example.name
   api_management_name      = azurerm_api_management.example.name
   api_name                 = azurerm_api_management_api.example.name

--- a/website/docs/r/api_management_api_diagnostic.html.markdown
+++ b/website/docs/r/api_management_api_diagnostic.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `api_name` - (Required) The name of the API on which to configure the Diagnostics Logs. Changing this forces a new API Management Service API Diagnostics Logs to be created.
 
-* `identifier` - (Required) Identifier of the Diagnostics Logs. Changing this forces a new API Management Service API Diagnostics Logs to be created.
+* `identifier` - (Required) Identifier of the Diagnostics Logs. Possible values are `applicationinsights` and `azuremonitor`. Changing this forces a new API Management Service API Diagnostics Logs to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the API Management Service API Diagnostics Logs should exist. Changing this forces a new API Management Service API Diagnostics Logs to be created.
 
@@ -102,7 +102,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-API Management Service API Diagnostics Logss can be imported using the `resource id`, e.g.
+API Management Service API Diagnostics Logs can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_api_management_api_diagnostic.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/apis/api1/diagnostics/diagnostic1/loggers/logger1

--- a/website/docs/r/api_management_api_diagnostic.html.markdown
+++ b/website/docs/r/api_management_api_diagnostic.html.markdown
@@ -1,0 +1,114 @@
+---
+subcategory: "API Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_api_diagnostic"
+description: |-
+  Manages a API Management Service API Diagnostics Logs.
+---
+
+# azurerm_api_management_api_diagnostic
+
+Manages a API Management Service API Diagnostics Logs.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_application_insights" "example" {
+  name                = "example-appinsights"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  application_type    = "web"
+}
+
+resource "azurerm_api_management" "example" {
+  name                = "example-apim"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  publisher_name      = "My Company"
+  publisher_email     = "company@terraform.io"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_api" "example" {
+  name                = "example-api"
+  resource_group_name = azurerm_resource_group.example.name
+  api_management_name = azurerm_api_management.example.name
+  revision            = "1"
+  display_name        = "Example API"
+  path                = "example"
+  protocols           = ["https"]
+
+  import {
+    content_format = "swagger-link-json"
+    content_value  = "http://conferenceapi.azurewebsites.net/?format=json"
+  }
+}
+
+resource "azurerm_api_management_logger" "example" {
+  name                = "example-apimlogger"
+  api_management_name = azurerm_api_management.example.name
+  resource_group_name = azurerm_resource_group.example.name
+
+  application_insights {
+    instrumentation_key = azurerm_application_insights.example.instrumentation_key
+  }
+}
+
+resource "azurerm_api_management_api_diagnostic" "example" {
+  resource_group_name      = "example"
+  resource_group_name      = azurerm_resource_group.example.name
+  api_management_name      = azurerm_api_management.example.name
+  api_name                 = azurerm_api_management_api.example.name
+  api_management_logger_id = azurerm_api_management_logger.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `api_management_logger_id` - (Required) The ID (name) of the Diagnostics Logger.
+
+* `api_management_name` - (Required) The name of the API Management Service instance. Changing this forces a new API Management Service API Diagnostics Logs to be created.
+
+* `api_name` - (Required) The name of the API on which to configure the Diagnostics Logs. Changing this forces a new API Management Service API Diagnostics Logs to be created.
+
+* `identifier` - (Required) Identifier of the Diagnostics Logs. Changing this forces a new API Management Service API Diagnostics Logs to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the API Management Service API Diagnostics Logs should exist. Changing this forces a new API Management Service API Diagnostics Logs to be created.
+
+---
+
+* `enabled` - (Optional) Should the Diagnostics Logs be enabled?
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the API Management Service API Diagnostics Logs.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Management Service API Diagnostics Logs.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Management Service API Diagnostics Logs.
+* `update` - (Defaults to 30 minutes) Used when updating the API Management Service API Diagnostics Logs.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Service API Diagnostics Logs.
+
+## Import
+
+API Management Service API Diagnostics Logss can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_api_diagnostic.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/apis/api1/diagnostics/diagnostic1/loggers/logger1
+```

--- a/website/docs/r/api_management_api_diagnostic.html.markdown
+++ b/website/docs/r/api_management_api_diagnostic.html.markdown
@@ -85,10 +85,6 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where the API Management Service API Diagnostics Logs should exist. Changing this forces a new API Management Service API Diagnostics Logs to be created.
 
----
-
-* `enabled` - (Optional) Should the Diagnostics Logs be enabled?
-
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
Closes #4760.
Adds support for `azuremonitor` as `identifier` to `azurerm_api_management_diagnostic`

Missing:
  - [x] Tests for the new resource