### PR TITLE
New resource/data source `azurerm_data_share_dataset_data_lake_gen2`

### DIFF
--- a/azurerm/internal/services/datashare/data_source_data_share_dataset_data_lake_gen2.go
+++ b/azurerm/internal/services/datashare/data_source_data_share_dataset_data_lake_gen2.go
@@ -1,0 +1,120 @@
+package datashare
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datashare/mgmt/2019-11-01/datashare"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare/helper"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+)
+
+func dataSourceDataShareDatasetDataLakeGen2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmDataShareDatasetDataLakeGen2Read,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.DatashareDataSetName(),
+			},
+
+			"share_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validate.DataShareID,
+			},
+
+			"storage_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"file_system_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"file_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"folder_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceArmDataShareDatasetDataLakeGen2Read(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataShare.DataSetClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	shareID := d.Get("share_id").(string)
+	shareId, err := parse.DataShareID(shareID)
+	if err != nil {
+		return err
+	}
+
+	respModel, err := client.Get(ctx, shareId.ResourceGroup, shareId.AccountName, shareId.Name, name)
+	if err != nil {
+		return fmt.Errorf("retrieving DataShare Data Lake Gen2 DataSet %q (Resource Group %q / accountName %q / shareName %q): %+v", name, shareId.ResourceGroup, shareId.AccountName, shareId.Name, err)
+	}
+
+	respId := helper.GetAzurermDataShareDataSetId(respModel.Value)
+	if respId == nil || *respId == "" {
+		return fmt.Errorf("empty or nil ID returned for DataShare Data Lake Gen2 DataSet %q (Resource Group %q / accountName %q / shareName %q)", name, shareId.ResourceGroup, shareId.AccountName, shareId.Name)
+	}
+
+	d.SetId(*respId)
+	d.Set("name", name)
+	d.Set("share_id", shareID)
+
+	switch resp := respModel.Value.(type) {
+	case datashare.ADLSGen2FileDataSet:
+		if props := resp.ADLSGen2FileProperties; props != nil {
+			d.Set("storage_account_id", fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", *props.SubscriptionID, *props.ResourceGroup, *props.StorageAccountName))
+			d.Set("file_system_name", props.FileSystem)
+			d.Set("file_path", props.FilePath)
+			d.Set("display_name", props.DataSetID)
+		}
+
+	case datashare.ADLSGen2FolderDataSet:
+		if props := resp.ADLSGen2FolderProperties; props != nil {
+			d.Set("storage_account_id", fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", *props.SubscriptionID, *props.ResourceGroup, *props.StorageAccountName))
+			d.Set("file_system_name", props.FileSystem)
+			d.Set("folder_path", props.FolderPath)
+			d.Set("display_name", props.DataSetID)
+		}
+
+	case datashare.ADLSGen2FileSystemDataSet:
+		if props := resp.ADLSGen2FileSystemProperties; props != nil {
+			d.Set("storage_account_id", fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", *props.SubscriptionID, *props.ResourceGroup, *props.StorageAccountName))
+			d.Set("file_system_name", props.FileSystem)
+			d.Set("display_name", props.DataSetID)
+		}
+
+	default:
+		return fmt.Errorf("data share dataset %q (Resource Group %q / accountName %q / shareName %q) is not a datalake store gen2 dataset", name, shareId.ResourceGroup, shareId.AccountName, shareId.Name)
+	}
+
+	return nil
+}

--- a/azurerm/internal/services/datashare/registration.go
+++ b/azurerm/internal/services/datashare/registration.go
@@ -23,6 +23,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 		"azurerm_data_share":                        dataSourceDataShare(),
 		"azurerm_data_share_dataset_blob_storage":   dataSourceDataShareDatasetBlobStorage(),
 		"azurerm_data_share_dataset_data_lake_gen1": dataSourceDataShareDatasetDataLakeGen1(),
+		"azurerm_data_share_dataset_data_lake_gen2": dataSourceDataShareDatasetDataLakeGen2(),
 	}
 }
 
@@ -33,5 +34,6 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_data_share":                        resourceArmDataShare(),
 		"azurerm_data_share_dataset_blob_storage":   resourceArmDataShareDataSetBlobStorage(),
 		"azurerm_data_share_dataset_data_lake_gen1": resourceArmDataShareDataSetDataLakeGen1(),
+		"azurerm_data_share_dataset_data_lake_gen2": resourceArmDataShareDataSetDataLakeGen2(),
 	}
 }

