### PR TITLE
rename "azurerm_synapse_big_data_pool" to "azurerm_synapse_spark_pool"

### DIFF
--- a/azurerm/internal/services/synapse/client/client.go
+++ b/azurerm/internal/services/synapse/client/client.go
@@ -6,18 +6,19 @@ import (
 )
 
 type Client struct {
-	BigDataPoolClient        *synapse.BigDataPoolsClient
 	FirewallRulesClient      *synapse.IPFirewallRulesClient
+	SparkPoolClient          *synapse.BigDataPoolsClient
 	WorkspaceClient          *synapse.WorkspacesClient
 	WorkspaceAadAdminsClient *synapse.WorkspaceAadAdminsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
-	bigDataPoolClient := synapse.NewBigDataPoolsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
-	o.ConfigureClient(&bigDataPoolClient.Client, o.ResourceManagerAuthorizer)
-
 	firewallRuleClient := synapse.NewIPFirewallRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&firewallRuleClient.Client, o.ResourceManagerAuthorizer)
+
+	// the service team hopes to rename it to sparkPool, so rename the sdk here
+	sparkPoolClient := synapse.NewBigDataPoolsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&sparkPoolClient.Client, o.ResourceManagerAuthorizer)
 
 	workspaceClient := synapse.NewWorkspacesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&workspaceClient.Client, o.ResourceManagerAuthorizer)
@@ -26,8 +27,8 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&workspaceAadAdminsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		BigDataPoolClient:        &bigDataPoolClient,
 		FirewallRulesClient:      &firewallRuleClient,
+		SparkPoolClient:          &sparkPoolClient,
 		WorkspaceClient:          &workspaceClient,
 		WorkspaceAadAdminsClient: &workspaceAadAdminsClient,
 	}

--- a/azurerm/internal/services/synapse/parse/synapse_spark_pool.go
+++ b/azurerm/internal/services/synapse/parse/synapse_spark_pool.go
@@ -6,32 +6,32 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 )
 
