### PR TITLE
Adding FQDN documentation for destination_address rule_collection

### DIFF
--- a/website/docs/r/firewall_network_rule_collection.html.markdown
+++ b/website/docs/r/firewall_network_rule_collection.html.markdown
@@ -74,7 +74,6 @@ resource "azurerm_firewall_network_rule_collection" "example" {
     destination_addresses = [
       "8.8.8.8",
       "8.8.4.4",
-      "ntp.ubuntu.com"
     ]
 
     protocols = [


### PR DESCRIPTION
FQDN is now supported in this field. The AzureRM provider accepts and utilizes this properly, so updating documentation to match. 