### PR TITLE
Support for VMSS in-line extensions behind feature flag

### DIFF
--- a/azurerm/internal/features/beta_features_opt_in.go
+++ b/azurerm/internal/features/beta_features_opt_in.go
@@ -2,6 +2,7 @@ package features
 
 import (
 	"os"
+	"strings"
 )
 
 // VMSSExtensionsBeta returns whether or not the beta for VMSS Extensions for Linux and Windows VMSS resources is
@@ -9,10 +10,5 @@ import (
 //
 // Set to any non-empty value to enable
 func VMSSExtensionsBeta() bool {
-	value := os.Getenv("ARM_PROVIDER_VMSS_EXTENSIONS_BETA")
-	if value == "" {
-		return false
-	} else {
-		return true
-	}
+	return strings.EqualFold(os.Getenv("ARM_PROVIDER_VMSS_EXTENSIONS_BETA"), "true")
 }

--- a/azurerm/internal/features/beta_features_opt_in.go
+++ b/azurerm/internal/features/beta_features_opt_in.go
@@ -1,0 +1,18 @@
+package features
+
+import (
+	"os"
+)
+
+// VMSSExtensionsBeta returns whether or not the beta for VMSS Extensions for Linux and Windows VMSS resources is
+// enabled.
+//
+// Set to any non-empty value to enable
+func VMSSExtensionsBeta() bool {
+	value := os.Getenv("ARM_PROVIDER_VMSS_EXTENSIONS_BETA")
+	if value == "" {
+		return false
+	} else {
+		return true
+	}
+}

--- a/azurerm/internal/features/beta_features_opt_in.go
+++ b/azurerm/internal/features/beta_features_opt_in.go
@@ -8,7 +8,7 @@ import (
 // VMSSExtensionsBeta returns whether or not the beta for VMSS Extensions for Linux and Windows VMSS resources is
 // enabled.
 //
-// Set to any non-empty value to enable
+// Set the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` to `true`
 func VMSSExtensionsBeta() bool {
 	return strings.EqualFold(os.Getenv("ARM_PROVIDER_VMSS_EXTENSIONS_BETA"), "true")
 }

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -13,7 +13,7 @@ type VirtualMachineFeatures struct {
 
 type VirtualMachineScaleSetFeatures struct {
 	RollInstancesWhenRequired bool
-	UseExtensionsBeta bool
+	UseExtensionsBeta         bool
 }
 
 type KeyVaultFeatures struct {

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -13,7 +13,6 @@ type VirtualMachineFeatures struct {
 
 type VirtualMachineScaleSetFeatures struct {
 	RollInstancesWhenRequired bool
-	UseExtensionsBeta         bool
 }
 
 type KeyVaultFeatures struct {

--- a/azurerm/internal/features/user_flags.go
+++ b/azurerm/internal/features/user_flags.go
@@ -13,6 +13,7 @@ type VirtualMachineFeatures struct {
 
 type VirtualMachineScaleSetFeatures struct {
 	RollInstancesWhenRequired bool
+	UseExtensionsBeta bool
 }
 
 type KeyVaultFeatures struct {

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -30,13 +30,8 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"roll_instances_when_required": {
-						Type: schema.TypeBool,
-						// TODO - switch back to Required after beta for extensions closes
-						Optional: true,
-					},
-					"use_extensions_beta": {
 						Type:     schema.TypeBool,
-						Optional: true,
+						Required: true,
 					},
 				},
 			},

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -31,7 +31,12 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"roll_instances_when_required": {
 						Type:     schema.TypeBool,
-						Required: true,
+						// TODO - switch back to Required after beta for extensions closes
+						Optional: true,
+					},
+					"use_extensions_beta": {
+						Type:     schema.TypeBool,
+						Optional: true,
 					},
 				},
 			},
@@ -104,6 +109,7 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 		},
 		VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 			RollInstancesWhenRequired: true,
+			UseExtensionsBeta: false,
 		},
 		KeyVault: features.KeyVaultFeatures{
 			PurgeSoftDeleteOnDestroy:    true,
@@ -149,6 +155,9 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			scaleSetRaw := items[0].(map[string]interface{})
 			if v, ok := scaleSetRaw["roll_instances_when_required"]; ok {
 				features.VirtualMachineScaleSet.RollInstancesWhenRequired = v.(bool)
+			}
+			if v, ok := scaleSetRaw["use_extensions_beta"]; ok {
+				features.VirtualMachineScaleSet.UseExtensionsBeta = v.(bool)
 			}
 		}
 	}

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -30,7 +30,7 @@ func schemaFeatures(supportLegacyTestSuite bool) *schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"roll_instances_when_required": {
-						Type:     schema.TypeBool,
+						Type: schema.TypeBool,
 						// TODO - switch back to Required after beta for extensions closes
 						Optional: true,
 					},
@@ -109,7 +109,7 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 		},
 		VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 			RollInstancesWhenRequired: true,
-			UseExtensionsBeta: false,
+			UseExtensionsBeta:         false,
 		},
 		KeyVault: features.KeyVaultFeatures{
 			PurgeSoftDeleteOnDestroy:    true,

--- a/azurerm/internal/provider/features.go
+++ b/azurerm/internal/provider/features.go
@@ -109,7 +109,6 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 		},
 		VirtualMachineScaleSet: features.VirtualMachineScaleSetFeatures{
 			RollInstancesWhenRequired: true,
-			UseExtensionsBeta:         false,
 		},
 		KeyVault: features.KeyVaultFeatures{
 			PurgeSoftDeleteOnDestroy:    true,
@@ -155,9 +154,6 @@ func expandFeatures(input []interface{}) features.UserFeatures {
 			scaleSetRaw := items[0].(map[string]interface{})
 			if v, ok := scaleSetRaw["roll_instances_when_required"]; ok {
 				features.VirtualMachineScaleSet.RollInstancesWhenRequired = v.(bool)
-			}
-			if v, ok := scaleSetRaw["use_extensions_beta"]; ok {
-				features.VirtualMachineScaleSet.UseExtensionsBeta = v.(bool)
 			}
 		}
 	}

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -396,9 +396,8 @@ func resourceArmLinuxVirtualMachineScaleSetCreate(d *schema.ResourceData, meta i
 		},
 	}
 
-	// useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-	// forced for dev testing
-	useExtensionsBeta := true
+	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+
 	if useExtensionsBeta {
 		if vmExtensionsRaw, ok := d.GetOk("vm_extension"); ok {
 			virtualMachineProfile.ExtensionProfile = expandVirtualMachineScaleSetExtensions(vmExtensionsRaw.([]interface{}))
@@ -739,9 +738,8 @@ func resourceArmLinuxVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta i
 		update.Sku = sku
 	}
 
-	// useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-	// forced for dev testing
-	useExtensionsBeta := true
+	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+
 	if useExtensionsBeta {
 		if d.HasChange("vm_extension") {
 			extensionProfile := expandVirtualMachineScaleSetExtensions(d.Get("vm_extension").([]interface{}))
@@ -927,9 +925,8 @@ func resourceArmLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta int
 			}
 		}
 
-		//useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-		// forced for dev testing
-		useExtensionsBeta := true
+		useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+
 		if useExtensionsBeta {
 			if profile.ExtensionProfile != nil {
 				if extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d); err != nil {

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -136,6 +136,8 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 				}, false),
 			},
 
+			"extension": VirtualMachineScaleSetExtensionsSchema(),
+
 			"health_probe_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -242,8 +244,6 @@ func resourceArmLinuxVirtualMachineScaleSet() *schema.Resource {
 			},
 
 			"terminate_notification": VirtualMachineScaleSetTerminateNotificationSchema(),
-
-			"vm_extension": VirtualMachineScaleSetExtensionsSchema(),
 
 			"zones": azure.SchemaZones(),
 
@@ -396,10 +396,8 @@ func resourceArmLinuxVirtualMachineScaleSetCreate(d *schema.ResourceData, meta i
 		},
 	}
 
