### PR TITLE
New resource: `azurerm_api_management_custom_domain`

### DIFF
--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -309,3 +309,20 @@ func FlattenApiManagementOperationParameterContract(input *[]apimanagement.Param
 
 	return outputs
 }
+
+// CopyCertificateAndPassword copies any certificate and password attributes
+// from the old config to the current to avoid state diffs.
+// Iterate through old state to find sensitive props not returned by API.
+// This must be done in order to avoid state diffs.
+// NOTE: this information won't be available during times like Import, so this is a best-effort.
+func CopyCertificateAndPassword(vals []interface{}, hostName string, output map[string]interface{}) {
+	for _, val := range vals {
+		oldConfig := val.(map[string]interface{})
+
+		if oldConfig["host_name"] == hostName {
+			output["certificate_password"] = oldConfig["certificate_password"]
+			output["certificate"] = oldConfig["certificate"]
+			break
+		}
+	}
+}

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -2,18 +2,12 @@ package azure
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
-)
-
-var (
-	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
-	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
 )
 
 func SchemaApiManagementName() *schema.Schema {
@@ -331,10 +325,4 @@ func CopyCertificateAndPassword(vals []interface{}, hostName string, output map[
 			break
 		}
 	}
-}
-
-func ToSnakeCase(str string) string {
-	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
-	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
-	return strings.ToLower(snake)
 }

--- a/azurerm/helpers/azure/api_management.go
+++ b/azurerm/helpers/azure/api_management.go
@@ -2,12 +2,18 @@ package azure
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+var (
+	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
 )
 
 func SchemaApiManagementName() *schema.Schema {
@@ -325,4 +331,10 @@ func CopyCertificateAndPassword(vals []interface{}, hostName string, output map[
 			break
 		}
 	}
+}
+
+func ToSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
 }

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -108,7 +108,7 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	if d.IsNewResource() {
-		if existing.ServiceProperties != nil && existing.ServiceProperties.HostnameConfigurations != nil {
+		if existing.ServiceProperties != nil && existing.ServiceProperties.HostnameConfigurations != nil && len(*existing.ServiceProperties.HostnameConfigurations) > 0 {
 			return tf.ImportAsExistsError(apiManagementCustomDomainResourceName, *existing.ID)
 		}
 	}

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -2,13 +2,14 @@ package apimanagement
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -123,7 +124,7 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 		Target:                    []string{"Succeeded", "Ready"},
 		Refresh:                   apiManagementRefreshFunc(ctx, client, serviceName, resourceGroup),
 		MinTimeout:                1 * time.Minute,
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 6,
 	}
 	if d.IsNewResource() {
 		stateConf.Timeout = d.Timeout(schema.TimeoutCreate)
@@ -229,7 +230,7 @@ func apiManagementCustomDomainDelete(d *schema.ResourceData, meta interface{}) e
 		Refresh:                   apiManagementRefreshFunc(ctx, client, serviceName, resourceGroup),
 		MinTimeout:                1 * time.Minute,
 		Timeout:                   d.Timeout(schema.TimeoutDelete),
-		ContinuousTargetOccurence: 5,
+		ContinuousTargetOccurence: 6,
 	}
 
 	if _, err = stateConf.WaitForState(); err != nil {

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -95,12 +95,12 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 	log.Printf("[INFO] preparing arguments for API Management Custom domain creation.")
 
 	apiManagementID := d.Get("api_management_id").(string)
-	id, err := azure.ParseAzureResourceID(apiManagementID)
+	id, err := parse.ApiManagementID(apiManagementID)
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	serviceName := id.Path["service"]
+	serviceName := id.ServiceName
 
 	existing, err := client.Get(ctx, resourceGroup, serviceName)
 	if err != nil {

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -330,12 +330,7 @@ func flattenApiManagementHostnameConfiguration(input *[]apimanagement.HostnameCo
 			output["key_vault_id"] = *config.KeyVaultID
 		}
 
-		snakeCaseConfigType := azure.ToSnakeCase(string(config.Type))
-		if valsRaw, ok := d.GetOk(snakeCaseConfigType); ok {
-			vals := valsRaw.([]interface{})
-			azure.CopyCertificateAndPassword(vals, *config.HostName, output)
-		}
-
+		var configType string
 		switch strings.ToLower(string(config.Type)) {
 		case strings.ToLower(string(apimanagement.HostnameTypeProxy)):
 			// only set SSL binding for proxy types
@@ -343,18 +338,30 @@ func flattenApiManagementHostnameConfiguration(input *[]apimanagement.HostnameCo
 				output["default_ssl_binding"] = *config.DefaultSslBinding
 			}
 			proxyResults = append(proxyResults, output)
+			configType = "proxy"
 
 		case strings.ToLower(string(apimanagement.HostnameTypeManagement)):
 			managementResults = append(managementResults, output)
+			configType = "management"
 
 		case strings.ToLower(string(apimanagement.HostnameTypePortal)):
 			portalResults = append(portalResults, output)
+			configType = "portal"
 
 		case strings.ToLower(string(apimanagement.HostnameTypeDeveloperPortal)):
 			developerPortalResults = append(developerPortalResults, output)
+			configType = "developer_portal"
 
 		case strings.ToLower(string(apimanagement.HostnameTypeScm)):
 			scmResults = append(scmResults, output)
+			configType = "scm"
+		}
+
+		if configType != "" {
+			if valsRaw, ok := d.GetOk(configType); ok {
+				vals := valsRaw.([]interface{})
+				azure.CopyCertificateAndPassword(vals, *config.HostName, output)
+			}
 		}
 	}
 

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -203,32 +203,47 @@ func expandApiManagementCustomDomains(input *schema.ResourceData) *[]apimanageme
 	results := make([]apimanagement.HostnameConfiguration, 0)
 
 	if managementRawVal, ok := input.GetOk("management"); ok {
-		v := managementRawVal.(map[string]interface{})
-		output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeManagement)
-		results = append(results, output)
+		vs := managementRawVal.([]interface{})
+		for _, rawVal := range vs {
+			v := rawVal.(map[string]interface{})
+			output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeManagement)
+			results = append(results, output)
+		}
 	}
 	if portalRawVal, ok := input.GetOk("portal"); ok {
-		v := portalRawVal.(map[string]interface{})
-		output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypePortal)
-		results = append(results, output)
+		vs := portalRawVal.([]interface{})
+		for _, rawVal := range vs {
+			v := rawVal.(map[string]interface{})
+			output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypePortal)
+			results = append(results, output)
+		}
 	}
 	if developerPortalRawVal, ok := input.GetOk("developer_portal"); ok {
-		v := developerPortalRawVal.(map[string]interface{})
-		output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeDeveloperPortal)
-		results = append(results, output)
+		vs := developerPortalRawVal.([]interface{})
+		for _, rawVal := range vs {
+			v := rawVal.(map[string]interface{})
+			output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeDeveloperPortal)
+			results = append(results, output)
+		}
 	}
 	if proxyRawVal, ok := input.GetOk("proxy"); ok {
-		v := proxyRawVal.(map[string]interface{})
-		output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeProxy)
-		if value, ok := v["default_ssl_binding"]; ok {
-			output.DefaultSslBinding = utils.Bool(value.(bool))
+		vs := proxyRawVal.([]interface{})
+		for _, rawVal := range vs {
+			v := rawVal.(map[string]interface{})
+			output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeProxy)
+			if value, ok := v["default_ssl_binding"]; ok {
+				output.DefaultSslBinding = utils.Bool(value.(bool))
+			}
+			results = append(results, output)
 		}
