### PR TITLE
Fix Dedicated Host Deleting issue.

### DIFF
--- a/azurerm/internal/services/compute/dedicated_host_resource.go
+++ b/azurerm/internal/services/compute/dedicated_host_resource.go
@@ -272,7 +272,7 @@ func resourceArmDedicatedHostDelete(d *schema.ResourceData, meta interface{}) er
 		Target:                    []string{"NotFound"},
 		Refresh:                   dedicatedHostDeletedRefreshFunc(ctx, client, id),
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 10,
+		ContinuousTargetOccurence: 20,
 		Timeout:                   d.Timeout(schema.TimeoutDelete),
 	}
 


### PR DESCRIPTION
Fix the issue
`
Error: errors during apply: Error deleting Dedicated Host Group "acctest-DHG-200822170337649258" (Resource Group "ACCTESTRG-COMPUTE-200822170337649258"): compute.DedicatedHostGroupsClient#Delete: Failure sending request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="CannotDeleteResource" Message="Can not delete resource before nested resources are deleted."`

go test -v -timeout=0 -count=10 -run TestAccAzureRMDedicatedHost_basic
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (338.32s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (331.00s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (337.11s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (380.68s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (337.43s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (330.48s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (390.69s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (337.80s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (332.35s)
=== RUN   TestAccAzureRMDedicatedHost_basic
=== PAUSE TestAccAzureRMDedicatedHost_basic
=== CONT  TestAccAzureRMDedicatedHost_basic
--- PASS: TestAccAzureRMDedicatedHost_basic (335.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/tests       3451.244s