### PR TITLE
Add autoscale_throughput to cosmosdb

### DIFF
--- a/azurerm/internal/services/cosmos/common/throughput.go
+++ b/azurerm/internal/services/cosmos/common/throughput.go
@@ -19,6 +19,20 @@ func GetThroughputFromResult(throughputResponse documentdb.ThroughputSettingsGet
 	return res.Throughput
 }
 
+func GetAutoScaleThroughputFromResult(throughputResponse documentdb.ThroughputSettingsGetResults) *int32 {
+	props := throughputResponse.ThroughputSettingsGetProperties
+	if props == nil {
+		return nil
+	}
+
+	res := props.Resource
+	if res == nil {
+		return nil
+	}
+
+	return res.AutoscaleSettings.MaxThroughput
+}
+
 func ConvertThroughputFromResourceData(throughput interface{}) *int32 {
 	return utils.Int32(int32(throughput.(int)))
 }


### PR DESCRIPTION
CosmosDB supports autoscaling throughput settings for SQL databases and containers.
This PR adds support for those settings.