-	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-
-	if useExtensionsBeta {
-		if vmExtensionsRaw, ok := d.GetOk("vm_extension"); ok {
+	if features.VMSSExtensionsBeta() {
+		if vmExtensionsRaw, ok := d.GetOk("extension"); ok {
 			virtualMachineProfile.ExtensionProfile = expandVirtualMachineScaleSetExtensions(vmExtensionsRaw.([]interface{}))
 		}
 	}
@@ -738,11 +736,11 @@ func resourceArmLinuxVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta i
 		update.Sku = sku
 	}
 
-	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+	if features.VMSSExtensionsBeta() {
+		if d.HasChange("extension") {
+			updateInstances = true
 
-	if useExtensionsBeta {
-		if d.HasChange("vm_extension") {
-			extensionProfile := expandVirtualMachineScaleSetExtensions(d.Get("vm_extension").([]interface{}))
+			extensionProfile := expandVirtualMachineScaleSetExtensions(d.Get("extension").([]interface{}))
 			updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
 		}
 	}
@@ -925,15 +923,15 @@ func resourceArmLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta int
 			}
 		}
 
-		useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-
-		if useExtensionsBeta {
+		if features.VMSSExtensionsBeta() {
 			if profile.ExtensionProfile != nil {
 				if extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d); err != nil {
 					return fmt.Errorf("failed flettening `vm_extension`: %+v", err)
-				} else if err := d.Set("vm_extension", extensionProfile); err != nil {
+				} else if err := d.Set("extension", extensionProfile); err != nil {
 					return fmt.Errorf("failed to set vm_extension: %+v", err)
 				}
+			} else {
+				d.Set("extension", []map[string]interface{}{})
 			}
 		}
 	}

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -264,15 +265,15 @@ func resourceArmLinuxVirtualMachineScaleSetCreate(d *schema.ResourceData, meta i
 	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
 
-	resp, err := client.Get(ctx, resourceGroup, name)
+	exists, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
-		if !utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("Error checking for existing Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
+		if !utils.ResponseWasNotFound(exists.Response) {
+			return fmt.Errorf("checking for existing Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(resp.Response) {
-		return tf.ImportAsExistsError("azurerm_linux_virtual_machine_scale_set", *resp.ID)
+	if !utils.ResponseWasNotFound(exists.Response) {
+		return tf.ImportAsExistsError("azurerm_linux_virtual_machine_scale_set", *exists.ID)
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
@@ -499,7 +500,7 @@ func resourceArmLinuxVirtualMachineScaleSetCreate(d *schema.ResourceData, meta i
 	log.Printf("[DEBUG] Virtual Machine Scale Set %q (Resource Group %q) was created", name, resourceGroup)
 
 	log.Printf("[DEBUG] Retrieving Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
-	resp, err = client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Linux Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}

--- a/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/linux_virtual_machine_scale_set_resource.go
@@ -932,7 +932,7 @@ func resourceArmLinuxVirtualMachineScaleSetRead(d *schema.ResourceData, meta int
 		if features.VMSSExtensionsBeta() {
 			extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
 			if err != nil {
-				return fmt.Errorf("failed flettening `extension`: %+v", err)
+				return fmt.Errorf("failed flattening `extension`: %+v", err)
 			}
 			d.Set("extension", extensionProfile)
 		}

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_other_resource_test.go
@@ -2037,11 +2037,7 @@ func testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensions(data acceptance
 %[1]s
 
 provider "azurerm" {
-  features {
-    virtual_machine_scale_set {
-      use_extensions_beta = true
-    }
-  }
+  features {}
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
@@ -2085,9 +2081,13 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     type_handler_version       = "2.0"
     auto_upgrade_minor_version = true
 
-    settings = jsonencode({ "commandToExecute" = "echo $HOSTNAME" })
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
 
-    protected_settings = jsonencode({ "managedIdentity" = {} })
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
 
   }
 
@@ -2104,11 +2104,7 @@ func testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsForceUpdateTag(d
 %[1]s
 
 provider "azurerm" {
-  features {
-    virtual_machine_scale_set {
-      use_extensions_beta = true
-    }
-  }
+  features {}
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
@@ -2153,10 +2149,13 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     auto_upgrade_minor_version = true
     force_update_tag           = %q
 
-    settings = jsonencode({ "commandToExecute" = "echo $HOSTNAME" })
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
 
-    protected_settings = jsonencode({ "managedIdentity" = {} })
-
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
   }
 
   tags = {
@@ -2172,11 +2171,7 @@ func testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsMultiple(data ac
 %[1]s
 
 provider "azurerm" {
-  features {
-    virtual_machine_scale_set {
-      use_extensions_beta = true
-    }
-  }
+  features {}
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
@@ -2220,9 +2215,15 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     type_handler_version       = "2.0"
     auto_upgrade_minor_version = true
 
-    settings = jsonencode({ "commandToExecute" = "echo $HOSTNAME" })
+    provision_after_extensions = ["VMAccessForLinux"]
 
-    protected_settings = jsonencode({ "managedIdentity" = {} })
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
+
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
 
   }
 
@@ -2233,7 +2234,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     type_handler_version       = "1.5"
     auto_upgrade_minor_version = true
 
-    protected_settings = jsonencode({ "reset_ssh" = "True" })
+    protected_settings = jsonencode({
+      "reset_ssh" = "True"
+    })
 
   }
 
@@ -2250,11 +2253,7 @@ func testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsUpdate(data acce
 %[1]s
 
 provider "azurerm" {
-  features {
-    virtual_machine_scale_set {
-      use_extensions_beta = true
-    }
-  }
+  features {}
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "test" {
@@ -2298,7 +2297,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
     type_handler_version       = "2.0"
     auto_upgrade_minor_version = true
 
-    settings = jsonencode({ "commandToExecute" = "echo $(date)" })
+    settings = jsonencode({
+      "commandToExecute" = "echo $(date)"
+    })
   }
 
   tags = {

--- a/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/tests/linux_virtual_machine_scale_set_other_resource_test.go
@@ -589,6 +589,58 @@ func TestAccAzureRMLinuxVirtualMachineScaleSet_otherUpgradeMode(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensions(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLinuxVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensions(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName)),
+			},
+			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "vm_extension"),
+		},
+	})
+}
+
+func TestAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine_scale_set", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMLinuxVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensions(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName)),
+			},
+			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "vm_extension.0.protected_settings"),
+			{
+				Config: testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsUpdate(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName)),
+			},
+			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "vm_extension.0.protected_settings"),
+			{
+				Config: testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensions(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName)),
+			},
+			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "vm_extension.0.protected_settings"),
+		},
+	})
+}
+
 func testAccAzureRMLinuxVirtualMachineScaleSet_otherBootDiagnostics(data acceptance.TestData) string {
 	template := testAccAzureRMLinuxVirtualMachineScaleSet_template(data)
 	return fmt.Sprintf(`
@@ -1932,4 +1984,147 @@ resource "azurerm_linux_virtual_machine_scale_set" "test" {
   }
 }
 `, template, data.RandomInteger, enabled)
+}
+
+func testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensions(data acceptance.TestData) string {
+	template := testAccAzureRMLinuxVirtualMachineScaleSet_template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurerm" {
+  features {
+    virtual_machine_scale_set {
+      use_extensions_beta = true
+    }
+  }
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  vm_extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = <<SETTINGS
+		{
+			"commandToExecute": "echo $HOSTNAME"
+		}
+SETTINGS
+
+    protected_settings = <<SETTINGS
+		{
+			"managedIdentity" : {}
+		}
+SETTINGS
+  }
+
+  tags = {
+    accTest = "true"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMLinuxVirtualMachineScaleSet_otherVmExtensionsUpdate(data acceptance.TestData) string {
+	template := testAccAzureRMLinuxVirtualMachineScaleSet_template(data)
+	return fmt.Sprintf(`
+%[1]s
+
+provider "azurerm" {
+  features {
+    virtual_machine_scale_set {
+      use_extensions_beta = true
+    }
+  }
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  vm_extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = <<SETTINGS
+		{
+			"commandToExecute": "echo $(date)"
+		}
+SETTINGS
+
+  }
+
+  tags = {
+    accTest = "true"
+  }
+}
+`, template, data.RandomInteger)
 }

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_other_resource_test.go
@@ -2422,6 +2422,10 @@ func testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensions(data acceptan
 	return fmt.Sprintf(`
 %s
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -2461,9 +2465,13 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     type_handler_version       = "1.10"
     auto_upgrade_minor_version = true
 
-    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\"" })
+    settings = jsonencode({
+      "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\""
+    })
 
-    protected_settings = jsonencode({ "managedIdentity" = {} })
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
   }
 }
 `, template)
@@ -2473,6 +2481,10 @@ func testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsForceUpdateTag
 	template := testAccAzureRMWindowsVirtualMachineScaleSet_template(data)
 	return fmt.Sprintf(`
 %s
+
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
@@ -2514,9 +2526,13 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     auto_upgrade_minor_version = true
     force_update_tag           = %q
 
-    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\"" })
+    settings = jsonencode({
+      "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\""
+    })
 
-    protected_settings = jsonencode({ "managedIdentity" = {} })
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
   }
 }
 `, template, updateTag)
@@ -2526,6 +2542,10 @@ func testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsMultiple(data 
 	template := testAccAzureRMWindowsVirtualMachineScaleSet_template(data)
 	return fmt.Sprintf(`
 %s
+
+provider "azurerm" {
+  features {}
+}
 
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
@@ -2566,9 +2586,15 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     type_handler_version       = "1.10"
     auto_upgrade_minor_version = true
 
-    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\"" })
+    provision_after_extensions = ["AADLoginForWindows"]
 
-    protected_settings = jsonencode({ "managedIdentity" = {} })
+    settings = jsonencode({
+      "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\""
+    })
+
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
   }
 
   extension {
@@ -2587,6 +2613,10 @@ func testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsUpdate(data ac
 	return fmt.Sprintf(`
 %s
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_windows_virtual_machine_scale_set" "test" {
   name                = local.vm_name
   resource_group_name = azurerm_resource_group.test.name
@@ -2626,8 +2656,9 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     type_handler_version       = "1.10"
     auto_upgrade_minor_version = true
 
-    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Process | Where-Object { $_.CPU -gt 10000 }\"" })
-
+    settings = jsonencode({
+      "commandToExecute" = "powershell.exe -c \"Get-Process | Where-Object { $_.CPU -gt 10000 }\""
+    })
   }
 }
 `, template)

--- a/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/azurerm/internal/services/compute/tests/windows_virtual_machine_scale_set_other_resource_test.go
@@ -659,7 +659,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherScaleInPolicy(t *testing.T
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherScaleInPolicy(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "scale_in_policy", "Default"),
 				),
 			},
@@ -682,7 +682,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherTerminateNotification(t *t
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherTerminateNotification(data, true),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "terminate_notification.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "terminate_notification.0.enabled", "true"),
 				),
@@ -694,7 +694,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherTerminateNotification(t *t
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherTerminateNotification(data, false),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "terminate_notification.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "terminate_notification.0.enabled", "false"),
 				),
@@ -706,7 +706,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherTerminateNotification(t *t
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherTerminateNotification(data, true),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 					resource.TestCheckResourceAttr(data.ResourceName, "terminate_notification.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "terminate_notification.0.enabled", "true"),
 				),
@@ -730,7 +730,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy(t *
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy(data, true),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(
@@ -740,7 +740,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy(t *
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy(data, false),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(
@@ -750,7 +750,7 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy(t *
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherAutomaticRepairsPolicy(data, true),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
 			data.ImportStep(
@@ -771,12 +771,59 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtension(t *testing.T) 
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensions(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "scale_in_policy", "Default"),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
-			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
-			data.ImportStep("admin_password", "vm_extension"),
+			// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "extension"),
+		},
+	})
+}
+
+func TestAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionForceUpdateTag(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMWindowsVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsForceUpdateTag(data, "first"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
+				),
+			},
+			// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "extension"),
+			{
+				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsForceUpdateTag(data, "second"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
+				),
+			},
+			// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "extension"),
+		},
+	})
+}
+
+func TestAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionMultiple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine_scale_set", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMWindowsVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsMultiple(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
+				),
+			},
+			// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "extension"),
 		},
 	})
 }
@@ -792,30 +839,27 @@ func TestAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionUpdate(t *testi
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensions(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "scale_in_policy", "Default"),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
-			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
-			data.ImportStep("admin_password", "vm_extension"),
+			// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "extension"),
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsUpdate(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "scale_in_policy", "Default"),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
-			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
-			data.ImportStep("admin_password", "vm_extension"),
+			// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "extension"),
 			{
 				Config: testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensions(data),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMLinuxVirtualMachineScaleSetExists(data.ResourceName),
-					resource.TestCheckResourceAttr(data.ResourceName, "scale_in_policy", "Default"),
+					testCheckAzureRMWindowsVirtualMachineScaleSetExists(data.ResourceName),
 				),
 			},
-			// TODO - vm_extension should be changed to vm_extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
-			data.ImportStep("admin_password", "vm_extension"),
+			// TODO - extension should be changed to extension.0.protected_settings when either binary testing is available or this feature is promoted from beta
+			data.ImportStep("admin_password", "extension"),
 		},
 	})
 }
@@ -2410,24 +2454,129 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 
-  vm_extension {
+  extension {
     name                       = "CustomScript"
     publisher                  = "Microsoft.Compute"
     type                       = "CustomScriptExtension"
     type_handler_version       = "1.10"
     auto_upgrade_minor_version = true
 
-    settings = <<SETTINGS
-		{
-			"commandToExecute": "powershell.exe -c \"Get-Content env:computername\""
-		}
-SETTINGS
+    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\"" })
 
-    protected_settings = <<SETTINGS
-		{
-			"managedIdentity" : {}
-		}
-SETTINGS
+    protected_settings = jsonencode({ "managedIdentity" = {} })
+  }
+}
+`, template)
+}
+
+func testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsForceUpdateTag(data acceptance.TestData, updateTag string) string {
+	template := testAccAzureRMWindowsVirtualMachineScaleSet_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Compute"
+    type                       = "CustomScriptExtension"
+    type_handler_version       = "1.10"
+    auto_upgrade_minor_version = true
+    force_update_tag           = %q
+
+    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\"" })
+
+    protected_settings = jsonencode({ "managedIdentity" = {} })
+  }
+}
+`, template, updateTag)
+}
+
+func testAccAzureRMWindowsVirtualMachineScaleSet_otherVmExtensionsMultiple(data acceptance.TestData) string {
+	template := testAccAzureRMWindowsVirtualMachineScaleSet_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine_scale_set" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard_F2"
+  instances           = 1
+  admin_username      = "adminuser"
+  admin_password      = "P@ssword1234!"
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.test.id
+    }
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Compute"
+    type                       = "CustomScriptExtension"
+    type_handler_version       = "1.10"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\"" })
+
+    protected_settings = jsonencode({ "managedIdentity" = {} })
+  }
+
+  extension {
+    name                       = "AADLoginForWindows"
+    publisher                  = "Microsoft.Azure.ActiveDirectory"
+    type                       = "AADLoginForWindows"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
   }
 }
 `, template)
