### PR TITLE
locations: patching the india location names

### DIFF
--- a/azurerm/internal/clients/builder.go
+++ b/azurerm/internal/clients/builder.go
@@ -52,10 +52,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 	}
 
 	if features.EnhancedValidationEnabled() {
-		// e.g. https://management.azure.com/ but we need management.azure.com
-		endpoint := strings.TrimPrefix(env.ResourceManagerEndpoint, "https://")
-		endpoint = strings.TrimSuffix(endpoint, "/")
-		location.CacheSupportedLocations(ctx, endpoint)
+		location.CacheSupportedLocations(ctx, env)
 	}
 
 	// client declarations:

--- a/azurerm/internal/location/supported.go
+++ b/azurerm/internal/location/supported.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/sdk"
 )
 
@@ -12,8 +13,8 @@ var supportedLocations *[]string
 
 // CacheSupportedLocations attempts to retrieve the supported locations from the Azure MetaData Service
 // and caches them, for used in enhanced validation
-func CacheSupportedLocations(ctx context.Context, endpoint string) {
-	locs, err := sdk.AvailableAzureLocations(ctx, endpoint)
+func CacheSupportedLocations(ctx context.Context, env *azure.Environment) {
+	locs, err := sdk.AvailableAzureLocations(ctx, env)
 	if err != nil {
 		log.Printf("[DEBUG] error retrieving locations: %s. Enhanced validation will be unavailable", err)
 		return


### PR DESCRIPTION
The Azure API returns these incorrectly (e.g. "indiasouth" instead of "southindia") so until that's resolved we need to patch these if running in Azure Public

Fixes #7906