### PR TITLE
`azurerm_servicebus_queue` - support `enable_batched_operations`, `status`, `forward_to`, `forward_dead_lettered_messages_to`

### DIFF
--- a/azurerm/internal/services/servicebus/resource_arm_servicebus_queue.go
+++ b/azurerm/internal/services/servicebus/resource_arm_servicebus_queue.go
@@ -124,6 +124,18 @@ func resourceArmServiceBusQueue() *schema.Resource {
 				Default:      10,
 				ValidateFunc: validation.IntAtLeast(1),
 			},
+
+			"forward_to": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: azure.ValidateServiceBusQueueName(),
+			},
+
+			"forward_dead_lettered_messages_to": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: azure.ValidateServiceBusQueueName(),
+			},
 		},
 	}
 }
@@ -186,6 +198,14 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 
 	if lockDuration := d.Get("lock_duration").(string); lockDuration != "" {
 		parameters.SBQueueProperties.LockDuration = &lockDuration
+	}
+
+	if forwardTo := d.Get("forward_to").(string); forwardTo != "" {
+		parameters.SBQueueProperties.ForwardTo = &forwardTo
+	}
+
+	if forwardDeadLetteredMessagesTo := d.Get("forward_dead_lettered_messages_to").(string); forwardDeadLetteredMessagesTo != "" {
+		parameters.SBQueueProperties.ForwardDeadLetteredMessagesTo = &forwardDeadLetteredMessagesTo
 	}
 
 	// We need to retrieve the namespace because Premium namespace works differently from Basic and Standard,
@@ -257,6 +277,8 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("requires_session", props.RequiresSession)
 		d.Set("dead_lettering_on_message_expiration", props.DeadLetteringOnMessageExpiration)
 		d.Set("max_delivery_count", props.MaxDeliveryCount)
+		d.Set("forward_to", props.ForwardTo)
+		d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
 
 		if maxSizeMB := props.MaxSizeInMegabytes; maxSizeMB != nil {
 			maxSize := int(*maxSizeMB)

--- a/azurerm/internal/services/servicebus/resource_arm_servicebus_queue.go
+++ b/azurerm/internal/services/servicebus/resource_arm_servicebus_queue.go
@@ -136,6 +136,12 @@ func resourceArmServiceBusQueue() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: azure.ValidateServiceBusQueueName(),
 			},
+
+			"enable_batched_operations": {
+				Type:     schema.TypeBool,
+				Default:  true,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -157,6 +163,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 	requiresDuplicateDetection := d.Get("requires_duplicate_detection").(bool)
 	requiresSession := d.Get("requires_session").(bool)
 	deadLetteringOnMessageExpiration := d.Get("dead_lettering_on_message_expiration").(bool)
+	enableBatchedOperations := d.Get("enable_batched_operations").(bool)
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.Get(ctx, resourceGroup, namespaceName, name)
@@ -181,6 +188,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 			RequiresDuplicateDetection:       &requiresDuplicateDetection,
 			RequiresSession:                  &requiresSession,
 			DeadLetteringOnMessageExpiration: &deadLetteringOnMessageExpiration,
+			EnableBatchedOperations:          &enableBatchedOperations,
 		},
 	}
 
@@ -279,6 +287,7 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("max_delivery_count", props.MaxDeliveryCount)
 		d.Set("forward_to", props.ForwardTo)
 		d.Set("forward_dead_lettered_messages_to", props.ForwardDeadLetteredMessagesTo)
