### PR TITLE
`azurerm_dns_x_record`: ignore case on `target_resource_id`

### DIFF
--- a/azurerm/internal/services/dns/dns_a_record_resource.go
+++ b/azurerm/internal/services/dns/dns_a_record_resource.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"net/http"
 	"time"
 
@@ -68,12 +69,12 @@ func resourceArmDnsARecord() *schema.Resource {
 			},
 
 			"target_resource_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  azure.ValidateResourceID,
-				ConflictsWith: []string{"records"},
-
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: azure.ValidateResourceID,
 				// TODO: switch ConflictsWith for ExactlyOneOf when the Provider SDK's updated
+				ConflictsWith:    []string{"records"},
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"tags": tags.Schema(),

--- a/azurerm/internal/services/dns/dns_aaaa_record_resource.go
+++ b/azurerm/internal/services/dns/dns_aaaa_record_resource.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"net/http"
 	"time"
 
@@ -75,10 +76,11 @@ func resourceArmDnsAAAARecord() *schema.Resource {
 			"tags": tags.Schema(),
 
 			"target_resource_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  azure.ValidateResourceID,
-				ConflictsWith: []string{"records"},
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     azure.ValidateResourceID,
+				ConflictsWith:    []string{"records"},
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 		},
 	}

--- a/azurerm/internal/services/dns/dns_cname_record_resource.go
+++ b/azurerm/internal/services/dns/dns_cname_record_resource.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"net/http"
 	"time"
 
@@ -67,10 +68,11 @@ func resourceArmDnsCNameRecord() *schema.Resource {
 			},
 
 			"target_resource_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  azure.ValidateResourceID,
-				ConflictsWith: []string{"record"},
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     azure.ValidateResourceID,
+				ConflictsWith:    []string{"record"},
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"tags": tags.Schema(),


### PR DESCRIPTION
In some case (at least for the cdn endpoint), the ID of target resource
read from API (which uses the API model of the target resource) doesn't match
the `target_resource_id` if it is imported via Terraform (which actually
uses the API model of the `azurerm_dns_x_record`) in casing.

Fixes: #8191