### PR TITLE
AKS - allow in-place upgrade from free to paid sku_tier

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
-
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-03-01/containerservice"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/containers/kubernetes_cluster_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_resource.go
@@ -521,7 +521,7 @@ func resourceArmKubernetesCluster() *schema.Resource {
 				// @tombuildsstuff (2020-05-29) - Preview limitations:
 				//  * Currently, there is no way to remove Uptime SLA from an AKS cluster after creation with it enabled.
 				//  * Private clusters aren't currently supported.
-				// @jackofallops (2020-07-21) - Preview Update:
+				// @jackofallops (2020-07-21) - Update:
 				//  * sku_tier can now be upgraded in place, downgrade requires rebuild
 				Default: string(containerservice.Free),
 				ValidateFunc: validation.StringInSlice([]string{

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -110,9 +110,9 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 -> **NOTE:** One of either `identity` or `service_principal` must be specified.
 
-* `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Changing this forces a new resource to be created. Possible values are `Free` and `Paid` (which includes the Uptime SLA). Defaults to `Free`.
+* `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are `Free` and `Paid` (which includes the Uptime SLA). Defaults to `Free`.
 
-~> **Note:** This functionality is in Preview and has [several limitations](https://docs.microsoft.com/en-us/azure/aks/uptime-sla).
+~> **Note:** This functionality is in Preview and has [several limitations](https://docs.microsoft.com/en-us/azure/aks/uptime-sla). It is currently possible to upgrade in place from `Free` to `Paid`, however, changing this value from `Paid` to `Free` will force a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -112,7 +112,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are `Free` and `Paid` (which includes the Uptime SLA). Defaults to `Free`.
 
-~> **Note:** This functionality is in Preview and has [several limitations](https://docs.microsoft.com/en-us/azure/aks/uptime-sla). It is currently possible to upgrade in place from `Free` to `Paid`, however, changing this value from `Paid` to `Free` will force a new resource to be created.
+~> **Note:**  It is currently possible to upgrade in place from `Free` to `Paid`. However, changing this value from `Paid` to `Free` will force a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Notes: 
- Feature is out of preview, and supports upgrade from `Free` -> `Paid`.
- Downgrade is not supported and changing `sku_tier` from `Paid` -> `Free` will result in a cluster rebuild.

This PR:
fixes #7530 
supersedes #7790 