+		d.Set("enable_batched_operations", props.EnableBatchedOperations)
 
 		if maxSizeMB := props.MaxSizeInMegabytes; maxSizeMB != nil {
 			maxSize := int(*maxSizeMB)

--- a/azurerm/internal/services/servicebus/resource_arm_servicebus_queue.go
+++ b/azurerm/internal/services/servicebus/resource_arm_servicebus_queue.go
@@ -174,7 +174,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 
 	enableExpress := d.Get("enable_express").(bool)
 	enablePartitioning := d.Get("enable_partitioning").(bool)
-	maxSize := int32(d.Get("max_size_in_megabytes").(int))
+	maxSizeInMegabytes := int32(d.Get("max_size_in_megabytes").(int))
 	maxDeliveryCount := int32(d.Get("max_delivery_count").(int))
 	requiresDuplicateDetection := d.Get("requires_duplicate_detection").(bool)
 	requiresSession := d.Get("requires_session").(bool)
@@ -200,7 +200,7 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 		SBQueueProperties: &servicebus.SBQueueProperties{
 			EnableExpress:                    &enableExpress,
 			EnablePartitioning:               &enablePartitioning,
-			MaxSizeInMegabytes:               &maxSize,
+			MaxSizeInMegabytes:               &maxSizeInMegabytes,
 			MaxDeliveryCount:                 &maxDeliveryCount,
 			RequiresDuplicateDetection:       &requiresDuplicateDetection,
 			RequiresSession:                  &requiresSession,
@@ -214,12 +214,12 @@ func resourceArmServiceBusQueueCreateUpdate(d *schema.ResourceData, meta interfa
 		parameters.SBQueueProperties.AutoDeleteOnIdle = &autoDeleteOnIdle
 	}
 
-	if defaultTTL := d.Get("default_message_ttl").(string); defaultTTL != "" {
-		parameters.SBQueueProperties.DefaultMessageTimeToLive = &defaultTTL
+	if defaultMessageTTL := d.Get("default_message_ttl").(string); defaultMessageTTL != "" {
+		parameters.SBQueueProperties.DefaultMessageTimeToLive = &defaultMessageTTL
 	}
 
-	if duplicateWindow := d.Get("duplicate_detection_history_time_window").(string); duplicateWindow != "" {
-		parameters.SBQueueProperties.DuplicateDetectionHistoryTimeWindow = &duplicateWindow
+	if duplicateDetectionHistoryTimeWindow := d.Get("duplicate_detection_history_time_window").(string); duplicateDetectionHistoryTimeWindow != "" {
+		parameters.SBQueueProperties.DuplicateDetectionHistoryTimeWindow = &duplicateDetectionHistoryTimeWindow
 	}
 
 	if lockDuration := d.Get("lock_duration").(string); lockDuration != "" {
@@ -308,8 +308,8 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("enable_batched_operations", props.EnableBatchedOperations)
 		d.Set("status", props.Status)
 
-		if maxSizeMB := props.MaxSizeInMegabytes; maxSizeMB != nil {
-			maxSize := int(*maxSizeMB)
+		if apiMaxSizeInMegabytes := props.MaxSizeInMegabytes; apiMaxSizeInMegabytes != nil {
+			maxSizeInMegabytes := int(*apiMaxSizeInMegabytes)
 
 			// If the queue is NOT in a premium namespace (ie. it is Basic or Standard) and partitioning is enabled
 			// then the max size returned by the API will be 16 times greater than the value set.
@@ -322,11 +322,11 @@ func resourceArmServiceBusQueueRead(d *schema.ResourceData, meta interface{}) er
 
 				if namespace.Sku.Name != servicebus.Premium {
 					const partitionCount = 16
-					maxSize = int(*props.MaxSizeInMegabytes / partitionCount)
+					maxSizeInMegabytes = int(*apiMaxSizeInMegabytes / partitionCount)
 				}
 			}
 
-			d.Set("max_size_in_megabytes", maxSize)
+			d.Set("max_size_in_megabytes", maxSizeInMegabytes)
 		}
 	}
 

--- a/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_queue_test.go
+++ b/azurerm/internal/services/servicebus/tests/resource_arm_servicebus_queue_test.go
@@ -63,6 +63,7 @@ func TestAccAzureRMServiceBusQueue_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMServiceBusQueueExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "enable_express", "false"),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_batched_operations", "true"),
 				),
 			},
 			{
@@ -70,6 +71,7 @@ func TestAccAzureRMServiceBusQueue_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "enable_express", "true"),
 					resource.TestCheckResourceAttr(data.ResourceName, "max_size_in_megabytes", "2048"),
+					resource.TestCheckResourceAttr(data.ResourceName, "enable_batched_operations", "false"),
 				),
 			},
 			data.ImportStep(),
