### PR TITLE
Remove computed attribute for public_ip_address_id and public_ip_prefix_id of load balancer

### DIFF
--- a/azurerm/internal/services/network/lb_resource.go
+++ b/azurerm/internal/services/network/lb_resource.go
@@ -102,14 +102,12 @@ func resourceArmLoadBalancer() *schema.Resource {
 						"public_ip_address_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
 						},
 
 						"public_ip_prefix_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
 							ValidateFunc: azure.ValidateResourceIDOrEmpty,
 						},
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/4648

--- PASS: TestAccAzureRMLoadBalancer_standard (95.51s)
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfigPublicIPPrefix (108.71s)
--- PASS: TestAccAzureRMLoadBalancer_basic (156.25s)
--- PASS: TestAccAzureRMLoadBalancer_emptyPrivateIP (156.70s)
--- PASS: TestAccAzureRMLoadBalancer_requiresImport (164.48s)
--- PASS: TestAccAzureRMLoadBalancer_privateIP (172.30s)
--- PASS: TestAccAzureRMLoadBalancer_tags (179.52s)
--- PASS: TestAccAzureRMLoadBalancer_frontEndConfig (235.25s)
--- PASS: TestAccAzureRMLoadBalancer_removeFirstPublicIPAddress (142.33s)
--- PASS: TestAccAzureRMLoadBalancer_removeFirstPublicIPPrefix (145.89s)