### PR TITLE
azurerm_iothub_shared_access_policy - prevent primary_connection_string & seconday_connection_string from regenerating

### DIFF
--- a/azurerm/internal/services/iothub/iothub_shared_access_policy_resource.go
+++ b/azurerm/internal/services/iothub/iothub_shared_access_policy_resource.go
@@ -171,6 +171,15 @@ func resourceArmIotHubSharedAccessPolicyCreateUpdate(d *schema.ResourceData, met
 			if features.ShouldResourcesBeImported() && d.IsNewResource() {
 				return tf.ImportAsExistsError("azurerm_iothub_shared_access_policy", resourceId)
 			}
+
+			if existingAccessPolicy.PrimaryKey != nil {
+				expandedAccessPolicy.PrimaryKey = existingAccessPolicy.PrimaryKey
+			}
+
+			if existingAccessPolicy.SecondaryKey != nil {
+				expandedAccessPolicy.SecondaryKey = existingAccessPolicy.SecondaryKey
+			}
+
 			accessPolicies = append(accessPolicies, expandedAccessPolicy)
 			alreadyExists = true
 		} else {


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/7445

--- PASS: TestAccAzureRMIotHubSharedAccessPolicy_writeWithoutRead (9.74s)
--- PASS: TestAccAzureRMIotHubSharedAccessPolicy_basic (401.00s)
--- PASS: TestAccAzureRMIotHubSharedAccessPolicy_requiresImport (563.10s)
PASS
ok