### PR TITLE
`azurerm_monitor_metric_alert_resource`: keep using SingleResourceMultiMetricCriteria for legacy metric alerts

### DIFF
--- a/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/azurerm/internal/services/monitor/monitor_metric_alert_resource.go
@@ -399,16 +399,22 @@ func resourceArmMonitorMetricAlertCreateUpdate(d *schema.ResourceData, meta inte
 	t := d.Get("tags").(map[string]interface{})
 	expandedTags := tags.Expand(t)
 
-
-	// To keep backward compatibility for the "old" created resources, whose criteria type
-	// is `MetricAlertSingleResourceMultipleMetricCriteria` (rather than `MetricAlertMultipleResourceMultipleMetricCriteria`).
-	// We need to check whether this is such an "old" resource already existed.
-	existing, err := client.Get(ctx, resourceGroup, name)
-	if err != nil {
-		// TODO
+	// The criteria type of "old" resource is `MetricAlertSingleResourceMultipleMetricCriteria` (rather than `MetricAlertMultipleResourceMultipleMetricCriteria`).
+	// We need to keep using that type in order to keep backward compatibility. Otherwise, changing the criteria type will cause error as reported in issue:
+	// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7910
+	var isLegacy bool
+	if !d.IsNewResource() {
+		existing, err := client.Get(ctx, resourceGroup, name)
+		if err != nil {
+			return fmt.Errorf("retrieving Monitor Metric Alert %q (Resource Group %q): %+v", name, resourceGroup, err)
+		}
+		if existing.MetricAlertProperties == nil || existing.MetricAlertProperties.Criteria == nil {
+			return fmt.Errorf("unexpected nil properties of Monitor Metric Alert %q (Resource Group %q)", name, resourceGroup)
+		}
+		_, isLegacy = existing.MetricAlertProperties.Criteria.AsMetricAlertSingleResourceMultipleMetricCriteria()
 	}
 
-	criteria, err := expandMonitorMetricAlertCriteria(d)
+	criteria, err := expandMonitorMetricAlertCriteria(d, isLegacy)
 	if err != nil {
 		return fmt.Errorf(`Expanding criteria: %+v`, err)
 	}
@@ -540,12 +546,15 @@ func resourceArmMonitorMetricAlertDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func expandMonitorMetricAlertCriteria(d *schema.ResourceData) (insights.BasicMetricAlertCriteria, error) {
+func expandMonitorMetricAlertCriteria(d *schema.ResourceData, isLegacy bool) (insights.BasicMetricAlertCriteria, error) {
 	switch {
 	case d.Get("criteria").(*schema.Set).Len() != 0:
-		return expandMonitorMetricAlertMetricCriteria(d.Get("criteria").(*schema.Set).List()), nil
+		if isLegacy {
+			return expandMonitorMetricAlertSingleResourceMultiMetricCriteria(d.Get("criteria").(*schema.Set).List()), nil
+		}
+		return expandMonitorMetricAlertMultiResourceMultiMetricForStaticMetricCriteria(d.Get("criteria").(*schema.Set).List()), nil
 	case d.Get("dynamic_criteria").(*schema.Set).Len() != 0:
-		return expandMonitorMetricAlertDynamicMetricCriteria(d.Get("dynamic_criteria").(*schema.Set).List()), nil
+		return expandMonitorMetricAlertMultiResourceMultiMetricForDynamicMetricCriteria(d.Get("dynamic_criteria").(*schema.Set).List()), nil
 	case len(d.Get("application_insights_web_test_location_availability_criteria").([]interface{})) != 0:
 		return expandMonitorMetricAlertWebtestLocAvailCriteria(d.Get("application_insights_web_test_location_availability_criteria").([]interface{})), nil
 	default:
@@ -554,11 +563,32 @@ func expandMonitorMetricAlertCriteria(d *schema.ResourceData) (insights.BasicMet
 	}
 }
 
-func expandMonitorMetricAlertMetricCriteria(input []interface{}) insights.BasicMetricAlertCriteria {
+func expandMonitorMetricAlertSingleResourceMultiMetricCriteria(input []interface{}) insights.BasicMetricAlertCriteria {
+	criteria := make([]insights.MetricCriteria, 0)
+	for i, item := range input {
+		v := item.(map[string]interface{})
+		dimensions := expandMonitorMetricDimension(v["dimension"].([]interface{}))
+		criteria = append(criteria, insights.MetricCriteria{
+			Name:            utils.String(fmt.Sprintf("Metric%d", i+1)),
+			MetricNamespace: utils.String(v["metric_namespace"].(string)),
+			MetricName:      utils.String(v["metric_name"].(string)),
+			TimeAggregation: v["aggregation"].(string),
+			Dimensions:      &dimensions,
+			Operator:        insights.Operator(v["operator"].(string)),
+			Threshold:       utils.Float(v["threshold"].(float64)),
+		})
+	}
+	return &insights.MetricAlertSingleResourceMultipleMetricCriteria{
+		AllOf:     &criteria,
+		OdataType: insights.OdataTypeMicrosoftAzureMonitorSingleResourceMultipleMetricCriteria,
+	}
+}
+
+func expandMonitorMetricAlertMultiResourceMultiMetricForStaticMetricCriteria(input []interface{}) insights.BasicMetricAlertCriteria {
 	criteria := make([]insights.BasicMultiMetricCriteria, 0)
 	for i, item := range input {
 		v := item.(map[string]interface{})
-		dimensions := expandMonitorMetricAlertMultiMetricCriteriaDimension(v["dimension"].([]interface{}))
+		dimensions := expandMonitorMetricDimension(v["dimension"].([]interface{}))
 		criteria = append(criteria, insights.MetricCriteria{
 			Name:            utils.String(fmt.Sprintf("Metric%d", i+1)),
 			MetricNamespace: utils.String(v["metric_namespace"].(string)),
@@ -574,11 +604,12 @@ func expandMonitorMetricAlertMetricCriteria(input []interface{}) insights.BasicM
 		OdataType: insights.OdataTypeMicrosoftAzureMonitorMultipleResourceMultipleMetricCriteria,
 	}
 }
-func expandMonitorMetricAlertDynamicMetricCriteria(input []interface{}) insights.BasicMetricAlertCriteria {
+
+func expandMonitorMetricAlertMultiResourceMultiMetricForDynamicMetricCriteria(input []interface{}) insights.BasicMetricAlertCriteria {
 	criteria := make([]insights.BasicMultiMetricCriteria, 0)
 	for i, item := range input {
 		v := item.(map[string]interface{})
-		dimensions := expandMonitorMetricAlertMultiMetricCriteriaDimension(v["dimension"].([]interface{}))
+		dimensions := expandMonitorMetricDimension(v["dimension"].([]interface{}))
 		var ignoreDataBefore *date.Time
 		if v := v["ignore_data_before"].(string); v != "" {
 			// Guaranteed in schema validation func.
@@ -619,7 +650,7 @@ func expandMonitorMetricAlertWebtestLocAvailCriteria(input []interface{}) insigh
 	}
 }
 
-func expandMonitorMetricAlertMultiMetricCriteriaDimension(input []interface{}) []insights.MetricDimension {
+func expandMonitorMetricDimension(input []interface{}) []insights.MetricDimension {
 	result := make([]insights.MetricDimension, 0)
 	for _, dimension := range input {
 		dVal := dimension.(map[string]interface{})


### PR DESCRIPTION
The change in #7159 deprecates the usage of `SingleResourceMultiMetricCriteria` outright (replaced by `MultipleResourceMultipleMetricCriteria`). Unfortunately, that breaks the users who have metric alert created before that PR merged, which was using `SingleResourceMultiMetricCriteria` as its type. Then once those metric alerts get updated, current code will trigger an update from `SingleResourceMultiMetricCriteria` to `MultipleResourceMultipleMetricCriteria`, which seems not supported by service (as reported in #7910).

This PR keeps those legacy resource to use the `SingleResourceMultiMetricCriteria`. If user wants to use the `MultipleResourceMultipleMetricCriteria`, they will have to recreate the resource.

(fixes #7910)

## Test Result

```bash
💢 make testacc TEST=./azurerm/internal/services/monitor/tests TESTARGS='-run TestAccAzureRMMonitorMetricAlert_'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/monitor/tests -v -run TestAccAzureRMMonitorMetricAlert_ -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMMonitorMetricAlert_basic
=== PAUSE TestAccAzureRMMonitorMetricAlert_basic
=== RUN   TestAccAzureRMMonitorMetricAlert_requiresImport
=== PAUSE TestAccAzureRMMonitorMetricAlert_requiresImport
=== RUN   TestAccAzureRMMonitorMetricAlert_complete
=== PAUSE TestAccAzureRMMonitorMetricAlert_complete
=== RUN   TestAccAzureRMMonitorMetricAlert_basicAndCompleteUpdate
=== PAUSE TestAccAzureRMMonitorMetricAlert_basicAndCompleteUpdate
=== RUN   TestAccAzureRMMonitorMetricAlert_multiScope
=== PAUSE TestAccAzureRMMonitorMetricAlert_multiScope
=== RUN   TestAccAzureRMMonitorMetricAlert_applicationInsightsWebTest
=== PAUSE TestAccAzureRMMonitorMetricAlert_applicationInsightsWebTest
=== CONT  TestAccAzureRMMonitorMetricAlert_basic
=== CONT  TestAccAzureRMMonitorMetricAlert_multiScope
=== CONT  TestAccAzureRMMonitorMetricAlert_applicationInsightsWebTest
=== CONT  TestAccAzureRMMonitorMetricAlert_requiresImport
=== CONT  TestAccAzureRMMonitorMetricAlert_basicAndCompleteUpdate
=== CONT  TestAccAzureRMMonitorMetricAlert_complete
--- PASS: TestAccAzureRMMonitorMetricAlert_complete (167.69s)
--- PASS: TestAccAzureRMMonitorMetricAlert_basic (167.70s)
--- PASS: TestAccAzureRMMonitorMetricAlert_requiresImport (180.59s)
--- PASS: TestAccAzureRMMonitorMetricAlert_applicationInsightsWebTest (181.70s)
--- PASS: TestAccAzureRMMonitorMetricAlert_basicAndCompleteUpdate (393.81s)
--- PASS: TestAccAzureRMMonitorMetricAlert_multiScope (647.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/monitor/tests       647.820s
```