@@ -2470,18 +2619,14 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     }
   }
 
-  vm_extension {
+  extension {
     name                       = "CustomScript"
     publisher                  = "Microsoft.Compute"
     type                       = "CustomScriptExtension"
     type_handler_version       = "1.10"
     auto_upgrade_minor_version = true
 
-    settings = <<SETTINGS
-		{
-			"commandToExecute": "powershell.exe -c \"Get-Process | Where-Object { $_.CPU -gt 10000 }\""
-		}
-SETTINGS
+    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Process | Where-Object { $_.CPU -gt 10000 }\"" })
 
   }
 }

--- a/azurerm/internal/services/compute/virtual_machine_scale_set.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set.go
@@ -1416,7 +1416,7 @@ func expandVirtualMachineScaleSetExtensions(input []interface{}) (*compute.Virtu
 
 func flattenVirtualMachineScaleSetExtensions(input *compute.VirtualMachineScaleSetExtensionProfile, d *schema.ResourceData) ([]map[string]interface{}, error) {
 	result := make([]map[string]interface{}, 0)
-	if input == nil {
+	if input == nil || input.Extensions == nil {
 		return result, nil
 	}
 

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
@@ -111,6 +111,8 @@ func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceT
 					d.Set("extension", updatedExtensions)
 				}
 			}
+		} else {
+			d.Set("extension", map[string]interface{}{})
 		}
 
 		return []*schema.ResourceData{d}, nil

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
@@ -96,9 +96,8 @@ func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceT
 			d.Set("admin_password", "ignored-as-imported")
 		}
 
-		//useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-		// forced for dev testing
-		useExtensionsBeta := true
+		useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+
 		if useExtensionsBeta {
 			if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile != nil {
 				if extensionsProfile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile; extensionsProfile != nil {

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
@@ -112,7 +112,7 @@ func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceT
 				}
 			}
 		} else {
-			d.Set("extension", map[string]interface{}{})
+			d.Set("extension", []map[string]interface{}{})
 		}
 
 		return []*schema.ResourceData{d}, nil

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
@@ -96,6 +96,24 @@ func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceT
 			d.Set("admin_password", "ignored-as-imported")
 		}
 
