### PR TITLE
New Data Source: `azurerm_key_vault_certificate_data` 

### DIFF
--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -99,7 +99,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *schema.ResourceData, meta inter
 	cert, err := client.GetCertificate(ctx, *keyVaultBaseUri, name, version)
 	if err != nil {
 		if utils.ResponseWasNotFound(cert.Response) {
-			log.Printf("[DEBUG] Certificate %q was not found in Key Vault at URI %q - removing from state", name, keyVaultBaseUri)
+			log.Printf("[DEBUG] Certificate %q was not found in Key Vault at URI %q - removing from state", name, *keyVaultBaseUri)
 			d.SetId("")
 			return nil
 		}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -137,7 +137,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("converting text to Time struct: %+v", err)
 	}
 
-	d.Set("certificate_expires", t.Format(time.RFC3339))
+	d.Set("expires", t.Format(time.RFC3339))
 
 	// Get PFX
 	pfx, err := client.GetSecret(ctx, id.KeyVaultBaseUrl, id.Name, id.Version)

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -15,7 +15,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/keyvault/validate"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -35,13 +34,13 @@ func dataSourceKeyVaultCertificateData() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validate.NestedItemId,
+				ValidateFunc: validate.NestedItemName,
 			},
 
 			"key_vault_id": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				ValidateFunc: validate.VaultID,
 			},
 
 			"version": {
@@ -68,7 +67,7 @@ func dataSourceKeyVaultCertificateData() *schema.Resource {
 				Computed:  true,
 			},
 
-			"certificate_expires": {
+			"expires": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -113,7 +112,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *schema.ResourceData, meta inter
 
 	d.SetId(*cert.ID)
 
-	id, err := parse.ParseNestedItemID(*cert.ID)
+	id, err := parse.ParseNestedItemID(d.Id())
 	if err != nil {
 		return err
 	}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -1,0 +1,180 @@
+package keyvault
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+	"golang.org/x/crypto/pkcs12"
+)
+
+func dataSourceArmKeyVaultCertificateData() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceArmKeyVaultCertificateDataRead,
+
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azure.ValidateKeyVaultChildName,
+			},
+
+			"key_vault_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			// Computed
+
+			"certificate_hex": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"certificate_pem": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"certificate_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"certificate_expires": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tags.SchemaDataSource(),
+		},
+	}
+}
+
+func dataSourceArmKeyVaultCertificateDataRead(d *schema.ResourceData, meta interface{}) error {
+	vaultClient := meta.(*clients.Client).KeyVault.VaultsClient
+	client := meta.(*clients.Client).KeyVault.ManagementClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	keyVaultId := d.Get("key_vault_id").(string)
+	version := d.Get("version").(string)
+
+	keyVaultBaseUri, err := azure.GetKeyVaultBaseUrlFromID(ctx, vaultClient, keyVaultId)
+	if err != nil {
+		return fmt.Errorf("Error looking up Key %q vault url from id %q: %+v", name, keyVaultId, err)
+	}
+
+	cert, err := client.GetCertificate(ctx, keyVaultBaseUri, name, version)
+	if err != nil {
+		if utils.ResponseWasNotFound(cert.Response) {
+			log.Printf("[DEBUG] Certificate %q was not found in Key Vault at URI %q - removing from state", name, keyVaultBaseUri)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error reading Key Vault Certificate: %+v", err)
+	}
+
+	if cert.ID == nil || *cert.ID == "" {
+		return fmt.Errorf("failure reading Key Vault Certificate ID for %q", name)
+	}
+
+	d.SetId(*cert.ID)
+
+	id, err := azure.ParseKeyVaultChildID(*cert.ID)
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", id.Name)
+
+	d.Set("version", id.Version)
+
+	certificateData := ""
+	if contents := cert.Cer; contents != nil {
+		certificateData = strings.ToUpper(hex.EncodeToString(*contents))
+	}
+	d.Set("certificate_hex", certificateData)
+
+	timeString, err := cert.Attributes.Expires.MarshalText()
+	if err != nil {
+		return fmt.Errorf("Error parsing expiry time of certificate: %+v", err)
+	}
+
+	t, err := time.Parse(time.RFC3339, string(timeString))
+	if err != nil {
+		return fmt.Errorf("Error converting text to Time struct: %+v", err)
+	}
+
+	d.Set("certificate_expires", t.Format(time.RFC3339))
+
+	// Get PFX
+	pfx, err := client.GetSecret(ctx, id.KeyVaultBaseUrl, id.Name, id.Version)
+	if err != nil {
+		return fmt.Errorf("Error retrieving cert from keyvault: %+v", err)
+	}
+	pfxBytes, err := base64.StdEncoding.DecodeString(*pfx.Value)
+	if err != nil {
+		return fmt.Errorf("Error decoding base64 certificate: %+v", err)
+	}
+	pfxKey, pfxCert, err := pkcs12.Decode(pfxBytes, "")
+	if err != nil {
+		return fmt.Errorf("Error decoding PFX cert: %+v", err)
+	}
+	keyX509, err := x509.MarshalPKCS8PrivateKey(pfxKey)
+	if err != nil {
+		return fmt.Errorf("Error reading key from PFX cert: %+v", err)
+	}
+
+	// Encode Key and PEM
+	keyBlock := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyX509,
+	}
+	var keyPEM bytes.Buffer
+	err = pem.Encode(&keyPEM, keyBlock)
+	if err != nil {
+		return fmt.Errorf("Error encoding Key Vault Certificate Key: %+v", err)
+	}
+
+	certBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: pfxCert.Raw,
+	}
+
+	var certPEM bytes.Buffer
+	err = pem.Encode(&certPEM, certBlock)
+	if err != nil {
+		return fmt.Errorf("Error encoding Key Vault Certificate PEM: %+v", err)
+	}
+
+	d.Set("certificate_pem", certPEM.String())
+	d.Set("certificate_key", keyPEM.String())
+
+	return tags.FlattenAndSet(d, cert.Tags)
+}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/crypto/pkcs12"
 )
 
