### PR TITLE
Use API version 2020-03-01 for Loadbalancer

### DIFF
--- a/azurerm/internal/services/network/client/client.go
+++ b/azurerm/internal/services/network/client/client.go
@@ -18,7 +18,7 @@ type Client struct {
 	ExpressRouteGatewaysClient           *network.ExpressRouteGatewaysClient
 	ExpressRoutePeeringsClient           *network.ExpressRouteCircuitPeeringsClient
 	InterfacesClient                     *network.InterfacesClient
-	LoadBalancersClient                  *network.LoadBalancersClient
+	LoadBalancersClient                  *networkLegacy.LoadBalancersClient
 	LocalNetworkGatewaysClient           *network.LocalNetworkGatewaysClient
 	PointToSiteVpnGatewaysClient         *network.P2sVpnGatewaysClient
 	ProfileClient                        *network.ProfilesClient
@@ -82,7 +82,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	InterfacesClient := network.NewInterfacesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&InterfacesClient.Client, o.ResourceManagerAuthorizer)
 
-	LoadBalancersClient := network.NewLoadBalancersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	LoadBalancersClient := networkLegacy.NewLoadBalancersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&LoadBalancersClient.Client, o.ResourceManagerAuthorizer)
 
 	LocalNetworkGatewaysClient := network.NewLocalNetworkGatewaysClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)

--- a/azurerm/internal/services/network/lb_backend_address_pool_resource.go
+++ b/azurerm/internal/services/network/lb_backend_address_pool_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/lb_data_source.go
+++ b/azurerm/internal/services/network/lb_data_source.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/lb_nat_pool_resource.go
+++ b/azurerm/internal/services/network/lb_nat_pool_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/lb_nat_rule_resource.go
+++ b/azurerm/internal/services/network/lb_nat_rule_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/lb_outbound_rule_resource.go
+++ b/azurerm/internal/services/network/lb_outbound_rule_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/lb_probe_resource.go
+++ b/azurerm/internal/services/network/lb_probe_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/lb_resource.go
+++ b/azurerm/internal/services/network/lb_resource.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/lb_rule_resource.go
+++ b/azurerm/internal/services/network/lb_rule_resource.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/loadbalancer.go
+++ b/azurerm/internal/services/network/loadbalancer.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"

--- a/azurerm/internal/services/network/tests/loadbalancer_backend_address_pool_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_backend_address_pool_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/tests/loadbalancer_nat_pool_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_nat_pool_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/tests/loadbalancer_nat_rule_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_nat_rule_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/tests/loadbalancer_outbound_rule_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_outbound_rule_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/tests/loadbalancer_probe_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_probe_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"

--- a/azurerm/internal/services/network/tests/loadbalancer_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"

--- a/azurerm/internal/services/network/tests/loadbalancer_rule_resource_test.go
+++ b/azurerm/internal/services/network/tests/loadbalancer_rule_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-05-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-03-01/network"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"


### PR DESCRIPTION
Closes #7691 by using the 2020-03-01 network API version. Based off a comment by @tombuildsstuff from #7741 as this issue is present on more than just `azurerm_lb_rule` deletion 

The reason for that issue is that service can't tolerate the client sending properties.backendAddressPools.n.properties.backendIPConfigurations in request body for load balancer resource since 2020-05-01, as it is a READ-ONLY attribute (this only occurs when azurerm_lb's sku is Standard).
Currently, Azure Go SDK can trim the READ-ONLY attributes during marshaling, but only for the root level attributes, so, in this case, Go SDK will still marshal the attribute into the request body. This is tracked in issue: Azure/autorest.go#438.

**Acceptance Tests**

```
--- PASS: TestAccAzureRMLoadBalancer_standard (74.84s)
--- PASS: TestAccAzureRMLoadBalancer_requiresImport (126.75s)
--- PASS: TestAccAzureRMLoadBalancerRule_disappears (136.04s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_basic (140.11s)
--- PASS: TestAccAzureRMLoadBalancerRule_updateMultipleRules (211.43s)
--- PASS: TestAccAzureRMLoadBalancerRule_removal (211.44s)
--- PASS: TestAccAzureRMLoadBalancer_basic (136.61s)
--- PASS: TestAccAzureRMLoadBalancerRule_inconsistentReads (211.45s)
--- PASS: TestAccAzureRMLoadBalancerProbe_basic (321.01s)
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix (132.72s)
--- PASS: TestAccAzureRMLoadBalancerRule_complete (147.61s)
--- PASS: TestAccAzureRMLoadBalancerProbe_update (341.34s)
--- PASS: TestAccAzureRMLoadBalancerRule_basic (137.91s)
--- PASS: TestAccAzureRMLoadBalancerProbe_requiresImport (169.84s)
--- PASS: TestAccAzureRMLoadBalancerProbe_disappears (392.64s)
--- PASS: TestAccAzureRMLoadBalancerProbe_removal (202.78s)
--- PASS: TestAccAzureRMLoadBalancerProbe_updateProtocol (389.76s)
--- PASS: TestAccAzureRMLoadBalancerRule_update (1464.92s)
--- PASS: TestAccAzureRMLoadBalancerNatPool_removal (1194.92s)
--- PASS: TestAccAzureRMLoadBalancerRule_requiresImport (1464.96s)
--- PASS: TestAccAzureRMLoadBalancer_privateIP (1179.42s)
--- PASS: TestAccAzureRMLoadBalancer_emptyPrivateIP (1157.00s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_basic (1152.61s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_complete (1162.42s)
--- PASS: TestAccAzureRMLoadBalancer_tags (1196.95s)
--- PASS: TestAccAzureRMLoadBalancerOutboundRule_disappears (94.63s)
--- PASS: TestAccAzureRMLoadBalancerOutboundRule_requiresImport (105.37s)
--- PASS: TestAccAzureRMLoadBalancerNatPool_requiresImport (145.97s)
--- PASS: TestAccAzureRMLoadBalancerNatPool_disappears (149.86s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_disappears (156.94s)
--- PASS: TestAccAzureRMLoadBalancerNatPool_update (173.39s)
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfig (213.04s)
--- PASS: TestAccAzureRMLoadBalancerOutboundRule_basic (119.46s)
--- PASS: TestAccAzureRMLoadBalancerNatPool_basic (137.47s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_update (192.43s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_disappears (137.54s)
--- PASS: TestAccAzureRMLoadBalancerOutboundRule_update (118.24s)
--- PASS: TestAccAzureRMLoadBalancerOutboundRule_withPublicIPPrefix (164.61s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_updateMultipleRules (193.30s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_removal (171.90s)
--- PASS: TestAccAzureRMLoadBalancerNatRule_requiresImport (180.32s)
--- PASS: TestAccAzureRMLoadBalancerOutboundRule_removal (201.86s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_requiresImport (181.10s)
--- PASS: TestAccAzureRMLoadBalancerBackEndAddressPool_removal (226.18s)
```