### PR TITLE
`azurerm_storage_account` - Support `static_website` for `BlockBlobStorage` account type

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -741,9 +741,9 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if val, ok := d.GetOk("static_website"); ok {
-		// static website only supported on Storage V2
-		if accountKind != string(storage.StorageV2) {
-			return fmt.Errorf("`static_website` is only supported for Storage V2.")
+		// static website only supported on StorageV2 and BlockBlobStorage
+		if accountKind != string(storage.StorageV2) && accountKind != string(storage.BlockBlobStorage) {
+			return fmt.Errorf("`static_website` is only supported for StorageV2 and BlockBlobStorage.")
 		}
 		storageClient := meta.(*clients.Client).Storage
 
@@ -948,9 +948,9 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if d.HasChange("static_website") {
-		// static website only supported on Storage V2
-		if accountKind != string(storage.StorageV2) {
-			return fmt.Errorf("`static_website` is only supported for Storage V2.")
+		// static website only supported on StorageV2 and BlockBlobStorage
+		if accountKind != string(storage.StorageV2) && accountKind != string(storage.BlockBlobStorage) {
+			return fmt.Errorf("`static_website` is only supported for StorageV2 and BlockBlobStorage.")
 		}
 		storageClient := meta.(*clients.Client).Storage
 
@@ -1159,8 +1159,8 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 
 	var staticWebsite []interface{}
 
-	// static website only supported on Storage V2
-	if resp.Kind == storage.StorageV2 {
+	// static website only supported on StorageV2 and BlockBlobStorage
+	if resp.Kind == storage.StorageV2 || resp.Kind == storage.BlockBlobStorage {
 		storageClient := meta.(*clients.Client).Storage
 
 		account, err := storageClient.FindAccount(ctx, name)

--- a/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
+++ b/azurerm/internal/services/storage/tests/resource_arm_storage_account_test.go
@@ -657,7 +657,7 @@ func TestAccAzureRMStorageAccount_staticWebsiteEnabled(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMStorageAccount_staticWebsiteProperties(t *testing.T) {
+func TestAccAzureRMStorageAccount_staticWebsitePropertiesForStorageV2(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -666,14 +666,40 @@ func TestAccAzureRMStorageAccount_staticWebsiteProperties(t *testing.T) {
 		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMStorageAccount_staticWebsiteProperties(data),
+				Config: testAccAzureRMStorageAccount_staticWebsitePropertiesForStorageV2(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMStorageAccount_staticWebsitePropertiesUpdated(data),
+				Config: testAccAzureRMStorageAccount_staticWebsitePropertiesUpdatedForStorageV2(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMStorageAccount_staticWebsitePropertiesForBlockBlobStorage(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMStorageAccount_staticWebsitePropertiesForBlockBlobStorage(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMStorageAccountExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMStorageAccount_staticWebsitePropertiesUpdatedForBlockBlobStorage(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMStorageAccountExists(data.ResourceName),
 				),
@@ -1739,7 +1765,7 @@ resource "azurerm_storage_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func testAccAzureRMStorageAccount_staticWebsiteProperties(data acceptance.TestData) string {
+func testAccAzureRMStorageAccount_staticWebsitePropertiesForStorageV2(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1767,7 +1793,35 @@ resource "azurerm_storage_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func testAccAzureRMStorageAccount_staticWebsitePropertiesUpdated(data acceptance.TestData) string {
+func testAccAzureRMStorageAccount_staticWebsitePropertiesForBlockBlobStorage(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlockBlobStorage"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+
+  static_website {
+    index_document     = "index.html"
+    error_404_document = "404.html"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMStorageAccount_staticWebsitePropertiesUpdatedForStorageV2(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1785,6 +1839,34 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_kind             = "StorageV2"
   account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  static_website {
+    index_document     = "index-2.html"
+    error_404_document = "404-2.html"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func testAccAzureRMStorageAccount_staticWebsitePropertiesUpdatedForBlockBlobStorage(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlockBlobStorage"
+  account_tier             = "Premium"
   account_replication_type = "LRS"
 
   static_website {

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -115,7 +115,7 @@ The following arguments are supported:
 
 * `static_website` - (Optional) A `static_website` block as defined below.
 
-~> **NOTE:** `static_website` can only be set when the `account_kind` is set to `StorageV2`
+~> **NOTE:** `static_website` can only be set when the `account_kind` is set to `StorageV2` or `BlockBlobStorage`.
 
 * `network_rules` - (Optional) A `network_rules` block as documented below.
 


### PR DESCRIPTION
Microsoft Azure supports `static_website` for `BlockBlobStorage` and so this PR adds support for this into `terraform-provider-azurerm`

![image](https://user-images.githubusercontent.com/2973219/88402851-fb83de80-cdcb-11ea-9ee8-5913167335fa.png)
