### PR TITLE
Update spacing for #7877 

### DIFF
--- a/website/docs/r/eventgrid_topic.html.markdown
+++ b/website/docs/r/eventgrid_topic.html.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 * `input_mapping_default_values` - (Optional) A `input_mapping_default_values` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
 
 A `input_mapping_fields` supports the following:


### PR DESCRIPTION
Add an additional new line to fix a spacing issue when viewing the documentation on the official documentation page https://www.terraform.io/docs/providers/azurerm/r/eventgrid_topic.html.

Fixes #7877 