### PR TITLE
`azurerm_kubernetes_cluster` - Updates no longer fail when using managed AAD integration

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -884,7 +884,7 @@ func resourceArmKubernetesClusterUpdate(d *schema.ResourceData, meta interface{}
 		}
 
 		// changing rbacEnabled must still force cluster recreation
-		if *props.EnableRBAC == rbacEnabled {
+		if *props.EnableRBAC == rbacEnabled && !*props.AadProfile.Managed {
 			props.AadProfile = azureADProfile
 			props.EnableRBAC = utils.Bool(rbacEnabled)
 
@@ -898,6 +898,11 @@ func resourceArmKubernetesClusterUpdate(d *schema.ResourceData, meta interface{}
 				return fmt.Errorf("waiting for update of RBAC AAD profile of Managed Cluster %q (Resource Group %q):, %+v", id.Name, id.ResourceGroup, err)
 			}
 		} else {
+			updateCluster = true
+		}
+
+		if *props.AadProfile.Managed {
+			existing.ManagedClusterProperties.AadProfile = azureADProfile
 			updateCluster = true
 		}
 	}

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_auth_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_auth_resource_test.go
@@ -13,7 +13,10 @@ var kubernetesAuthTests = map[string]func(t *testing.T){
 	"enablePodSecurityPolicy":     testAccAzureRMKubernetesCluster_enablePodSecurityPolicy,
 	"managedClusterIdentity":      testAccAzureRMKubernetesCluster_managedClusterIdentity,
 	"roleBasedAccessControl":      testAccAzureRMKubernetesCluster_roleBasedAccessControl,
-	"roleBasedAccessControlAAD":   testAccAzureRMKubernetesCluster_roleBasedAccessControlAAD,
+	"AAD":                         testAccAzureRMKubernetesCluster_roleBasedAccessControlAAD,
+	"AADUpdateToManaged":          testAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged,
+	"AADManaged":                  testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManaged,
+	"AADManagedChange":            testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange,
 	"servicePrincipal":            testAccAzureRMKubernetesCluster_servicePrincipal,
 }
 
@@ -178,6 +181,56 @@ func testAccAzureRMKubernetesCluster_roleBasedAccessControlAAD(t *testing.T) {
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged(t)
+}
+
+func testAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	clientData := data.Client()
+	auth := clientData.Default
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKubernetesCluster_roleBasedAccessControlAADConfig(data, auth.ClientID, auth.ClientSecret, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.0.enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.0.azure_active_directory.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.client_app_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.server_app_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.server_app_secret"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.tenant_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "kube_admin_config.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "kube_admin_config_raw"),
+				),
+			},
+			data.ImportStep(
+				"role_based_access_control.0.azure_active_directory.0.server_app_secret",
+			),
+			{
+				Config: testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedConfig(data, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.0.enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.0.azure_active_directory.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.tenant_id"),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.managed", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "kube_admin_config.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "kube_admin_config_raw"),
+				),
+			},
 			data.ImportStep(
 				"role_based_access_control.0.azure_active_directory.0.server_app_secret",
 			),
@@ -221,6 +274,51 @@ func testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManaged(t *testing
 				PlanOnly: true,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(
+				"role_based_access_control.0.azure_active_directory.0.server_app_secret",
+			),
+		},
+	})
+}
+
+func TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange(t)
+}
+
+func testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	clientData := data.Client()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedConfig(data, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.#", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.0.enabled", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "role_based_access_control.0.azure_active_directory.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.tenant_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "role_based_access_control.0.azure_active_directory.0.managed"),
+					resource.TestCheckResourceAttr(data.ResourceName, "kube_admin_config.#", "1"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "kube_admin_config_raw"),
+					resource.TestCheckResourceAttr(data.ResourceName, "default_node_pool.0.node_count", "1"),
+				),
+			},
+			data.ImportStep(
+				"role_based_access_control.0.azure_active_directory.0.server_app_secret",
+			),
+			{
+				Config: testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedConfigScale(data, clientData.TenantID),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesClusterExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "default_node_pool.0.node_count", "2"),
 				),
 			},
 			data.ImportStep(
@@ -561,6 +659,53 @@ resource "azurerm_kubernetes_cluster" "test" {
   default_node_pool {
     name       = "default"
     node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  role_based_access_control {
+    enabled = true
+
+    azure_active_directory {
+      tenant_id = var.tenant_id
+      managed   = true
+    }
+  }
+}
+`, tenantId, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedConfigScale(data acceptance.TestData, tenantId string) string {
+	return fmt.Sprintf(`
+variable "tenant_id" {
+  default = "%s"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = "${azurerm_resource_group.test.location}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 2
     vm_size    = "Standard_DS2_v2"
   }
 


### PR DESCRIPTION
Fixes #7325

## Acceptance Tests:
```bash
make acctests SERVICE='containers' TESTARGS='-run=TestAccAzureRMKubernetesCluster_roleBasedAccessControlAAD'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/containers/tests/ -run=TestAccAzureRMKubernetesCluster_roleBasedAccessControlAAD -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMKubernetesCluster_roleBasedAccessControlAAD
=== PAUSE TestAccAzureRMKubernetesCluster_roleBasedAccessControlAAD
=== RUN   TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged
=== PAUSE TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged
=== RUN   TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManaged
=== PAUSE TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManaged
=== RUN   TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange
=== PAUSE TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange
=== CONT  TestAccAzureRMKubernetesCluster_roleBasedAccessControlAAD
=== CONT  TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange
=== CONT  TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManaged
=== CONT  TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged
--- PASS: TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManaged (720.09s)
--- PASS: TestAccAzureRMKubernetesCluster_roleBasedAccessControlAAD (776.63s)
--- PASS: TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADUpdateToManaged (853.89s)
--- PASS: TestAccAzureRMKubernetesCluster_roleBasedAccessControlAADManagedChange (979.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/containers/tests      981.018s
```