-func dataSourceArmKeyVaultCertificateData() *schema.Resource {
+func dataSourceKeyVaultCertificateData() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceArmKeyVaultCertificateDataRead,
 

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceKeyVaultCertificateData_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("certificate_hex").Exists(),
 				check.That(data.ResourceName).Key("certificate_pem").Exists(),
 				check.That(data.ResourceName).Key("certificate_key").Exists(),
-				check.That(data.ResourceName).Key("certificate_expires").Exists(),
+				check.That(data.ResourceName).Key("certificate_expires").HasValue("2027-10-08T08:27:55Z"),
 			),
 		},
 	})
@@ -36,6 +36,7 @@ func (KeyVaultCertificateDataDataSource) basic(data acceptance.TestData) string 
 data "azurerm_key_vault_certificate_data" "test" {
   name         = azurerm_key_vault_certificate.test.name
   key_vault_id = azurerm_key_vault.test.id
+  version      = azurerm_key_vault_certificate.test.version
 }
 `, KeyVaultCertificateResource{}.basicImportPFX(data))
 }

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
@@ -1,0 +1,76 @@
+package keyvault_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance/check"
+)
+
+type KeyVaultCertificateDataDataSource struct {
+}
+
+func TestAccDataSourceKeyVaultCertificateData_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_certificate_data", "test")
+	r := KeyVaultCertificateDataDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.basic(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("certificate_hex").Exists(),
+				check.That(data.ResourceName).Key("certificate_pem").Exists(),
+				check.That(data.ResourceName).Key("certificate_key").Exists(),
+				check.That(data.ResourceName).Key("certificate_expires").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceKeyVaultCertificate_generated(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_certificate", "test")
+	r := KeyVaultCertificateDataSource{}
+
+	data.DataSourceTest(t, []resource.TestStep{
+		{
+			Config: r.generated(data),
+			Check: resource.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("certificate_data").Exists(),
+				check.That(data.ResourceName).Key("certificate_policy.0.issuer_parameters.0.name").HasValue("Self"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.exportable").HasValue("true"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("2048"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_type").HasValue("RSA"),
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.reuse_key").HasValue("true"),
+				check.That(data.ResourceName).Key("certificate_policy.0.lifetime_action.0.action.0.action_type").HasValue("AutoRenew"),
+				check.That(data.ResourceName).Key("certificate_policy.0.lifetime_action.0.trigger.0.days_before_expiry").HasValue("30"),
+				check.That(data.ResourceName).Key("certificate_policy.0.secret_properties.0.content_type").HasValue("application/x-pkcs12"),
+				check.That(data.ResourceName).Key("certificate_policy.0.x509_certificate_properties.0.subject").HasValue("CN=hello-world"),
+				check.That(data.ResourceName).Key("certificate_policy.0.x509_certificate_properties.0.validity_in_months").HasValue("12"),
+			),
+		},
+	})
+}
+
+func (KeyVaultCertificateDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_key_vault_certificate_data" "test" {
+  name         = azurerm_key_vault_certificate.test.name
+  key_vault_id = azurerm_key_vault.test.id
+}
+`, KeyVaultCertificateResource{}.basicImportPFX(data))
+}
+
+func (KeyVaultCertificateDataSource) generated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_key_vault_certificate" "test" {
+  name         = azurerm_key_vault_certificate.test.name
+  key_vault_id = azurerm_key_vault.test.id
+}
+`, KeyVaultCertificateResource{}.basicGenerate(data))
+}

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
@@ -20,10 +20,10 @@ func TestAccDataSourceKeyVaultCertificateData_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("certificate_hex").Exists(),
-				check.That(data.ResourceName).Key("certificate_pem").Exists(),
-				check.That(data.ResourceName).Key("certificate_key").Exists(),
-				check.That(data.ResourceName).Key("certificate_expires").HasValue("2027-10-08T08:27:55Z"),
+				check.That(data.ResourceName).Key("hex").Exists(),
+				check.That(data.ResourceName).Key("pem").Exists(),
+				check.That(data.ResourceName).Key("key").Exists(),
+				check.That(data.ResourceName).Key("expires").HasValue("2027-10-08T08:27:55Z"),
 			),
 		},
 	})

--- a/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_data_data_source_test.go
@@ -29,31 +29,7 @@ func TestAccDataSourceKeyVaultCertificateData_basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceKeyVaultCertificate_generated(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_certificate", "test")
-	r := KeyVaultCertificateDataSource{}
-
-	data.DataSourceTest(t, []resource.TestStep{
-		{
-			Config: r.generated(data),
-			Check: resource.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("certificate_data").Exists(),
-				check.That(data.ResourceName).Key("certificate_policy.0.issuer_parameters.0.name").HasValue("Self"),
-				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.exportable").HasValue("true"),
-				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("2048"),
-				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_type").HasValue("RSA"),
-				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.reuse_key").HasValue("true"),
-				check.That(data.ResourceName).Key("certificate_policy.0.lifetime_action.0.action.0.action_type").HasValue("AutoRenew"),
-				check.That(data.ResourceName).Key("certificate_policy.0.lifetime_action.0.trigger.0.days_before_expiry").HasValue("30"),
-				check.That(data.ResourceName).Key("certificate_policy.0.secret_properties.0.content_type").HasValue("application/x-pkcs12"),
-				check.That(data.ResourceName).Key("certificate_policy.0.x509_certificate_properties.0.subject").HasValue("CN=hello-world"),
-				check.That(data.ResourceName).Key("certificate_policy.0.x509_certificate_properties.0.validity_in_months").HasValue("12"),
-			),
-		},
-	})
-}
-
-func (KeyVaultCertificateDataSource) basic(data acceptance.TestData) string {
+func (KeyVaultCertificateDataDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -62,15 +38,4 @@ data "azurerm_key_vault_certificate_data" "test" {
   key_vault_id = azurerm_key_vault.test.id
 }
 `, KeyVaultCertificateResource{}.basicImportPFX(data))
