### PR TITLE
`azurerm_cosmosdb_account` fix all acctests

### DIFF
--- a/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
+++ b/azurerm/internal/services/cosmos/tests/cosmosdb_account_resource_test.go
@@ -238,7 +238,7 @@ func testAccAzureRMCosmosDBAccount_updateWith(t *testing.T, kind documentdb.Data
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMCosmosDBAccount_basic(data, kind, documentdb.Eventual),
+				Config: testAccAzureRMCosmosDBAccount_basicWithResources(data, kind, documentdb.Eventual),
 				Check:  resource.ComposeAggregateTestCheckFunc(
 				// checkAccAzureRMCosmosDBAccount_basic(data, documentdb.Eventual, 1),
 				),
@@ -682,6 +682,29 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 }
 `, testAccAzureRMCosmosDBAccount_completePreReqs(data), data.RandomInteger, string(kind), string(consistency), data.Locations.Secondary, data.Locations.Ternary)
+}
+
+func testAccAzureRMCosmosDBAccount_basicWithResources(data acceptance.TestData, kind documentdb.DatabaseAccountKind, consistency documentdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "%s"
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+}
+`, testAccAzureRMCosmosDBAccount_completePreReqs(data), data.RandomInteger, string(kind), string(consistency))
 }
 
 func testAccAzureRMCosmosDBAccount_capabilities(data acceptance.TestData, kind documentdb.DatabaseAccountKind, capabilities []string) string {


### PR DESCRIPTION
Fix three failed acctests in PR https://github.com/terraform-providers/terraform-provider-azurerm/pull/7597. It was caused by Terraform core will destroy resources before updating dependencies. 
--- FAIL: TestAccAzureRMCosmosDBAccount_update_global (4025.25s)
--- FAIL: TestAccAzureRMCosmosDBAccount_update_parse (1672.24s)
--- FAIL: TestAccAzureRMCosmosDBAccount_update_mongo (1664.29s)


=== RUN   TestAccAzureRMCosmosDBAccount_update_global
=== PAUSE TestAccAzureRMCosmosDBAccount_update_global
=== CONT  TestAccAzureRMCosmosDBAccount_update_global
--- PASS: TestAccAzureRMCosmosDBAccount_update_global (4978.75s)
=== RUN   TestAccAzureRMCosmosDBAccount_update_parse
=== PAUSE TestAccAzureRMCosmosDBAccount_update_parse
=== CONT  TestAccAzureRMCosmosDBAccount_update_parse
--- PASS: TestAccAzureRMCosmosDBAccount_update_parse (4650.45s)
=== RUN   TestAccAzureRMCosmosDBAccount_update_mongo
=== PAUSE TestAccAzureRMCosmosDBAccount_update_mongo
=== CONT  TestAccAzureRMCosmosDBAccount_update_mongo
--- PASS: TestAccAzureRMCosmosDBAccount_update_mongo (5184.38s)