### PR TITLE
Test fix `TestAccDataSourceAzureRMImage_basic`

### DIFF
--- a/azurerm/internal/services/compute/tests/image_data_source_test.go
+++ b/azurerm/internal/services/compute/tests/image_data_source_test.go
@@ -116,6 +116,7 @@ resource "azurerm_storage_account" "test" {
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  allow_blob_public_access = true
 
   tags = {
     environment = "Dev"


### PR DESCRIPTION
go test -v ./tests -timeout=0 -run TestAccDataSourceAzureRMImage_basic
=== RUN   TestAccDataSourceAzureRMImage_basic
=== PAUSE TestAccDataSourceAzureRMImage_basic
=== CONT  TestAccDataSourceAzureRMImage_basic
--- PASS: TestAccDataSourceAzureRMImage_basic (545.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/tests       545.657s