--- a/azurerm/internal/services/datashare/resource_arm_data_share_dataset_data_lake_gen2.go
+++ b/azurerm/internal/services/datashare/resource_arm_data_share_dataset_data_lake_gen2.go
@@ -1,0 +1,247 @@
+package datashare
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/datashare/mgmt/2019-11-01/datashare"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare/helper"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare/parse"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare/validate"
+	storageParsers "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
+	azSchema "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmDataShareDataSetDataLakeGen2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDataShareDataSetDataLakeGen2Create,
+		Read:   resourceArmDataShareDataSetDataLakeGen2Read,
+		Delete: resourceArmDataShareDataSetDataLakeGen2Delete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.DataShareDataSetID(id)
+			return err
+		}),
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DatashareDataSetName(),
+			},
+
+			"share_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DataShareID,
+			},
+
+			"storage_account_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.StorageAccountID,
+			},
+
+			"file_system_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"file_path": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.StringIsNotEmpty,
+				ConflictsWith: []string{"folder_path"},
+			},
+
+			"folder_path": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.StringIsNotEmpty,
+				ConflictsWith: []string{"file_path"},
+			},
+
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+func resourceArmDataShareDataSetDataLakeGen2Create(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataShare.DataSetClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	shareId, err := parse.DataShareID(d.Get("share_id").(string))
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, shareId.ResourceGroup, shareId.AccountName, shareId.Name, name)
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for present of existing  DataShare DataSet %q (Resource Group %q / accountName %q / shareName %q): %+v", name, shareId.ResourceGroup, shareId.AccountName, shareId.Name, err)
+		}
+	}
+	existingId := helper.GetAzurermDataShareDataSetId(existing.Value)
+	if existingId != nil && *existingId != "" {
+		return tf.ImportAsExistsError("azurerm_data_share_dataset_data_lake_gen2", *existingId)
+	}
+
+	strId, err := storageParsers.ParseAccountID(d.Get("storage_account_id").(string))
+	if err != nil {
+		return err
+	}
+
+	var dataSet datashare.BasicDataSet
+
+	if filePath, ok := d.GetOk("file_path"); ok {
+		dataSet = datashare.ADLSGen2FileDataSet{
+			Kind: datashare.KindAdlsGen2File,
+			ADLSGen2FileProperties: &datashare.ADLSGen2FileProperties{
+				StorageAccountName: utils.String(strId.Name),
+				ResourceGroup:      utils.String(strId.ResourceGroup),
+				SubscriptionID:     utils.String(strId.SubscriptionId),
+				FileSystem:         utils.String(d.Get("file_system_name").(string)),
+				FilePath:           utils.String(filePath.(string)),
+			},
+		}
+	} else if folderPath, ok := d.GetOk("folder_path"); ok {
+		dataSet = datashare.ADLSGen2FolderDataSet{
+			Kind: datashare.KindAdlsGen2Folder,
+			ADLSGen2FolderProperties: &datashare.ADLSGen2FolderProperties{
+				StorageAccountName: utils.String(strId.Name),
+				ResourceGroup:      utils.String(strId.ResourceGroup),
+				SubscriptionID:     utils.String(strId.SubscriptionId),
+				FileSystem:         utils.String(d.Get("file_system_name").(string)),
+				FolderPath:         utils.String(folderPath.(string)),
+			},
+		}
+	} else {
+		dataSet = datashare.ADLSGen2FileSystemDataSet{
+			Kind: datashare.KindAdlsGen2FileSystem,
+			ADLSGen2FileSystemProperties: &datashare.ADLSGen2FileSystemProperties{
+				StorageAccountName: utils.String(strId.Name),
+				ResourceGroup:      utils.String(strId.ResourceGroup),
+				SubscriptionID:     utils.String(strId.SubscriptionId),
+				FileSystem:         utils.String(d.Get("file_system_name").(string)),
+			},
+		}
+	}
+
+	if _, err := client.Create(ctx, shareId.ResourceGroup, shareId.AccountName, shareId.Name, name, dataSet); err != nil {
+		return fmt.Errorf("creating DataShare DataSet %q (Resource Group %q / accountName %q / shareName %q): %+v", name, shareId.ResourceGroup, shareId.AccountName, shareId.Name, err)
+	}
+
+	resp, err := client.Get(ctx, shareId.ResourceGroup, shareId.AccountName, shareId.Name, name)
+	if err != nil {
+		return fmt.Errorf("retrieving DataShare DataSet %q (Resource Group %q / accountName %q / shareName %q): %+v", name, shareId.ResourceGroup, shareId.AccountName, shareId.Name, err)
+	}
+
+	respId := helper.GetAzurermDataShareDataSetId(resp.Value)
+	if respId == nil || *respId == "" {
+		return fmt.Errorf("empty or nil ID returned for DataShare DataSet %q (Resource Group %q / accountName %q / shareName %q)", name, shareId.ResourceGroup, shareId.AccountName, shareId.Name)
+	}
+
+	d.SetId(*respId)
+	return resourceArmDataShareDataSetDataLakeGen2Read(d, meta)
+}
+
+func resourceArmDataShareDataSetDataLakeGen2Read(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataShare.DataSetClient
+	shareClient := meta.(*clients.Client).DataShare.SharesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DataShareDataSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.AccountName, id.ShareName, id.Name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[INFO] DataShare %q does not exist - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving DataShare DataSet %q (Resource Group %q / accountName %q / shareName %q): %+v", id.Name, id.ResourceGroup, id.AccountName, id.ShareName, err)
+	}
+	d.Set("name", id.Name)
+	shareResp, err := shareClient.Get(ctx, id.ResourceGroup, id.AccountName, id.ShareName)
+	if err != nil {
+		return fmt.Errorf("retrieving DataShare %q (Resource Group %q / accountName %q): %+v", id.ShareName, id.ResourceGroup, id.AccountName, err)
+	}
+	if shareResp.ID == nil || *shareResp.ID == "" {
+		return fmt.Errorf("empty or nil ID returned for DataShare %q (Resource Group %q / accountName %q)", id.ShareName, id.ResourceGroup, id.AccountName)
+	}
+	d.Set("share_id", shareResp.ID)
+
+	switch resp := resp.Value.(type) {
+	case datashare.ADLSGen2FileDataSet:
+		if props := resp.ADLSGen2FileProperties; props != nil {
+			d.Set("storage_account_id", fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", *props.SubscriptionID, *props.ResourceGroup, *props.StorageAccountName))
+			d.Set("file_system_name", props.FileSystem)
+			d.Set("file_path", props.FilePath)
+			d.Set("display_name", props.DataSetID)
+		}
+
+	case datashare.ADLSGen2FolderDataSet:
+		if props := resp.ADLSGen2FolderProperties; props != nil {
+			d.Set("storage_account_id", fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", *props.SubscriptionID, *props.ResourceGroup, *props.StorageAccountName))
+			d.Set("file_system_name", props.FileSystem)
+			d.Set("folder_path", props.FolderPath)
+			d.Set("display_name", props.DataSetID)
+		}
+
+	case datashare.ADLSGen2FileSystemDataSet:
+		if props := resp.ADLSGen2FileSystemProperties; props != nil {
+			d.Set("storage_account_id", fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s", *props.SubscriptionID, *props.ResourceGroup, *props.StorageAccountName))
+			d.Set("file_system_name", props.FileSystem)
+			d.Set("display_name", props.DataSetID)
+		}
+
+	default:
+		return fmt.Errorf("data share dataset %q (Resource Group %q / accountName %q / shareName %q) is not a datalake store gen2 dataset", id.Name, id.ResourceGroup, id.AccountName, id.ShareName)
+	}
+
+	return nil
+}
+
+func resourceArmDataShareDataSetDataLakeGen2Delete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).DataShare.DataSetClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.DataShareDataSetID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.Delete(ctx, id.ResourceGroup, id.AccountName, id.ShareName, id.Name); err != nil {
+		return fmt.Errorf("deleting DataShare DataSet %q (Resource Group %q / accountName %q / shareName %q): %+v", id.Name, id.ResourceGroup, id.AccountName, id.ShareName, err)
+	}
+	return nil
+}

