### PR TITLE
`azurerm_app_service_plan` - update the relation between `kind` and `reserved`

### DIFF
--- a/azurerm/internal/services/web/resource_arm_app_service_plan.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_plan.go
@@ -193,10 +193,6 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("`reserved` has to be set to true when kind is set to `Linux`")
 	}
 
-	if !strings.EqualFold(kind, "Linux") && reserved {
-		return fmt.Errorf("`reserved` has to be set to false when kind isn't set to `Linux`")
-	}
-
 	if v := d.Get("maximum_elastic_worker_count").(int); v > 0 {
 		appServicePlan.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(v))
 	}

--- a/azurerm/internal/services/web/resource_arm_app_service_plan.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_plan.go
@@ -193,6 +193,10 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("`reserved` has to be set to true when kind is set to `Linux`")
 	}
 
+	if strings.EqualFold(kind, "Windows") && reserved {
+		return fmt.Errorf("`reserved` has to be set to false when kind is set to `Windows`")
+	}
+
 	if v := d.Get("maximum_elastic_worker_count").(int); v > 0 {
 		appServicePlan.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(v))
 	}

--- a/azurerm/internal/services/web/tests/resource_arm_app_service_plan_test.go
+++ b/azurerm/internal/services/web/tests/resource_arm_app_service_plan_test.go
@@ -198,6 +198,25 @@ func TestAccAzureRMAppServicePlan_consumptionPlan(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMAppServicePlan_linuxConsumptionPlan(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMAppServicePlanDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMAppServicePlan_linuxConsumptionPlan(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMAppServicePlanExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMAppServicePlan_premiumConsumptionPlan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_service_plan", "test")
 
@@ -551,6 +570,32 @@ resource "azurerm_app_service_plan" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   kind                = "FunctionApp"
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func testAccAzureRMAppServicePlan_linuxConsumptionPlan(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_app_service_plan" "test" {
+  name                = "acctestASP-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  kind                = "FunctionApp"
+  reserved            = true
 
   sku {
     tier = "Dynamic"

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -107,7 +107,7 @@ The following arguments are supported:
 
 * `kind` - (Optional) The kind of the App Service Plan to create. Possible values are `Windows` (also available as `App`), `Linux`, `elastic` (for Premium Consumption) and `FunctionApp` (for a Consumption Plan). Defaults to `Windows`. Changing this forces a new resource to be created.
 
-~> **NOTE:** When creating a `Linux` App Service Plan, the `reserved` field must be set to `true`, and when creating other kinds of App Service Plan, the `reserved` field must be set to `false`.
+~> **NOTE:** When creating a `Linux` App Service Plan, the `reserved` field must be set to `true`, and when creating a `Windows`/`app` App Service Plan the `reserved` field must be set to `false`.
 
 * `maximum_elastic_worker_count` - The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan.
 


### PR DESCRIPTION
revert PR #7661
correctly fix #2840
fix #7759

I have emailed the service team:
 `kind` is just an ARM level property that is used primarily to drive UX – i.e. what kind of icons or text to show.
 `reserved` is the field to control whether the compute resource is linux or windows.

So when creating an app service plan. 
if we choose "windows" as `kind`, the `reserved` should be false
if we choose "linux" as `kind`, the `reserved` should be true
for other type of `kind`, users may choose windows or linux

The original document is right

![image](https://user-images.githubusercontent.com/2786738/88760642-0eb5f600-d1a0-11ea-9c7e-0104107782de.png)
