### PR TITLE
Nomalised Azure frontdoor IDs

### DIFF
--- a/azurerm/internal/services/frontdoor/frontdoor_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_resource.go
@@ -1453,11 +1453,11 @@ func flattenArmFrontDoorSubResource(input *frontdoor.SubResource, resourceType s
 	name := ""
 
 	if id := input.ID; id != nil {
-		aid, err := azure.ParseAzureResourceID(*id)
+		aid, err := azure.ParseAzureResourceID(strings.ToLower(*id))
 		if err != nil {
 			return ""
 		}
-		name = aid.Path[resourceType]
+		name = aid.Path[strings.ToLower(resourceType)]
 	}
 
 	return name


### PR DESCRIPTION
Fixes #8036 

As of the 5th/6th of August 2020, the Azure FrontDoor response has become very inconsistent where case is used in resource IDs

Frontdoor JSON:
```
{
"name":"bink-frontdoor","id":"/subscriptions/00000000/resourcegroups/frontdoor/providers/Microsoft.Network/fro
  "Environment":"Production"
},"location":"Global","properties":{
  "provisioningState":"Succeeded","resourceState":"Enabled","backendPools":[
    {
      "id":"/subscriptions/00000000/resourcegroups/frontdoor/providers/Microsoft.Network/Frontdoors/bink-front
        "backends":[
          {
            "address":"api.snip","httpPort":80,"httpsPort":443,"priority":1,"weight":50,"backendHostHeader":"api.snip
          }
        ],"healthProbeSettings":{
          "id":"/subscriptions/00000000/resourcegroups/frontdoor/providers/microsoft.network/frontdoors/bink-f
        },"loadBalancingSettings":{
          "id":"/subscriptions/00000000/resourcegroups/frontdoor/providers/microsoft.network/frontdoors/bink-f
        },"resourceState":"Enabled"
      }
    },{
...
...
],"healthProbeSettings":[
  {
    "id":"/subscriptions/00000000/resourcegroups/frontdoor/providers/Microsoft.Network/Frontdoors/bink-front
      "intervalInSeconds":120,"path":"/healthz","protocol":"Https","resourceState":"Enabled","enabledState":"Enabled","healthProbeMethod
    }
  },{
    "id":"/subscriptions/00000000/resourcegroups/frontdoor/providers/Microsoft.Network/Frontdoors/bink-front
      "intervalInSeconds":120,"path":"/api/health","protocol":"Https","resourceState":"Enabled","enabledState":"Enabled","healthProbeMet
    }
  }
],"frontendEndpoints":[
```

So when processing the backend pools, the provider uses the lowercase ids to look up the healthProbeSettings which use mixed case ids

Am not super familiar with the AzureRM provider so there might be something I'm missing but these changes seem to fix the issues I am seeing.