### PR TITLE
`azurerm_security_center_workspace` fix all acctests

### DIFF
--- a/azurerm/internal/services/securitycenter/resource_arm_security_center_workspace.go
+++ b/azurerm/internal/services/securitycenter/resource_arm_security_center_workspace.go
@@ -10,9 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
@@ -62,19 +60,6 @@ func resourceArmSecurityCenterWorkspaceCreateUpdate(d *schema.ResourceData, meta
 	defer cancel()
 
 	name := securityCenterWorkspaceName
-
-	if features.ShouldResourcesBeImported() && d.IsNewResource() {
-		existing, err := client.Get(ctx, name)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("Error checking for presence of existing Security Center Workspace: %+v", err)
-			}
-		}
-
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_security_center_workspace", *existing.ID)
-		}
-	}
 
 	// get pricing tier, workspace can only be configured when tier is not Free.
 	// API does not error, it just doesn't set the workspace scope

--- a/azurerm/internal/services/securitycenter/tests/resource_arm_security_center_test.go
+++ b/azurerm/internal/services/securitycenter/tests/resource_arm_security_center_test.go
@@ -12,9 +12,8 @@ func TestAccAzureRMSecurityCenter_pricingAndWorkspace(t *testing.T) {
 			"update": testAccAzureRMSecurityCenterSubscriptionPricing_update,
 		},
 		"workspace": {
-			"basic":          testAccAzureRMSecurityCenterWorkspace_basic,
-			"update":         testAccAzureRMSecurityCenterWorkspace_update,
-			"requiresImport": testAccAzureRMSecurityCenterWorkspace_requiresImport,
+			"basic":  testAccAzureRMSecurityCenterWorkspace_basic,
+			"update": testAccAzureRMSecurityCenterWorkspace_update,
 		},
 	}
 

--- a/azurerm/internal/services/securitycenter/tests/resource_arm_security_center_workspace_test.go
+++ b/azurerm/internal/services/securitycenter/tests/resource_arm_security_center_workspace_test.go
@@ -38,34 +38,6 @@ func testAccAzureRMSecurityCenterWorkspace_basic(t *testing.T) {
 	})
 }
 
-func testAccAzureRMSecurityCenterWorkspace_requiresImport(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_security_center_workspace", "test")
-	scope := fmt.Sprintf("/subscriptions/%s", os.Getenv("ARM_SUBSCRIPTION_ID"))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { acceptance.PreCheck(t) },
-		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMSecurityCenterWorkspaceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAzureRMSecurityCenterWorkspace_basicCfg(data, scope),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSecurityCenterWorkspaceExists(),
-					resource.TestCheckResourceAttr(data.ResourceName, "scope", scope),
-				),
-			},
-			{
-				Config:      testAccAzureRMSecurityCenterWorkspace_requiresImportCfg(data, scope),
-				ExpectError: acceptance.RequiresImportError("azurerm_security_center_workspace"),
-			},
-			{
-				// reset pricing to free
-				Config: testAccAzureRMSecurityCenterSubscriptionPricing_tier("Free"),
-			},
-		},
-	})
-}
-
 func testAccAzureRMSecurityCenterWorkspace_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_workspace", "test")
 	scope := fmt.Sprintf("/subscriptions/%s", os.Getenv("ARM_SUBSCRIPTION_ID"))
@@ -169,18 +141,6 @@ resource "azurerm_security_center_workspace" "test" {
   workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, scope)
-}
-
-func testAccAzureRMSecurityCenterWorkspace_requiresImportCfg(data acceptance.TestData, scope string) string {
-	template := testAccAzureRMSecurityCenterWorkspace_basicCfg(data, scope)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_security_center_workspace" "import" {
-  scope        = azurerm_security_center_workspace.test.scope
-  workspace_id = azurerm_security_center_workspace.test.workspace_id
-}
-`, template)
 }
 
 func testAccAzureRMSecurityCenterWorkspace_differentWorkspaceCfg(data acceptance.TestData, scope string) string {


### PR DESCRIPTION
Refer to https://docs.microsoft.com/en-us/azure/security-center/security-center-enable-data-collection#workspace-configuration.

Currently, by default, there'll be a default workspace created by Security Center. So I'd like to suggest to remove existence checking and require_import test to get the acctests passed.

=== RUN   TestAccAzureRMSecurityCenter_pricingAndWorkspace
--- PASS: TestAccAzureRMSecurityCenter_pricingAndWorkspace (2056.96s)
=== RUN   TestAccAzureRMSecurityCenter_pricingAndWorkspace/pricing
    --- PASS: TestAccAzureRMSecurityCenter_pricingAndWorkspace/pricing (93.78s)
=== RUN   TestAccAzureRMSecurityCenter_pricingAndWorkspace/pricing/update
        --- PASS: TestAccAzureRMSecurityCenter_pricingAndWorkspace/pricing/update (93.78s)
=== RUN   TestAccAzureRMSecurityCenter_pricingAndWorkspace/workspace
    --- PASS: TestAccAzureRMSecurityCenter_pricingAndWorkspace/workspace (1963.19s)
=== RUN   TestAccAzureRMSecurityCenter_pricingAndWorkspace/workspace/basic
        --- PASS: TestAccAzureRMSecurityCenter_pricingAndWorkspace/workspace/basic (618.82s)
=== RUN   TestAccAzureRMSecurityCenter_pricingAndWorkspace/workspace/update
        --- PASS: TestAccAzureRMSecurityCenter_pricingAndWorkspace/workspace/update (1344.36s)