+		//useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+		// forced for dev testing
+		useExtensionsBeta := true
+		if useExtensionsBeta {
+			if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile != nil {
+				if extensionsProfile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile; extensionsProfile != nil {
+					for _, v := range *extensionsProfile.Extensions {
+						v.ProtectedSettings = ""
+					}
+					updatedExtensions, err := flattenVirtualMachineScaleSetExtensions(extensionsProfile, d)
+					if err != nil {
+						return []*schema.ResourceData{}, fmt.Errorf("could not read VMSS extensions data for %q (resource group %q)", id.Name, id.ResourceGroup)
+					}
+					d.Set("vm_extension", updatedExtensions)
+				}
+			}
+		}
+
 		return []*schema.ResourceData{d}, nil
 	}
 }

--- a/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
+++ b/azurerm/internal/services/compute/virtual_machine_scale_set_import.go
@@ -3,6 +3,8 @@ package compute
 import (
 	"fmt"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -96,9 +98,7 @@ func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceT
 			d.Set("admin_password", "ignored-as-imported")
 		}
 
-		useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-
-		if useExtensionsBeta {
+		if features.VMSSExtensionsBeta() {
 			if vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile != nil {
 				if extensionsProfile := vm.VirtualMachineScaleSetProperties.VirtualMachineProfile.ExtensionProfile; extensionsProfile != nil {
 					for _, v := range *extensionsProfile.Extensions {
@@ -108,7 +108,7 @@ func importVirtualMachineScaleSet(osType compute.OperatingSystemTypes, resourceT
 					if err != nil {
 						return []*schema.ResourceData{}, fmt.Errorf("could not read VMSS extensions data for %q (resource group %q)", id.Name, id.ResourceGroup)
 					}
-					d.Set("vm_extension", updatedExtensions)
+					d.Set("extension", updatedExtensions)
 				}
 			}
 		}

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/features"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/parse"
 	computeValidate "github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/compute/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
@@ -281,15 +282,15 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 	resourceGroup := d.Get("resource_group_name").(string)
 	name := d.Get("name").(string)
 
-	resp, err := client.Get(ctx, resourceGroup, name)
+	exists, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
-		if !utils.ResponseWasNotFound(resp.Response) {
+		if !utils.ResponseWasNotFound(exists.Response) {
 			return fmt.Errorf("Error checking for existing Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(resp.Response) {
-		return tf.ImportAsExistsError("azurerm_windows_virtual_machine_scale_set", *resp.ID)
+	if !utils.ResponseWasNotFound(exists.Response) {
+		return tf.ImportAsExistsError("azurerm_windows_virtual_machine_scale_set", *exists.ID)
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
@@ -526,7 +527,7 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 	log.Printf("[DEBUG] Virtual Machine Scale Set %q (Resource Group %q) was created", name, resourceGroup)
 
 	log.Printf("[DEBUG] Retrieving Virtual Machine Scale Set %q (Resource Group %q)..", name, resourceGroup)
-	resp, err = client.Get(ctx, resourceGroup, name)
+	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
 		return fmt.Errorf("Error retrieving Windows Virtual Machine Scale Set %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -413,9 +413,8 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 		},
 	}
 
-	// useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-	// forced for dev testing
-	useExtensionsBeta := true
+	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+
 	if useExtensionsBeta {
 		if vmExtensionsRaw, ok := d.GetOk("vm_extension"); ok {
 			virtualMachineProfile.ExtensionProfile = expandVirtualMachineScaleSetExtensions(vmExtensionsRaw.([]interface{}))
@@ -771,9 +770,8 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 		update.Sku = sku
 	}
 
-	// useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-	// forced for dev testing
-	useExtensionsBeta := true
+	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+
 	if useExtensionsBeta {
 		if d.HasChange("vm_extension") {
 			extensionProfile := expandVirtualMachineScaleSetExtensions(d.Get("vm_extension").([]interface{}))
@@ -987,9 +985,8 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 				return fmt.Errorf("Error setting `terminate_notification`: %+v", err)
 			}
 		}
-		//useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-		// forced for dev testing
-		useExtensionsBeta := true
+		useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+
 		if useExtensionsBeta {
 			if profile.ExtensionProfile != nil {
 				if extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d); err != nil {

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -991,7 +991,7 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 		if features.VMSSExtensionsBeta() {
 			extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d)
 			if err != nil {
-				return fmt.Errorf("failed flettening `extension`: %+v", err)
+				return fmt.Errorf("failed flattening `extension`: %+v", err)
 			}
 			d.Set("extension", extensionProfile)
 		}

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -260,6 +260,8 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 
 			"terminate_notification": VirtualMachineScaleSetTerminateNotificationSchema(),
 
+			"vm_extension": VirtualMachineScaleSetExtensionsSchema(),
+
 			"zones": azure.SchemaZones(),
 
 			// Computed
@@ -409,6 +411,15 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 			OsDisk:         osDisk,
 			DataDisks:      dataDisks,
 		},
+	}
+
+	// useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+	// forced for dev testing
+	useExtensionsBeta := true
+	if useExtensionsBeta {
+		if vmExtensionsRaw, ok := d.GetOk("vm_extension"); ok {
+			virtualMachineProfile.ExtensionProfile = expandVirtualMachineScaleSetExtensions(vmExtensionsRaw.([]interface{}))
+		}
 	}
 
 	enableAutomaticUpdates := d.Get("enable_automatic_updates").(bool)
@@ -760,6 +771,16 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 		update.Sku = sku
 	}
 
+	// useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+	// forced for dev testing
+	useExtensionsBeta := true
+	if useExtensionsBeta {
+		if d.HasChange("vm_extension") {
+			extensionProfile := expandVirtualMachineScaleSetExtensions(d.Get("vm_extension").([]interface{}))
+			updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
+		}
+	}
+
 	if d.HasChange("tags") {
 		update.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
@@ -964,6 +985,18 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 		if scheduleProfile := profile.ScheduledEventsProfile; scheduleProfile != nil {
 			if err := d.Set("terminate_notification", FlattenVirtualMachineScaleSetScheduledEventsProfile(scheduleProfile)); err != nil {
 				return fmt.Errorf("Error setting `terminate_notification`: %+v", err)
+			}
+		}
+		//useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
+		// forced for dev testing
+		useExtensionsBeta := true
+		if useExtensionsBeta {
+			if profile.ExtensionProfile != nil {
+				if extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d); err != nil {
+					return fmt.Errorf("failed flettening `vm_extension`: %+v", err)
+				} else if err := d.Set("vm_extension", extensionProfile); err != nil {
+					return fmt.Errorf("failed to set vm_extension: %+v", err)
+				}
 			}
 		}
 	}

--- a/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
+++ b/azurerm/internal/services/compute/windows_virtual_machine_scale_set_resource.go
@@ -138,6 +138,8 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 				}, false),
 			},
 
+			"extension": VirtualMachineScaleSetExtensionsSchema(),
+
 			"health_probe_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -259,8 +261,6 @@ func resourceArmWindowsVirtualMachineScaleSet() *schema.Resource {
 			},
 
 			"terminate_notification": VirtualMachineScaleSetTerminateNotificationSchema(),
-
-			"vm_extension": VirtualMachineScaleSetExtensionsSchema(),
 
 			"zones": azure.SchemaZones(),
 
@@ -413,10 +413,8 @@ func resourceArmWindowsVirtualMachineScaleSetCreate(d *schema.ResourceData, meta
 		},
 	}
 
