### PR TITLE
allow "global" for enhanced location validation

### DIFF
--- a/azurerm/internal/location/validation.go
+++ b/azurerm/internal/location/validation.go
@@ -46,6 +46,11 @@ func enhancedValidation(i interface{}, k string) ([]string, []error) {
 		}
 
 		if !found {
+			// Some resources use a location named "global".
+			if normalizedUserInput == "global" {
+				return nil, nil
+			}
+
 			locations := strings.Join(*supportedLocations, ",")
 			return nil, []error{
 				fmt.Errorf("%q was not found in the list of supported Azure Locations: %q", normalizedUserInput, locations),

--- a/azurerm/internal/location/validation_test.go
+++ b/azurerm/internal/location/validation_test.go
@@ -31,6 +31,10 @@ func TestEnhancedValidationDisabled(t *testing.T) {
 			input: "West Europe",
 			valid: true,
 		},
+		{
+			input: "global",
+			valid: true,
+		},
 	}
 	enhancedEnabled = false
 	defer func() {
@@ -71,6 +75,10 @@ func TestEnhancedValidationEnabledButIsOffline(t *testing.T) {
 		},
 		{
 			input: "West Europe",
+			valid: true,
+		},
+		{
+			input: "global",
 			valid: true,
 		},
 	}
@@ -142,6 +150,11 @@ func TestEnhancedValidationEnabled(t *testing.T) {
 			availableLocations: chinaLocations,
 			input:              "West Europe",
 			valid:              false,
+		},
+		{
+			availableLocations: publicLocations,
+			input:              "global",
+			valid:              true,
 		},
 	}
 	enhancedEnabled = true


### PR DESCRIPTION
related #6927 #7881 #7891 #8034

I feel that disabling all validations using environment variables for a particular resource is not a good solution.
So allow "global".

fixes #6927
fixes #7881
fixes #7891
fixes #8034