### PR TITLE
Update `azurerm_linux|windows_virtual_machine` - defaulting the value of allow extension operations if it's not returned

### DIFF
--- a/azurerm/internal/services/compute/linux_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_resource.go
@@ -568,7 +568,11 @@ func resourceLinuxVirtualMachineRead(d *schema.ResourceData, meta interface{}) e
 
 	if profile := props.OsProfile; profile != nil {
 		d.Set("admin_username", profile.AdminUsername)
-		d.Set("allow_extension_operations", profile.AllowExtensionOperations)
+		allowExtensionOperations := true // this is the default value of allowExtensionOperations. If the service returns null for this property, it should mean `true`
+		if profile.AllowExtensionOperations != nil {
+			allowExtensionOperations = *profile.AllowExtensionOperations
+		}
+		d.Set("allow_extension_operations", allowExtensionOperations)
 		d.Set("computer_name", profile.ComputerName)
 
 		if config := profile.LinuxConfiguration; config != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_resource.go
@@ -593,7 +593,11 @@ func resourceWindowsVirtualMachineRead(d *schema.ResourceData, meta interface{})
 
 	if profile := props.OsProfile; profile != nil {
 		d.Set("admin_username", profile.AdminUsername)
-		d.Set("allow_extension_operations", profile.AllowExtensionOperations)
+		allowExtensionOperations := true // this is the default value of allowExtensionOperations. If the service returns null for this property, it should mean `true`
+		if profile.AllowExtensionOperations != nil {
+			allowExtensionOperations = *profile.AllowExtensionOperations
+		}
+		d.Set("allow_extension_operations", allowExtensionOperations)
 		d.Set("computer_name", profile.ComputerName)
 
 		if config := profile.WindowsConfiguration; config != nil {


### PR DESCRIPTION
Fixes #7986 