@@ -469,11 +471,12 @@ resource "azurerm_servicebus_namespace" "test" {
 }
 
 resource "azurerm_servicebus_queue" "test" {
-  name                  = "acctestservicebusqueue-%d"
-  resource_group_name   = azurerm_resource_group.test.name
-  namespace_name        = azurerm_servicebus_namespace.test.name
-  enable_express        = true
-  max_size_in_megabytes = 2048
+  name                      = "acctestservicebusqueue-%d"
+  resource_group_name       = azurerm_resource_group.test.name
+  namespace_name            = azurerm_servicebus_namespace.test.name
+  enable_express            = true
+  max_size_in_megabytes     = 2048
+  enable_batched_operations = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -99,6 +99,8 @@ The following arguments are supported:
 
 * `enable_batched_operations` - (Optional) Boolean flag which controls whether server-side batched operations are enabled. Defaults to `true`.
 
+* `status` - (Optional) The status of the Queue. Possible values are `Active`, `Creating`, `Deleting`, `Disabled`, `ReceiveDisabled`, `Renaming`, `SendDisabled`, `Unknown`. Note that `Restoring` is not accepted. Defaults to `Active`.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -97,6 +97,8 @@ The following arguments are supported:
 
 * `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward deadlettered messages to.
 
+* `enable_batched_operations` - (Optional) Boolean flag which controls whether server-side batched operations are enabled. Defaults to `true`.
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -42,60 +42,41 @@ resource "azurerm_servicebus_queue" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the ServiceBus Queue resource. Changing this forces a
-    new resource to be created.
+* `name` - (Required) Specifies the name of the ServiceBus Queue resource. Changing this forces a new resource to be created.
 
-* `namespace_name` - (Required) The name of the ServiceBus Namespace to create
-    this queue in. Changing this forces a new resource to be created.
+* `namespace_name` - (Required) The name of the ServiceBus Namespace to create this queue in. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
-    create the namespace. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the namespace. Changing this forces a new resource to be created.
 
-* `auto_delete_on_idle` - (Optional) The ISO 8601 timespan duration of the idle interval after which the
-    Queue is automatically deleted, minimum of 5 minutes.
+* `auto_delete_on_idle` - (Optional) The ISO 8601 timespan duration of the idle interval after which the Queue is automatically deleted, minimum of 5 minutes.
 
-* `default_message_ttl` - (Optional) The ISO 8601 timespan duration of the TTL of messages sent to this
-    queue. This is the default value used when TTL is not set on message itself.
+* `default_message_ttl` - (Optional) The ISO 8601 timespan duration of the TTL of messages sent to this queue. This is the default value used when TTL is not set on message itself.
 
-* `duplicate_detection_history_time_window` - (Optional) The ISO 8601 timespan duration during which
-    duplicates can be detected. Default value is 10 minutes. (`PT10M`)
+* `duplicate_detection_history_time_window` - (Optional) The ISO 8601 timespan duration during which duplicates can be detected. Defaults to 10 minute (`PT10M`).
 
-* `enable_express` - (Optional) Boolean flag which controls whether Express Entities
-    are enabled. An express queue holds a message in memory temporarily before writing
-    it to persistent storage. Defaults to `false` for Basic and Standard. For Premium, it MUST
-    be set to `false`.
+* `enable_express` - (Optional) Boolean flag which controls whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `false`.
 
 ~> **NOTE:** Service Bus Premium namespaces do not support Express Entities, so `enable_express` MUST be set to `false`.
 
-* `enable_partitioning` - (Optional) Boolean flag which controls whether to enable
-    the queue to be partitioned across multiple message brokers. Changing this forces
-    a new resource to be created. Defaults to `false` for Basic and Standard. For Premium, it MUST
-    be set to `true`.
+* `enable_partitioning` - (Optional) Boolean flag which controls whether to enable the queue to be partitioned across multiple message brokers. Changing this forces a new resource to be created. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `true`.
 
 -> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. It is not available for the Premium messaging SKU, but any previously existing partitioned entities in Premium namespaces continue to work as expected. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning) for more information.
 
-* `lock_duration` - (Optional) The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. Maximum value is 5 minutes. Defaults to 1 minute. (`PT1M`)
+* `lock_duration` - (Optional) The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. Maximum value is 5 minutes. Defaults to 1 minute (`PT1M`).
 
-* `max_size_in_megabytes` - (Optional) Integer value which controls the size of
-    memory allocated for the queue. For supported values see the "Queue/topic size"
-    section of [this document](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).
+* `max_size_in_megabytes` - (Optional) Integer value which controls the size of memory allocated for the queue. For supported values see the "Queue or topic size" section of [Service Bus Quotas](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas). Defaults to `1024`.
 
-* `requires_duplicate_detection` - (Optional) Boolean flag which controls whether
-    the Queue requires duplicate detection. Changing this forces
-    a new resource to be created. Defaults to `false`.
+* `requires_duplicate_detection` - (Optional) Boolean flag which controls whether the Queue requires duplicate detection. Changing this forces a new resource to be created. Defaults to `false`.
 
-* `requires_session` - (Optional) Boolean flag which controls whether the Queue requires sessions.
-    This will allow ordered handling of unbounded sequences of related messages. With sessions enabled
-    a queue can guarantee first-in-first-out delivery of messages.
-    Changing this forces a new resource to be created. Defaults to `false`.
+* `requires_session` - (Optional) Boolean flag which controls whether the Queue requires sessions. This will allow ordered handling of unbounded sequences of related messages. With sessions enabled a queue can guarantee first-in-first-out delivery of messages. Changing this forces a new resource to be created. Defaults to `false`.
 
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls whether the Queue has dead letter support when a message expires. Defaults to `false`.
 
-* `max_delivery_count` - (Optional) Integer value which controls when a message is automatically deadlettered. Defaults to `10`.
+* `max_delivery_count` - (Optional) Integer value which controls when a message is automatically dead lettered. Defaults to `10`.
 
 * `forward_to` - (Optional) The name of a Queue or Topic to automatically forward messages to. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-auto-forwarding) for more information.
 
-* `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward deadlettered messages to.
+* `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward dead lettered messages to.
 
 * `enable_batched_operations` - (Optional) Boolean flag which controls whether server-side batched operations are enabled. Defaults to `true`.
 

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -48,20 +48,6 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the namespace. Changing this forces a new resource to be created.
 
-* `auto_delete_on_idle` - (Optional) The ISO 8601 timespan duration of the idle interval after which the Queue is automatically deleted, minimum of 5 minutes.
-
-* `default_message_ttl` - (Optional) The ISO 8601 timespan duration of the TTL of messages sent to this queue. This is the default value used when TTL is not set on message itself.
-
-* `duplicate_detection_history_time_window` - (Optional) The ISO 8601 timespan duration during which duplicates can be detected. Defaults to 10 minute (`PT10M`).
-
-* `enable_express` - (Optional) Boolean flag which controls whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `false`.
-
-~> **NOTE:** Service Bus Premium namespaces do not support Express Entities, so `enable_express` MUST be set to `false`.
-
-* `enable_partitioning` - (Optional) Boolean flag which controls whether to enable the queue to be partitioned across multiple message brokers. Changing this forces a new resource to be created. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `true`.
-
--> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. It is not available for the Premium messaging SKU, but any previously existing partitioned entities in Premium namespaces continue to work as expected. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning) for more information.
-
 * `lock_duration` - (Optional) The ISO 8601 timespan duration of a peek-lock; that is, the amount of time that the message is locked for other receivers. Maximum value is 5 minutes. Defaults to 1 minute (`PT1M`).
 
 * `max_size_in_megabytes` - (Optional) Integer value which controls the size of memory allocated for the queue. For supported values see the "Queue or topic size" section of [Service Bus Quotas](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas). Defaults to `1024`.
@@ -70,17 +56,31 @@ The following arguments are supported:
 
 * `requires_session` - (Optional) Boolean flag which controls whether the Queue requires sessions. This will allow ordered handling of unbounded sequences of related messages. With sessions enabled a queue can guarantee first-in-first-out delivery of messages. Changing this forces a new resource to be created. Defaults to `false`.
 
+* `default_message_ttl` - (Optional) The ISO 8601 timespan duration of the TTL of messages sent to this queue. This is the default value used when TTL is not set on message itself.
+
 * `dead_lettering_on_message_expiration` - (Optional) Boolean flag which controls whether the Queue has dead letter support when a message expires. Defaults to `false`.
 
+* `duplicate_detection_history_time_window` - (Optional) The ISO 8601 timespan duration during which duplicates can be detected. Defaults to 10 minute (`PT10M`).
+
 * `max_delivery_count` - (Optional) Integer value which controls when a message is automatically dead lettered. Defaults to `10`.
+
+* `status` - (Optional) The status of the Queue. Possible values are `Active`, `Creating`, `Deleting`, `Disabled`, `ReceiveDisabled`, `Renaming`, `SendDisabled`, `Unknown`. Note that `Restoring` is not accepted. Defaults to `Active`.
+
+* `enable_batched_operations` - (Optional) Boolean flag which controls whether server-side batched operations are enabled. Defaults to `true`.
+
+* `auto_delete_on_idle` - (Optional) The ISO 8601 timespan duration of the idle interval after which the Queue is automatically deleted, minimum of 5 minutes.
+
+* `enable_partitioning` - (Optional) Boolean flag which controls whether to enable the queue to be partitioned across multiple message brokers. Changing this forces a new resource to be created. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `true`.
+
+-> **NOTE:** Partitioning is available at entity creation for all queues and topics in Basic or Standard SKUs. It is not available for the Premium messaging SKU, but any previously existing partitioned entities in Premium namespaces continue to work as expected. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-partitioning) for more information.
+
+* `enable_express` - (Optional) Boolean flag which controls whether Express Entities are enabled. An express queue holds a message in memory temporarily before writing it to persistent storage. Defaults to `false` for Basic and Standard. For Premium, it MUST be set to `false`.
+
+~> **NOTE:** Service Bus Premium namespaces do not support Express Entities, so `enable_express` MUST be set to `false`.
 
 * `forward_to` - (Optional) The name of a Queue or Topic to automatically forward messages to. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-auto-forwarding) for more information.
 
 * `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward dead lettered messages to.
-
-* `enable_batched_operations` - (Optional) Boolean flag which controls whether server-side batched operations are enabled. Defaults to `true`.
-
-* `status` - (Optional) The status of the Queue. Possible values are `Active`, `Creating`, `Deleting`, `Disabled`, `ReceiveDisabled`, `Renaming`, `SendDisabled`, `Unknown`. Note that `Restoring` is not accepted. Defaults to `Active`.
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_queue.html.markdown
+++ b/website/docs/r/servicebus_queue.html.markdown
@@ -93,6 +93,10 @@ The following arguments are supported:
 
 * `max_delivery_count` - (Optional) Integer value which controls when a message is automatically deadlettered. Defaults to `10`.
 
+* `forward_to` - (Optional) The name of a Queue or Topic to automatically forward messages to. Please [see the documentation](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-auto-forwarding) for more information.
+
+* `forward_dead_lettered_messages_to` - (Optional) The name of a Queue or Topic to automatically forward deadlettered messages to.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
## Description

🗣️ This pull requests is easier to read commit by commit

`SBQueueProperties` struct contains a handful of read-write attributes, with a few of them not being exposed to the terraform schema representing it. This includes `enable_batched_operations`, `forward_to`, `forward_dead_lettered_messages_to` ( fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/6472 )  and `status`. 

The spec itself is described in <https://docs.microsoft.com/en-us/azure/templates/microsoft.servicebus/2017-04-01/namespaces/queues>.

This pulls requests aims to align the current terraform schema with the `2017-01-01` spec for Azure ServiceBus Queues, with the following three components : 

1. Add the missing attributes
2. Reorder the attributes to match the official doc
3. Update the doc accordingly

## Motivation

- [x] Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/6472
- [x] Backport https://github.com/terraform-providers/terraform-provider-azurerm/commit/d331091b361cc5e0c4e3cfabbdc2a93273864c23 ( `enable_batched_operations` )
- [x] Backport https://github.com/terraform-providers/terraform-provider-azurerm/pull/861 ( `forward_to` )
- [x] Backport https://github.com/terraform-providers/terraform-provider-azurerm/pull/4789 ( `forward_dead_lettered_messages_to` )
- [x] Backport https://github.com/terraform-providers/terraform-provider-azurerm/pull/7852 ( `status` )

## Testing

### Initialization

<details><summary>This section is merely a small doc for myself</summary>
<p>

See details in <https://medium.com/@gmusumeci/getting-started-with-terraform-and-microsoft-azure-a2fcb690eb67>

```bash
$ az login
$ az ad sp create-for-rbac --name terraform-provider-azurerm-acceptance-tests --role Contributor --scopes /subscriptions/00000000-0000-0000-0000-000000000000
Changing "terraform-provider-azurerm-acceptance-tests" to a valid URI of "http://ayaz-tf-acceptance-tests", which is the required format used for service principal names
Creating a role assignment under the scope of "/subscriptions/00000000-0000-0000-0000-000000000000"
  Retrying role assignment creation: 1/36
  Retrying role assignment creation: 2/36
{
  "appId": "<client-id>",
  "displayName": "terraform-provider-azurerm-acceptance-tests",
  "name": "http://terraform-provider-azurerm-acceptance-tests",
  "password": "<client-secret>",
  "tenant": "<tenant-id>"
}
```

Once the credentials have been retrieved, save them as environment variables.
⚠️ Never run these commands as is, otherwise they will be written to disk within the shell history file.

```bash
$ export ARM_CLIENT_ID='<client-id>'
$ export ARM_CLIENT_SECRET='<client-secret>'
$ export ARM_SUBSCRIPTION_ID='00000000-0000-0000-0000-000000000000'
$ export ARM_TENANT_ID='<tenant-id>'
$ export ARM_TEST_LOCATION='West US 2'
$ export ARM_TEST_LOCATION_ALT='West US 2'
$ export ARM_TEST_LOCATION_ALT2='West US 2'
```

And now we're good to go testing !

</p>
</details>

### Run

Run tests with the following commands : 

```bash
$ make acctests SERVICE="servicebus" TESTARGS="-run=TestAccAzureRMServiceBusQueue" TESTTIMEOUT="6h" ; terminal-notifier -title "terraform-provider-azurerm" -message "Acceptance tests just finished \!"
Wed Aug  5 21:43:16 CEST 2020
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./azurerm/internal/services/servicebus/tests/ -run=TestAccAzureRMServiceBusQueue -timeout 6h -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMServiceBusQueueAuthorizationRule_listen
=== PAUSE TestAccAzureRMServiceBusQueueAuthorizationRule_listen
=== RUN   TestAccAzureRMServiceBusQueueAuthorizationRule_send
=== PAUSE TestAccAzureRMServiceBusQueueAuthorizationRule_send
=== RUN   TestAccAzureRMServiceBusQueueAuthorizationRule_listensend
=== PAUSE TestAccAzureRMServiceBusQueueAuthorizationRule_listensend
=== RUN   TestAccAzureRMServiceBusQueueAuthorizationRule_manage
=== PAUSE TestAccAzureRMServiceBusQueueAuthorizationRule_manage
=== RUN   TestAccAzureRMServiceBusQueueAuthorizationRule_rightsUpdate
=== PAUSE TestAccAzureRMServiceBusQueueAuthorizationRule_rightsUpdate
=== RUN   TestAccAzureRMServiceBusQueueAuthorizationRule_requiresImport
=== PAUSE TestAccAzureRMServiceBusQueueAuthorizationRule_requiresImport
=== RUN   TestAccAzureRMServiceBusQueue_basic
=== PAUSE TestAccAzureRMServiceBusQueue_basic
=== RUN   TestAccAzureRMServiceBusQueue_requiresImport
=== PAUSE TestAccAzureRMServiceBusQueue_requiresImport
=== RUN   TestAccAzureRMServiceBusQueue_update
=== PAUSE TestAccAzureRMServiceBusQueue_update
=== RUN   TestAccAzureRMServiceBusQueue_enablePartitioningStandard
=== PAUSE TestAccAzureRMServiceBusQueue_enablePartitioningStandard
=== RUN   TestAccAzureRMServiceBusQueue_defaultEnablePartitioningPremium
=== PAUSE TestAccAzureRMServiceBusQueue_defaultEnablePartitioningPremium
=== RUN   TestAccAzureRMServiceBusQueue_enableDuplicateDetection
=== PAUSE TestAccAzureRMServiceBusQueue_enableDuplicateDetection
=== RUN   TestAccAzureRMServiceBusQueue_enableRequiresSession
=== PAUSE TestAccAzureRMServiceBusQueue_enableRequiresSession
=== RUN   TestAccAzureRMServiceBusQueue_enableDeadLetteringOnMessageExpiration
=== PAUSE TestAccAzureRMServiceBusQueue_enableDeadLetteringOnMessageExpiration
=== RUN   TestAccAzureRMServiceBusQueue_lockDuration
=== PAUSE TestAccAzureRMServiceBusQueue_lockDuration
=== RUN   TestAccAzureRMServiceBusQueue_isoTimeSpanAttributes
=== PAUSE TestAccAzureRMServiceBusQueue_isoTimeSpanAttributes
=== RUN   TestAccAzureRMServiceBusQueue_maxDeliveryCount
=== PAUSE TestAccAzureRMServiceBusQueue_maxDeliveryCount
=== RUN   TestAccAzureRMServiceBusQueue_forwardTo
=== PAUSE TestAccAzureRMServiceBusQueue_forwardTo
=== RUN   TestAccAzureRMServiceBusQueue_forwardDeadLetteredMessagesTo
=== PAUSE TestAccAzureRMServiceBusQueue_forwardDeadLetteredMessagesTo
=== RUN   TestAccAzureRMServiceBusQueue_status
=== PAUSE TestAccAzureRMServiceBusQueue_status
=== CONT  TestAccAzureRMServiceBusQueueAuthorizationRule_listen
=== CONT  TestAccAzureRMServiceBusQueue_enableDuplicateDetection
=== CONT  TestAccAzureRMServiceBusQueue_maxDeliveryCount
=== CONT  TestAccAzureRMServiceBusQueue_lockDuration
--- PASS: TestAccAzureRMServiceBusQueueAuthorizationRule_listen (227.06s)
=== CONT  TestAccAzureRMServiceBusQueue_defaultEnablePartitioningPremium
--- PASS: TestAccAzureRMServiceBusQueue_enableDuplicateDetection (271.59s)
=== CONT  TestAccAzureRMServiceBusQueue_enablePartitioningStandard
--- PASS: TestAccAzureRMServiceBusQueue_lockDuration (286.99s)
=== CONT  TestAccAzureRMServiceBusQueue_update
--- PASS: TestAccAzureRMServiceBusQueue_maxDeliveryCount (286.99s)
=== CONT  TestAccAzureRMServiceBusQueue_requiresImport
--- PASS: TestAccAzureRMServiceBusQueue_requiresImport (247.19s)
=== CONT  TestAccAzureRMServiceBusQueue_basic
--- PASS: TestAccAzureRMServiceBusQueue_enablePartitioningStandard (344.15s)
=== CONT  TestAccAzureRMServiceBusQueueAuthorizationRule_requiresImport
--- PASS: TestAccAzureRMServiceBusQueue_defaultEnablePartitioningPremium (407.24s)
=== CONT  TestAccAzureRMServiceBusQueueAuthorizationRule_rightsUpdate
--- PASS: TestAccAzureRMServiceBusQueue_basic (197.08s)
=== CONT  TestAccAzureRMServiceBusQueueAuthorizationRule_manage
--- PASS: TestAccAzureRMServiceBusQueueAuthorizationRule_rightsUpdate (247.67s)
=== CONT  TestAccAzureRMServiceBusQueueAuthorizationRule_listensend
--- PASS: TestAccAzureRMServiceBusQueue_update (614.87s)
=== CONT  TestAccAzureRMServiceBusQueueAuthorizationRule_send
--- PASS: TestAccAzureRMServiceBusQueueAuthorizationRule_manage (207.24s)
=== CONT  TestAccAzureRMServiceBusQueue_isoTimeSpanAttributes
--- PASS: TestAccAzureRMServiceBusQueueAuthorizationRule_requiresImport (395.49s)
=== CONT  TestAccAzureRMServiceBusQueue_status
--- PASS: TestAccAzureRMServiceBusQueueAuthorizationRule_listensend (260.17s)
=== CONT  TestAccAzureRMServiceBusQueue_forwardDeadLetteredMessagesTo
--- PASS: TestAccAzureRMServiceBusQueue_isoTimeSpanAttributes (212.45s)
=== CONT  TestAccAzureRMServiceBusQueue_enableDeadLetteringOnMessageExpiration
--- PASS: TestAccAzureRMServiceBusQueue_forwardDeadLetteredMessagesTo (230.64s)
=== CONT  TestAccAzureRMServiceBusQueue_forwardTo
--- PASS: TestAccAzureRMServiceBusQueueAuthorizationRule_send (492.21s)
=== CONT  TestAccAzureRMServiceBusQueue_enableRequiresSession
--- PASS: TestAccAzureRMServiceBusQueue_enableDeadLetteringOnMessageExpiration (291.38s)
--- PASS: TestAccAzureRMServiceBusQueue_status (571.67s)
--- PASS: TestAccAzureRMServiceBusQueue_forwardTo (228.06s)
--- PASS: TestAccAzureRMServiceBusQueue_enableRequiresSession (233.17s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/servicebus/tests	1628.884s
```

### Document

<details><summary>Do not use this section, the diff is huge</summary>
<p>

```bash
$ make scaffold-website BRAND_NAME="ServiceBus Queue" RESOURCE_NAME="azurerm_servicebus_queue" RESOURCE_TYPE="resource" RESOURCE_ID="/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1/queues/snqueue1"
./scripts/scaffold-website.sh
==> Verifying required variables are set...
==> Validated.
==> Scaffolding Documentation...
==> Done.
```

</p>
</details>

### Cleanup

<details><summary>This section is merely a small doc for myself</summary>
<p>

In this code block, `$ARM_CLIENT_ID` is the content of the `appId` retrieved in the initialization section.

```bash
$ az ad sp delete --id $ARM_CLIENT_ID
Removing role assignments
```

</p>
</details>