-type SynapseBigDataPoolId struct {
+type SynapseSparkPoolId struct {
 	Workspace *SynapseWorkspaceId
 	Name      string
 }
 
-func SynapseBigDataPoolID(input string) (*SynapseBigDataPoolId, error) {
+func SynapseSparkPoolID(input string) (*SynapseSparkPoolId, error) {
 	id, err := azure.ParseAzureResourceID(input)
 	if err != nil {
-		return nil, fmt.Errorf("parsing synapseBigDataPool ID %q: %+v", input, err)
+		return nil, fmt.Errorf("parsing synapse Spark Pool ID %q: %+v", input, err)
 	}
 
-	synapseBigDataPool := SynapseBigDataPoolId{
+	synapseSparkPool := SynapseSparkPoolId{
 		Workspace: &SynapseWorkspaceId{
 			SubscriptionID: id.SubscriptionID,
 			ResourceGroup:  id.ResourceGroup,
 		},
 	}
-	if synapseBigDataPool.Workspace.Name, err = id.PopSegment("workspaces"); err != nil {
+	if synapseSparkPool.Workspace.Name, err = id.PopSegment("workspaces"); err != nil {
 		return nil, err
 	}
-	if synapseBigDataPool.Name, err = id.PopSegment("bigDataPools"); err != nil {
+	if synapseSparkPool.Name, err = id.PopSegment("bigDataPools"); err != nil {
 		return nil, err
 	}
 	if err := id.ValidateNoEmptySegments(input); err != nil {
 		return nil, err
 	}
 
-	return &synapseBigDataPool, nil
+	return &synapseSparkPool, nil
 }

--- a/azurerm/internal/services/synapse/parse/synapse_spark_pool_test.go
+++ b/azurerm/internal/services/synapse/parse/synapse_spark_pool_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 )
 
-func TestSynapseBigDataPoolID(t *testing.T) {
+func TestSynapseSparkPoolID(t *testing.T) {
 	testData := []struct {
 		Name     string
 		Input    string
-		Expected *SynapseBigDataPoolId
+		Expected *SynapseSparkPoolId
 	}{
 		{
 			Name:     "Empty",
@@ -38,7 +38,7 @@ func TestSynapseBigDataPoolID(t *testing.T) {
 		{
 			Name:  "synapse BigDataPool ID",
 			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Synapse/workspaces/workspace1/bigDataPools/bigDataPool1",
-			Expected: &SynapseBigDataPoolId{
+			Expected: &SynapseSparkPoolId{
 				Workspace: &SynapseWorkspaceId{
 					ResourceGroup: "resourceGroup1",
 					Name:          "workspace1",
@@ -56,7 +56,7 @@ func TestSynapseBigDataPoolID(t *testing.T) {
 	for _, v := range testData {
 		t.Logf("[DEBUG] Testing %q..", v.Name)
 
-		actual, err := SynapseBigDataPoolID(v.Input)
+		actual, err := SynapseSparkPoolID(v.Input)
 		if err != nil {
 			if v.Expected == nil {
 				continue

--- a/azurerm/internal/services/synapse/parse/synapse_spark_pool_test.go
+++ b/azurerm/internal/services/synapse/parse/synapse_spark_pool_test.go
@@ -37,18 +37,18 @@ func TestSynapseSparkPoolID(t *testing.T) {
 		},
 		{
 			Name:  "synapse BigDataPool ID",
-			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Synapse/workspaces/workspace1/bigDataPools/bigDataPool1",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Synapse/workspaces/workspace1/bigDataPools/sparkPool1",
 			Expected: &SynapseSparkPoolId{
 				Workspace: &SynapseWorkspaceId{
 					ResourceGroup: "resourceGroup1",
 					Name:          "workspace1",
 				},
-				Name: "bigDataPool1",
+				Name: "sparkPool1",
 			},
 		},
 		{
 			Name:     "Wrong Casing",
-			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Synapse/workspaces/workspace1/BigDataPools/bigDataPool1",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Synapse/workspaces/workspace1/BigDataPools/sparkPool1",
 			Expected: nil,
 		},
 	}

--- a/azurerm/internal/services/synapse/registration.go
+++ b/azurerm/internal/services/synapse/registration.go
@@ -26,8 +26,8 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
-		"azurerm_synapse_big_data_pool": resourceArmSynapseBigDataPool(),
 		"azurerm_synapse_firewall_rule": resourceArmSynapseFirewallRule(),
+		"azurerm_synapse_spark_pool":    resourceArmSynapseSparkPool(),
 		"azurerm_synapse_workspace":     resourceArmSynapseWorkspace(),
 	}
 }

--- a/azurerm/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/azurerm/internal/services/synapse/synapse_spark_pool_resource.go
@@ -160,7 +160,7 @@ func resourceArmSynapseSparkPool() *schema.Resource {
 }
 
 func resourceArmSynapseSparkPoolCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Synapse.BigDataPoolClient
+	client := meta.(*clients.Client).Synapse.SparkPoolClient
 	workspaceClient := meta.(*clients.Client).Synapse.WorkspaceClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -227,7 +227,7 @@ func resourceArmSynapseSparkPoolCreateUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceArmSynapseSparkPoolRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Synapse.BigDataPoolClient
+	client := meta.(*clients.Client).Synapse.SparkPoolClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -266,7 +266,7 @@ func resourceArmSynapseSparkPoolRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceArmSynapseSparkPoolDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Synapse.BigDataPoolClient
+	client := meta.(*clients.Client).Synapse.SparkPoolClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/azurerm/internal/services/synapse/tests/synapse_spark_pool_resource_test.go
+++ b/azurerm/internal/services/synapse/tests/synapse_spark_pool_resource_test.go
@@ -102,7 +102,7 @@ func TestAccAzureRMSynapseSparkPool_update(t *testing.T) {
 
 func testCheckAzureRMSynapseSparkPoolExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := acceptance.AzureProvider.Meta().(*clients.Client).Synapse.BigDataPoolClient
+		client := acceptance.AzureProvider.Meta().(*clients.Client).Synapse.SparkPoolClient
 		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -116,14 +116,14 @@ func testCheckAzureRMSynapseSparkPoolExists(resourceName string) resource.TestCh
 			if !utils.ResponseWasNotFound(resp.Response) {
 				return fmt.Errorf("bad: Synapse BigDataPool %q does not exist", id.Name)
 			}
-			return fmt.Errorf("bad: Get on Synapse.BigDataPoolClient: %+v", err)
+			return fmt.Errorf("bad: Get on Synapse.SparkPoolClient: %+v", err)
 		}
 		return nil
 	}
 }
 
 func testCheckAzureRMSynapseSparkPoolDestroy(s *terraform.State) error {
-	client := acceptance.AzureProvider.Meta().(*clients.Client).Synapse.BigDataPoolClient
+	client := acceptance.AzureProvider.Meta().(*clients.Client).Synapse.SparkPoolClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
 
 	for _, rs := range s.RootModule().Resources {
@@ -137,7 +137,7 @@ func testCheckAzureRMSynapseSparkPoolDestroy(s *terraform.State) error {
 		resp, err := client.Get(ctx, id.Workspace.ResourceGroup, id.Workspace.Name, id.Name)
 		if err != nil {
 			if !utils.ResponseWasNotFound(resp.Response) {
-				return fmt.Errorf("bad: Get on Synapse.BigDataPoolClient: %+v", err)
+				return fmt.Errorf("bad: Get on Synapse.SparkPoolClient: %+v", err)
 			}
 			return nil
 		}

--- a/azurerm/internal/services/synapse/tests/synapse_spark_pool_resource_test.go
+++ b/azurerm/internal/services/synapse/tests/synapse_spark_pool_resource_test.go
@@ -12,17 +12,17 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 
-func TestAccAzureRMSynapseBigDataPool_basic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_synapse_big_data_pool", "test")
+func TestAccAzureRMSynapseSparkPool_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMSynapseBigDataPoolDestroy,
+		CheckDestroy: testCheckAzureRMSynapseSparkPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMSynapseBigDataPool_basic(data),
+				Config: testAccAzureRMSynapseSparkPool_basic(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSynapseBigDataPoolExists(data.ResourceName),
+					testCheckAzureRMSynapseSparkPoolExists(data.ResourceName),
 				),
 			},
 			// not returned by service
@@ -31,35 +31,35 @@ func TestAccAzureRMSynapseBigDataPool_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMSynapseBigDataPool_requiresImport(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_synapse_big_data_pool", "test")
+func TestAccAzureRMSynapseSparkPool_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMSynapseBigDataPoolDestroy,
+		CheckDestroy: testCheckAzureRMSynapseSparkPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMSynapseBigDataPool_basic(data),
+				Config: testAccAzureRMSynapseSparkPool_basic(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSynapseBigDataPoolExists(data.ResourceName),
+					testCheckAzureRMSynapseSparkPoolExists(data.ResourceName),
 				),
 			},
-			data.RequiresImportErrorStep(testAccAzureRMSynapseBigDataPool_requiresImport),
+			data.RequiresImportErrorStep(testAccAzureRMSynapseSparkPool_requiresImport),
 		},
 	})
 }
 
-func TestAccAzureRMSynapseBigDataPool_complete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_synapse_big_data_pool", "test")
+func TestAccAzureRMSynapseSparkPool_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMSynapseBigDataPoolDestroy,
+		CheckDestroy: testCheckAzureRMSynapseSparkPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMSynapseBigDataPool_complete(data),
+				Config: testAccAzureRMSynapseSparkPool_complete(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSynapseBigDataPoolExists(data.ResourceName),
+					testCheckAzureRMSynapseSparkPoolExists(data.ResourceName),
 				),
 			},
 			// not returned by service
@@ -68,31 +68,31 @@ func TestAccAzureRMSynapseBigDataPool_complete(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMSynapseBigDataPool_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_synapse_big_data_pool", "test")
+func TestAccAzureRMSynapseSparkPool_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_spark_pool", "test")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { acceptance.PreCheck(t) },
 		Providers:    acceptance.SupportedProviders,
-		CheckDestroy: testCheckAzureRMSynapseBigDataPoolDestroy,
+		CheckDestroy: testCheckAzureRMSynapseSparkPoolDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAzureRMSynapseBigDataPool_basic(data),
+				Config: testAccAzureRMSynapseSparkPool_basic(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSynapseBigDataPoolExists(data.ResourceName),
+					testCheckAzureRMSynapseSparkPoolExists(data.ResourceName),
 				),
 			},
 			data.ImportStep("spark_events_folder", "spark_log_folder"),
 			{
-				Config: testAccAzureRMSynapseBigDataPool_complete(data),
+				Config: testAccAzureRMSynapseSparkPool_complete(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSynapseBigDataPoolExists(data.ResourceName),
+					testCheckAzureRMSynapseSparkPoolExists(data.ResourceName),
 				),
 			},
 			data.ImportStep("spark_events_folder", "spark_log_folder"),
 			{
-				Config: testAccAzureRMSynapseBigDataPool_basic(data),
+				Config: testAccAzureRMSynapseSparkPool_basic(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSynapseBigDataPoolExists(data.ResourceName),
+					testCheckAzureRMSynapseSparkPoolExists(data.ResourceName),
 				),
 			},
 			data.ImportStep("spark_events_folder", "spark_log_folder"),
@@ -100,7 +100,7 @@ func TestAccAzureRMSynapseBigDataPool_update(t *testing.T) {
 	})
 }
 
-func testCheckAzureRMSynapseBigDataPoolExists(resourceName string) resource.TestCheckFunc {
+func testCheckAzureRMSynapseSparkPoolExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := acceptance.AzureProvider.Meta().(*clients.Client).Synapse.BigDataPoolClient
 		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
@@ -108,7 +108,7 @@ func testCheckAzureRMSynapseBigDataPoolExists(resourceName string) resource.Test
 		if !ok {
 			return fmt.Errorf("synapse BigDataPool not found: %s", resourceName)
 		}
-		id, err := parse.SynapseBigDataPoolID(rs.Primary.ID)
+		id, err := parse.SynapseSparkPoolID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -122,15 +122,15 @@ func testCheckAzureRMSynapseBigDataPoolExists(resourceName string) resource.Test
 	}
 }
 
-func testCheckAzureRMSynapseBigDataPoolDestroy(s *terraform.State) error {
+func testCheckAzureRMSynapseSparkPoolDestroy(s *terraform.State) error {
 	client := acceptance.AzureProvider.Meta().(*clients.Client).Synapse.BigDataPoolClient
 	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "azurerm_synapse_big_data_pool" {
+		if rs.Type != "azurerm_synapse_spark_pool" {
 			continue
 		}
-		id, err := parse.SynapseBigDataPoolID(rs.Primary.ID)
+		id, err := parse.SynapseSparkPoolID(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -146,12 +146,12 @@ func testCheckAzureRMSynapseBigDataPoolDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAzureRMSynapseBigDataPool_basic(data acceptance.TestData) string {
-	template := testAccAzureRMSynapseBigDataPool_template(data)
+func testAccAzureRMSynapseSparkPool_basic(data acceptance.TestData) string {
+	template := testAccAzureRMSynapseSparkPool_template(data)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_synapse_big_data_pool" "test" {
+resource "azurerm_synapse_spark_pool" "test" {
   name                 = "acctestSSP%s"
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   node_size_family     = "MemoryOptimized"
@@ -161,27 +161,27 @@ resource "azurerm_synapse_big_data_pool" "test" {
 `, template, data.RandomString)
 }
 
-func testAccAzureRMSynapseBigDataPool_requiresImport(data acceptance.TestData) string {
-	config := testAccAzureRMSynapseBigDataPool_basic(data)
+func testAccAzureRMSynapseSparkPool_requiresImport(data acceptance.TestData) string {
+	config := testAccAzureRMSynapseSparkPool_basic(data)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_synapse_big_data_pool" "import" {
-  name                 = azurerm_synapse_big_data_pool.test.name
-  synapse_workspace_id = azurerm_synapse_big_data_pool.test.synapse_workspace_id
-  node_size_family     = azurerm_synapse_big_data_pool.test.node_size_family
-  node_size            = azurerm_synapse_big_data_pool.test.node_size
-  node_count           = azurerm_synapse_big_data_pool.test.node_count
+resource "azurerm_synapse_spark_pool" "import" {
+  name                 = azurerm_synapse_spark_pool.test.name
+  synapse_workspace_id = azurerm_synapse_spark_pool.test.synapse_workspace_id
+  node_size_family     = azurerm_synapse_spark_pool.test.node_size_family
+  node_size            = azurerm_synapse_spark_pool.test.node_size
+  node_count           = azurerm_synapse_spark_pool.test.node_count
 }
 `, config)
 }
 
-func testAccAzureRMSynapseBigDataPool_complete(data acceptance.TestData) string {
-	template := testAccAzureRMSynapseBigDataPool_template(data)
+func testAccAzureRMSynapseSparkPool_complete(data acceptance.TestData) string {
+	template := testAccAzureRMSynapseSparkPool_template(data)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_synapse_big_data_pool" "test" {
+resource "azurerm_synapse_spark_pool" "test" {
   name                 = "acctestSSP%s"
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   node_size_family     = "MemoryOptimized"
@@ -215,7 +215,7 @@ EOF
 `, template, data.RandomString)
 }
 
-func testAccAzureRMSynapseBigDataPool_template(data acceptance.TestData) string {
+func testAccAzureRMSynapseSparkPool_template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -2695,7 +2695,7 @@
               <a href="#">Synapse Resources</a>
               <ul class="nav">
                 <li>
-                  <a href="/docs/providers/azurerm/r/synapse_workspace.html">azurerm_synapse_workspace</a>
+                  <a href="/docs/providers/azurerm/r/synapse_firewall_rule.html">azurerm_synapse_firewall_rule</a>
                 </li>
 
                 <li>
@@ -2703,7 +2703,7 @@
                 </li>
 
                 <li>
-                  <a href="/docs/providers/azurerm/r/synapse_firewall_rule.html">azurerm_synapse_firewall_rule</a>
+                  <a href="/docs/providers/azurerm/r/synapse_workspace.html">azurerm_synapse_workspace</a>
                 </li>
               </ul>
             </li>

--- a/website/azurerm.erb
+++ b/website/azurerm.erb
@@ -2695,11 +2695,11 @@
               <a href="#">Synapse Resources</a>
               <ul class="nav">
                 <li>
-                  <a href="/docs/providers/azurerm/r/synapse_big_data_pool.html">azurerm_synapse_big_data_pool</a>
+                  <a href="/docs/providers/azurerm/r/synapse_workspace.html">azurerm_synapse_workspace</a>
                 </li>
 
                 <li>
-                  <a href="/docs/providers/azurerm/r/synapse_workspace.html">azurerm_synapse_workspace</a>
+                  <a href="/docs/providers/azurerm/r/synapse_spark_pool.html">azurerm_synapse_spark_pool</a>
                 </li>
 
                 <li>

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -1,14 +1,14 @@
 ---
 subcategory: "Synapse"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_synapse_big_data_pool"
+page_title: "Azure Resource Manager: azurerm_synapse_spark_pool"
 description: |-
-  Manages a Synapse Big Data Pool.
+  Manages a Synapse Spark Pool.
 ---
 
-# azurerm_synapse_big_data_pool
+# azurerm_synapse_spark_pool
 
-Manages a Synapse Big Data Pool.
+Manages a Synapse Spark Pool.
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ resource "azurerm_synapse_workspace" "example" {
   sql_administrator_login_password     = "H@Sh1CoR3!"
 }
 
-resource "azurerm_synapse_big_data_pool" "example" {
+resource "azurerm_synapse_spark_pool" "example" {
   name                 = "example"
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   node_size_family     = "MemoryOptimized"
@@ -67,15 +67,15 @@ resource "azurerm_synapse_big_data_pool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Synapse Big Data Pool. Changing this forces a new Synapse Big Data Pool to be created.
+* `name` - (Required) The name which should be used for this Synapse Spark Pool. Changing this forces a new Synapse Spark Pool to be created.
 
-* `synapse_workspace_id` - (Required) The ID of the Synapse Workspace where the Synapse Big Data Pool should exist. Changing this forces a new Synapse Big Data Pool to be created.
+* `synapse_workspace_id` - (Required) The ID of the Synapse Workspace where the Synapse Spark Pool should exist. Changing this forces a new Synapse Spark Pool to be created.
 
-* `node_size_family` - (Required) The kind of nodes that the Big Data pool provides. Possible value is `MemoryOptimized`.
+* `node_size_family` - (Required) The kind of nodes that the Spark Pool provides. Possible value is `MemoryOptimized`.
 
-* `node_size` - (Required) The level of node in the Big Data pool. Possible value is `Small`, `Medium` and `Large`.
+* `node_size` - (Required) The level of node in the Spark Pool. Possible value is `Small`, `Medium` and `Large`.
 
-* `node_count` - (Optional) The number of nodes in the Big Data pool. Exactly one of `node_count` or `auto_scale` must be specified.
+* `node_count` - (Optional) The number of nodes in the Spark Pool. Exactly one of `node_count` or `auto_scale` must be specified.
 
 * `auto_scale` - (Optional)  An `auto_scale` block as defined below. Exactly one of `node_count` or `auto_scale` must be specified.
 
@@ -89,21 +89,21 @@ The following arguments are supported:
 
 * `spark_version` - (Optional) The Apache Spark version. Possible value is `2.4`. Defaults to `2.4`.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Big Data Pool.
+* `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 
 ---
 
 An `auto_pause` block exports the following:
 
-* `delay_in_minutes` - (Required) Number of minutes of idle time before the Big Data pool is automatically paused. Must be between `5` and `10080`.
+* `delay_in_minutes` - (Required) Number of minutes of idle time before the Spark Pool is automatically paused. Must be between `5` and `10080`.
 
 ---
 
 An `auto_scale` block exports the following:
 
-* `max_node_count` - (Required) The maximum number of nodes the Big Data pool can support. Must be between `3` and `200`.
+* `max_node_count` - (Required) The maximum number of nodes the Spark Pool can support. Must be between `3` and `200`.
 
-* `min_node_count` - (Required) The minimum number of nodes the Big Data pool can support. Must be between `3` and `200`.
+* `min_node_count` - (Required) The minimum number of nodes the Spark Pool can support. Must be between `3` and `200`.
 
 ---
 
@@ -117,21 +117,21 @@ An `library_requirement` block exports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the Synapse BigDataPool.
+* `id` - The ID of the Synapse Spark Pool.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Synapse BigDataPool.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Synapse BigDataPool.
-* `update` - (Defaults to 30 minutes) Used when updating the Synapse BigDataPool.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Synapse BigDataPool.
+* `create` - (Defaults to 30 minutes) Used when creating the Synapse Spark Pool.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Synapse Spark Pool.
+* `update` - (Defaults to 30 minutes) Used when updating the Synapse Spark Pool.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Synapse Spark Pool.
 
 ## Import
 
-Synapse BigDataPools can be imported using the `resource id`, e.g.
+Synapse Spark Pool can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_synapse_big_data_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/bigDataPools/bigDataPool1
+terraform import azurerm_synapse_spark_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/bigDataPools/bigDataPool1
 ```

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -133,5 +133,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Synapse Spark Pool can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_synapse_spark_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/bigDataPools/bigDataPool1
+terraform import azurerm_synapse_spark_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/bigDataPools/sparkPool1
 ```

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -107,7 +107,7 @@ An `auto_scale` block supports the following:
 
 ---
 
-An `library_requirement` block exports the following:
+An `library_requirement` block supports the following:
 
 * `content` - (Required) The content of library requirements.
 

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -99,7 +99,7 @@ An `auto_pause` block exports the following:
 
 ---
 
-An `auto_scale` block exports the following:
+An `auto_scale` block supports the following:
 
 * `max_node_count` - (Required) The maximum number of nodes the Spark Pool can support. Must be between `3` and `200`.
 

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 ---
 
-An `auto_pause` block exports the following:
+An `auto_pause` block supports the following:
 
 * `delay_in_minutes` - (Required) Number of minutes of idle time before the Spark Pool is automatically paused. Must be between `5` and `10080`.
 


### PR DESCRIPTION
for PR https://github.com/terraform-providers/terraform-provider-azurerm/pull/7886

the service team suddenly come up with a requirement: rename it to "azurerm_synapse_spark_pool", they say bigdatapool is just api name, they hope the product name is "sparkpool"