### PR TITLE
Remove case diff suppress for property rule_type of azurerm_application_gateway

### DIFF
--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -486,13 +486,12 @@ func resourceArmApplicationGateway() *schema.Resource {
 						},
 
 						"rule_type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							DiffSuppressFunc: suppress.CaseDifference,
+							Type:     schema.TypeString,
+							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(network.Basic),
 								string(network.PathBasedRouting),
-							}, true),
+							}, false),
 						},
 
 						"http_listener_name": {


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/8043

After investigated, I found `TypeSet + suppress.CaseDifference` doesn't take effect. But I suppose it's expected since I assume terraform cannot compare the case difference for unordered collection. So I made this fix to remove case diff suppress for property rule_type.


--- PASS: TestAccAzureRMApplicationGateway_rewriteRuleSets_redirect (852.25s)
--- PASS: TestAccAzureRMApplicationGateway_rewriteRuleSets_backend (854.63s)
--- PASS: TestAccAzureRMApplicationGateway_routingRedirect_httpListenerError (92.84s)
--- PASS: TestAccAzureRMApplicationGateway_probesPickHostNameFromBackendHTTPSettings (958.90s)
--- PASS: TestAccAzureRMApplicationGateway_webApplicationFirewall_exclusions (1006.69s)
--- PASS: TestAccAzureRMApplicationGateway_probes (1064.49s)
--- PASS: TestAccAzureRMApplicationGateway_probesEmptyMatch (1065.48s)
--- PASS: TestAccAzureRMApplicationGateway_customErrorConfigurations (1066.04s)
--- PASS: TestAccAzureRMApplicationGateway_basic (1066.74s)
--- PASS: TestAccAzureRMApplicationGateway_backendHttpSettingsHostName (1098.70s)
--- PASS: TestAccAzureRMApplicationGateway_cookieAffinity (1352.01s)
--- PASS: TestAccAzureRMApplicationGateway_IncludePathWithTargetURL (1402.16s)
--- PASS: TestAccAzureRMApplicationGateway_customFirewallPolicy (764.58s)
--- PASS: TestAccAzureRMApplicationGateway_trustedRootCertificate (864.00s)
--- PASS: TestAccAzureRMApplicationGateway_customHttpListenerFirewallPolicy (867.43s)
--- PASS: TestAccAzureRMApplicationGateway_routingRedirect_pathBased (1096.88s)
--- PASS: TestAccAzureRMApplicationGateway_routingRedirect_httpListener (1053.13s)
--- PASS: TestAccAzureRMApplicationGateway_pathBasedRouting (1054.51s)
--- PASS: TestAccAzureRMApplicationGateway_requiresImport (968.40s)
--- PASS: TestAccAzureRMApplicationGateway_http2 (1057.89s)
--- PASS: TestAccAzureRMApplicationGateway_zones (799.22s)
--- PASS: TestAccAzureRMApplicationGateway_authCertificate (1350.40s)
--- PASS: TestAccAzureRMApplicationGateway_overridePath (1090.78s)
--- PASS: TestAccAzureRMApplicationGateway_sslPolicy_policyType_custom (696.77s)
--- PASS: TestAccAzureRMApplicationGateway_autoscaleConfigurationNoMaxCapacity (799.68s)
--- PASS: TestAccAzureRMApplicationGateway_sslPolicy_disabledProtocols (693.20s)
--- PASS: TestAccAzureRMApplicationGateway_webApplicationFirewall_disabledRuleGroups (754.13s)
--- PASS: TestAccAzureRMApplicationGateway_sslPolicy_policyType_predefined (794.96s)
--- PASS: TestAccAzureRMApplicationGateway_autoscaleConfiguration (1107.61s)
--- PASS: TestAccAzureRMApplicationGateway_backendHttpSettingsHostNameAndPick (88.07s)
--- PASS: TestAccAzureRMApplicationGateway_sslCertificate_EmptyPassword (1056.90s)
--- PASS: TestAccAzureRMApplicationGateway_UserAssignedIdentity (800.00s)
--- PASS: TestAccAzureRMApplicationGateway_webApplicationFirewall (1161.24s)
--- PASS: TestAccAzureRMApplicationGateway_V2SKUCapacity (910.32s)
--- PASS: TestAccAzureRMApplicationGateway_sslCertificate_keyvault_versioned (999.51s)
--- PASS: TestAccAzureRMApplicationGateway_settingsPickHostNameFromBackendAddress (1052.08s)
--- PASS: TestAccAzureRMApplicationGateway_sslCertificate_keyvault_versionless (924.79s)
--- PASS: TestAccAzureRMApplicationGateway_connectionDraining (1644.33s)
--- PASS: TestAccAzureRMApplicationGateway_withHttpListenerHostNames (818.61s)
--- PASS: TestAccAzureRMApplicationGateway_sslCertificate (1868.86s)
--- PASS: TestAccAzureRMApplicationGateway_gatewayIP (1903.94s)
