### PR TITLE
add check for functionApp kind and dynamic sku tier - "azurerm_app_service_plan"

### DIFF
--- a/azurerm/internal/services/web/resource_arm_app_service_plan.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_plan.go
@@ -201,6 +201,10 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("`kind` has to be set to `FunctionApp` when `sku.tier` is `Dynamic`")
 	}
 
+	if strings.EqualFold(*sku.Tier, "ElasticPremium") && !strings.EqualFold(kind, "elastic") {
+		return fmt.Errorf("`kind` has to be set to `elastic` when `sku.tier` is `ElasticPremium`")
+	}
+
 	if v := d.Get("maximum_elastic_worker_count").(int); v > 0 {
 		appServicePlan.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(v))
 	}

--- a/azurerm/internal/services/web/resource_arm_app_service_plan.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_plan.go
@@ -197,7 +197,7 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("`reserved` has to be set to false when kind is set to `Windows`")
 	}
 
-	if *sku.Tier == "Dynamic" && !strings.EqualFold(kind, "FunctionApp") {
+	if strings.EqualFold(*sku.Tier, "Dynamic") && !strings.EqualFold(kind, "FunctionApp") {
 		return fmt.Errorf("`kind` has to be set to `FunctionApp` when `sku.tier` is `Dynamic`")
 	}
 

--- a/azurerm/internal/services/web/resource_arm_app_service_plan.go
+++ b/azurerm/internal/services/web/resource_arm_app_service_plan.go
@@ -197,6 +197,10 @@ func resourceArmAppServicePlanCreateUpdate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("`reserved` has to be set to false when kind is set to `Windows`")
 	}
 
+	if *sku.Tier == "Dynamic" && !strings.EqualFold(kind, "FunctionApp") {
+		return fmt.Errorf("`kind` has to be set to `FunctionApp` when `sku.tier` is `Dynamic`")
+	}
+
 	if v := d.Get("maximum_elastic_worker_count").(int); v > 0 {
 		appServicePlan.AppServicePlanProperties.MaximumElasticWorkerCount = utils.Int32(int32(v))
 	}

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -117,7 +117,7 @@ The following arguments are supported:
 
 ~> **NOTE:** Attaching to an App Service Environment requires the App Service Plan use a `Premium` SKU (when using an ASEv1) and the `Isolated` SKU (for an ASEv2).
 
-* `reserved` - (Optional) Is this App Service Plan `Reserved`. Defaults to `false`.
+* `reserved` - (Optional) Specifies whether it's Linux Platform. Should be `true` If Linux app service plan, false otherwise. Defaults to `false`.
 
 * `per_site_scaling` - (Optional) Can Apps assigned to this App Service Plan be scaled independently? If set to `false` apps assigned to this plan will scale to all instances of the plan.  Defaults to `false`.
 


### PR DESCRIPTION
fix #4396
fix #5971
1. the backend service will always change the kind to `functionapp` if sku tier is `dynamic`. will change kind to `elastic` if sku tier is `ElasticPremium`. add check to avoid such config.
2. update doc about `reserved`