### PR TITLE
docs: removing ambiguous usages of 'Resource ID'

### DIFF
--- a/website/docs/d/blueprint_definition.html.markdown
+++ b/website/docs/d/blueprint_definition.html.markdown
@@ -30,13 +30,13 @@ data "azurerm_blueprint_definition" "example" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Blueprint
+* `name` - (Required) The name of the Blueprint.
 
-* `scope_id` - (Required) The Resource ID of the scope at which the blueprint definition is stored. This will be with either a Subscription ID or Management Group ID.  
+* `scope_id` - (Required) The ID of the Subscription or Management Group, as the scope at which the blueprint definition is stored.
 
 ## Attribute Reference
 
-* `id` - The Azure Resource ID of the Blueprint Definition.  
+* `id` - The ID of the Blueprint Definition.  
 
 * `description` - The description of the Blueprint Definition.  
 

--- a/website/docs/d/blueprint_published_version.html.markdown
+++ b/website/docs/d/blueprint_published_version.html.markdown
@@ -8,12 +8,12 @@ description: |-
 
 # Data Source: azurerm_blueprint_published_version
 
-Use this data source to access information about an existing Azure Blueprint Published Version
+Use this data source to access information about an existing Blueprint Published Version
 
 ~> **NOTE:** Azure Blueprints are in Preview and potentially subject to breaking change without notice.
 
-
 ## Example Usage
+
 ```hcl
 data "azurerm_subscription" "current" {}
 
@@ -24,27 +24,26 @@ data "azurerm_blueprint_published_version" "test" {
 }
 ```
 
-
 ## Argument Reference
 
 * `blueprint_name` - (Required) The name of the Blueprint Definition
 
-* `scope_id` - (Required) The Resource ID of the scope where the Blueprint Definition is stored. This will be with either a Subscription ID or Management Group ID.
+* `scope_id` - (Required) The ID of the Management Group / Subscription where this Blueprint Definition is stored.
 
 * `version` - (Required) The Version name of the Published Version of the Blueprint Definition
 
 
 ## Attribute Reference
 
-* `id` - The Azure Resource ID of the Published Version  
+* `id` - The ID of the Published Version
 
-* `type` - The type of the Blueprint  
+* `type` - The type of the Blueprint
 
-* `target_scope` - The target scope  
+* `target_scope` - The target scope
 
-* `display_name` - The display name of the Blueprint Published Version  
+* `display_name` - The display name of the Blueprint Published Version
 
-* `description` - The description of the Blueprint Published Version  
+* `description` - The description of the Blueprint Published Version
 
 
 ## Timeouts

