### PR TITLE
`azurerm_storage_account` - switch logic to be if not public cloud instead of if us government cloud

### DIFF
--- a/azurerm/internal/services/storage/resource_arm_storage_account.go
+++ b/azurerm/internal/services/storage/resource_arm_storage_account.go
@@ -655,10 +655,10 @@ func resourceArmStorageAccountCreate(d *schema.ResourceData, meta interface{}) e
 		},
 	}
 
-	// For US Government Cloud, don't specify "allow_blob_public_access" and "min_tls_version" in request body.
+	// For all Clouds except Public, don't specify "allow_blob_public_access" and "min_tls_version" in request body.
 	// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7812
 	// https://github.com/terraform-providers/terraform-provider-azurerm/issues/8083
-	if envName == autorestAzure.USGovernmentCloud.Name {
+	if envName != autorestAzure.PublicCloud.Name {
 		if allowBlobPublicAccess || minimumTLSVersion != string(storage.TLS10) {
 			return fmt.Errorf(`"allow_blob_public_access" and "min_tls_version" are not supported for a Storage Account located in %q`, envName)
 		}
@@ -901,9 +901,9 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("min_tls_version") {
 		minimumTLSVersion := d.Get("min_tls_version").(string)
 
-		// For US Government Cloud, don't specify "min_tls_version" in request body.
+		// For all Clouds except Public, don't specify "min_tls_version" in request body.
 		// https://github.com/terraform-providers/terraform-provider-azurerm/issues/8083
-		if envName == autorestAzure.USGovernmentCloud.Name {
+		if envName != autorestAzure.PublicCloud.Name {
 			if minimumTLSVersion != string(storage.TLS10) {
 				return fmt.Errorf(`"min_tls_version" is not supported for a Storage Account located in %q`, envName)
 			}
@@ -923,9 +923,9 @@ func resourceArmStorageAccountUpdate(d *schema.ResourceData, meta interface{}) e
 	if d.HasChange("allow_blob_public_access") {
 		allowBlobPublicAccess := d.Get("allow_blob_public_access").(bool)
 
-		// For US Government Cloud, don't specify "allow_blob_public_access" in request body.
+		// For all Clouds except Public, don't specify "allow_blob_public_access" in request body.
 		// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7812
-		if envName == autorestAzure.USGovernmentCloud.Name {
+		if envName != autorestAzure.PublicCloud.Name {
 			if allowBlobPublicAccess {
 				return fmt.Errorf(`"allow_blob_public_access" is not supported for a Storage Account located in %q`, envName)
 			}
@@ -1097,10 +1097,10 @@ func resourceArmStorageAccountRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("enable_https_traffic_only", props.EnableHTTPSTrafficOnly)
 		d.Set("is_hns_enabled", props.IsHnsEnabled)
 		d.Set("allow_blob_public_access", props.AllowBlobPublicAccess)
-		// For US Government Cloud, "min_tls_version" is not returned from Azure so always persist the default values for "min_tls_version".
+		// For all Clouds except Public, "min_tls_version" is not returned from Azure so always persist the default values for "min_tls_version".
 		// https://github.com/terraform-providers/terraform-provider-azurerm/issues/7812
 		// https://github.com/terraform-providers/terraform-provider-azurerm/issues/8083
-		if meta.(*clients.Client).Account.Environment.Name == autorestAzure.USGovernmentCloud.Name {
+		if meta.(*clients.Client).Account.Environment.Name != autorestAzure.PublicCloud.Name {
 			d.Set("min_tls_version", string(storage.TLS10))
 		} else {
 			d.Set("min_tls_version", string(props.MinimumTLSVersion))

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -99,11 +99,11 @@ The following arguments are supported:
 
 * `min_tls_version` - (Optional) The minimum supported TLS version for the storage account. Possible values are `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLS1_0` for new storage accounts.
 
--> **NOTE:** At this time `min_tls_version` is not supported in US Government.
+-> **NOTE:** At this time `min_tls_version` is only supported in the Public Cloud.
 
 * `allow_blob_public_access` - Allow or disallow public access to all blobs or containers in the storage account. Defaults to `false`.
 
--> **NOTE:** At this time `allow_blob_public_access` is not supported in US Government.
+-> **NOTE:** At this time `allow_blob_public_access` is only supported in the Public Cloud.
 
 * `is_hns_enabled` - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created. 
 


### PR DESCRIPTION
Switching the logic will fix all clouds because the minTLSVersion & AllowBlobPublicAccess fields are only valid in the Azure public cloud at this time.