### PR TITLE
Azure Policy: 'mode' shouldn't force new Policy

### DIFF
--- a/azurerm/internal/services/policy/policy_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_definition_resource.go
@@ -63,7 +63,6 @@ func resourceArmPolicyDefinition() *schema.Resource {
 			"mode": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"management_group_id": {

--- a/website/docs/r/policy_definition.html.markdown
+++ b/website/docs/r/policy_definition.html.markdown
@@ -25,7 +25,7 @@ resource "azurerm_policy_definition" "policy" {
     {
     "category": "General"
     }
-  
+
 METADATA
 
 
@@ -71,8 +71,7 @@ The following arguments are supported:
 
 * `mode` - (Required) The policy mode that allows you to specify which resource
     types will be evaluated.  The value can be "All", "Indexed" or
-    "NotSpecified". Changing this resource forces a new resource to be
-    created.
+    "NotSpecified".
 
 * `display_name` - (Required) The display name of the policy definition.
 


### PR DESCRIPTION
It is possible to change Azure Policy Mode (All\Indexed) via the portal for existing policy, so it doesn't required `ForceNew` when changed.

Testing:
Deployed the policy & changed mode multiple times. Changes were reflected via the Azure Portal

```tf
provider "azurerm" {
    features{}
}

resource "azurerm_policy_definition" "policy" {
  name         = "accTestPolicy"
  policy_type  = "Custom"
  mode         = "Indexed"
  display_name = "acceptance test policy definition"

  metadata = <<METADATA
    {
    "category": "General"
    }

METADATA


  policy_rule = <<POLICY_RULE
    {
    "if": {
      "not": {
        "field": "location",
        "in": "[parameters('allowedLocations')]"
      }
    },
    "then": {
      "effect": "audit"
    }
  }
POLICY_RULE


  parameters = <<PARAMETERS
    {
    "allowedLocations": {
      "type": "Array",
      "metadata": {
        "description": "The list of allowed locations for resources.",
        "displayName": "Allowed locations",
        "strongType": "location"
      }
    }
  }
PARAMETERS
}
```