### PR TITLE
dependencies: updating to v44.2.0 of github.com/Azure/azure-sdk-for-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-azurerm
 
 require (
-	github.com/Azure/azure-sdk-for-go v44.1.0+incompatible
+	github.com/Azure/azure-sdk-for-go v44.2.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.10.0
 	github.com/Azure/go-autorest/autorest/azure/cli v0.3.1 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Azure/azure-sdk-for-go v32.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v35.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v42.1.0+incompatible h1:ZNliGuvGKIHedRdz8W9BTMSrxBv9Nzz5BjeobotQTAI=
 github.com/Azure/azure-sdk-for-go v42.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v44.1.0+incompatible h1:l1UGvaaoMCUwVGUauvHzeB4t+Y0yPX5iJwBhzc0LqyE=
-github.com/Azure/azure-sdk-for-go v44.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v44.2.0+incompatible h1:d0WY8HTXhnurVBAkLXzv4bRpd+P5r3U/W17Z88PJWiI=
+github.com/Azure/azure-sdk-for-go v44.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/adal v0.6.0/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=
 github.com/Azure/go-autorest/autorest/adal v0.8.0/go.mod h1:Z6vX6WXXuyieHAXwMj0S6HY6e6wcHn37qQMBQlvY3lc=

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/clusters.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/clusters.go
@@ -879,6 +879,84 @@ func (client ClustersClient) UpdateResponder(resp *http.Response) (result Cluste
 	return
 }
 
+// UpdateAutoScaleConfiguration updates the Autoscale Configuration for HDInsight cluster.
+// Parameters:
+// resourceGroupName - the name of the resource group.
+// clusterName - the name of the cluster.
+// parameters - the parameters for the update autoscale configuration operation.
+func (client ClustersClient) UpdateAutoScaleConfiguration(ctx context.Context, resourceGroupName string, clusterName string, parameters AutoscaleConfigurationUpdateParameter) (result ClustersUpdateAutoScaleConfigurationFuture, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/ClustersClient.UpdateAutoScaleConfiguration")
+		defer func() {
+			sc := -1
+			if result.Response() != nil {
+				sc = result.Response().StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.UpdateAutoScaleConfigurationPreparer(ctx, resourceGroupName, clusterName, parameters)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "hdinsight.ClustersClient", "UpdateAutoScaleConfiguration", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.UpdateAutoScaleConfigurationSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "hdinsight.ClustersClient", "UpdateAutoScaleConfiguration", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateAutoScaleConfigurationPreparer prepares the UpdateAutoScaleConfiguration request.
+func (client ClustersClient) UpdateAutoScaleConfigurationPreparer(ctx context.Context, resourceGroupName string, clusterName string, parameters AutoscaleConfigurationUpdateParameter) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"clusterName":       autorest.Encode("path", clusterName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"roleName":          autorest.Encode("path", "workernode"),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2018-06-01-preview"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HDInsight/clusters/{clusterName}/roles/{roleName}/autoscale", pathParameters),
+		autorest.WithJSON(parameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// UpdateAutoScaleConfigurationSender sends the UpdateAutoScaleConfiguration request. The method will close the
+// http.Response Body if it receives an error.
+func (client ClustersClient) UpdateAutoScaleConfigurationSender(req *http.Request) (future ClustersUpdateAutoScaleConfigurationFuture, err error) {
+	var resp *http.Response
+	resp, err = client.Send(req, azure.DoRetryWithRegistration(client.Client))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
+	return
+}
+
+// UpdateAutoScaleConfigurationResponder handles the response to the UpdateAutoScaleConfiguration request. The method always
+// closes the http.Response Body.
+func (client ClustersClient) UpdateAutoScaleConfigurationResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
 // UpdateGatewaySettings configures the gateway settings on the specified cluster.
 // Parameters:
 // resourceGroupName - the name of the resource group.

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/models.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/preview/hdinsight/mgmt/2018-06-01-preview/hdinsight/models.go
@@ -516,6 +516,12 @@ type AutoscaleCapacity struct {
 	MaxInstanceCount *int32 `json:"maxInstanceCount,omitempty"`
 }
 
+// AutoscaleConfigurationUpdateParameter the autoscale configuration update parameter.
+type AutoscaleConfigurationUpdateParameter struct {
+	// Autoscale - The autoscale configuration.
+	Autoscale *Autoscale `json:"autoscale,omitempty"`
+}
+
 // AutoscaleRecurrence schedule-based autoscale request parameters
 type AutoscaleRecurrence struct {
 	// TimeZone - The time zone for the autoscale schedule times
@@ -732,6 +738,8 @@ type ClusterCreateProperties struct {
 	StorageProfile *StorageProfile `json:"storageProfile,omitempty"`
 	// DiskEncryptionProperties - The disk encryption properties.
 	DiskEncryptionProperties *DiskEncryptionProperties `json:"diskEncryptionProperties,omitempty"`
+	// EncryptionInTransitProperties - The encryption-in-transit properties.
+	EncryptionInTransitProperties *EncryptionInTransitProperties `json:"encryptionInTransitProperties,omitempty"`
 	// MinSupportedTLSVersion - The minimal supported tls version.
 	MinSupportedTLSVersion *string `json:"minSupportedTlsVersion,omitempty"`
 	// NetworkSettings - The network settings.
@@ -808,6 +816,8 @@ type ClusterGetProperties struct {
 	ConnectivityEndpoints *[]ConnectivityEndpoint `json:"connectivityEndpoints,omitempty"`
 	// DiskEncryptionProperties - The disk encryption properties.
 	DiskEncryptionProperties *DiskEncryptionProperties `json:"diskEncryptionProperties,omitempty"`
+	// EncryptionInTransitProperties - The encryption-in-transit properties.
+	EncryptionInTransitProperties *EncryptionInTransitProperties `json:"encryptionInTransitProperties,omitempty"`
 	// MinSupportedTLSVersion - The minimal supported tls version.
 	MinSupportedTLSVersion *string `json:"minSupportedTlsVersion,omitempty"`
 	// NetworkSettings - The network settings.
@@ -1167,6 +1177,29 @@ func (future *ClustersRotateDiskEncryptionKeyFuture) Result(client ClustersClien
 	return
 }
 
+// ClustersUpdateAutoScaleConfigurationFuture an abstraction for monitoring and retrieving the results of a
+// long-running operation.
+type ClustersUpdateAutoScaleConfigurationFuture struct {
+	azure.Future
+}
+
+// Result returns the result of the asynchronous operation.
+// If the operation has not completed it will return an error.
+func (future *ClustersUpdateAutoScaleConfigurationFuture) Result(client ClustersClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.DoneWithContext(context.Background(), client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "hdinsight.ClustersUpdateAutoScaleConfigurationFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("hdinsight.ClustersUpdateAutoScaleConfigurationFuture")
+		return
+	}
+	ar.Response = future.Response()
+	return
+}
+
 // ClustersUpdateGatewaySettingsFuture an abstraction for monitoring and retrieving the results of a
 // long-running operation.
 type ClustersUpdateGatewaySettingsFuture struct {
@@ -1263,6 +1296,12 @@ type DiskEncryptionProperties struct {
 	EncryptionAlgorithm JSONWebKeyEncryptionAlgorithm `json:"encryptionAlgorithm,omitempty"`
 	// MsiResourceID - Resource ID of Managed Identity that is used to access the key vault.
 	MsiResourceID *string `json:"msiResourceId,omitempty"`
+}
+
+// EncryptionInTransitProperties the encryption-in-transit properties.
+type EncryptionInTransitProperties struct {
+	// IsEncryptionInTransitEnabled - Indicates whether or not inter cluster node communication is encrypted in transit.
+	IsEncryptionInTransitEnabled *bool `json:"isEncryptionInTransitEnabled,omitempty"`
 }
 
 // ErrorResponse describes the format of Error response.

--- a/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/version/version.go
@@ -18,4 +18,4 @@ package version
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 // Number contains the semantic version of this SDK.
-const Number = "v44.1.0"
+const Number = "v44.2.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/Azure/azure-sdk-for-go v44.1.0+incompatible
+# github.com/Azure/azure-sdk-for-go v44.2.0+incompatible
 github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources
 github.com/Azure/azure-sdk-for-go/services/advisor/mgmt/2020-01-01/advisor
 github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2017-08-01/analysisservices


### PR DESCRIPTION
Updating Azure SDK for Go to v44.2.0 to support https://github.com/terraform-providers/terraform-provider-azurerm/issues/6470
It's pretty minor update with additions only https://github.com/Azure/azure-sdk-for-go/pull/11841/files
We are vendoring only HDInsight parts of 44.2.0 update

cc @jackofallops @ArcturusZhang 