--- a/azurerm/internal/services/datashare/tests/data_source_data_share_dataset_data_lake_gen2_test.go
+++ b/azurerm/internal/services/datashare/tests/data_source_data_share_dataset_data_lake_gen2_test.go
@@ -1,0 +1,43 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccDataSourceAzureRMDataShareDatasetDataLakeGen2_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_data_share_dataset_data_lake_gen2", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataShareDataSetDestroy("azurerm_data_share_dataset_data_lake_gen2"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataShareDatasetDataLakeGen2_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataShareDataSetExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "storage_account_id"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "file_system_name"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "file_path"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "display_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDataShareDatasetDataLakeGen2_basic(data acceptance.TestData) string {
+	config := testAccAzureRMDataShareDataSetDataLakeGen2File_basic(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_data_share_dataset_data_lake_gen2" "test" {
+  name     = azurerm_data_share_dataset_data_lake_gen2.test.name
+  share_id = azurerm_data_share_dataset_data_lake_gen2.test.share_id
+}
+`, config)
+}

--- a/azurerm/internal/services/datashare/tests/resource_arm_data_share_dataset_data_lake_gen2_test.go
+++ b/azurerm/internal/services/datashare/tests/resource_arm_data_share_dataset_data_lake_gen2_test.go
@@ -1,0 +1,211 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+)
+
+func TestAccAzureRMDataShareDataSetDataLakeGen2File_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_share_dataset_data_lake_gen2", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataShareDataSetDestroy("azurerm_data_share_dataset_data_lake_gen2"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataShareDataSetDataLakeGen2File_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataShareDataSetExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "display_name"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDataShareDataSetDataLakeGen2Folder_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_share_dataset_data_lake_gen2", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataShareDataSetDestroy("azurerm_data_share_dataset_data_lake_gen2"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataShareDataSetDataLakeGen2Folder_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataShareDataSetExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "display_name"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDataShareDataSetDataLakeGen2FileSystem_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_share_dataset_data_lake_gen2", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataShareDataSetDestroy("azurerm_data_share_dataset_data_lake_gen2"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataShareDataSetDataLakeGen2FileSystem_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataShareDataSetExists(data.ResourceName),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "display_name"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMDataShareDataLakeGen2DataSet_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_data_share_dataset_data_lake_gen2", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMDataShareDataSetDestroy("azurerm_data_share_dataset_data_lake_gen2"),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMDataShareDataSetDataLakeGen2File_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDataShareDataSetExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMDataShareDataLakeGen2DataSet_requiresImport),
+		},
+	})
+}
+
+func testAccAzureRMDataShareDataLakeGen2DataSet_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+provider "azuread" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-datashare-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_data_share_account" "test" {
+  name                = "acctest-dsa-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_data_share" "test" {
+  name       = "acctest_ds_%[1]d"
+  account_id = azurerm_data_share_account.test.id
+  kind       = "CopyBased"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "accteststr%[3]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
+  name               = "acctest-%[1]d"
+  storage_account_id = azurerm_storage_account.test.id
+}
+
+data "azuread_service_principal" "test" {
+  display_name = azurerm_data_share_account.test.name
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_storage_account.test.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = data.azuread_service_principal.test.object_id
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(12))
+}
+
+func testAccAzureRMDataShareDataSetDataLakeGen2File_basic(data acceptance.TestData) string {
+	config := testAccAzureRMDataShareDataLakeGen2DataSet_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_share_dataset_data_lake_gen2" "test" {
+  name               = "acctest-dlds-%d"
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
+  file_path          = "myfile.txt"
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
+}
+`, config, data.RandomInteger)
+}
+
+func testAccAzureRMDataShareDataSetDataLakeGen2Folder_basic(data acceptance.TestData) string {
+	config := testAccAzureRMDataShareDataLakeGen2DataSet_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_share_dataset_data_lake_gen2" "test" {
+  name               = "acctest-dlds-%d"
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
+  folder_path        = "test"
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
+}
+`, config, data.RandomInteger)
+}
+
+func testAccAzureRMDataShareDataSetDataLakeGen2FileSystem_basic(data acceptance.TestData) string {
+	config := testAccAzureRMDataShareDataLakeGen2DataSet_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_share_dataset_data_lake_gen2" "test" {
+  name               = "acctest-dlds-%d"
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
+}
+`, config, data.RandomInteger)
+}
+
+func testAccAzureRMDataShareDataLakeGen2DataSet_requiresImport(data acceptance.TestData) string {
+	config := testAccAzureRMDataShareDataSetDataLakeGen2File_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_data_share_dataset_data_lake_gen2" "import" {
+  name               = azurerm_data_share_dataset_data_lake_gen2.test.name
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_data_share_dataset_data_lake_gen2.test.storage_account_id
+  file_system_name   = azurerm_data_share_dataset_data_lake_gen2.test.file_system_name
+  file_path          = azurerm_data_share_dataset_data_lake_gen2.test.file_path
+}
+`, config)
+}

--- a/azurerm/internal/services/datashare/validate/data_share.go
+++ b/azurerm/internal/services/datashare/validate/data_share.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	dataLakeParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datalake/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/datashare/parse"
+	StorageParse "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/storage/parsers"
 )
 
 func DataShareAccountName() schema.SchemaValidateFunc {
@@ -71,6 +72,20 @@ func DatalakeStoreID(i interface{}, k string) (warnings []string, errors []error
 
 	if _, err := dataLakeParse.DataLakeStoreID(v); err != nil {
 		errors = append(errors, fmt.Errorf("can not parse %q as a Data Lake Store id: %v", k, err))
+	}
+
+	return warnings, errors
+}
+
+func StorageAccountID(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := StorageParse.ParseAccountID(v); err != nil {
+		errors = append(errors, fmt.Errorf("can not parse %q as a Storage Account id: %v", k, err))
 	}
 
 	return warnings, errors

--- a/azurerm/internal/services/storage/parsers/id.go
+++ b/azurerm/internal/services/storage/parsers/id.go
@@ -5,8 +5,9 @@ import (
 )
 
 type AccountID struct {
-	Name          string
-	ResourceGroup string
+	Name           string
+	ResourceGroup  string
+	SubscriptionId string
 }
 
 func ParseAccountID(input string) (*AccountID, error) {
@@ -16,7 +17,8 @@ func ParseAccountID(input string) (*AccountID, error) {
 	}
 
 	account := AccountID{
-		ResourceGroup: id.ResourceGroup,
+		ResourceGroup:  id.ResourceGroup,
+		SubscriptionId: id.SubscriptionID,
 	}
 
 	if account.Name, err = id.PopSegment("storageAccounts"); err != nil {

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -214,6 +214,10 @@
                 </li>
 
                 <li>
+                  <a href="/docs/providers/azurerm/d/data_share_dataset_data_lake_gen2.html">azurerm_data_share_dataset_data_lake_gen2</a>
+                </li>
+
+                <li>
                     <a href="/docs/providers/azurerm/d/dedicated_host.html">azurerm_dedicated_host</a>
                 </li>
 
@@ -1601,6 +1605,9 @@
                 </li>
                 <li>
                   <a href="/docs/providers/azurerm/r/data_share_dataset_data_lake_gen1.html">azurerm_data_share_dataset_data_lake_gen1</a>
+                </li>
+                <li>
+                  <a href="/docs/providers/azurerm/r/data_share_dataset_data_lake_gen2.html">azurerm_data_share_dataset_data_lake_gen2</a>
                 </li>
               </ul>
             </li>

--- a/website/docs/d/data_share_dataset_data_lake_gen2.html.markdown
+++ b/website/docs/d/data_share_dataset_data_lake_gen2.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "Data Share"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_data_share_dataset_data_lake_gen2"
+description: |-
+  Gets information about an existing Data Share Data Lake Gen2 Dataset.
+---
+
+# Data Source: azurerm_data_share_dataset_data_lake_gen2
+
+Use this data source to access information about an existing Data Share Data Lake Gen2 Dataset.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_data_share_dataset_data_lake_gen2" "example" {
+  name     = "example-dsdlg2ds"
+  share_id = "example-share-id"
+}
+
+output "id" {
+  value = data.azurerm_data_share_dataset_data_lake_gen2.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this Data Share Data Lake Gen2 Dataset.
+
+* `share_id` - (Required) The resource ID of the Data Share where this Data Share Data Lake Gen2 Dataset should be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The resource ID of the Data Share Data Lake Gen2 Dataset.
+
+* `display_name` - The name of the Data Share Dataset.
+
+* `file_path` - The path of the file in the data lake file system to be shared with the receiver.
+
+* `file_system_name` - The name of the data lake file system to be shared with the receiver.
+
+* `folder_path` - The folder path in the data lake file system to be shared with the receiver.
+
+* `storage_account_id` - The resource ID of the storage account of the data lake file system to be shared with the receiver.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Share Data Lake Gen2 Dataset.

--- a/website/docs/r/data_share_dataset_data_lake_gen2.html.markdown
+++ b/website/docs/r/data_share_dataset_data_lake_gen2.html.markdown
@@ -1,0 +1,116 @@
+---
+subcategory: "Data Share"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_data_share_dataset_data_lake_gen2"
+description: |-
+  Manages a Data Share Data Lake Gen2 Dataset.
+---
+
+# azurerm_data_share_dataset_data_lake_gen2
+
+Manages a Data Share Data Lake Gen2 Dataset.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_data_share_account" "example" {
+  name                = "example-dsa"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_data_share" "example" {
+  name       = "example_ds"
+  account_id = azurerm_data_share_account.example.id
+  kind       = "CopyBased"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestr"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "example" {
+  name               = "example-dlg2fs"
+  storage_account_id = azurerm_storage_account.example.id
+}
+
+data "azuread_service_principal" "example" {
+  display_name = azurerm_data_share_account.example.name
+}
+
+resource "azurerm_role_assignment" "example" {
+  scope                = azurerm_storage_account.example.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = data.azuread_service_principal.example.object_id
+}
+
+resource "azurerm_data_share_dataset_data_lake_gen2" "example" {
+  name               = "accexample-dlg2ds"
+  share_id           = azurerm_data_share.example.id
+  storage_account_id = azurerm_storage_account.example.id
+  file_system_name   = azurerm_storage_data_lake_gen2_filesystem.example.name
+  file_path          = "myfile.txt"
+  depends_on = [
+    azurerm_role_assignment.example,
+  ]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Data Share Data Lake Gen2 Dataset. Changing this forces a new Data Share Data Lake Gen2 Dataset to be created.
+
+* `share_id` - (Required) The resource ID of the Data Share where this Data Share Data Lake Gen2 Dataset should be created. Changing this forces a new Data Share Data Lake Gen2 Dataset to be created.
+
+* `file_system_name` - (Required) The name of the data lake file system to be shared with the receiver. Changing this forces a new Data Share Data Lake Gen2 Dataset to be created.
+
+* `storage_account_id` - (Required) The resource id of the storage account of the data lake file system to be shared with the receiver. Changing this forces a new Data Share Data Lake Gen2 Dataset to be created.
+
+---
+
+* `file_path` - (Optional) The path of the file in the data lake file system to be shared with the receiver. Conflicts with `folder_path` Changing this forces a new Data Share Data Lake Gen2 Dataset to be created.
+
+* `folder_path` - (Optional) The folder path in the data lake file system to be shared with the receiver. Conflicts with `file_path` Changing this forces a new Data Share Data Lake Gen2 Dataset to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The resource ID of the Data Share Data Lake Gen2 Dataset.
+
+* `display_name` - The name of the Data Share Dataset.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Share Data Lake Gen2 Dataset.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Share Data Lake Gen2 Dataset.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Share Data Lake Gen2 Dataset.
+
+## Import
+
+Data Share Data Lake Gen2 Datasets can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_data_share_dataset_data_lake_gen2.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DataShare/accounts/account1/shares/share1/dataSets/dataSet1
+```