-}
-
-func (KeyVaultCertificateDataSource) generated(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_key_vault_certificate" "test" {
-  name         = azurerm_key_vault_certificate.test.name
-  key_vault_id = azurerm_key_vault.test.id
-}
-`, KeyVaultCertificateResource{}.basicGenerate(data))
 }

--- a/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/azurerm/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -1028,6 +1028,7 @@ resource "azurerm_key_vault" "test" {
 
     secret_permissions = [
       "set",
+      "get",
     ]
 
     storage_permissions = [

--- a/azurerm/internal/services/keyvault/registration.go
+++ b/azurerm/internal/services/keyvault/registration.go
@@ -23,6 +23,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_key_vault_access_policy":      dataSourceKeyVaultAccessPolicy(),
 		"azurerm_key_vault_certificate":        dataSourceKeyVaultCertificate(),
+		"azurerm_key_vault_certificate_data":   dataSourceArmKeyVaultCertificateData(),
 		"azurerm_key_vault_certificate_issuer": dataSourceKeyVaultCertificateIssuer(),
 		"azurerm_key_vault_key":                dataSourceKeyVaultKey(),
 		"azurerm_key_vault_secret":             dataSourceKeyVaultSecret(),

--- a/azurerm/internal/services/keyvault/registration.go
+++ b/azurerm/internal/services/keyvault/registration.go
@@ -23,7 +23,7 @@ func (r Registration) SupportedDataSources() map[string]*schema.Resource {
 	return map[string]*schema.Resource{
 		"azurerm_key_vault_access_policy":      dataSourceKeyVaultAccessPolicy(),
 		"azurerm_key_vault_certificate":        dataSourceKeyVaultCertificate(),
-		"azurerm_key_vault_certificate_data":   dataSourceArmKeyVaultCertificateData(),
+		"azurerm_key_vault_certificate_data":   dataSourceKeyVaultCertificateData(),
 		"azurerm_key_vault_certificate_issuer": dataSourceKeyVaultCertificateIssuer(),
 		"azurerm_key_vault_key":                dataSourceKeyVaultKey(),
 		"azurerm_key_vault_secret":             dataSourceKeyVaultSecret(),

--- a/website/docs/d/key_vault_certificate_data.html.markdown
+++ b/website/docs/d/key_vault_certificate_data.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_certificate_data"
+description: |-
+  Gets data contained in an existing Key Vault Certificate.
+---
+
+# Data Source: azurerm_key_vault_secret_data
+
+Use this data source to access data stored in an existing Key Vault Certificate.
+
+~> **Note:** All arguments including the secret value will be stored in the raw state as plain-text.
+[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+
+~> **Note:** This data source uses the `GetSecret` function of the Azure API, to get the key of the certificate. Therefore you need secret/get permission
+
+## Example Usage
+
+```hcl
+data "azurerm_key_vault" "example" {
+  name                = "examplekv"
+  resource_group_name = "some-resource-group"
+}
+
+data "azurerm_key_vault_certificate_data" "example" {
+  name         = "secret-sauce"
+  key_vault_id = data.azurerm_key_vault.example.id
+}
+
+output "certificate_pem" {
+  value = data.azurerm_key_vault_certificate.example.certificate_pem
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - Specifies the name of the Key Vault Secret.
+
+* `key_vault_id` - Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
+
+* `version` - (Optional) Specifies the version of the certificate to look up.  (Defaults to latest) 
+
+**NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+
+* `certificate_hex` - The raw Key Vault Certificate data represented as a hexadecimal string.
+
+* `certificate_pem` - The Key Vault Certificate in PEM format
+
+* `certificate_key` - The Key Vault Certificate Key
+
+* `certificate_expires` - Expiry date of certificate in RFC3339 format
+
+* `tags` - A mapping of tags to assign to the resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Certificate.

--- a/website/docs/d/key_vault_certificate_data.html.markdown
+++ b/website/docs/d/key_vault_certificate_data.html.markdown
@@ -28,8 +28,8 @@ data "azurerm_key_vault_certificate_data" "example" {
   key_vault_id = data.azurerm_key_vault.example.id
 }
 
-output "certificate_pem" {
-  value = data.azurerm_key_vault_certificate.example.certificate_pem
+output "example_pem" {
+  value = data.azurerm_key_vault_certificate.example.pem
 }
 ```
 
@@ -37,26 +37,25 @@ output "certificate_pem" {
 
 The following arguments are supported:
 
-* `name` - Specifies the name of the Key Vault Secret.
+* `name` - (Required) Specifies the name of the Key Vault Secret.
 
-* `key_vault_id` - Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
+* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
 
 * `version` - (Optional) Specifies the version of the certificate to look up.  (Defaults to latest) 
 
-**NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
+~> **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `hex` - The raw Key Vault Certificate data represented as a hexadecimal string. 
 
-* `certificate_hex` - The raw Key Vault Certificate data represented as a hexadecimal string.
+* `pem` - The Key Vault Certificate in PEM format. 
 
-* `certificate_pem` - The Key Vault Certificate in PEM format
+* `key` - The Key Vault Certificate Key. 
 
-* `certificate_key` - The Key Vault Certificate Key
-
-* `certificate_expires` - Expiry date of certificate in RFC3339 format
+* `expires` - Expiry date of certificate in RFC3339 format. 
 
 * `tags` - A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Currently it is only possible to get the raw certificate in hex format. This allows users to get the certificate in PEM format, and get the key. This gives the possibility of creating a Service Principal certificate with a Key Vault Certificate.

Fixes #8072