### PR TITLE
Update `azurerm_backup_policy_vm` -  check for <7 daily backups

### DIFF
--- a/azurerm/internal/services/recoveryservices/resource_arm_backup_policy_vm.go
+++ b/azurerm/internal/services/recoveryservices/resource_arm_backup_policy_vm.go
@@ -118,7 +118,8 @@ func resourceArmBackupProtectionPolicyVM() *schema.Resource {
 						"count": {
 							Type:         schema.TypeInt,
 							Required:     true,
-							ValidateFunc: validation.IntBetween(1, 9999),
+							ValidateFunc: validation.IntBetween(1, 9999), // Azure no longer supports less than 7 daily backups. This should be updated in 3.0 provider
+
 						},
 					},
 				},
@@ -312,6 +313,11 @@ func resourceArmBackupProtectionPolicyVMCreateUpdate(d *schema.ResourceData, met
 		if existing.ID != nil && *existing.ID != "" {
 			return tf.ImportAsExistsError("azurerm_backup_policy_vm", *existing.ID)
 		}
+	}
+
+	// Less than 7 daily backups is no longer supported for create/update
+	if (d.IsNewResource() || d.HasChange("retention_daily.0.count")) && (d.Get("retention_daily.0.count").(int) > 1 && d.Get("retention_daily.0.count").(int) < 7) {
+		return fmt.Errorf("The Azure API has recently changed behaviour so that provisioning a `count` for the `retention_daily` field can no longer be less than 7 days for new/updates to existing Backup Policies. Please ensure that `count` is less than 7, currently %d", d.Get("retention_daily.0.count").(int))
 	}
 
 	policy := backup.ProtectionPolicyResource{

--- a/website/docs/r/backup_policy_vm.markdown
+++ b/website/docs/r/backup_policy_vm.markdown
@@ -99,7 +99,9 @@ The `backup` block supports:
 
 The `retention_daily` block supports:
 
-* `count` - (Required) The number of daily backups to keep. Must be between `1` and `9999`
+* `count` - (Required) The number of daily backups to keep. Must be between `7` and `9999`.
+
+~> **Note:** Azure previously allows this field to be set to a minimum of 1 (day) - but for new resources/to update this value on existing Backup Policies - this value must now be at least 7 (days).
 
 ---
 


### PR DESCRIPTION
Fixes #7792 

(If there's a better way to do this, please let me know.)

```
$ make acctests SERVICE='recoveryservices' TESTARGS='-run=TestAccAzureRMBackupProtectionPolicyVM' TESTTIMEOUT='60m'

$ make website
$ visit http://localhost:4567/docs/providers/azurerm/r/backup_policy_vm.html
```