### PR TITLE
Test Fix: `data.azurerm_monitor_diagnostic_categories_acctest`

### DIFF
--- a/azurerm/internal/services/monitor/tests/monitor_diagnostic_categories_data_source_test.go
+++ b/azurerm/internal/services/monitor/tests/monitor_diagnostic_categories_data_source_test.go
@@ -18,8 +18,8 @@ func TestAccDataSourceArmMonitorDiagnosticCategories_appService(t *testing.T) {
 			{
 				Config: testAccDataSourceArmMonitorDiagnosticCategories_appService(data),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "metrics.#", "1"),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.#", "6"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "metrics.#"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "logs.#"),
 				),
 			},
 		},
@@ -36,8 +36,8 @@ func TestAccDataSourceArmMonitorDiagnosticCategories_storageAccount(t *testing.T
 			{
 				Config: testAccDataSourceArmMonitorDiagnosticCategories_storageAccount(data),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(data.ResourceName, "metrics.#", "2"),
-					resource.TestCheckResourceAttr(data.ResourceName, "logs.#", "0"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "metrics.#"),
+					resource.TestCheckResourceAttrSet(data.ResourceName, "logs.#"),
 				),
 			},
 		},


### PR DESCRIPTION
As the diagnostic categories for each resource type might change as time goes by, it might be better to only check the functionality of this data source works, instead of testing against the exact amount of categories. Otherwise, we will frequently get failed test once service team added new log/metric entries (as the app service one, changed from 6->7 in this case).

## Test Result

```bash
💤 make testacc TEST=./azurerm/internal/services/monitor/tests TESTARGS='-run TestAccDataSourceArmMonitorDiagnosticCategories_'              
                                                                                                                                             
==> Checking that code complies with gofmt requirements...                                                                                   
==> Checking that Custom Timeouts are used...                 
==> Checking that acceptance test packages are used...                                                                                       
TF_ACC=1 go test ./azurerm/internal/services/monitor/tests -v -run TestAccDataSourceArmMonitorDiagnosticCategories_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceArmMonitorDiagnosticCategories_appService                                                                         
=== PAUSE TestAccDataSourceArmMonitorDiagnosticCategories_appService
=== RUN   TestAccDataSourceArmMonitorDiagnosticCategories_storageAccount
=== PAUSE TestAccDataSourceArmMonitorDiagnosticCategories_storageAccount                                                                     
=== CONT  TestAccDataSourceArmMonitorDiagnosticCategories_appService
=== CONT  TestAccDataSourceArmMonitorDiagnosticCategories_storageAccount
--- PASS: TestAccDataSourceArmMonitorDiagnosticCategories_storageAccount (156.74s)                                                           
--- PASS: TestAccDataSourceArmMonitorDiagnosticCategories_appService (221.74s)                                                               
PASS                                                                                                                                         
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/monitor/tests       221.780s
```