### PR TITLE
Add lock for iothub while operating iothub consumer group

### DIFF
--- a/azurerm/internal/services/iothub/iothub_consumer_group_resource.go
+++ b/azurerm/internal/services/iothub/iothub_consumer_group_resource.go
@@ -2,6 +2,7 @@ package iothub
 
 import (
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"log"
 	"time"
 
@@ -67,6 +68,9 @@ func resourceArmIotHubConsumerGroupCreate(d *schema.ResourceData, meta interface
 	iotHubName := d.Get("iothub_name").(string)
 	endpointName := d.Get("eventhub_endpoint_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
+
+	locks.ByName(iotHubName, IothubResourceName)
+	defer locks.UnlockByName(iotHubName, IothubResourceName)
 
 	if features.ShouldResourcesBeImported() && d.IsNewResource() {
 		existing, err := client.GetEventHubConsumerGroup(ctx, resourceGroup, iotHubName, endpointName, name)
@@ -144,6 +148,9 @@ func resourceArmIotHubConsumerGroupDelete(d *schema.ResourceData, meta interface
 	iotHubName := id.Path["IotHubs"]
 	endpointName := id.Path["eventHubEndpoints"]
 	name := id.Path["ConsumerGroups"]
+
+	locks.ByName(iotHubName, IothubResourceName)
+	defer locks.UnlockByName(iotHubName, IothubResourceName)
 
 	resp, err := client.DeleteEventHubConsumerGroup(ctx, resourceGroup, iotHubName, endpointName, name)
 

--- a/azurerm/internal/services/iothub/iothub_consumer_group_resource.go
+++ b/azurerm/internal/services/iothub/iothub_consumer_group_resource.go
@@ -2,7 +2,6 @@ package iothub
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"log"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/locks"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )

--- a/azurerm/internal/services/iothub/iothub_shared_access_policy_resource.go
+++ b/azurerm/internal/services/iothub/iothub_shared_access_policy_resource.go
@@ -21,6 +21,8 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
+var IothubSharedAccessPolicyResourceName = "azurerm_iothub_shared_access_policy"
+
 func resourceArmIotHubSharedAccessPolicy() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmIotHubSharedAccessPolicyCreateUpdate,

--- a/azurerm/internal/services/iothub/iothub_shared_access_policy_resource.go
+++ b/azurerm/internal/services/iothub/iothub_shared_access_policy_resource.go
@@ -21,8 +21,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-var IothubSharedAccessPolicyResourceName = "azurerm_iothub_shared_access_policy"
-
 func resourceArmIotHubSharedAccessPolicy() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceArmIotHubSharedAccessPolicyCreateUpdate,

--- a/azurerm/internal/services/iothub/tests/iothub_consumer_group_resource_test.go
+++ b/azurerm/internal/services/iothub/tests/iothub_consumer_group_resource_test.go
@@ -73,6 +73,25 @@ func TestAccAzureRMIotHubConsumerGroup_operationsMonitoringEvents(t *testing.T) 
 	})
 }
 
+func TestAccAzureRMIotHubConsumerGroup_withSharedAccessPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_iothub_consumer_group", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMIotHubConsumerGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMIotHubConsumerGroup_withSharedAccessPolicy(data, "events"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMIotHubConsumerGroupExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func testCheckAzureRMIotHubConsumerGroupDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).IoTHub.ResourceClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -173,6 +192,20 @@ resource "azurerm_iothub_consumer_group" "import" {
   iothub_name            = azurerm_iothub_consumer_group.test.iothub_name
   eventhub_endpoint_name = azurerm_iothub_consumer_group.test.eventhub_endpoint_name
   resource_group_name    = azurerm_iothub_consumer_group.test.resource_group_name
+}
+`, template)
+}
+
+func testAccAzureRMIotHubConsumerGroup_withSharedAccessPolicy(data acceptance.TestData, eventName string) string {
+	template := testAccAzureRMIotHubConsumerGroup_basic(data, eventName)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_iothub_shared_access_policy" "test" {
+  name                = "acctestSharedAccessPolicy"
+  resource_group_name = azurerm_resource_group.test.name
+  iothub_name         = azurerm_iothub.test.name
+  service_connect     = true
 }
 `, template)
 }


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/7444

--- PASS: TestAccAzureRMIotHubConsumerGroup_operationsMonitoringEvents (253.00s)
--- PASS: TestAccAzureRMIotHubConsumerGroup_events (313.41s)
--- PASS: TestAccAzureRMIotHubConsumerGroup_requiresImport (397.78s)
--- PASS: TestAccAzureRMIotHubConsumerGroup_withSharedAccessPolicy (465.63s)
PASS
