### PR TITLE
Updates doc for resource_group_name property of azurerm_private_dns_a_record

### DIFF
--- a/website/docs/r/private_dns_a_record.html.markdown
+++ b/website/docs/r/private_dns_a_record.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the DNS A Record.
 
-* `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) Specifies the resource group where the Private DNS Zone exists. Changing this forces a new resource to be created.
 
 * `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
Equivalent PR of #7998 but for the `azurerm_private_dns_a_record` instead of `azurerm_private_dns_zone_virtual_network_link`.