### PR DESCRIPTION
Partially fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/6480

Sub PR of : https://github.com/terraform-providers/terraform-provider-azurerm/pull/7064

resource:
=== RUN   TestAccAzureRMDataShareDataSetDataLakeGen2File_basic
=== PAUSE TestAccAzureRMDataShareDataSetDataLakeGen2File_basic
=== CONT  TestAccAzureRMDataShareDataSetDataLakeGen2File_basic
--- PASS: TestAccAzureRMDataShareDataSetDataLakeGen2File_basic (362.76s)
=== RUN   TestAccAzureRMDataShareDataSetDataLakeGen2Folder_basic
=== PAUSE TestAccAzureRMDataShareDataSetDataLakeGen2Folder_basic
=== CONT  TestAccAzureRMDataShareDataSetDataLakeGen2Folder_basic
--- PASS: TestAccAzureRMDataShareDataSetDataLakeGen2Folder_basic (362.81s)
=== RUN   TestAccAzureRMDataShareDataSetDataLakeGen2FileSystem_basic
=== PAUSE TestAccAzureRMDataShareDataSetDataLakeGen2FileSystem_basic
=== CONT  TestAccAzureRMDataShareDataSetDataLakeGen2FileSystem_basic
--- PASS: TestAccAzureRMDataShareDataSetDataLakeGen2FileSystem_basic (428.79s)
=== RUN   TestAccAzureRMDataShareDataLakeGen2DataSet_requiresImport
=== PAUSE TestAccAzureRMDataShareDataLakeGen2DataSet_requiresImport
=== CONT  TestAccAzureRMDataShareDataLakeGen2DataSet_requiresImport
--- PASS: TestAccAzureRMDataShareDataLakeGen2DataSet_requiresImport (438.13s)

data source:
=== RUN   TestAccDataSourceAzureRMDataShareDatasetDataLakeGen2_basic
=== PAUSE TestAccDataSourceAzureRMDataShareDatasetDataLakeGen2_basic
=== CONT  TestAccDataSourceAzureRMDataShareDatasetDataLakeGen2_basic
--- PASS: TestAccDataSourceAzureRMDataShareDatasetDataLakeGen2_basic (428.36s)