### PR TITLE
Add signed_version attribute to azurerm_storage_account_sas

### DIFF
--- a/azurerm/internal/services/storage/data_source_storage_account_sas.go
+++ b/azurerm/internal/services/storage/data_source_storage_account_sas.go
@@ -39,6 +39,12 @@ func dataSourceArmStorageAccountSharedAccessSignature() *schema.Resource {
 				Default:  true,
 			},
 
+			"signed_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  sasSignedVersion,
+			},
+
 			"resource_types": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -167,6 +173,7 @@ func dataSourceArmStorageAccountSharedAccessSignature() *schema.Resource {
 func dataSourceArmStorageAccountSasRead(d *schema.ResourceData, _ interface{}) error {
 	connString := d.Get("connection_string").(string)
 	httpsOnly := d.Get("https_only").(bool)
+	signedVersion := d.Get("signed_version").(string)
 	resourceTypesIface := d.Get("resource_types").([]interface{})
 	servicesIface := d.Get("services").([]interface{})
 	start := d.Get("start").(string)
@@ -194,7 +201,6 @@ func dataSourceArmStorageAccountSasRead(d *schema.ResourceData, _ interface{}) e
 		signedProtocol = "https"
 	}
 	signedIp := ""
-	signedVersion := sasSignedVersion
 
 	sasToken, err := storage.ComputeAccountSASToken(accountName, accountKey, permissions, services, resourceTypes,
 		start, expiry, signedProtocol, signedIp, signedVersion)

--- a/azurerm/internal/services/storage/tests/data_source_storage_account_sas_test.go
+++ b/azurerm/internal/services/storage/tests/data_source_storage_account_sas_test.go
@@ -25,6 +25,7 @@ func TestAccDataSourceArmStorageAccountSas_basic(t *testing.T) {
 				Config: testAccDataSourceAzureRMStorageAccountSas_basic(data, startDate, endDate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(data.ResourceName, "https_only", "true"),
+					resource.TestCheckResourceAttr(data.ResourceName, "signed_version", "2019-10-10"),
 					resource.TestCheckResourceAttr(data.ResourceName, "start", startDate),
 					resource.TestCheckResourceAttr(data.ResourceName, "expiry", endDate),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "sas"),
@@ -61,6 +62,7 @@ resource "azurerm_storage_account" "test" {
 data "azurerm_storage_account_sas" "test" {
   connection_string = azurerm_storage_account.test.primary_connection_string
   https_only        = true
+  signed_version    = "2019-10-10"
 
   resource_types {
     service   = true

--- a/website/docs/d/storage_account_sas.html.markdown
+++ b/website/docs/d/storage_account_sas.html.markdown
@@ -39,6 +39,7 @@ resource "azurerm_storage_account" "example" {
 data "azurerm_storage_account_sas" "example" {
   connection_string = azurerm_storage_account.example.primary_connection_string
   https_only        = true
+  signed_version    = "2017-07-29"
 
   resource_types {
     service   = true
@@ -77,6 +78,7 @@ output "sas_url_query_string" {
 
 * `connection_string` - The connection string for the storage account to which this SAS applies. Typically directly from the `primary_connection_string` attribute of a terraform created `azurerm_storage_account` resource.
 * `https_only` - (Optional) Only permit `https` access. If `false`, both `http` and `https` are permitted. Defaults to `true`.
+* `signed_version` - (Optional) Specifies the signed storage service version to use to authorize requests made with this account SAS. Defaults to `2017-07-29`.
 * `resource_types` - A `resource_types` block as defined below.
 * `services` - A `services` block as defined below.
 * `start` - The starting time and date of validity of this SAS. Must be a valid ISO-8601 format time/date string.


### PR DESCRIPTION
Implements #7619

- [ ] Should I add a proper version validator for `signed_version`?