-	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-
-	if useExtensionsBeta {
-		if vmExtensionsRaw, ok := d.GetOk("vm_extension"); ok {
+	if features.VMSSExtensionsBeta() {
+		if vmExtensionsRaw, ok := d.GetOk("extension"); ok {
 			virtualMachineProfile.ExtensionProfile = expandVirtualMachineScaleSetExtensions(vmExtensionsRaw.([]interface{}))
 		}
 	}
@@ -770,11 +768,9 @@ func resourceArmWindowsVirtualMachineScaleSetUpdate(d *schema.ResourceData, meta
 		update.Sku = sku
 	}
 
-	useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
-
-	if useExtensionsBeta {
-		if d.HasChange("vm_extension") {
-			extensionProfile := expandVirtualMachineScaleSetExtensions(d.Get("vm_extension").([]interface{}))
+	if features.VMSSExtensionsBeta() {
+		if d.HasChange("extension") {
+			extensionProfile := expandVirtualMachineScaleSetExtensions(d.Get("extension").([]interface{}))
 			updateProps.VirtualMachineProfile.ExtensionProfile = extensionProfile
 		}
 	}
@@ -985,15 +981,16 @@ func resourceArmWindowsVirtualMachineScaleSetRead(d *schema.ResourceData, meta i
 				return fmt.Errorf("Error setting `terminate_notification`: %+v", err)
 			}
 		}
-		useExtensionsBeta := meta.(*clients.Client).Features.VirtualMachineScaleSet.UseExtensionsBeta
 
-		if useExtensionsBeta {
+		if features.VMSSExtensionsBeta() {
 			if profile.ExtensionProfile != nil {
 				if extensionProfile, err := flattenVirtualMachineScaleSetExtensions(profile.ExtensionProfile, d); err != nil {
 					return fmt.Errorf("failed flettening `vm_extension`: %+v", err)
-				} else if err := d.Set("vm_extension", extensionProfile); err != nil {
+				} else if err := d.Set("extension", extensionProfile); err != nil {
 					return fmt.Errorf("failed to set vm_extension: %+v", err)
 				}
+			} else {
+				d.Set("extension", []map[string]interface{}{})
 			}
 		}
 	}

--- a/examples/service-fabric/windows-vmss-self-signed-certs/0-base.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/0-base.tf
@@ -1,0 +1,37 @@
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "example" {
+  name                = "example-sf-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+  name                 = "example"
+  resource_group_name  = azurerm_resource_group.example.name
+  virtual_network_name = azurerm_virtual_network.example.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "sfexamplesa0123456"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+
+  tags = {
+    environment = "example"
+  }
+}

--- a/examples/service-fabric/windows-vmss-self-signed-certs/0-base.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/0-base.tf
@@ -6,26 +6,26 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_resource_group" "example" {
-  name     = "example-resources"
+  name     = "${var.prefix}-resources"
   location = var.location
 }
 
 resource "azurerm_virtual_network" "example" {
-  name                = "example-sf-network"
+  name                = "${var.prefix}-sf-network"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 }
 
 resource "azurerm_subnet" "example" {
-  name                 = "example"
+  name                 = "${var.prefix}-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_storage_account" "example" {
-  name                     = "sfexamplesa0123456"
+  name                     = "${var.prefix}sfexamplesa"
   resource_group_name      = azurerm_resource_group.example.name
   location                 = azurerm_resource_group.example.location
   account_tier             = "Standard"

--- a/examples/service-fabric/windows-vmss-self-signed-certs/1-keyvault.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/1-keyvault.tf
@@ -1,5 +1,5 @@
 resource "azurerm_key_vault" "example" {
-  name                = "examplekv1234560"
+  name                = "${var.prefix}examplekv"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
@@ -35,7 +35,7 @@ resource "azurerm_key_vault" "example" {
 }
 
 resource "azurerm_key_vault_certificate" "example" {
-  name         = "acctestcert1234560"
+  name         = "${var.prefix}acctestcert"
   key_vault_id = azurerm_key_vault.example.id
 
   certificate_policy {
@@ -79,7 +79,7 @@ resource "azurerm_key_vault_certificate" "example" {
         "keyEncipherment",
       ]
 
-      subject            = "CN=exampleservicefabric.${var.location}.cloudapp.azure.com"
+      subject            = "CN=${var.prefix}servicefabric.${var.location}.cloudapp.azure.com"
       validity_in_months = 12
     }
   }

--- a/examples/service-fabric/windows-vmss-self-signed-certs/1-keyvault.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/1-keyvault.tf
@@ -1,0 +1,86 @@
+resource "azurerm_key_vault" "example" {
+  name                = "examplekv1234560"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name = "standard"
+
+  enabled_for_deployment = true
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    certificate_permissions = [
+      "create",
+      "delete",
+      "get",
+      "update",
+      "list",
+    ]
+
+    key_permissions = [
+      "create",
+    ]
+
+    secret_permissions = [
+      "set",
+    ]
+
+    storage_permissions = [
+      "set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_certificate" "example" {
+  name         = "acctestcert1234560"
+  key_vault_id = azurerm_key_vault.example.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      extended_key_usage = [
+        "1.3.6.1.5.5.7.3.1",
+        "1.3.6.1.5.5.7.3.2",
+      ]
+
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=exampleservicefabric.${var.location}.cloudapp.azure.com"
+      validity_in_months = 12
+    }
+  }
+}

--- a/examples/service-fabric/windows-vmss-self-signed-certs/2-loadbalancer.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/2-loadbalancer.tf
@@ -1,0 +1,72 @@
+resource "azurerm_public_ip" "example" {
+  name                = "PublicIPForLB"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  allocation_method   = "Dynamic"
+  domain_name_label   = "exampleservicefabric"
+}
+
+resource "azurerm_lb" "example" {
+  name                = "TestLoadBalancer"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  frontend_ip_configuration {
+    name                 = "PublicIPAddress"
+    public_ip_address_id = azurerm_public_ip.example.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  loadbalancer_id     = azurerm_lb.example.id
+  name                = "BackEndAddressPool"
+}
+
+resource "azurerm_lb_nat_pool" "example" {
+  resource_group_name            = azurerm_resource_group.example.name
+  loadbalancer_id                = azurerm_lb.example.id
+  name                           = "SFApplicationPool"
+  protocol                       = "Tcp"
+  frontend_port_start            = 3389
+  frontend_port_end              = 4500
+  backend_port                   = 3389
+  frontend_ip_configuration_name = azurerm_lb.example.frontend_ip_configuration[0].name
+}
+
+resource "azurerm_lb_rule" "example_tcp" {
+  resource_group_name            = azurerm_resource_group.example.name
+  loadbalancer_id                = azurerm_lb.example.id
+  name                           = "LBRuleTcp"
+  protocol                       = "Tcp"
+  frontend_port                  = 19000
+  backend_port                   = 19000
+  frontend_ip_configuration_name = azurerm_lb.example.frontend_ip_configuration[0].name
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.example.id
+}
+
+resource "azurerm_lb_rule" "example_http" {
+  resource_group_name            = azurerm_resource_group.example.name
+  loadbalancer_id                = azurerm_lb.example.id
+  name                           = "LBRuleHttp"
+  protocol                       = "Tcp"
+  frontend_port                  = 19080
+  backend_port                   = 19080
+  frontend_ip_configuration_name = azurerm_lb.example.frontend_ip_configuration[0].name
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.example.id
+}
+
+resource "azurerm_lb_probe" "example_tcp" {
+  resource_group_name = azurerm_resource_group.example.name
+  loadbalancer_id     = azurerm_lb.example.id
+  name                = "FabricGatewayProbe"
+  port                = 19000
+}
+
+resource "azurerm_lb_probe" "example_http" {
+  resource_group_name = azurerm_resource_group.example.name
+  loadbalancer_id     = azurerm_lb.example.id
+  name                = "FabricHttpGatewayProbe"
+  port                = 19080
+}
+

--- a/examples/service-fabric/windows-vmss-self-signed-certs/2-loadbalancer.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/2-loadbalancer.tf
@@ -1,5 +1,5 @@
 resource "azurerm_public_ip" "example" {
-  name                = "PublicIPForLB"
+  name                = "${var.prefix}PIPForLB"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   allocation_method   = "Dynamic"
@@ -7,7 +7,7 @@ resource "azurerm_public_ip" "example" {
 }
 
 resource "azurerm_lb" "example" {
-  name                = "TestLoadBalancer"
+  name                = "${var.prefix}LoadBalancer"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
 
@@ -20,13 +20,13 @@ resource "azurerm_lb" "example" {
 resource "azurerm_lb_backend_address_pool" "example" {
   resource_group_name = azurerm_resource_group.example.name
   loadbalancer_id     = azurerm_lb.example.id
-  name                = "BackEndAddressPool"
+  name                = "${var.prefix}BEAPool"
 }
 
 resource "azurerm_lb_nat_pool" "example" {
   resource_group_name            = azurerm_resource_group.example.name
   loadbalancer_id                = azurerm_lb.example.id
-  name                           = "SFApplicationPool"
+  name                           = "${var.prefix}SFApplicationPool"
   protocol                       = "Tcp"
   frontend_port_start            = 3389
   frontend_port_end              = 4500
@@ -37,7 +37,7 @@ resource "azurerm_lb_nat_pool" "example" {
 resource "azurerm_lb_rule" "example_tcp" {
   resource_group_name            = azurerm_resource_group.example.name
   loadbalancer_id                = azurerm_lb.example.id
-  name                           = "LBRuleTcp"
+  name                           = "${var.prefix}LBRuleTcp"
   protocol                       = "Tcp"
   frontend_port                  = 19000
   backend_port                   = 19000
@@ -48,7 +48,7 @@ resource "azurerm_lb_rule" "example_tcp" {
 resource "azurerm_lb_rule" "example_http" {
   resource_group_name            = azurerm_resource_group.example.name
   loadbalancer_id                = azurerm_lb.example.id
-  name                           = "LBRuleHttp"
+  name                           = "${var.prefix}LBRuleHttp"
   protocol                       = "Tcp"
   frontend_port                  = 19080
   backend_port                   = 19080
@@ -59,14 +59,14 @@ resource "azurerm_lb_rule" "example_http" {
 resource "azurerm_lb_probe" "example_tcp" {
   resource_group_name = azurerm_resource_group.example.name
   loadbalancer_id     = azurerm_lb.example.id
-  name                = "FabricGatewayProbe"
+  name                = "${var.prefix}SFTcpGatewayProbe"
   port                = 19000
 }
 
 resource "azurerm_lb_probe" "example_http" {
   resource_group_name = azurerm_resource_group.example.name
   loadbalancer_id     = azurerm_lb.example.id
-  name                = "FabricHttpGatewayProbe"
+  name                = "${var.prefix}SFHttpGatewayProbe"
   port                = 19080
 }
 

--- a/examples/service-fabric/windows-vmss-self-signed-certs/3-servicefabric.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/3-servicefabric.tf
@@ -1,12 +1,12 @@
 
 resource "azurerm_service_fabric_cluster" "example" {
-  name                = "exampleservicefabric"
+  name                = "${var.prefix}servicefabric"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   reliability_level   = "Bronze"
   upgrade_mode        = "Automatic"
   vm_image            = "Windows"
-  management_endpoint = "https://exampleservicefabric.${var.location}.cloudapp.azure.com:19080"
+  management_endpoint = "https://${var.prefix}servicefabric.${var.location}.cloudapp.azure.com:19080"
 
   node_type {
     name                 = "Windows"
@@ -18,12 +18,12 @@ resource "azurerm_service_fabric_cluster" "example" {
 
 
   reverse_proxy_certificate {
-    thumbprint = azurerm_key_vault_certificate.example.thumbprint
+    thumbprint      = azurerm_key_vault_certificate.example.thumbprint
     x509_store_name = "My"
   }
-  
+
   certificate {
-    thumbprint = azurerm_key_vault_certificate.example.thumbprint
+    thumbprint      = azurerm_key_vault_certificate.example.thumbprint
     x509_store_name = "My"
   }
 
@@ -34,15 +34,16 @@ resource "azurerm_service_fabric_cluster" "example" {
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "example" {
-  name                = "examplesf"
-  resource_group_name = azurerm_resource_group.example.name
-  location            = azurerm_resource_group.example.location
-  sku                 = "Standard_D1_v2"
-  instances           = azurerm_service_fabric_cluster.example.node_type[0].instance_count
-  admin_password      = "P@55w0rd1234!"
-  admin_username      = "adminuser"
-  overprovision       = false
-  upgrade_mode        = "Automatic"
+  name                 = "${var.prefix}examplesf"
+  computer_name_prefix = var.prefix
+  resource_group_name  = azurerm_resource_group.example.name
+  location             = azurerm_resource_group.example.location
+  sku                  = "Standard_D1_v2"
+  instances            = azurerm_service_fabric_cluster.example.node_type[0].instance_count
+  admin_password       = "P@55w0rd1234!"
+  admin_username       = "adminuser"
+  overprovision        = false
+  upgrade_mode         = "Automatic"
 
 
   source_image_reference {
@@ -83,7 +84,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
   }
 
   extension {
-    name                       = "ServiceFabricNode"
+    name                       = "${var.prefix}ServiceFabricNode"
     publisher                  = "Microsoft.Azure.ServiceFabric"
     type                       = "ServiceFabricNode"
     type_handler_version       = "1.1"
@@ -97,7 +98,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
       "enableParallelJobs" = true
       "certificate" = {
         "commonNames" = [
-          "exampleservicefabric.${var.location}.cloudapp.azure.com",
+          "${var.prefix}servicefabric.${var.location}.cloudapp.azure.com",
         ]
         "x509StoreName" = "My"
       }

--- a/examples/service-fabric/windows-vmss-self-signed-certs/3-servicefabric.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/3-servicefabric.tf
@@ -1,0 +1,112 @@
+
+resource "azurerm_service_fabric_cluster" "example" {
+  name                = "exampleservicefabric"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  reliability_level   = "Bronze"
+  upgrade_mode        = "Automatic"
+  vm_image            = "Windows"
+  management_endpoint = "https://exampleservicefabric.${var.location}.cloudapp.azure.com:19080"
+
+  node_type {
+    name                 = "Windows"
+    instance_count       = 3
+    is_primary           = true
+    client_endpoint_port = 19000
+    http_endpoint_port   = 19080
+  }
+
+
+  reverse_proxy_certificate {
+    thumbprint = azurerm_key_vault_certificate.example.thumbprint
+    x509_store_name = "My"
+  }
+  
+  certificate {
+    thumbprint = azurerm_key_vault_certificate.example.thumbprint
+    x509_store_name = "My"
+  }
+
+  client_certificate_thumbprint {
+    thumbprint = azurerm_key_vault_certificate.example.thumbprint
+    is_admin   = true
+  }
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "example" {
+  name                = "examplesf"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  sku                 = "Standard_D1_v2"
+  instances           = azurerm_service_fabric_cluster.example.node_type[0].instance_count
+  admin_password      = "P@55w0rd1234!"
+  admin_username      = "adminuser"
+  overprovision       = false
+  upgrade_mode        = "Automatic"
+
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter-with-Containers"
+    version   = "latest"
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.example.id
+      load_balancer_backend_address_pool_ids = [
+        azurerm_lb_backend_address_pool.example.id
+      ]
+      load_balancer_inbound_nat_rules_ids = [
+        azurerm_lb_nat_pool.example.id
+      ]
+    }
+  }
+
+  secret {
+    certificate {
+      store = "My"
+      url   = azurerm_key_vault_certificate.example.secret_id
+    }
+    key_vault_id = azurerm_key_vault.example.id
+  }
+
+  extension {
+    name                       = "ServiceFabricNode"
+    publisher                  = "Microsoft.Azure.ServiceFabric"
+    type                       = "ServiceFabricNode"
+    type_handler_version       = "1.1"
+    auto_upgrade_minor_version = false
+
+    settings = jsonencode({
+      "clusterEndpoint"    = azurerm_service_fabric_cluster.example.cluster_endpoint
+      "nodeTypeRef"        = azurerm_service_fabric_cluster.example.node_type[0].name
+      "durabilityLevel"    = "bronze"
+      "nicPrefixOverride"  = azurerm_subnet.example.address_prefixes[0]
+      "enableParallelJobs" = true
+      "certificate" = {
+        "commonNames" = [
+          "exampleservicefabric.${var.location}.cloudapp.azure.com",
+        ]
+        "x509StoreName" = "My"
+      }
+    })
+
+    protected_settings = jsonencode({
+      "StorageAccountKey1" = azurerm_storage_account.example.primary_access_key
+      "StorageAccountKey2" = azurerm_storage_account.example.secondary_access_key
+    })
+  }
+
+}

--- a/examples/service-fabric/windows-vmss-self-signed-certs/README.md
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/README.md
@@ -1,0 +1,4 @@
+## Example: Service Fabric using Windows VMSS and Self Signed Certificate
+
+### Notes:
+* This example requires the use of the VMSS Extensions beta functionality, set `ARM_PROVIDER_VMSS_EXTENSIONS_BETA=1` to enable.  

--- a/examples/service-fabric/windows-vmss-self-signed-certs/README.md
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/README.md
@@ -1,4 +1,4 @@
 ## Example: Service Fabric using Windows VMSS and Self Signed Certificate
 
 ### Notes:
-* This example requires the use of the VMSS Extensions beta functionality, set `ARM_PROVIDER_VMSS_EXTENSIONS_BETA=1` to enable.  
+* This example requires the use of the VMSS Extensions beta functionality, set `ARM_PROVIDER_VMSS_EXTENSIONS_BETA=true` to enable.  

--- a/examples/service-fabric/windows-vmss-self-signed-certs/variables.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/variables.tf
@@ -1,3 +1,7 @@
+variable "prefix" {
+  description = "The prefix which should be used for all resources in this example"
+}
+
 variable "location" {
   description = "The Azure Region in which all resources in this example should be created. Use the `Name` value from `az account list-locations -otable` for your chosen region"
   default = "westeurope"

--- a/examples/service-fabric/windows-vmss-self-signed-certs/variables.tf
+++ b/examples/service-fabric/windows-vmss-self-signed-certs/variables.tf
@@ -1,0 +1,4 @@
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created. Use the `Name` value from `az account list-locations -otable` for your chosen region"
+  default = "westeurope"
+}

--- a/examples/vm-scale-set/linux/basic/main.tf
+++ b/examples/vm-scale-set/linux/basic/main.tf
@@ -4,20 +4,20 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "main" {
   name     = "${var.prefix}-resources"
-  location = var.location
+  location = "${var.location}"
 }
 
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/boot-diagnostics/main.tf
+++ b/examples/vm-scale-set/linux/boot-diagnostics/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
@@ -63,6 +63,6 @@ resource "azurerm_linux_virtual_machine_scale_set" "main" {
   }
 
   boot_diagnostics {
-    storage_account_uri = azurerm_storage_account.test.primary_blob_endpoint
+    storage_account_uri = azurerm_storage_account.main.primary_blob_endpoint
   }
 }

--- a/examples/vm-scale-set/linux/custom-data/main.tf
+++ b/examples/vm-scale-set/linux/custom-data/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/data-disks/main.tf
+++ b/examples/vm-scale-set/linux/data-disks/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/ephemeral-os-disk/main.tf
+++ b/examples/vm-scale-set/linux/ephemeral-os-disk/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/extensions/README.md
+++ b/examples/vm-scale-set/linux/extensions/README.md
@@ -1,0 +1,3 @@
+## Example: Linux Virtual Machine Scale Set with VM Extensions
+
+This example provisions a basic Linux Virtual Machine Scale Set using a password for authentication and a `CustomScript` extension.

--- a/examples/vm-scale-set/linux/extensions/main.tf
+++ b/examples/vm-scale-set/linux/extensions/main.tf
@@ -4,7 +4,7 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "main" {
   name     = "${var.prefix}-resources"
-  location = "${var.location}"
+  location = var.location
 }
 
 resource "azurerm_virtual_network" "main" {

--- a/examples/vm-scale-set/linux/extensions/main.tf
+++ b/examples/vm-scale-set/linux/extensions/main.tf
@@ -1,0 +1,72 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = "${var.location}"
+}
+
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.prefix}-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_linux_virtual_machine_scale_set" "main" {
+  name                            = "${var.prefix}-vmss"
+  resource_group_name             = azurerm_resource_group.main.name
+  location                        = azurerm_resource_group.main.location
+  sku                             = "Standard_F2"
+  instances                       = 3
+  admin_username                  = "adminuser"
+  admin_password                  = "P@ssw0rd1234!"
+  disable_password_authentication = false
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.internal.id
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({
+      "commandToExecute" = "echo $HOSTNAME"
+    })
+
+    protected_settings = jsonencode({
+      "managedIdentity" = {}
+    })
+  }
+}

--- a/examples/vm-scale-set/linux/extensions/variables.tf
+++ b/examples/vm-scale-set/linux/extensions/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix which should be used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created."
+}

--- a/examples/vm-scale-set/linux/multiple-nics/main.tf
+++ b/examples/vm-scale-set/linux/multiple-nics/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/public-ip-per-instance/main.tf
+++ b/examples/vm-scale-set/linux/public-ip-per-instance/main.tf
@@ -10,21 +10,21 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip_prefix" "main" {
   name                = "${var.prefix}-pip"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "main" {

--- a/examples/vm-scale-set/linux/secrets/main.tf
+++ b/examples/vm-scale-set/linux/secrets/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/spot/main.tf
+++ b/examples/vm-scale-set/linux/spot/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/ssh-keys/main.tf
+++ b/examples/vm-scale-set/linux/ssh-keys/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/system-assigned-identity/main.tf
+++ b/examples/vm-scale-set/linux/system-assigned-identity/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/user-assigned-identity/main.tf
+++ b/examples/vm-scale-set/linux/user-assigned-identity/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/linux/zones/main.tf
+++ b/examples/vm-scale-set/linux/zones/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/basic/main.tf
+++ b/examples/vm-scale-set/windows/basic/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/boot-diagnostics/main.tf
+++ b/examples/vm-scale-set/windows/boot-diagnostics/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
@@ -62,6 +62,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "main" {
   }
 
   boot_diagnostics {
-    storage_account_uri = azurerm_storage_account.test.primary_blob_endpoint
+    storage_account_uri = azurerm_storage_account.main.primary_blob_endpoint
   }
 }

--- a/examples/vm-scale-set/windows/custom-data/main.tf
+++ b/examples/vm-scale-set/windows/custom-data/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/custom-timezone/main.tf
+++ b/examples/vm-scale-set/windows/custom-timezone/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/data-disks/main.tf
+++ b/examples/vm-scale-set/windows/data-disks/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/ephemeral-os-disk/main.tf
+++ b/examples/vm-scale-set/windows/ephemeral-os-disk/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/extensions/README.md
+++ b/examples/vm-scale-set/windows/extensions/README.md
@@ -1,0 +1,3 @@
+## Example: Windows Virtual Machine Scale Set with VM Extensions
+
+This example provisions a basic Windows Virtual Machine Scale Set with two VM Extensions.

--- a/examples/vm-scale-set/windows/extensions/main.tf
+++ b/examples/vm-scale-set/windows/extensions/main.tf
@@ -1,0 +1,77 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.prefix}-resources"
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.prefix}-network"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_subnet" "internal" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_windows_virtual_machine_scale_set" "main" {
+  name                 = "${var.prefix}vmss"
+  resource_group_name  = azurerm_resource_group.main.name
+  location             = azurerm_resource_group.main.location
+  sku                  = "Standard_F2"
+  instances            = 3
+  admin_username       = "adminuser"
+  admin_password       = "P@ssw0rd1234!"
+  computer_name_prefix = var.prefix
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2019-Datacenter"
+    version   = "latest"
+  }
+
+  network_interface {
+    name    = "example"
+    primary = true
+
+    ip_configuration {
+      name      = "internal"
+      primary   = true
+      subnet_id = azurerm_subnet.internal.id
+    }
+  }
+
+  os_disk {
+    storage_account_type = "Standard_LRS"
+    caching              = "ReadWrite"
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Compute"
+    type                       = "CustomScriptExtension"
+    type_handler_version       = "1.10"
+    auto_upgrade_minor_version = true
+
+    settings = jsonencode({ "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\"" })
+
+    protected_settings = jsonencode({ "managedIdentity" = {} })
+  }
+
+  extension {
+    name                       = "AADLoginForWindows"
+    publisher                  = "Microsoft.Azure.ActiveDirectory"
+    type                       = "AADLoginForWindows"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
+  }
+
+}

--- a/examples/vm-scale-set/windows/extensions/variables.tf
+++ b/examples/vm-scale-set/windows/extensions/variables.tf
@@ -1,0 +1,7 @@
+variable "prefix" {
+  description = "The prefix which should be used for all resources in this example"
+}
+
+variable "location" {
+  description = "The Azure Region in which all resources in this example should be created."
+}

--- a/examples/vm-scale-set/windows/hybrid-use-benefit/main.tf
+++ b/examples/vm-scale-set/windows/hybrid-use-benefit/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/multiple-nics/main.tf
+++ b/examples/vm-scale-set/windows/multiple-nics/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/public-ip-per-instance/main.tf
+++ b/examples/vm-scale-set/windows/public-ip-per-instance/main.tf
@@ -10,21 +10,21 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip_prefix" "main" {
   name                = "${var.prefix}-pip"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_windows_virtual_machine_scale_set" "main" {

--- a/examples/vm-scale-set/windows/rolling-upgrade-policy/main.tf
+++ b/examples/vm-scale-set/windows/rolling-upgrade-policy/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
@@ -28,7 +28,7 @@ resource "azurerm_public_ip" "main" {
   allocation_method   = "Static"
 }
 
-resource "azurerm_lb" "test" {
+resource "azurerm_lb" "main" {
   name                = "${var.prefix}-lb"
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name

--- a/examples/vm-scale-set/windows/secrets/main.tf
+++ b/examples/vm-scale-set/windows/secrets/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 data "azurerm_client_config" "current" {}
@@ -117,7 +117,7 @@ resource "azurerm_key_vault" "main" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current._object_id
+    object_id = data.azurerm_client_config.current.object_id
 
     certificate_permissions = [
       "create",

--- a/examples/vm-scale-set/windows/service-fabric/3-service-fabric.tf
+++ b/examples/vm-scale-set/windows/service-fabric/3-service-fabric.tf
@@ -5,7 +5,7 @@ resource "azurerm_service_fabric_cluster" "main" {
   reliability_level   = "Bronze"
   upgrade_mode        = "Automatic"
   vm_image            = "Windows"
-  management_endpoint = "https://${azurerm_public_ip.test.fqdn}:19080"
+  management_endpoint = "https://${azurerm_public_ip.main.fqdn}:19080"
   add_on_features = ["DnsService"]
 
   node_type {

--- a/examples/vm-scale-set/windows/spot/main.tf
+++ b/examples/vm-scale-set/windows/spot/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/system-assigned-identity/main.tf
+++ b/examples/vm-scale-set/windows/system-assigned-identity/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/user-assigned-identity/main.tf
+++ b/examples/vm-scale-set/windows/user-assigned-identity/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/examples/vm-scale-set/windows/zones/main.tf
+++ b/examples/vm-scale-set/windows/zones/main.tf
@@ -10,14 +10,14 @@ resource "azurerm_resource_group" "main" {
 resource "azurerm_virtual_network" "main" {
   name                = "${var.prefix}-network"
   address_space       = ["10.0.0.0/16"]
-  location            = "${azurerm_resource_group.main.location}"
-  resource_group_name = "${azurerm_resource_group.main.name}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
-  resource_group_name  = "${azurerm_resource_group.main.name}"
-  virtual_network_name = "${azurerm_virtual_network.main.name}"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -146,7 +146,7 @@ The following arguments are supported:
 
 * `extension` - (Optional) One or more `extension` blocks as defined below
 
-~> **NOTE:** This block is in Opt-In beta and requires the environment variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` to be set to a non-empty value to be used
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
 
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 
@@ -282,6 +282,8 @@ A `diff_disk_settings` block supports the following:
 
 An `extension` block supports the following:
 
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
+
 * `name` - (Required) The name for the Virtual Machine Scale Set Extension.
 
 * `publisher` - (Required) Specifies the Publisher of the Extension.
@@ -298,11 +300,15 @@ An `extension` block supports the following:
 
 ~> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
 
+-> **Note:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
+
 * `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
 
 * `settings` - (Optional) A JSON String which specifies Settings for the Extension.
 
 ~> **NOTE:** Keys within the `settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+-> **Note:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -144,6 +144,10 @@ The following arguments are supported:
 
 * `do_not_run_extensions_on_overprovisioned_machines` - (Optional) Should Virtual Machine Extensions be run on Overprovisioned Virtual Machines in the Scale Set? Defaults to `false`.
 
+* `extension` - (Optional) One or more `extension` blocks as defined below
+
+~> **NOTE:** This block is in Opt-In beta and requires the environment variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` to be set to a non-empty value to be used
+
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
@@ -273,6 +277,32 @@ A `data_disk` block supports the following:
 A `diff_disk_settings` block supports the following:
 
 `option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
+
+---
+
+An `extension` block supports the following:
+
+* `name` - (Required) The name for the Virtual Machine Scale Set Extension.
+
+* `publisher` - (Required) Specifies the Publisher of the Extension.
+
+* `type` - (Required) Specifies the Type of the Extension.
+
+* `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
+
+* `auto_upgrade_minor_version` - (Optional) Should the latest version of the Extension be used at Deployment Time, if one is available? This won't auto-update the extension on existing installation. Defaults to `true`.
+
+* `force_update_tag` - (Optional) A value which, when different to the previous value can be used to force-run the Extension even if the Extension Configuration hasn't changed.
+
+* `protected_settings` - (Optional) A JSON String which specifies Sensitive Settings (such as Passwords) for the Extension.
+
+~> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+* `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
+
+* `settings` - (Optional) A JSON String which specifies Settings for the Extension.
+
+~> **NOTE:** Keys within the `settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
 
 ---
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -24,7 +24,7 @@ resource "azurerm_service_fabric_cluster" "example" {
   location             = azurerm_resource_group.example.location
   reliability_level    = "Bronze"
   upgrade_mode         = "Manual"
-  cluster_code_version = "6.5.639.9590"
+  cluster_code_version = "7.1.456.959"
   vm_image             = "Windows"
   management_endpoint  = "https://example:80"
 
@@ -36,7 +36,7 @@ resource "azurerm_service_fabric_cluster" "example" {
     http_endpoint_port   = 80
   }
 }
-}
+
 ```
 ## Argument Reference
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -36,6 +36,7 @@ resource "azurerm_service_fabric_cluster" "example" {
     http_endpoint_port   = 80
   }
 }
+}
 ```
 ## Argument Reference
 
@@ -145,7 +146,7 @@ A `client_certificate_thumbprint` block supports the following:
 
 A `client_certificate_common_name` block supports the following:
 
-* `certificate_common_name` - (Required) The common or subject name of the certificate.
+* `common_name` - (Required) The common or subject name of the certificate.
 
 * `certificate_issuer_thumbprint` - (Optional) The Issuer Thumbprint of the Certificate.
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -132,7 +132,7 @@ The following arguments are supported:
 
 * `extension` - (Optional) One or more `extension` blocks as defined below
 
-~> **NOTE:** This block is in Opt-In beta and requires the environment variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` to be set to a non-empty value to be used
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
 
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 
@@ -272,6 +272,8 @@ A `diff_disk_settings` block supports the following:
 
 An `extension` block supports the following:
 
+!> **NOTE:** This block is only available in the Opt-In beta and requires that the Environment Variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` is set to `true` to be used.
+
 * `name` - (Required) The name for the Virtual Machine Scale Set Extension.
 
 * `publisher` - (Required) Specifies the Publisher of the Extension.
@@ -288,11 +290,15 @@ An `extension` block supports the following:
 
 ~> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
 
+-> **Note:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
+
 * `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
 
 * `settings` - (Optional) A JSON String which specifies Settings for the Extension.
 
 ~> **NOTE:** Keys within the `settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+-> **Note:** Rather than defining JSON inline [you can use the `jsonencode` interpolation function](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to define this in a cleaner way.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -130,6 +130,10 @@ The following arguments are supported:
 
 * `enable_automatic_updates` - (Optional) Are automatic updates enabled for this Virtual Machine? Defaults to `true`.
 
+* `extension` - (Optional) One or more `extension` blocks as defined below
+
+~> **NOTE:** This block is in Opt-In beta and requires the environment variable `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` to be set to a non-empty value to be used
+
 * `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can only be configured when `priority` is set to `Spot`.
@@ -263,6 +267,32 @@ A `data_disk` block supports the following:
 A `diff_disk_settings` block supports the following:
 
 `option` - (Required) Specifies the Ephemeral Disk Settings for the OS Disk. At this time the only possible value is `Local`. Changing this forces a new resource to be created.
+
+---
+
+An `extension` block supports the following:
+
+* `name` - (Required) The name for the Virtual Machine Scale Set Extension.
+
+* `publisher` - (Required) Specifies the Publisher of the Extension.
+
+* `type` - (Required) Specifies the Type of the Extension.
+
+* `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
+
+* `auto_upgrade_minor_version` - (Optional) Should the latest version of the Extension be used at Deployment Time, if one is available? This won't auto-update the extension on existing installation. Defaults to `true`.
+
+* `force_update_tag` - (Optional) A value which, when different to the previous value can be used to force-run the Extension even if the Extension Configuration hasn't changed.
+
+* `protected_settings` - (Optional) A JSON String which specifies Sensitive Settings (such as Passwords) for the Extension.
+
+~> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
+
+* `provision_after_extensions` - (Optional) An ordered list of Extension names which this should be provisioned after.
+
+* `settings` - (Optional) A JSON String which specifies Settings for the Extension.
+
+~> **NOTE:** Keys within the `settings` block are notoriously case-sensitive, where the casing required (e.g. TitleCase vs snakeCase) depends on the Extension being used. Please refer to the documentation for the specific Virtual Machine Extension you're looking to use for more information.
 
 ---
 


### PR DESCRIPTION
This PR adds beta support for adding VM Extensions to `azurerm_linux_virtual_machine_scale_set` and `azurerm_windows_virtual_machine_scale_set`

Set the env var `ARM_PROVIDER_VMSS_EXTENSIONS_BETA` to anything but an empty string to enable

resolves #5976  

Adds example of Service Fabric with VMSS + inline extension.

TODO's
- [x] docs