--- a/website/docs/d/firewall.html.markdown
+++ b/website/docs/d/firewall.html.markdown
@@ -34,7 +34,7 @@ output "firewall_private_ip" {
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the Azure Firewall.
+* `id` - The ID of the Azure Firewall.
 
 * `ip_configuration` - A `ip_configuration` block as defined below.
 
@@ -42,11 +42,11 @@ The following attributes are exported:
 
 A `ip_configuration` block exports the following:
 
-* `subnet_id` - The Resource ID of the subnet where the Azure Firewall is deployed.
+* `subnet_id` - The ID of the Subnet where the Azure Firewall is deployed.
 
-* `private_ip_address` - The private IP address of the Azure Firewall.
+* `private_ip_address` - The Private IP Address of the Azure Firewall.
 
-* `public_ip_address_id`- The Resource ID of the public IP address of the Azure Firewall.
+* `public_ip_address_id`- The ID of the Public IP address of the Azure Firewall.
 
 ## Timeouts
 

--- a/website/docs/d/log_analytics_workspace.html.markdown
+++ b/website/docs/d/log_analytics_workspace.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Azure Resource ID of the Log Analytics Workspace.
+* `id` - The ID of the Log Analytics Workspace.
 
 * `primary_shared_key` - The Primary shared key for the Log Analytics Workspace.
 

--- a/website/docs/d/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/d/monitor_scheduled_query_rules_alert.html.markdown
@@ -32,7 +32,7 @@ output "query_rule_id" {
 
 * `id` - The ID of the scheduled query rule.
 * `action` - An `action` block as defined below.
-* `authorized_resource_ids` - List of Resource IDs referred into query.
+* `authorized_resource_ids` - The list of Resource IDs referred into query.
 * `data_source_id` - The resource URI over which log search query is to be run.
 * `description` - The description of the scheduled query rule.
 * `enabled` - Whether this scheduled query rule is enabled.

--- a/website/docs/d/network_ddos_protection_plan.html.markdown
+++ b/website/docs/d/network_ddos_protection_plan.html.markdown
@@ -36,13 +36,13 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the DDoS Protection Plan
+* `id` - The ID of the DDoS Protection Plan
 
 * `location` - Specifies the supported Azure location where the resource exists.
 
 * `tags` - A mapping of tags assigned to the resource.
 
-* `virtual_network_ids` - The Resource ID list of the Virtual Networks associated with DDoS Protection Plan.
+* `virtual_network_ids` - A list of ID's of the Virtual Networks associated with this DDoS Protection Plan.
 
 ## Timeouts
 

--- a/website/docs/d/shared_image.html.markdown
+++ b/website/docs/d/shared_image.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the Shared Image.
+* `id` - The ID of the Shared Image.
 
 * `description` - The description of this Shared Image.
 

--- a/website/docs/d/shared_image_gallery.html.markdown
+++ b/website/docs/d/shared_image_gallery.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the Shared Image Gallery.
+* `id` - The ID of the Shared Image Gallery.
 
 * `description` - A description for the Shared Image Gallery.
 

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the Shared Image.
+* `id` - The ID of the Shared Image.
 
 * `exclude_from_latest` - Is this Image Version excluded from the `latest` filter?
 

--- a/website/docs/d/user_assigned_identity.html.markdown
+++ b/website/docs/d/user_assigned_identity.html.markdown
@@ -37,7 +37,7 @@ output "uai_principal_id" {
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the User Assigned Identity.
+* `id` - The ID of the User Assigned Identity.
 * `location` - The Azure location where the User Assigned Identity exists.
 * `principal_id` - The Service Principal ID of the User Assigned Identity.
 * `client_id` - The Client ID of the User Assigned Identity.

--- a/website/docs/r/app_service_hybrid_connection.html.markdown
+++ b/website/docs/r/app_service_hybrid_connection.html.markdown
@@ -13,7 +13,7 @@ Manages an App Service Hybrid Connection for an existing App Service, Relay and 
 
 ## Example Usage
 
-This example provisions an App Service, a Relay Hybrid Connection, and a Service Bus using their outputs to create the App Service Hybrid Connection. 
+This example provisions an App Service, a Relay Hybrid Connection, and a Service Bus using their outputs to create the App Service Hybrid Connection.
 
 ```hcl
 resource "azurerm_resource_group" "example" {
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the App Service.  Changing this forces a new resource to be created.
 
-* `relay_id` - (Required) The Resource ID of Service Bus relay. Changing this forces a new resource to be created.
+* `relay_id` - (Required) The ID of the Service Bus Relay. Changing this forces a new resource to be created.
 
 * `hostname` - (Optional) The hostname of the endpoint.
 
@@ -100,5 +100,5 @@ The following attributes are exported:
 App Service Hybrid Connections can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_app_service_hybrid_connection.example /subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/exampleResourceGroup1/providers/Microsoft.Web/sites/exampleAppService1/hybridConnectionNamespaces/exampleRN1/relays/exampleRHC1 
+terraform import azurerm_app_service_hybrid_connection.example /subscriptions/00000000-0000-0000-0000-00000000000/resourceGroups/exampleResourceGroup1/providers/Microsoft.Web/sites/exampleAppService1/hybridConnectionNamespaces/exampleRN1/relays/exampleRHC1
 ```

--- a/website/docs/r/backup_container_storage_account.html.markdown
+++ b/website/docs/r/backup_container_storage_account.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `recovery_vault_name` - (Required) The name of the vault where the storage account will be registered.
 
-* `storage_account_id` - (Required) Azure Resource ID of the storage account to be registered
+* `storage_account_id` - (Required) The ID of the Storage Account to be registered
 
 -> **NOTE** Azure Backup places a Resource Lock on the storage account that will cause deletion to fail until the account is unregistered from Azure Backup
 

--- a/website/docs/r/blueprint_assignment.html.markdown
+++ b/website/docs/r/blueprint_assignment.html.markdown
@@ -110,17 +110,17 @@ resource "azurerm_blueprint_assignment" "example" {
 
 * `target_subscription_id` - (Required) The Subscription ID the Blueprint Published Version is to be applied to.
 
-* `location` - (Required) The Azure location of the Assignment. 
+* `location` - (Required) The Azure location of the Assignment.
 
 * `identitiy` - (Required) an identity block, as detailed below.
 
-* `version_id` - (Required) The ID of the Published Version of the blueprint to be assigned. 
+* `version_id` - (Required) The ID of the Published Version of the blueprint to be assigned.
 
 * `parameter_values` - (Optional) a JSON string to supply Blueprint Assignment parameter values.
 
 ~> **NOTE:** Improperly formatted JSON, or missing values required by a Blueprint will cause the assignment to fail.
 
-* `resource_groups` - (Optional) a JSON string to supply the Blueprint Resource Group information. 
+* `resource_groups` - (Optional) a JSON string to supply the Blueprint Resource Group information.
 
 ~> **NOTE:** Improperly formatted JSON, or missing values required by a Blueprint will cause the assignment to fail.
 
@@ -139,7 +139,7 @@ An `identity` block supports the following Arguments
 
 ## Attribute Reference
 
-* `id` - the Azure Resource ID of the Blueprint Assignment
+* `id` - The ID of the Blueprint Assignment
 
 * `description` - The Description on the Blueprint
 

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the ExpressRoute circuit.
+* `id` - The ID of the ExpressRoute circuit.
 * `service_provider_provisioning_state` - The ExpressRoute circuit provisioning state from your chosen service provider. Possible values are "NotProvisioned", "Provisioning", "Provisioned", and "Deprovisioning".
 * `service_key` - The string needed by the service provider to provision the ExpressRoute circuit.
 

--- a/website/docs/r/express_route_circuit_authorization.html.markdown
+++ b/website/docs/r/express_route_circuit_authorization.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the ExpressRoute Circuit Authorization.
+* `id` - The ID of the ExpressRoute Circuit Authorization.
 
 * `authorization_key` - The Authorization Key.
 

--- a/website/docs/r/express_route_circuit_peering.html.markdown
+++ b/website/docs/r/express_route_circuit_peering.html.markdown
@@ -86,7 +86,7 @@ A `microsoft_peering_config` block contains:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the ExpressRoute Circuit Peering.
+* `id` - The ID of the ExpressRoute Circuit Peering.
 
 * `azure_asn` - The ASN used by Azure.
 

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -86,7 +86,7 @@ A `ip_configuration` block supports the following:
 
 -> **NOTE** At least one and only one `ip_configuration` block may contain a `subnet_id`.
 
-* `public_ip_address_id` - (Required) The Resource ID of the Public IP Address associated with the firewall.
+* `public_ip_address_id` - (Required) The ID of the Public IP Address associated with the firewall.
 
 -> **NOTE** The Public IP must have a `Static` allocation and `Standard` sku.
 
@@ -94,7 +94,7 @@ A `ip_configuration` block supports the following:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the Azure Firewall.
+* `id` - The ID of the Azure Firewall.
 
 * `ip_configuration` - A `ip_configuration` block as defined below.
 
@@ -102,11 +102,9 @@ The following attributes are exported:
 
 A `ip_configuration` block exports the following:
 
-* `private_ip_address` - The private IP address of the Azure Firewall.
+* `private_ip_address` - The Private IP address of the Azure Firewall.
 
 ## Timeouts
-
-
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -254,17 +254,19 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 
 `backend_pool` exports the following:
 
-* `id` - The Resource ID of the Azure Front Door Backend Pool.
+* `id` - The ID of the Azure Front Door Backend Pool.
 
+---
 
 `backend` exports the following:
 
-* `id` - The Resource ID of the Azure Front Door Backend.
+* `id` - The ID of the Azure Front Door Backend.
 
+---
 
 `frontend_endpoint` exports the following:
 
-* `id` - The Resource ID of the Azure Front Door Frontend Endpoint.
+* `id` - The ID of the Azure Front Door Frontend Endpoint.
 
 * `provisioning_state` - Provisioning state of the Front Door.
 
@@ -272,25 +274,31 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 
 [//]: * "* `web_application_firewall_policy_link_id` - (Optional) The `id` of the `web_application_firewall_policy_link` to use for this Frontend Endpoint."
 
+---
 
 `backend_pool_health_probe` exports the following:
 
-* `id` - The Resource ID of the Azure Front Door Backend Health Probe.
+* `id` - The ID of the Azure Front Door Backend Health Probe.
 
+---
 
 `backend_pool_load_balancing` exports the following:
 
-* `id` - The Resource ID of the Azure Front Door Backend Load Balancer.
+* `id` - The ID of the Azure Front Door Backend Load Balancer.
 
+---
 
 `routing_rule` exports the following:
 
-* `id` - The Resource ID of the Azure Front Door Backend Routing Rule.
+* `id` - The ID of the Azure Front Door Backend Routing Rule.
+
+---
 
 `custom_https_configuration` exports the following:
 
 * `minimum_tls_version` - Minimum client TLS version supported.
 
+---
 
 The following attributes are exported:
 

--- a/website/docs/r/marketplace_agreement.html.markdown
+++ b/website/docs/r/marketplace_agreement.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the Marketplace Agreement.
+* `id` - The ID of the Marketplace Agreement.
 
 ## Timeouts
 

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 -> **NOTE:** At least one `log` or `metric` block must be specified.
 
-* `storage_account_id` - (Optional) With this parameter you can specify a storage account which should be used to send the logs to. Parameter must be a valid Azure Resource ID. Changing this forces a new resource to be created.
+* `storage_account_id` - (Optional) The ID of the Storage Account where logs should be sent. Changing this forces a new resource to be created.
 
 -> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id` and `storage_account_id` must be specified.
 

--- a/website/docs/r/policy_remediation.html.markdown
+++ b/website/docs/r/policy_remediation.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
     1. A resource, e.g. `/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM`
     1. A management group, e.g. `/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000`
 
-* `policy_assignment_id` - (Required) The resource ID of the policy assignment that should be remediated.
+* `policy_assignment_id` - (Required) The ID of the Policy Assignment that should be remediated.
 
 * `policy_definition_reference_id` - (Optional) The unique ID for the policy definition within the policy set definition that should be remediated. Required when the policy assignment being remediated assigns a policy set definition.
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-Policy Set Definitions can be imported using the Resource ID, e.g.
+Policy Set Definitions can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_policy_set_definition.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policySetDefinitions/testPolicySet

--- a/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_zone_virtual_network_link.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the resource group where the Private DNS Zone exists. Changing this forces a new resource to be created.
 
-* `virtual_network_id` - (Required) The Resource ID of the Virtual Network that should be linked to the DNS Zone. Changing this forces a new resource to be created.
+* `virtual_network_id` - (Required) The ID of the Virtual Network that should be linked to the DNS Zone. Changing this forces a new resource to be created.
 
 * `registration_enabled` - (Optional) Is auto-registration of virtual machine records in the virtual network in the Private DNS zone enabled? Defaults to `false`.
 
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The Resource ID of the Private DNS Zone Virtual Network Link.
+* `id` - The ID of the Private DNS Zone Virtual Network Link.
 
 ## Timeouts
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -105,7 +105,7 @@ The following arguments are supported:
 
 -> **NOTE:** At this time `allow_blob_public_access` is only supported in the Public Cloud.
 
-* `is_hns_enabled` - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created. 
+* `is_hns_enabled` - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created.
 
 -> **NOTE:** When this is set to `true` the `account_tier` argument must be set to `Standard`
 
@@ -251,7 +251,7 @@ A `static_website` block supports the following:
 
 The following attributes are exported in addition to the arguments listed above:
 
-* `id` - The storage account Resource ID.
+* `id` - The ID of the Storage Account.
 
 * `primary_location` - The primary location of the storage account.
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the virtual network.
 
-* `address_space` - (Required) The address space that is used the virtual network. You can supply more than one address space. 
+* `address_space` - (Required) The address space that is used the virtual network. You can supply more than one address space.
 
 * `location` - (Required) The location/region where the virtual network is created. Changing this forces a new resource to be created.
 
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 A `ddos_protection_plan` block supports the following:
 
-* `id` - (Required) The Resource ID of DDoS Protection Plan.
+* `id` - (Required) The ID of DDoS Protection Plan.
 
 * `enable` - (Required) Enable/disable DDoS Protection Plan on Virtual Network.
 


### PR DESCRIPTION
Resource ID is ambiguous in these contexts between the Terraform Resource ID and the Azure Resource ID - which are not necessarily the same thing. As such the term "Resource ID" should generally be phrased as "The ID of the {thing}" - rather than "the Resource ID of the {thing}" to ensure the Terraform Resource ID is used here.