### PR TITLE
Remove computed attribute for endpoint and route of azurerm_iothub

### DIFF
--- a/azurerm/internal/services/iothub/iothub_resource.go
+++ b/azurerm/internal/services/iothub/iothub_resource.go
@@ -209,8 +209,10 @@ func resourceArmIotHub() *schema.Resource {
 			},
 
 			"endpoint": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -284,8 +286,10 @@ func resourceArmIotHub() *schema.Resource {
 			},
 
 			"route": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Computed:   true,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/azurerm/internal/services/iothub/iothub_resource.go
+++ b/azurerm/internal/services/iothub/iothub_resource.go
@@ -211,7 +211,6 @@ func resourceArmIotHub() *schema.Resource {
 			"endpoint": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {
@@ -287,7 +286,6 @@ func resourceArmIotHub() *schema.Resource {
 			"route": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {

--- a/azurerm/internal/services/iothub/tests/iothub_resource_test.go
+++ b/azurerm/internal/services/iothub/tests/iothub_resource_test.go
@@ -99,7 +99,7 @@ func TestAccAzureRMIotHub_customRoutes(t *testing.T) {
 		CheckDestroy: testCheckAzureRMIotHubDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMIotHub_customRoutes(data, "S1"),
+				Config: testAccAzureRMIotHub_customRoutes(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMIotHubExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "endpoint.#", "2"),
@@ -122,14 +122,14 @@ func TestAccAzureRMIotHub_removeEndpointsAndRoutes(t *testing.T) {
 		CheckDestroy: testCheckAzureRMIotHubDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMIotHub_customRoutes(data, "B1"),
+				Config: testAccAzureRMIotHub_customRoutes(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMIotHubExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMIotHub_basic(data),
+				Config: testAccAzureRMIotHub_removeEndpointsAndRoutes(data),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMIotHubExists(data.ResourceName),
 				),
@@ -347,7 +347,7 @@ resource "azurerm_iothub" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMIotHub_customRoutes(data acceptance.TestData, skuName string) string {
+func testAccAzureRMIotHub_customRoutes(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -401,7 +401,7 @@ resource "azurerm_iothub" "test" {
   location            = azurerm_resource_group.test.location
 
   sku {
-    name     = "%s"
+    name     = "S1"
     capacity = "1"
   }
 
@@ -445,7 +445,79 @@ resource "azurerm_iothub" "test" {
     purpose = "testing"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, skuName)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMIotHub_removeEndpointsAndRoutes(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "test"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "private"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "acctest-%d"
+  sku                 = "Basic"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctest"
+  resource_group_name = azurerm_resource_group.test.name
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_authorization_rule" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  eventhub_name       = azurerm_eventhub.test.name
+  name                = "acctest"
+  send                = true
+}
+
+resource "azurerm_iothub" "test" {
+  name                = "acctestIoTHub-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "S1"
+    capacity = "1"
+  }
+
+  event_hub_retention_in_days = 7
+  event_hub_partition_count   = 77
+
+  endpoint = []
+
+  route = []
+
+  tags = {
+    purpose = "testing"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
 }
 
 func testAccAzureRMIotHub_fallbackRoute(data acceptance.TestData) string {

--- a/azurerm/internal/services/iothub/tests/iothub_resource_test.go
+++ b/azurerm/internal/services/iothub/tests/iothub_resource_test.go
@@ -99,13 +99,39 @@ func TestAccAzureRMIotHub_customRoutes(t *testing.T) {
 		CheckDestroy: testCheckAzureRMIotHubDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMIotHub_customRoutes(data),
+				Config: testAccAzureRMIotHub_customRoutes(data, "S1"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMIotHubExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "endpoint.#", "2"),
 					resource.TestCheckResourceAttr(data.ResourceName, "endpoint.0.type", "AzureIotHub.StorageContainer"),
 					resource.TestCheckResourceAttr(data.ResourceName, "endpoint.1.type", "AzureIotHub.EventHub"),
 					resource.TestCheckResourceAttr(data.ResourceName, "route.#", "2"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMIotHub_removeEndpointsAndRoutes(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMIotHubDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMIotHub_customRoutes(data, "B1"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMIotHubExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+			{
+				Config: testAccAzureRMIotHub_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMIotHubExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(),
@@ -321,7 +347,7 @@ resource "azurerm_iothub" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
-func testAccAzureRMIotHub_customRoutes(data acceptance.TestData) string {
+func testAccAzureRMIotHub_customRoutes(data acceptance.TestData, skuName string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -375,7 +401,7 @@ resource "azurerm_iothub" "test" {
   location            = azurerm_resource_group.test.location
 
   sku {
-    name     = "S1"
+    name     = "%s"
     capacity = "1"
   }
 
@@ -419,7 +445,7 @@ resource "azurerm_iothub" "test" {
     purpose = "testing"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, skuName)
 }
 
 func testAccAzureRMIotHub_fallbackRoute(data acceptance.TestData) string {


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/5065

--- PASS: TestAccAzureRMIotHub_fallbackRoute (245.99s)
--- PASS: TestAccAzureRMIotHub_fileUpload (303.89s)
--- PASS: TestAccAzureRMIotHub_basic (306.01s)
--- PASS: TestAccAzureRMIotHub_standard (320.62s)
--- PASS: TestAccAzureRMIotHub_ipFilterRules (330.66s)
--- PASS: TestAccAzureRMIotHub_requiresImport (336.06s)
--- PASS: TestAccAzureRMIotHub_removeEndpointsAndRoutes (467.11s)
--- PASS: TestAccAzureRMIotHub_customRoutes (514.77s)
PASS