### PR TITLE
`azurerm_mysql_server` Sku Tier `Basic` doesn't support `infrastructure_encryption_enabled`

### DIFF
--- a/azurerm/internal/services/mysql/mysql_server_resource.go
+++ b/azurerm/internal/services/mysql/mysql_server_resource.go
@@ -402,6 +402,10 @@ func resourceArmMySqlServerCreate(d *schema.ResourceData, meta interface{}) erro
 		infraEncrypt = mysql.InfrastructureEncryptionDisabled
 	}
 
+	if sku.Tier == mysql.Basic && infraEncrypt == mysql.InfrastructureEncryptionEnabled {
+		return fmt.Errorf("`infrastructure_encryption_enabled` is not supported for sku Tier `Basic` in MySQL Server %q (Resource Group %q)", name, resourceGroup)
+	}
+
 	publicAccess := mysql.PublicNetworkAccessEnumEnabled
 	if v := d.Get("public_network_access_enabled"); !v.(bool) {
 		publicAccess = mysql.PublicNetworkAccessEnumDisabled


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-azurerm/issues/7905.

The system error message `StatusCode=405 -- Original Error: Code="FeatureSwitchNotEnabled" Message="Requested feature is not enabled` is not specific enough for users.