### PR TITLE
Fix shared_image Tests

### DIFF
--- a/azurerm/internal/services/compute/tests/image_resource_test.go
+++ b/azurerm/internal/services/compute/tests/image_resource_test.go
@@ -550,6 +550,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "%s"
+  allow_blob_public_access = true
 
   tags = {
     environment = "Dev"


### PR DESCRIPTION
go test -v ./tests -timeout=0 -run TestAccAzureRMSharedImageVersion_basic
=== RUN   TestAccAzureRMSharedImageVersion_basic
=== PAUSE TestAccAzureRMSharedImageVersion_basic
=== CONT  TestAccAzureRMSharedImageVersion_basic
--- PASS: TestAccAzureRMSharedImageVersion_basic (2823.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/tests       2823.101s