### PR TITLE
Update doc for default_ttl_seconds of azurerm_cosmosdb_mongo_collection

### DIFF
--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Cosmos DB Mongo Collection. Changing this forces a new resource to be created.
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `database_name` - (Required) The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
-* `default_ttl_seconds` - (Required) The default Time To Live in seconds. If the value is `0` items are not automatically expired.
+* `default_ttl_seconds` - (Required) The default Time To Live in seconds. If the value is `-1` or `0`, items are not automatically expired.
 * `shard_key` - (Required) The name of the key to partition on for sharding. There must not be any other unique index keys.
 * `index` - (Optional) One or more `index` blocks as defined below.
 * `throughput` - (Optional) The throughput of the MongoDB collection (RU/s). Must be set in increments of `100`. The minimum value is `400`. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply.


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/6081

Related reference:
https://docs.microsoft.com/en-us/azure/cosmos-db/time-to-live#example-2