-		results = append(results, output)
 	}
 	if scmRawVal, ok := input.GetOk("scm"); ok {
-		v := scmRawVal.(map[string]interface{})
-		output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeScm)
-		results = append(results, output)
+		vs := scmRawVal.([]interface{})
+		for _, rawVal := range vs {
+			v := rawVal.(map[string]interface{})
+			output := expandApiManagementCommonHostnameConfiguration(v, apimanagement.HostnameTypeScm)
+			results = append(results, output)
+		}
 	}
 	return &results
 }

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -95,6 +95,9 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 
 	apiManagementID := d.Get("api_management_id").(string)
 	id, err := azure.ParseAzureResourceID(apiManagementID)
+	if err != nil {
+		return err
+	}
 	resourceGroup := id.Path["resourceGroups"]
 	name := id.Path["service"]
 

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -95,7 +95,7 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 
 	existing, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error finding API Management (API Management %q / Resource Group %q): %s", name, resourceGroup, err)
+		return fmt.Errorf("finding API Management (API Management %q / Resource Group %q): %s", name, resourceGroup, err)
 	}
 
 	if d.IsNewResource() {
@@ -107,15 +107,15 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 	existing.ServiceProperties.HostnameConfigurations = expandAzureRmApiManagementHostnameConfigurations(d)
 
 	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, existing); err != nil {
-		return fmt.Errorf("Error creating/updating Custom Custom domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("creating/updating Custom Domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	read, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error retrieving Custom Custom domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("retrieving Custom Domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
 	}
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read Custom domain (API Management %q / Resource Group %q) ID", name, resourceGroup)
+		return fmt.Errorf("cannot read ID for Custom Domain (API Management %q / Resource Group %q)", name, resourceGroup)
 	}
 
 	d.SetId(*read.ID)
@@ -193,7 +193,7 @@ func apiManagementCustomDomainDelete(d *schema.ResourceData, meta interface{}) e
 	resp.ServiceProperties.HostnameConfigurations = nil
 
 	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, resp); err != nil {
-		return fmt.Errorf("Error deleting Custom Custom domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
+		return fmt.Errorf("deleting Custom Domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
 	return nil

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -1,0 +1,276 @@
+package apimanagement
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+var apiManagementCustomDomainResourceName = "azurerm_api_management_custom_domain"
+
+func resourceArmApiManagementCustomDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: apiManagementCustomDomainCreateUpdate,
+		Read:   apiManagementCustomDomainRead,
+		Update: apiManagementCustomDomainCreateUpdate,
+		Delete: apiManagementCustomDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"api_management_name": azure.SchemaApiManagementName(),
+
+			"management": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"management", "portal", "developer_portal", "proxy", "scm"},
+				Elem: &schema.Resource{
+					Schema: apiManagementResourceHostnameSchema(),
+				},
+			},
+			"portal": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"management", "portal", "developer_portal", "proxy", "scm"},
+				Elem: &schema.Resource{
+					Schema: apiManagementResourceHostnameSchema(),
+				},
+			},
+			"developer_portal": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"management", "portal", "developer_portal", "proxy", "scm"},
+				Elem: &schema.Resource{
+					Schema: apiManagementResourceHostnameSchema(),
+				},
+			},
+			"proxy": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"management", "portal", "developer_portal", "proxy", "scm"},
+				Elem: &schema.Resource{
+					Schema: apiManagementResourceHostnameProxySchema(),
+				},
+			},
+			"scm": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"management", "portal", "developer_portal", "proxy", "scm"},
+				Elem: &schema.Resource{
+					Schema: apiManagementResourceHostnameSchema(),
+				},
+			},
+		},
+	}
+}
+
+func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.ServiceClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	log.Printf("[INFO] preparing arguments for API Management Custom domain creation.")
+
+	name := d.Get("api_management_name").(string)
+	resourceGroup := d.Get("resource_group_name").(string)
+
+	existing, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error finding API Management (API Management %q / Resource Group %q): %s", name, resourceGroup, err)
+	}
+
+	if d.IsNewResource() {
+		if existing.ServiceProperties.HostnameConfigurations != nil {
+			return tf.ImportAsExistsError(apiManagementCustomDomainResourceName, *existing.ID)
+		}
+	}
+
+	existing.ServiceProperties.HostnameConfigurations = expandAzureRmApiManagementHostnameConfigurations(d)
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, existing); err != nil {
+		return fmt.Errorf("Error creating/updating Custom Custom domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	read, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		return fmt.Errorf("Error retrieving Custom Custom domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read Custom domain (API Management %q / Resource Group %q) ID", name, resourceGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return apiManagementCustomDomainRead(d, meta)
+}
+
+func apiManagementCustomDomainRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.ServiceClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	name := id.Path["service"]
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("API Management Service %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("making Read request on API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	d.Set("resource_group_name", resourceGroup)
+	d.Set("api_management_name", resp.Name)
+
+	if props := resp.ServiceProperties.HostnameConfigurations; props != nil {
+		configs := flattenApiManagementHostnameConfiguration(resp.ServiceProperties.HostnameConfigurations, d)
+		for _, config := range configs {
+			for key, v := range config.(map[string]interface{}) {
+				if err := d.Set(key, v); err != nil {
+					return fmt.Errorf("setting `hostname_configuration` %q: %+v", key, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func apiManagementCustomDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).ApiManagement.ServiceClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resourceGroup := id.ResourceGroup
+	name := id.Path["service"]
+
+	resp, err := client.Get(ctx, resourceGroup, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("API Management Service %q was not found in Resource Group %q - removing from state!", name, resourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("making Read request on API Management Service %q (Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	log.Printf("[DEBUG] Deleting API Management Custom domain (API Management %q / Resource Group %q)", name, resourceGroup)
+
+	resp.ServiceProperties.HostnameConfigurations = nil
+
+	if _, err := client.CreateOrUpdate(ctx, resourceGroup, name, resp); err != nil {
+		return fmt.Errorf("Error deleting Custom Custom domain (API Management %q / Resource Group %q): %+v", name, resourceGroup, err)
+	}
+
+	return nil
+}
+
+func flattenApiManagementHostnameConfiguration(input *[]apimanagement.HostnameConfiguration, d *schema.ResourceData) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	managementResults := make([]interface{}, 0)
+	portalResults := make([]interface{}, 0)
+	developerPortalResults := make([]interface{}, 0)
+	proxyResults := make([]interface{}, 0)
+	scmResults := make([]interface{}, 0)
+
+	for _, config := range *input {
+		output := make(map[string]interface{})
+
+		if config.HostName != nil {
+			output["host_name"] = *config.HostName
+		}
+
+		if config.NegotiateClientCertificate != nil {
+			output["negotiate_client_certificate"] = *config.NegotiateClientCertificate
+		}
+
+		if config.KeyVaultID != nil {
+			output["key_vault_id"] = *config.KeyVaultID
+		}
+
+		// Iterate through old state to find sensitive props not returned by API.
+		// This must be done in order to avoid state diffs.
+		// NOTE: this information won't be available during times like Import, so this is a best-effort.
+		snakeCaseConfigType := azure.ToSnakeCase(string(config.Type))
+		if valsRaw, ok := d.GetOk(snakeCaseConfigType); ok {
+			vals := valsRaw.([]interface{})
+			for _, val := range vals {
+				oldConfig := val.(map[string]interface{})
+
+				if oldConfig["host_name"] == *config.HostName {
+					output["certificate_password"] = oldConfig["certificate_password"]
+					output["certificate"] = oldConfig["certificate"]
+				}
+			}
+		}
+
+		switch strings.ToLower(string(config.Type)) {
+		case strings.ToLower(string(apimanagement.HostnameTypeProxy)):
+			// only set SSL binding for proxy types
+			if config.DefaultSslBinding != nil {
+				output["default_ssl_binding"] = *config.DefaultSslBinding
+			}
+			proxyResults = append(proxyResults, output)
+
+		case strings.ToLower(string(apimanagement.HostnameTypeManagement)):
+			managementResults = append(managementResults, output)
+
+		case strings.ToLower(string(apimanagement.HostnameTypePortal)):
+			portalResults = append(portalResults, output)
+
+		case strings.ToLower(string(apimanagement.HostnameTypeDeveloperPortal)):
+			developerPortalResults = append(developerPortalResults, output)
+
+		case strings.ToLower(string(apimanagement.HostnameTypeScm)):
+			scmResults = append(scmResults, output)
+		}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"management":       managementResults,
+			"portal":           portalResults,
+			"developer_portal": developerPortalResults,
+			"proxy":            proxyResults,
+			"scm":              scmResults,
+		},
+	}
+}

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -98,7 +98,7 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	resourceGroup := id.Path["resourceGroups"]
+	resourceGroup := id.ResourceGroup
 	name := id.Path["service"]
 
 	existing, err := client.Get(ctx, resourceGroup, name)

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -108,7 +108,7 @@ func apiManagementCustomDomainCreateUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	if d.IsNewResource() {
-		if existing.ServiceProperties != nil && existing.ServiceProperties.HostnameConfigurations != nil && len(*existing.ServiceProperties.HostnameConfigurations) > 0 {
+		if existing.ServiceProperties != nil && existing.ServiceProperties.HostnameConfigurations != nil && len(*existing.ServiceProperties.HostnameConfigurations) > 1 {
 			return tf.ImportAsExistsError(apiManagementCustomDomainResourceName, *existing.ID)
 		}
 	}

--- a/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -156,7 +156,6 @@ func apiManagementCustomDomainRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("making Read request on API Management Service %q (Resource Group %q): %+v", serviceName, resourceGroup, err)
 	}
 
-	d.Set("resource_group_name", resourceGroup)
 	d.Set("api_management_id", resp.ID)
 
 	if resp.ServiceProperties != nil && resp.ServiceProperties.HostnameConfigurations != nil {

--- a/azurerm/internal/services/apimanagement/api_management_data_source.go
+++ b/azurerm/internal/services/apimanagement/api_management_data_source.go
@@ -229,6 +229,11 @@ func dataSourceApiManagementRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
+	identity := flattenAzureRmApiManagementMachineIdentity(resp.Identity)
+	if err := d.Set("identity", identity); err != nil {
+		return fmt.Errorf("setting `identity`: %+v", err)
+	}
+
 	if props := resp.ServiceProperties; props != nil {
 		d.Set("publisher_email", props.PublisherEmail)
 		d.Set("publisher_name", props.PublisherName)

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -1180,54 +1180,6 @@ func flattenApiManagementVirtualNetworkConfiguration(input *apimanagement.Virtua
 	return []interface{}{virtualNetworkConfiguration}
 }
 
-func apiManagementResourceHostnameSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"host_name": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		},
-
-		"key_vault_id": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: azure.ValidateKeyVaultChildIdVersionOptional,
-		},
-
-		"certificate": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Sensitive:    true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		},
-
-		"certificate_password": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Sensitive:    true,
-			ValidateFunc: validation.StringIsNotEmpty,
-		},
-
-		"negotiate_client_certificate": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
-	}
-}
-
-func apiManagementResourceHostnameProxySchema() map[string]*schema.Schema {
-	hostnameSchema := apiManagementResourceHostnameSchema()
-
-	hostnameSchema["default_ssl_binding"] = &schema.Schema{
-		Type:     schema.TypeBool,
-		Optional: true,
-		Computed: true, // Azure has certain logic to set this, which we cannot predict
-	}
-
-	return hostnameSchema
-}
-
 func parseApiManagementNilableDictionary(input map[string]*string, key string) bool {
 	log.Printf("Parsing value for %q", key)
 

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -503,19 +503,21 @@ func resourceArmApiManagementServiceCreateUpdate(d *schema.ResourceData, meta in
 
 	customProperties := expandApiManagementCustomProperties(d)
 	certificates := expandAzureRmApiManagementCertificates(d)
-	hostnameConfigurations := expandAzureRmApiManagementHostnameConfigurations(d)
 
 	properties := apimanagement.ServiceResource{
 		Location: utils.String(location),
 		ServiceProperties: &apimanagement.ServiceProperties{
-			PublisherName:          utils.String(publisherName),
-			PublisherEmail:         utils.String(publisherEmail),
-			CustomProperties:       customProperties,
-			Certificates:           certificates,
-			HostnameConfigurations: hostnameConfigurations,
+			PublisherName:    utils.String(publisherName),
+			PublisherEmail:   utils.String(publisherEmail),
+			CustomProperties: customProperties,
+			Certificates:     certificates,
 		},
 		Tags: tags.Expand(t),
 		Sku:  sku,
+	}
+
+	if _, ok := d.GetOk("hostname_configuration"); ok {
+		properties.ServiceProperties.HostnameConfigurations = expandAzureRmApiManagementHostnameConfigurations(d)
 	}
 
 	// intentionally not gated since we specify a default value (of None) in the expand, which we need on updates

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -863,7 +863,7 @@ func flattenApiManagementHostnameConfigurations(input *[]apimanagement.HostnameC
 		if len(existingHostnames) > 0 {
 			v := existingHostnames[0].(map[string]interface{})
 
-			if valsRaw, ok := v[strings.ToLower(string(config.Type))]; ok {
+			if valsRaw, ok := v[azure.ToSnakeCase(string(config.Type))]; ok {
 				vals := valsRaw.([]interface{})
 				for _, val := range vals {
 					oldConfig := val.(map[string]interface{})

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -750,7 +750,11 @@ func resourceArmApiManagementServiceDelete(d *schema.ResourceData, meta interfac
 
 func expandAzureRmApiManagementHostnameConfigurations(d *schema.ResourceData) *[]apimanagement.HostnameConfiguration {
 	results := make([]apimanagement.HostnameConfiguration, 0)
-	hostnameVs := d.Get("hostname_configuration").([]interface{})
+	vs := d.Get("hostname_configuration")
+	if vs == nil {
+		return &results
+	}
+	hostnameVs := vs.([]interface{})
 
 	for _, hostnameRawVal := range hostnameVs {
 		hostnameV := hostnameRawVal.(map[string]interface{})

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/suppress"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeouts"
@@ -617,13 +618,13 @@ func resourceArmApiManagementServiceRead(d *schema.ResourceData, meta interface{
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ApiManagementID(d.Id())
 	if err != nil {
 		return err
 	}
 
 	resourceGroup := id.ResourceGroup
-	name := id.Path["service"]
+	name := id.ServiceName
 
 	resp, err := client.Get(ctx, resourceGroup, name)
 	if err != nil {
@@ -728,12 +729,12 @@ func resourceArmApiManagementServiceDelete(d *schema.ResourceData, meta interfac
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := azure.ParseAzureResourceID(d.Id())
+	id, err := parse.ApiManagementID(d.Id())
 	if err != nil {
 		return err
 	}
 	resourceGroup := id.ResourceGroup
-	name := id.Path["service"]
+	name := id.ServiceName
 
 	log.Printf("[DEBUG] Deleting API Management Service %q (Resource Grouo %q)", name, resourceGroup)
 	future, err := client.Delete(ctx, resourceGroup, name)

--- a/azurerm/internal/services/apimanagement/api_management_resource.go
+++ b/azurerm/internal/services/apimanagement/api_management_resource.go
@@ -3,7 +3,6 @@ package apimanagement
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"log"
 	"strconv"
 	"strings"
@@ -11,8 +10,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2019-12-01/apimanagement"
 	"github.com/hashicorp/go-azure-helpers/response"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"

--- a/azurerm/internal/services/apimanagement/parse/api_diagnostic_id_test.go
+++ b/azurerm/internal/services/apimanagement/parse/api_diagnostic_id_test.go
@@ -101,7 +101,7 @@ func TestApiManagementApiDiagnosticID(t *testing.T) {
 		}
 
 		if actual.ServiceName != v.Expected.ServiceName {
-			t.Fatalf("Expected %q but got %q for Service Name", v.Expected.Name, actual.Name)
+			t.Fatalf("Expected %q but got %q for Service Name", v.Expected.ServiceName, actual.ServiceName)
 		}
 
 		if actual.ResourceGroup != v.Expected.ResourceGroup {

--- a/azurerm/internal/services/apimanagement/parse/api_management_id.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management_id.go
@@ -1,0 +1,31 @@
+package parse
+
+import (
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ApiManagementId struct {
+	ResourceGroup string
+	ServiceName   string
+}
+
+func ApiManagementID(input string) (*ApiManagementId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	apiManagement := ApiManagementId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if apiManagement.ServiceName, err = id.PopSegment("service"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &apiManagement, nil
+}

--- a/azurerm/internal/services/apimanagement/parse/api_management_id_test.go
+++ b/azurerm/internal/services/apimanagement/parse/api_management_id_test.go
@@ -1,0 +1,71 @@
+package parse
+
+import "testing"
+
+func TestApiManagementID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *ApiManagementId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Service Name",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/",
+			Expected: nil,
+		},
+		{
+			Name:  "API Management service name",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1",
+			Expected: &ApiManagementId{
+				ServiceName:   "service1",
+				ResourceGroup: "resGroup1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/Service/service1",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ApiManagementID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.ServiceName != v.Expected.ServiceName {
+			t.Fatalf("Expected %q but got %q for Service Name", v.Expected.ServiceName, actual.ServiceName)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/apimanagement/parse/custom_domain_id.go
+++ b/azurerm/internal/services/apimanagement/parse/custom_domain_id.go
@@ -1,0 +1,36 @@
+package parse
+
+import (
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+type ApiManagementCustomDomainId struct {
+	ResourceGroup string
+	ServiceName   string
+	Name          string
+}
+
+func ApiManagementCustomDomainID(input string) (*ApiManagementCustomDomainId, error) {
+	id, err := azure.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	logger := ApiManagementCustomDomainId{
+		ResourceGroup: id.ResourceGroup,
+	}
+
+	if logger.ServiceName, err = id.PopSegment("service"); err != nil {
+		return nil, err
+	}
+
+	if logger.Name, err = id.PopSegment("customDomains"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &logger, nil
+}

--- a/azurerm/internal/services/apimanagement/parse/custom_domain_id_test.go
+++ b/azurerm/internal/services/apimanagement/parse/custom_domain_id_test.go
@@ -1,0 +1,86 @@
+package parse
+
+import "testing"
+
+func TestApiManagementCustomDomainID(t *testing.T) {
+	testData := []struct {
+		Name     string
+		Input    string
+		Expected *ApiManagementCustomDomainId
+	}{
+		{
+			Name:     "Empty",
+			Input:    "",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Segment",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000",
+			Expected: nil,
+		},
+		{
+			Name:     "No Resource Groups Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/",
+			Expected: nil,
+		},
+		{
+			Name:     "Resource Group ID",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foo/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Service Name",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Custom Domain",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1",
+			Expected: nil,
+		},
+		{
+			Name:     "Missing Custom Domain Value",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/customDomains",
+			Expected: nil,
+		},
+		{
+			Name:  "Custom Domain ID",
+			Input: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/customDomains/default",
+			Expected: &ApiManagementCustomDomainId{
+				Name:          "default",
+				ServiceName:   "service1",
+				ResourceGroup: "resGroup1",
+			},
+		},
+		{
+			Name:     "Wrong Casing",
+			Input:    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.ApiManagement/service/service1/CstomDomains/default",
+			Expected: nil,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Name)
+
+		actual, err := ApiManagementCustomDomainID(v.Input)
+		if err != nil {
+			if v.Expected == nil {
+				continue
+			}
+
+			t.Fatalf("Expected a value but got an error: %s", err)
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.ServiceName != v.Expected.ServiceName {
+			t.Fatalf("Expected %q but got %q for Service Name", v.Expected.Name, actual.Name)
+		}
+
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for Resource Group", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+	}
+}

--- a/azurerm/internal/services/apimanagement/registration.go
+++ b/azurerm/internal/services/apimanagement/registration.go
@@ -44,6 +44,7 @@ func (r Registration) SupportedResources() map[string]*schema.Resource {
 		"azurerm_api_management_authorization_server":        resourceArmApiManagementAuthorizationServer(),
 		"azurerm_api_management_backend":                     resourceArmApiManagementBackend(),
 		"azurerm_api_management_certificate":                 resourceArmApiManagementCertificate(),
+		"azurerm_api_management_custom_domain":               resourceArmApiManagementCustomDomain(),
 		"azurerm_api_management_diagnostic":                  resourceArmApiManagementDiagnostic(),
 		"azurerm_api_management_group":                       resourceArmApiManagementGroup(),
 		"azurerm_api_management_group_user":                  resourceArmApiManagementGroupUser(),

--- a/azurerm/internal/services/apimanagement/schema.go
+++ b/azurerm/internal/services/apimanagement/schema.go
@@ -3,15 +3,18 @@ package apimanagement
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tf/suppress"
 )
 
 func apiManagementResourceHostnameSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"host_name": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			Type:             schema.TypeString,
+			Required:         true,
+			DiffSuppressFunc: suppress.CaseDifference,
+			ValidateFunc:     validation.StringIsNotEmpty,
 		},
 
 		"key_vault_id": {

--- a/azurerm/internal/services/apimanagement/schema.go
+++ b/azurerm/internal/services/apimanagement/schema.go
@@ -1,0 +1,55 @@
+package apimanagement
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+)
+
+func apiManagementResourceHostnameSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"host_name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"key_vault_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: azure.ValidateKeyVaultChildIdVersionOptional,
+		},
+
+		"certificate": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Sensitive:    true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"certificate_password": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Sensitive:    true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"negotiate_client_certificate": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+	}
+}
+
+func apiManagementResourceHostnameProxySchema() map[string]*schema.Schema {
+	hostnameSchema := apiManagementResourceHostnameSchema()
+
+	hostnameSchema["default_ssl_binding"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Computed: true, // Azure has certain logic to set this, which we cannot predict
+	}
+
+	return hostnameSchema
+}

--- a/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
@@ -288,7 +288,7 @@ resource "azurerm_api_management" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                = "acctestkeyvault%s"
+  name                = "apimkv%[3]s"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
@@ -317,7 +317,7 @@ resource "azurerm_key_vault" "test" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = azurerm_api_management.test.identity.principal_id
+    object_id = azurerm_api_management.test.identity.0.principal_id
 
     certificate_permissions = [
       "get",

--- a/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
@@ -117,8 +117,7 @@ func testAccAzureRMApiManagementCustomDomain_basic(data acceptance.TestData) str
 %s
 
 resource "azurerm_api_management_custom_domain" "test" {
-  api_management_name = azurerm_api_management.test.name
-  resource_group_name = azurerm_resource_group.test.name
+  api_management_id = azurerm_api_management.test.id
 
   proxy {
     host_name    = "api.example.com"

--- a/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
@@ -1,0 +1,177 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestAccAzureRMApiManagementCustomDomain_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_custom_domain", "test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementCustomDomain_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementCustomDomainExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
+func TestAccAzureRMApiManagementCustomDomain_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_custom_domain", "test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApiManagementCustomDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApiManagementCustomDomain_basic(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApiManagementCustomDomainExists(data.ResourceName),
+				),
+			},
+			data.RequiresImportErrorStep(testAccAzureRMApiManagementCustomDomain_requiresImport),
+		},
+	})
+}
+
+func testCheckAzureRMApiManagementCustomDomainDestroy(s *terraform.State) error {
+	conn := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.ServiceClient
+	ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_api_management_custom_domain" {
+			continue
+		}
+
+		serviceName := rs.Primary.Attributes["api_management_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(ctx, resourceGroup, serviceName)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				// TODO: Is this an error case? If Custom Domains is destroyed, it should not destroy the API Management Service, so what are we testing for here?
+				// If the entire configuration is torn down, including the API Management Service, then it, too, will not be found, and returning nil is correct.
+				return nil
+			}
+
+			if resp.ServiceProperties != nil && resp.ServiceProperties.HostnameConfigurations != nil && len(*resp.ServiceProperties.HostnameConfigurations) > 0 {
+				return fmt.Errorf("Bad: Expected there to be no Custom Domains in the hostname_configurations field: %+v", resp.ServiceProperties.HostnameConfigurations)
+			}
+
+			return err
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func testCheckAzureRMApiManagementCustomDomainExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acceptance.AzureProvider.Meta().(*clients.Client).ApiManagement.ServiceClient
+		ctx := acceptance.AzureProvider.Meta().(*clients.Client).StopContext
+
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		serviceName := rs.Primary.Attributes["api_management_name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(ctx, resourceGroup, serviceName)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return fmt.Errorf("Bad: Custom Domains on API Management Service %q / Resource Group: %q does not exist (because API Management Service %q does not exist)", serviceName, resourceGroup, serviceName)
+			}
+
+			if resp.ServiceProperties == nil || resp.ServiceProperties.HostnameConfigurations == nil || len(*resp.ServiceProperties.HostnameConfigurations) == 0 {
+				return fmt.Errorf("Bad: Expected there to be Custom Domains defined in the hostname_configurations field for API Management Service %q / Resource Group: %q", serviceName, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on apiManagementCustomDomainsClient: %+v", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccAzureRMApiManagementCustomDomain_basic(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementCustomDomain_template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_custom_domain" "test" {
+  api_management_name = azurerm_api_management.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template)
+}
+
+func testAccAzureRMApiManagementCustomDomain_requiresImport(data acceptance.TestData) string {
+	template := testAccAzureRMApiManagementCustomDomain_basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_custom_domain" "import" {
+  api_management_name = azurerm_api_management_custom_domain.test.api_management_name
+  resource_group_name = azurerm_api_management_custom_domain.test.resource_group_name
+}
+`, template)
+}
+
+func testAccAzureRMApiManagementCustomDomain_template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_api_management" "test" {
+  name                = "acctestAM-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  publisher_name      = "pub1"
+  publisher_email     = "pub1@email.com"
+  sku_name            = "Developer_1"
+}
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  display_name        = "Butter Parser"
+  path                = "butter-parser"
+  protocols           = ["https", "http"]
+  revision            = "3"
+  description         = "What is my purpose? You parse butter."
+  service_url         = "https://example.com/foo/bar"
+
+  subscription_key_parameter_names {
+    header = "X-Butter-Robot-API-Key"
+    query  = "location"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
@@ -64,8 +64,6 @@ func testCheckAzureRMApiManagementCustomDomainDestroy(s *terraform.State) error 
 		resp, err := conn.Get(ctx, resourceGroup, serviceName)
 		if err != nil {
 			if utils.ResponseWasNotFound(resp.Response) {
-				// TODO: Is this an error case? If Custom Domains is destroyed, it should not destroy the API Management Service, so what are we testing for here?
-				// If the entire configuration is torn down, including the API Management Service, then it, too, will not be found, and returning nil is correct.
 				return nil
 			}
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
@@ -308,6 +308,7 @@ resource "azurerm_key_vault" "test" {
 
     key_permissions = [
       "create",
+      "get",
     ]
 
     secret_permissions = [

--- a/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
@@ -178,7 +178,7 @@ resource "azurerm_api_management" "test" {
   sku_name            = "Developer_1"
 
   identity {
-	type = "SystemAssigned"
+    type = "SystemAssigned"
   }
 }
 
@@ -199,7 +199,7 @@ resource "azurerm_key_vault" "test" {
       "delete",
       "get",
       "update",
-	]
+    ]
 
     key_permissions = [
       "create",
@@ -216,7 +216,7 @@ resource "azurerm_key_vault" "test" {
 
     certificate_permissions = [
       "get",
-	]
+    ]
 
     secret_permissions = [
       "get",

--- a/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_custom_domain_resource_test.go
@@ -2,13 +2,13 @@ package tests
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/acceptance"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/apimanagement/parse"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
 )
 

--- a/azurerm/internal/services/apimanagement/tests/api_management_data_source_test.go
+++ b/azurerm/internal/services/apimanagement/tests/api_management_data_source_test.go
@@ -44,7 +44,7 @@ func TestAccDataSourceAzureRMApiManagement_identitySystemAssigned(t *testing.T) 
 					resource.TestCheckResourceAttr(data.ResourceName, "sku_name", "Developer_1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttrSet(data.ResourceName, "public_ip_addresses.#"),
-					resource.TestCheckResourceAttr(data.ResourceName, "identity.%", "1"),
+					resource.TestCheckResourceAttr(data.ResourceName, "identity.#", "1"),
 					resource.TestCheckResourceAttr(data.ResourceName, "identity.0.type", "SystemAssigned"),
 				),
 			},

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Manages an API Management Service.
 
+## Disclaimers
+
+~> **Note:** It's possible to define Custom Domains both within [the `azurerm_api_management` resource](api_management.html) via the `hostname_configurations` block and by using [the `azurerm_api_management_custom_domain` resource](api_management_custom_domain.html). However it's not possible to use both methods to manage Custom Domains within an API Management Service, since there'll be conflicts.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -1,0 +1,152 @@
+---
+subcategory: "API Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_api_management_custom_domain"
+description: |-
+  Manages a API Management Custom Domain.
+---
+
+# azurerm_api_management_custom_domain
+
+Manages a API Management Custom Domain.
+
+## Disclaimers
+
+~> **Note:** It's possible to define Custom Domains both within [the `azurerm_api_management` resource](api_management.html) via the `hostname_configurations` block and by using [the `azurerm_api_management_custom_domain` resource](api_management_custom_domain.html). However it's not possible to use both methods to manage Custom Domains within an API Management Service, since there'll be conflicts.
+
+## Example Usage
+
+```hcl
+resource "azurerm_key_vault" "example" {
+  // TODO
+}
+
+resource "azurerm_key_vault_certificate" "example" {
+  key_vault_id = azurerm_key_vault.example.id
+  // TODO
+}
+
+resource "azurerm_api_management_custom_domain" "example" {
+  resource_group_name = "example"
+  api_management_name = "example"
+  proxy {
+    host_name    = "api.example.com"
+    key_vault_id = azurerm_key_vault_certificate.example.secret_id
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `api_management_name` - (Required) TODO. Changing this forces a new API Management Custom Domain to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the API Management Custom Domain should exist. Changing this forces a new API Management Custom Domain to be created.
+
+---
+
+* `developer_portal` - (Optional) One or more `developer_portal` blocks as defined below.
+
+* `management` - (Optional) One or more `management` blocks as defined below.
+
+* `portal` - (Optional) One or more `portal` blocks as defined below.
+
+* `proxy` - (Optional) One or more `proxy` blocks as defined below.
+
+* `scm` - (Optional) One or more `scm` blocks as defined below.
+
+---
+
+A `developer_portal` block supports the following:
+
+* `host_name` - (Required) The Hostname to use for the Developer Portal.
+
+* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
+
+* `certificate_password` - (Optional) The password associated with the certificate provided above.
+
+* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
+
+* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
+
+---
+
+A `management` block supports the following:
+
+* `host_name` - (Required) The Hostname to use for the Management API.
+
+* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
+
+* `certificate_password` - (Optional) The password associated with the certificate provided above.
+
+* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
+
+* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
+
+---
+
+A `portal` block supports the following:
+
+* `host_name` - (Required) The Hostname to use for the legacy Developer Portal.
+
+* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
+
+* `certificate_password` - (Optional) The password associated with the certificate provided above.
+
+* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
+
+* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
+
+---
+
+A `proxy` block supports the following:
+
+* `host_name` - (Required) The Hostname to use for the legacy Developer Portal.
+
+* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
+
+* `certificate_password` - (Optional) The password associated with the certificate provided above.
+
+* `default_ssl_binding` - (Optional) Is the certificate associated with this Hostname the Default SSL Certificate? This is used when an SNI header isn't specified by a client. Defaults to false.
+
+* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
+
+* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
+
+---
+
+A `scm` block supports the following:
+
+* `host_name` - (Required) The Hostname to use for the SCM domain.
+
+* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
+
+* `certificate_password` - (Optional) The password associated with the certificate provided above.
+
+* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
+
+* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the API Management Custom Domain.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Management Custom Domain.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Management Custom Domain.
+* `update` - (Defaults to 30 minutes) Used when updating the API Management Custom Domain.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Custom Domain.
+
+## Import
+
+API Management Custom Domains can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_api_management_custom_domain.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/instance1
+```

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -122,37 +122,9 @@ The following arguments are supported:
 
 ---
 
-A `developer_portal` block supports the following:
+A `developer_portal`, `management`, `portal` or `scm` block supports the following:
 
-* `host_name` - (Required) The Hostname to use for the Developer Portal.
-
-* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
-
-* `certificate_password` - (Optional) The password associated with the certificate provided above.
-
-* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
-
-* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
-
----
-
-A `management` block supports the following:
-
-* `host_name` - (Required) The Hostname to use for the Management API.
-
-* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
-
-* `certificate_password` - (Optional) The password associated with the certificate provided above.
-
-* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
-
-* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
-
----
-
-A `portal` block supports the following:
-
-* `host_name` - (Required) The Hostname to use for the legacy Developer Portal.
+* `host_name` - (Required) The Hostname to use for the corresponding endpoint.
 
 * `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
 
@@ -166,27 +138,13 @@ A `portal` block supports the following:
 
 A `proxy` block supports the following:
 
-* `host_name` - (Required) The Hostname to use for the legacy Developer Portal.
+* `host_name` - (Required) The Hostname to use for the API Proxy Endpoint.
 
 * `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
 
 * `certificate_password` - (Optional) The password associated with the certificate provided above.
 
 * `default_ssl_binding` - (Optional) Is the certificate associated with this Hostname the Default SSL Certificate? This is used when an SNI header isn't specified by a client. Defaults to false.
-
-* `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
-
-* `negotiate_client_certificate` - (Optional) Should Client Certificate Negotiation be enabled for this Hostname? Defaults to false.
-
----
-
-A `scm` block supports the following:
-
-* `host_name` - (Required) The Hostname to use for the SCM domain.
-
-* `certificate` - (Optional) The Base64 Encoded Certificate. (Mutually exlusive with `key_vault_id`.)
-
-* `certificate_password` - (Optional) The password associated with the certificate provided above.
 
 * `key_vault_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be should be of the type application/x-pkcs12.
 

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -12,7 +12,7 @@ Manages a API Management Custom Domain.
 
 ## Disclaimers
 
-~> **Note:** It's possible to define Custom Domains both within [the `azurerm_api_management` resource](api_management.html) via the `hostname_configurations` block and by using [the `azurerm_api_management_custom_domain` resource](api_management_custom_domain.html). However it's not possible to use both methods to manage Custom Domains within an API Management Service, since there'll be conflicts.
+~> **Note:** It's possible to define Custom Domains both within [the `azurerm_api_management` resource](api_management.html) via the `hostname_configurations` block and by using this resource. However it's not possible to use both methods to manage Custom Domains within an API Management Service, since there will be conflicts.
 
 ## Example Usage
 
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `api_management_name` - (Required) TODO. Changing this forces a new API Management Custom Domain to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the API Management Custom Domain should exist. Changing this forces a new API Management Custom Domain to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the API Management resource exists. Changing this forces a new API Management Custom Domain to be created.
 
 ---
 

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -85,8 +85,7 @@ resource "azurerm_key_vault_certificate" "example" {
 }
 
 resource "azurerm_api_management_custom_domain" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  api_management_name = azurerm_api_management.example.name
+  api_management_id = azurerm_api_management.example.id
 
   proxy {
     host_name    = "api.example.com"
@@ -104,9 +103,7 @@ resource "azurerm_api_management_custom_domain" "example" {
 
 The following arguments are supported:
 
-* `api_management_name` - (Required) The name of the API Management service to configure Custom Domain for. Changing this forces a new API Management Custom Domain to be created.
-
-* `resource_group_name` - (Required) The name of the Resource Group where the API Management resource exists. Changing this forces a new API Management Custom Domain to be created.
+* `api_management_id` - (Required) The ID of the API Management service for which to configure Custom Domains. Changing this forces a new API Management Custom Domain resource to be created.
 
 ---
 


### PR DESCRIPTION
Closes #3058.

The approach used is to modify the API Management service (corresponding to an `azurerm_api_management` resource) by updating an existing instance. A note is added to the documentation in both that and the new resource telling that you should not configure the custom domains in _both_ resources, as that would likely create conflicts.

Semantically, if you delete an `azurerm_api_management_custom_domain`, the `hostname_configurations` field will be set to be empty (null) when the API Management service instance is updated. There should not be more than one `azurerm_api_management_custom_domain` resource for an `azurerm_api_management`, but I have not found a way to enforce this using the Terraform Provider SDK.

---

Includes:
  - [x] Implementation
  - [x] Acceptance tests
  - [x] Website docs