### PR TITLE
`azurerm_api_management_api`  `subscription_required` default to `true`

### DIFF
--- a/azurerm/internal/services/apimanagement/api_management_api_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_resource.go
@@ -167,6 +167,7 @@ func resourceArmApiManagementApi() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
+				Default:  true,
 			},
 
 			"soap_pass_through": {

--- a/azurerm/internal/services/apimanagement/api_management_api_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_api_resource.go
@@ -166,7 +166,6 @@ func resourceArmApiManagementApi() *schema.Resource {
 			"subscription_required": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
 				Default:  true,
 			},
 


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/7950
It's caused by we change the code to d.get("subscription_required"), but not assign the default value to `true`