### PR TITLE
`azurerm_cdn_endpoint` - Standardize the resource ID to be case sensitive

### DIFF
--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/migration"
+
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2019-04-15/cdn"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -200,6 +202,15 @@ func resourceArmCdnEndpoint() *schema.Resource {
 			"delivery_rule": endpointDeliveryRule(),
 
 			"tags": tags.Schema(),
+		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceArmCdnEndpoint().CoreConfigSchema().ImpliedType(),
+				Upgrade: migration.CdnEndpointV0ToV1,
+				Version: 0,
+			},
 		},
 	}
 }

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -23,167 +23,169 @@ import (
 )
 
 func resourceArmCdnEndpoint() *schema.Resource {
-	schemaDef := map[string]*schema.Schema{
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
-		},
-
-		"location": azure.SchemaLocation(),
-
-		"resource_group_name": azure.SchemaResourceGroupName(),
-
-		"profile_name": {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
-		},
-
-		"origin_host_header": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-
-		"is_http_allowed": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-		},
-
-		"is_https_allowed": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-		},
-
-		"origin": {
-			Type:     schema.TypeSet,
-			Required: true,
-			ForceNew: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"name": {
-						Type:     schema.TypeString,
-						Required: true,
-						ForceNew: true,
-					},
-
-					"host_name": {
-						Type:     schema.TypeString,
-						Required: true,
-						ForceNew: true,
-					},
-
-					"http_port": {
-						Type:     schema.TypeInt,
-						Optional: true,
-						ForceNew: true,
-						Default:  80,
-					},
-
-					"https_port": {
-						Type:     schema.TypeInt,
-						Optional: true,
-						ForceNew: true,
-						Default:  443,
-					},
-				},
+	tmpResource := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
-		},
 
-		"origin_path": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
+			"location": azure.SchemaLocation(),
 
-		"querystring_caching_behaviour": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  string(cdn.IgnoreQueryString),
-			ValidateFunc: validation.StringInSlice([]string{
-				string(cdn.BypassCaching),
-				string(cdn.IgnoreQueryString),
-				string(cdn.NotSet),
-				string(cdn.UseQueryString),
-			}, false),
-		},
+			"resource_group_name": azure.SchemaResourceGroupName(),
 
-		"content_types_to_compress": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			Computed: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
+			"profile_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
-			Set: schema.HashString,
-		},
 
-		"is_compression_enabled": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
+			"origin_host_header": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 
-		"probe_path": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-		},
+			"is_http_allowed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 
-		"geo_filter": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"relative_path": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-					"action": {
-						Type:     schema.TypeString,
-						Required: true,
-						ValidateFunc: validation.StringInSlice([]string{
-							string(cdn.Allow),
-							string(cdn.Block),
-						}, true),
-						DiffSuppressFunc: suppress.CaseDifference,
-					},
-					"country_codes": {
-						Type:     schema.TypeList,
-						Required: true,
-						Elem: &schema.Schema{
-							Type: schema.TypeString,
+			"is_https_allowed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"origin": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"host_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"http_port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Default:  80,
+						},
+
+						"https_port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Default:  443,
 						},
 					},
 				},
 			},
+
+			"origin_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"querystring_caching_behaviour": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(cdn.IgnoreQueryString),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cdn.BypassCaching),
+					string(cdn.IgnoreQueryString),
+					string(cdn.NotSet),
+					string(cdn.UseQueryString),
+				}, false),
+			},
+
+			"content_types_to_compress": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Set: schema.HashString,
+			},
+
+			"is_compression_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"probe_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"geo_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"relative_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(cdn.Allow),
+								string(cdn.Block),
+							}, true),
+							DiffSuppressFunc: suppress.CaseDifference,
+						},
+						"country_codes": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"optimization_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cdn.DynamicSiteAcceleration),
+					string(cdn.GeneralMediaStreaming),
+					string(cdn.GeneralWebDelivery),
+					string(cdn.LargeFileDownload),
+					string(cdn.VideoOnDemandMediaStreaming),
+				}, true),
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+
+			"host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"global_delivery_rule": endpointGlobalDeliveryRule(),
+
+			"delivery_rule": endpointDeliveryRule(),
+
+			"tags": tags.Schema(),
 		},
-
-		"optimization_type": {
-			Type:     schema.TypeString,
-			Optional: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(cdn.DynamicSiteAcceleration),
-				string(cdn.GeneralMediaStreaming),
-				string(cdn.GeneralWebDelivery),
-				string(cdn.LargeFileDownload),
-				string(cdn.VideoOnDemandMediaStreaming),
-			}, true),
-			DiffSuppressFunc: suppress.CaseDifference,
-		},
-
-		"host_name": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-
-		"global_delivery_rule": endpointGlobalDeliveryRule(),
-
-		"delivery_rule": endpointDeliveryRule(),
-
-		"tags": tags.Schema(),
 	}
 
 	return &schema.Resource{
@@ -204,12 +206,12 @@ func resourceArmCdnEndpoint() *schema.Resource {
 			return err
 		}),
 
-		Schema: schemaDef,
+		Schema: tmpResource.Schema,
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type:    schema.Resource{Schema: schemaDef}.CoreConfigSchema().ImpliedType(),
+				Type:    tmpResource.CoreConfigSchema().ImpliedType(),
 				Upgrade: migration.CdnEndpointV0ToV1,
 				Version: 0,
 			},

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -23,7 +23,25 @@ import (
 )
 
 func resourceArmCdnEndpoint() *schema.Resource {
-	tmpResource := &schema.Resource{
+
+	return &schema.Resource{
+		Create: resourceArmCdnEndpointCreate,
+		Read:   resourceArmCdnEndpointRead,
+		Update: resourceArmCdnEndpointUpdate,
+		Delete: resourceArmCdnEndpointDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.CdnEndpointID(id)
+			return err
+		}),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -186,32 +204,11 @@ func resourceArmCdnEndpoint() *schema.Resource {
 
 			"tags": tags.Schema(),
 		},
-	}
-
-	return &schema.Resource{
-		Create: resourceArmCdnEndpointCreate,
-		Read:   resourceArmCdnEndpointRead,
-		Update: resourceArmCdnEndpointUpdate,
-		Delete: resourceArmCdnEndpointDelete,
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
-		},
-
-		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
-			_, err := parse.CdnEndpointID(id)
-			return err
-		}),
-
-		Schema: tmpResource.Schema,
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type:    tmpResource.CoreConfigSchema().ImpliedType(),
+				Type:    migration.CdnEndpointV0Schema().CoreConfigSchema().ImpliedType(),
 				Upgrade: migration.CdnEndpointV0ToV1,
 				Version: 0,
 			},

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -23,6 +23,169 @@ import (
 )
 
 func resourceArmCdnEndpoint() *schema.Resource {
+	schemaDef := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": azure.SchemaLocation(),
+
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"profile_name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"origin_host_header": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+
+		"is_http_allowed": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"is_https_allowed": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
+
+		"origin": {
+			Type:     schema.TypeSet,
+			Required: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"host_name": {
+						Type:     schema.TypeString,
+						Required: true,
+						ForceNew: true,
+					},
+
+					"http_port": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						ForceNew: true,
+						Default:  80,
+					},
+
+					"https_port": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						ForceNew: true,
+						Default:  443,
+					},
+				},
+			},
+		},
+
+		"origin_path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"querystring_caching_behaviour": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  string(cdn.IgnoreQueryString),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(cdn.BypassCaching),
+				string(cdn.IgnoreQueryString),
+				string(cdn.NotSet),
+				string(cdn.UseQueryString),
+			}, false),
+		},
+
+		"content_types_to_compress": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Set: schema.HashString,
+		},
+
+		"is_compression_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+
+		"probe_path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"geo_filter": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"relative_path": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"action": {
+						Type:     schema.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(cdn.Allow),
+							string(cdn.Block),
+						}, true),
+						DiffSuppressFunc: suppress.CaseDifference,
+					},
+					"country_codes": {
+						Type:     schema.TypeList,
+						Required: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+
+		"optimization_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(cdn.DynamicSiteAcceleration),
+				string(cdn.GeneralMediaStreaming),
+				string(cdn.GeneralWebDelivery),
+				string(cdn.LargeFileDownload),
+				string(cdn.VideoOnDemandMediaStreaming),
+			}, true),
+			DiffSuppressFunc: suppress.CaseDifference,
+		},
+
+		"host_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"global_delivery_rule": endpointGlobalDeliveryRule(),
+
+		"delivery_rule": endpointDeliveryRule(),
+
+		"tags": tags.Schema(),
+	}
+
 	return &schema.Resource{
 		Create: resourceArmCdnEndpointCreate,
 		Read:   resourceArmCdnEndpointRead,
@@ -41,173 +204,12 @@ func resourceArmCdnEndpoint() *schema.Resource {
 			return err
 		}),
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"location": azure.SchemaLocation(),
-
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"profile_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"origin_host_header": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"is_http_allowed": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"is_https_allowed": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-
-			"origin": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-
-						"host_name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-
-						"http_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Default:  80,
-						},
-
-						"https_port": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Default:  443,
-						},
-					},
-				},
-			},
-
-			"origin_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"querystring_caching_behaviour": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  string(cdn.IgnoreQueryString),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(cdn.BypassCaching),
-					string(cdn.IgnoreQueryString),
-					string(cdn.NotSet),
-					string(cdn.UseQueryString),
-				}, false),
-			},
-
-			"content_types_to_compress": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-				Set: schema.HashString,
-			},
-
-			"is_compression_enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"probe_path": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"geo_filter": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"relative_path": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"action": {
-							Type:     schema.TypeString,
-							Required: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								string(cdn.Allow),
-								string(cdn.Block),
-							}, true),
-							DiffSuppressFunc: suppress.CaseDifference,
-						},
-						"country_codes": {
-							Type:     schema.TypeList,
-							Required: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-					},
-				},
-			},
-
-			"optimization_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(cdn.DynamicSiteAcceleration),
-					string(cdn.GeneralMediaStreaming),
-					string(cdn.GeneralWebDelivery),
-					string(cdn.LargeFileDownload),
-					string(cdn.VideoOnDemandMediaStreaming),
-				}, true),
-				DiffSuppressFunc: suppress.CaseDifference,
-			},
-
-			"host_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"global_delivery_rule": endpointGlobalDeliveryRule(),
-
-			"delivery_rule": endpointDeliveryRule(),
-
-			"tags": tags.Schema(),
-		},
+		Schema: schemaDef,
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type:    resourceArmCdnEndpoint().CoreConfigSchema().ImpliedType(),
+				Type:    schema.Resource{Schema: schemaDef}.CoreConfigSchema().ImpliedType(),
 				Upgrade: migration.CdnEndpointV0ToV1,
 				Version: 0,
 			},

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -205,6 +205,7 @@ func resourceArmCdnEndpoint() *schema.Resource {
 }
 
 func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	endpointsClient := meta.(*clients.Client).Cdn.EndpointsClient
 	profilesClient := meta.(*clients.Client).Cdn.ProfilesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
@@ -308,7 +309,7 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	d.SetId(id.ID())
+	d.SetId(id.ID(subscriptionId))
 
 	return resourceArmCdnEndpointRead(d, meta)
 }

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -23,7 +23,6 @@ import (
 )
 
 func resourceArmCdnEndpoint() *schema.Resource {
-
 	return &schema.Resource{
 		Create: resourceArmCdnEndpointCreate,
 		Read:   resourceArmCdnEndpointRead,

--- a/azurerm/internal/services/cdn/cdn_endpoint_resource.go
+++ b/azurerm/internal/services/cdn/cdn_endpoint_resource.go
@@ -303,7 +303,12 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error retrieving CDN Endpoint %q (Profile %q / Resource Group %q): %+v", name, profileName, resourceGroup, err)
 	}
 
-	d.SetId(*read.ID)
+	id, err := parse.CdnEndpointID(*read.ID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id.ID())
 
 	return resourceArmCdnEndpointRead(d, meta)
 }

--- a/azurerm/internal/services/cdn/cdn_profile_data_source.go
+++ b/azurerm/internal/services/cdn/cdn_profile_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/clients"
@@ -41,6 +43,7 @@ func dataSourceArmCdnProfile() *schema.Resource {
 }
 
 func dataSourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Cdn.ProfilesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -56,7 +59,12 @@ func dataSourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error making Read request on Azure CDN Profile %q (Resource Group %q): %+v", name, resourceGroup, err)
 	}
 
-	d.SetId(*resp.ID)
+	id, err := parse.CdnProfileID(*resp.ID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id.ID(subscriptionId))
 
 	d.Set("name", name)
 	d.Set("resource_group_name", resourceGroup)

--- a/azurerm/internal/services/cdn/cdn_profile_data_source.go
+++ b/azurerm/internal/services/cdn/cdn_profile_data_source.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/migration"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -38,6 +40,15 @@ func dataSourceArmCdnProfile() *schema.Resource {
 			},
 
 			"tags": tags.SchemaDataSource(),
+		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceArmCdnProfile().CoreConfigSchema().ImpliedType(),
+				Upgrade: migration.CdnProfileV0ToV1,
+				Version: 0,
+			},
 		},
 	}
 }

--- a/azurerm/internal/services/cdn/cdn_profile_data_source.go
+++ b/azurerm/internal/services/cdn/cdn_profile_data_source.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/migration"
-
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -40,15 +38,6 @@ func dataSourceArmCdnProfile() *schema.Resource {
 			},
 
 			"tags": tags.SchemaDataSource(),
-		},
-
-		SchemaVersion: 1,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    resourceArmCdnProfile().CoreConfigSchema().ImpliedType(),
-				Upgrade: migration.CdnProfileV0ToV1,
-				Version: 0,
-			},
 		},
 	}
 }

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -23,6 +23,34 @@ import (
 )
 
 func resourceArmCdnProfile() *schema.Resource {
+	schemaDef := map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"location": azure.SchemaLocation(),
+
+		"resource_group_name": azure.SchemaResourceGroupName(),
+
+		"sku": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(cdn.StandardAkamai),
+				string(cdn.StandardChinaCdn),
+				string(cdn.StandardVerizon),
+				string(cdn.StandardMicrosoft),
+				string(cdn.PremiumVerizon),
+			}, true),
+			DiffSuppressFunc: suppress.CaseDifference,
+		},
+
+		"tags": tags.Schema(),
+	}
+
 	return &schema.Resource{
 		Create: resourceArmCdnProfileCreate,
 		Read:   resourceArmCdnProfileRead,
@@ -41,38 +69,12 @@ func resourceArmCdnProfile() *schema.Resource {
 			return err
 		}),
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-
-			"location": azure.SchemaLocation(),
-
-			"resource_group_name": azure.SchemaResourceGroupName(),
-
-			"sku": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(cdn.StandardAkamai),
-					string(cdn.StandardChinaCdn),
-					string(cdn.StandardVerizon),
-					string(cdn.StandardMicrosoft),
-					string(cdn.PremiumVerizon),
-				}, true),
-				DiffSuppressFunc: suppress.CaseDifference,
-			},
-
-			"tags": tags.Schema(),
-		},
+		Schema: schemaDef,
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type:    resourceArmCdnProfile().CoreConfigSchema().ImpliedType(),
+				Type:    schema.Resource{Schema: schemaDef}.CoreConfigSchema().ImpliedType(),
 				Upgrade: migration.CdnProfileV0ToV1,
 				Version: 0,
 			},

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -23,32 +23,34 @@ import (
 )
 
 func resourceArmCdnProfile() *schema.Resource {
-	schemaDef := map[string]*schema.Schema{
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
+	tmpResource := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"sku": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cdn.StandardAkamai),
+					string(cdn.StandardChinaCdn),
+					string(cdn.StandardVerizon),
+					string(cdn.StandardMicrosoft),
+					string(cdn.PremiumVerizon),
+				}, true),
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+
+			"tags": tags.Schema(),
 		},
-
-		"location": azure.SchemaLocation(),
-
-		"resource_group_name": azure.SchemaResourceGroupName(),
-
-		"sku": {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
-			ValidateFunc: validation.StringInSlice([]string{
-				string(cdn.StandardAkamai),
-				string(cdn.StandardChinaCdn),
-				string(cdn.StandardVerizon),
-				string(cdn.StandardMicrosoft),
-				string(cdn.PremiumVerizon),
-			}, true),
-			DiffSuppressFunc: suppress.CaseDifference,
-		},
-
-		"tags": tags.Schema(),
 	}
 
 	return &schema.Resource{
@@ -69,12 +71,12 @@ func resourceArmCdnProfile() *schema.Resource {
 			return err
 		}),
 
-		Schema: schemaDef,
+		Schema: tmpResource.Schema,
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type:    schema.Resource{Schema: schemaDef}.CoreConfigSchema().ImpliedType(),
+				Type:    tmpResource.CoreConfigSchema().ImpliedType(),
 				Upgrade: migration.CdnProfileV0ToV1,
 				Version: 0,
 			},

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -23,7 +23,24 @@ import (
 )
 
 func resourceArmCdnProfile() *schema.Resource {
-	tmpResource := &schema.Resource{
+	return &schema.Resource{
+		Create: resourceArmCdnProfileCreate,
+		Read:   resourceArmCdnProfileRead,
+		Update: resourceArmCdnProfileUpdate,
+		Delete: resourceArmCdnProfileDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
+			_, err := parse.CdnProfileID(id)
+			return err
+		}),
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -51,32 +68,11 @@ func resourceArmCdnProfile() *schema.Resource {
 
 			"tags": tags.Schema(),
 		},
-	}
-
-	return &schema.Resource{
-		Create: resourceArmCdnProfileCreate,
-		Read:   resourceArmCdnProfileRead,
-		Update: resourceArmCdnProfileUpdate,
-		Delete: resourceArmCdnProfileDelete,
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Read:   schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
-		},
-
-		Importer: azSchema.ValidateResourceIDPriorToImport(func(id string) error {
-			_, err := parse.CdnProfileID(id)
-			return err
-		}),
-
-		Schema: tmpResource.Schema,
 
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{
 			{
-				Type:    tmpResource.CoreConfigSchema().ImpliedType(),
+				Type:    migration.CdnProfileV0Schema().CoreConfigSchema().ImpliedType(),
 				Upgrade: migration.CdnProfileV0ToV1,
 				Version: 0,
 			},

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/migration"
+
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2019-04-15/cdn"
 	"github.com/hashicorp/go-azure-helpers/response"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -65,6 +67,15 @@ func resourceArmCdnProfile() *schema.Resource {
 			},
 
 			"tags": tags.Schema(),
+		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceArmCdnProfile().CoreConfigSchema().ImpliedType(),
+				Upgrade: migration.CdnProfileV0ToV1,
+				Version: 0,
+			},
 		},
 	}
 }

--- a/azurerm/internal/services/cdn/cdn_profile_resource.go
+++ b/azurerm/internal/services/cdn/cdn_profile_resource.go
@@ -70,6 +70,7 @@ func resourceArmCdnProfile() *schema.Resource {
 }
 
 func resourceArmCdnProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	client := meta.(*clients.Client).Cdn.ProfilesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -121,7 +122,12 @@ func resourceArmCdnProfileCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Cannot read CDN Profile %s (resource group %s) ID", name, resGroup)
 	}
 
-	d.SetId(*read.ID)
+	id, err := parse.CdnProfileID(*read.ID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id.ID(subscriptionId))
 
 	return resourceArmCdnProfileRead(d, meta)
 }

--- a/azurerm/internal/services/cdn/migration/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/migration/cdn_endpoint.go
@@ -3,9 +3,379 @@ package migration
 import (
 	"log"
 
+	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2019-04-15/cdn"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/deliveryruleactions"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/deliveryruleconditions"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/tags"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
 )
+
+func CdnEndpointV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": azure.SchemaLocation(),
+
+			"resource_group_name": azure.SchemaResourceGroupName(),
+
+			"profile_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"origin_host_header": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"is_http_allowed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"is_https_allowed": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"origin": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"host_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"http_port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Default:  80,
+						},
+
+						"https_port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+							Default:  443,
+						},
+					},
+				},
+			},
+
+			"origin_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"querystring_caching_behaviour": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(cdn.IgnoreQueryString),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cdn.BypassCaching),
+					string(cdn.IgnoreQueryString),
+					string(cdn.NotSet),
+					string(cdn.UseQueryString),
+				}, false),
+			},
+
+			"content_types_to_compress": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Set: schema.HashString,
+			},
+
+			"is_compression_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"probe_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"geo_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"relative_path": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(cdn.Allow),
+								string(cdn.Block),
+							}, true),
+							DiffSuppressFunc: suppress.CaseDifference,
+						},
+						"country_codes": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"optimization_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cdn.DynamicSiteAcceleration),
+					string(cdn.GeneralMediaStreaming),
+					string(cdn.GeneralWebDelivery),
+					string(cdn.LargeFileDownload),
+					string(cdn.VideoOnDemandMediaStreaming),
+				}, true),
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+
+			"host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// This is a point-in-time copy paste of the return value of `endpointGlobalDeliveryRule()` used in V1 schema
+			"global_delivery_rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cache_expiration_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.CacheExpiration(),
+						},
+
+						"cache_key_query_string_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.CacheKeyQueryString(),
+						},
+
+						"modify_request_header_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleactions.ModifyRequestHeader(),
+						},
+
+						"modify_response_header_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleactions.ModifyResponseHeader(),
+						},
+
+						"url_redirect_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.URLRedirect(),
+						},
+
+						"url_rewrite_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.URLRewrite(),
+						},
+					},
+				},
+			},
+
+			// This is a point-in-time copy paste of the return value of `endpointDeliveryRule()` used in V1 schema
+			"delivery_rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validate.EndpointDeliveryRuleName(),
+						},
+
+						"order": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+
+						"cookies_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.Cookies(),
+						},
+
+						"http_version_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.HTTPVersion(),
+						},
+
+						"device_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleconditions.Device(),
+						},
+
+						"post_arg_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.PostArg(),
+						},
+
+						"query_string_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.QueryString(),
+						},
+
+						"remote_address_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.RemoteAddress(),
+						},
+
+						"request_body_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.RequestBody(),
+						},
+
+						"request_header_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.RequestHeader(),
+						},
+
+						"request_method_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleconditions.RequestMethod(),
+						},
+
+						"request_scheme_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleconditions.RequestScheme(),
+						},
+
+						"request_uri_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.RequestURI(),
+						},
+
+						"url_file_extension_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.URLFileExtension(),
+						},
+
+						"url_file_name_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.URLFileName(),
+						},
+
+						"url_path_condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleconditions.URLPath(),
+						},
+
+						"cache_expiration_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.CacheExpiration(),
+						},
+
+						"cache_key_query_string_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.CacheKeyQueryString(),
+						},
+
+						"modify_request_header_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleactions.ModifyRequestHeader(),
+						},
+
+						"modify_response_header_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     deliveryruleactions.ModifyResponseHeader(),
+						},
+
+						"url_redirect_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.URLRedirect(),
+						},
+
+						"url_rewrite_action": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem:     deliveryruleactions.URLRewrite(),
+						},
+					},
+				},
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
 
 func CdnEndpointV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	// old

--- a/azurerm/internal/services/cdn/migration/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/migration/cdn_endpoint.go
@@ -1,0 +1,41 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
+)
+
+func CdnEndpointV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	// old
+	// 	/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
+	// new:
+	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}
+	// summary:
+	// resourcegroups -> resourceGroups
+	oldId := rawState["id"].(string)
+	oldParsedId, err := azure.ParseAzureResourceID(oldId)
+	if err != nil {
+		return rawState, err
+	}
+
+	resourceGroup := oldParsedId.ResourceGroup
+	profileName, err := oldParsedId.PopSegment("profiles")
+	if err != nil {
+		return rawState, err
+	}
+	name, err := oldParsedId.PopSegment("endpoints")
+	if err != nil {
+		return rawState, err
+	}
+
+	newId := parse.NewCdnEndpointID(parse.NewCdnProfileID(resourceGroup, profileName), name)
+	newIdStr := newId.ID(oldParsedId.SubscriptionID)
+
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
+
+	rawState["id"] = newIdStr
+
+	return rawState, nil
+}

--- a/azurerm/internal/services/cdn/migration/cdn_endpoint_test.go
+++ b/azurerm/internal/services/cdn/migration/cdn_endpoint_test.go
@@ -1,0 +1,55 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestCdnEndpointV1ToV2(t *testing.T) {
+	testData := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *string
+	}{
+		{
+			name: "missing id",
+			input: map[string]interface{}{
+				"id": "",
+			},
+			expected: nil,
+		},
+		{
+			name: "old id",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"),
+		},
+		{
+			name: "new id",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"),
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Testing %q..", test.name)
+		result, err := CdnEndpointV0ToV1(test.input, nil)
+		if err != nil && test.expected == nil {
+			continue
+		} else {
+			if err == nil && test.expected == nil {
+				t.Fatalf("Expected an error but didn't get one")
+			} else if err != nil && test.expected != nil {
+				t.Fatalf("Expected no error but got: %+v", err)
+			}
+		}
+
+		actualId := result["id"].(string)
+		if *test.expected != actualId {
+			t.Fatalf("expected %q but got %q!", *test.expected, actualId)
+		}
+	}
+}

--- a/azurerm/internal/services/cdn/migration/cdn_profile.go
+++ b/azurerm/internal/services/cdn/migration/cdn_profile.go
@@ -3,9 +3,54 @@ package migration
 import (
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/location"
+
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
 	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
 )
+
+func CdnProfileV0Schema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				StateFunc:        location.StateFunc,
+				DiffSuppressFunc: location.DiffSuppressFunc,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"sku": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
 
 func CdnProfileV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	// old

--- a/azurerm/internal/services/cdn/migration/cdn_profile.go
+++ b/azurerm/internal/services/cdn/migration/cdn_profile.go
@@ -1,0 +1,37 @@
+package migration
+
+import (
+	"log"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/parse"
+)
+
+func CdnProfileV0ToV1(rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	// old
+	// 	/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}
+	// new:
+	// 	/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}
+	// summary:
+	// resourcegroups -> resourceGroups
+	oldId := rawState["id"].(string)
+	oldParsedId, err := azure.ParseAzureResourceID(oldId)
+	if err != nil {
+		return rawState, err
+	}
+
+	resourceGroup := oldParsedId.ResourceGroup
+	name, err := oldParsedId.PopSegment("profiles")
+	if err != nil {
+		return rawState, err
+	}
+
+	newId := parse.NewCdnProfileID(resourceGroup, name)
+	newIdStr := newId.ID(oldParsedId.SubscriptionID)
+
+	log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newIdStr)
+
+	rawState["id"] = newIdStr
+
+	return rawState, nil
+}

--- a/azurerm/internal/services/cdn/migration/cdn_profile_test.go
+++ b/azurerm/internal/services/cdn/migration/cdn_profile_test.go
@@ -1,0 +1,55 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func TestCdnProfileV1ToV2(t *testing.T) {
+	testData := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *string
+	}{
+		{
+			name: "missing id",
+			input: map[string]interface{}{
+				"id": "",
+			},
+			expected: nil,
+		},
+		{
+			name: "old id",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/group1/providers/Microsoft.Cdn/profiles/profile1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"),
+		},
+		{
+			name: "new id",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"),
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Testing %q..", test.name)
+		result, err := CdnProfileV0ToV1(test.input, nil)
+		if err != nil && test.expected == nil {
+			continue
+		} else {
+			if err == nil && test.expected == nil {
+				t.Fatalf("Expected an error but didn't get one")
+			} else if err != nil && test.expected != nil {
+				t.Fatalf("Expected no error but got: %+v", err)
+			}
+		}
+
+		actualId := result["id"].(string)
+		if *test.expected != actualId {
+			t.Fatalf("expected %q but got %q!", *test.expected, actualId)
+		}
+	}
+}

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint.go
@@ -45,7 +45,7 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	return &endpoint, nil
 }
 
-func (id CdnEndpointId) ID(subscription string) string {
+func (id CdnEndpointId) ID(subscriptionId string) string {
 	base := NewCdnProfileID(id.ResourceGroup, id.ProfileName).ID(subscription)
 	return fmt.Sprintf("%s/endpoints/%s", base, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint.go
@@ -46,6 +46,6 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 }
 
 func (id CdnEndpointId) ID(subscriptionId string) string {
-	base := NewCdnProfileID(id.ResourceGroup, id.ProfileName).ID(subscription)
+	base := NewCdnProfileID(id.ResourceGroup, id.ProfileName).ID(subscriptionId)
 	return fmt.Sprintf("%s/endpoints/%s", base, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint.go
@@ -7,6 +7,8 @@ import (
 )
 
 type CdnEndpointId struct {
+	Subscription  string
+	Provider      string
 	ResourceGroup string
 	ProfileName   string
 	Name          string
@@ -19,6 +21,8 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	}
 
 	endpoint := CdnEndpointId{
+		Subscription:  id.SubscriptionID,
+		Provider:      id.Provider,
 		ResourceGroup: id.ResourceGroup,
 	}
 
@@ -35,4 +39,10 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	}
 
 	return &endpoint, nil
+}
+
+// This ID is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10576
+func (id CdnEndpointId) ID() string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/profiles/%s/endpoints/%s",
+		id.Subscription, id.ResourceGroup, id.Provider, id.ProfileName, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint.go
@@ -7,11 +7,17 @@ import (
 )
 
 type CdnEndpointId struct {
-	Subscription  string
-	Provider      string
 	ResourceGroup string
 	ProfileName   string
 	Name          string
+}
+
+func NewCdnEndpointID(id CdnProfileId, name string) CdnEndpointId {
+	return CdnEndpointId{
+		ResourceGroup: id.ResourceGroup,
+		ProfileName:   id.Name,
+		Name:          name,
+	}
 }
 
 func CdnEndpointID(input string) (*CdnEndpointId, error) {
@@ -21,8 +27,6 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	}
 
 	endpoint := CdnEndpointId{
-		Subscription:  id.SubscriptionID,
-		Provider:      id.Provider,
 		ResourceGroup: id.ResourceGroup,
 	}
 
@@ -41,8 +45,7 @@ func CdnEndpointID(input string) (*CdnEndpointId, error) {
 	return &endpoint, nil
 }
 
-// This ID is a workaround for issue: https://github.com/Azure/azure-rest-api-specs/issues/10576
-func (id CdnEndpointId) ID() string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/profiles/%s/endpoints/%s",
-		id.Subscription, id.ResourceGroup, id.Provider, id.ProfileName, id.Name)
+func (id CdnEndpointId) ID(subscription string) string {
+	base := NewCdnProfileID(id.ResourceGroup, id.ProfileName).ID(subscription)
+	return fmt.Sprintf("%s/endpoints/%s", base, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_endpoint_test.go
+++ b/azurerm/internal/services/cdn/parse/cdn_endpoint_test.go
@@ -2,7 +2,20 @@ package parse
 
 import (
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = CdnEndpointId{}
+
+func TestCdnEndpointIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewCdnEndpointID(NewCdnProfileID("group1", "profile1"), "endpoint1").ID(subscriptionId)
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1/endpoints/endpoint1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
 
 func TestCdnEndpointId(t *testing.T) {
 	testData := []struct {

--- a/azurerm/internal/services/cdn/parse/cdn_profile.go
+++ b/azurerm/internal/services/cdn/parse/cdn_profile.go
@@ -9,7 +9,13 @@ import (
 type CdnProfileId struct {
 	ResourceGroup string
 	Name          string
-	ProfileName   string
+}
+
+func NewCdnProfileID(resourceGroup, name string) CdnProfileId {
+	return CdnProfileId{
+		ResourceGroup: resourceGroup,
+		Name:          name,
+	}
 }
 
 func CdnProfileID(input string) (*CdnProfileId, error) {
@@ -31,4 +37,9 @@ func CdnProfileID(input string) (*CdnProfileId, error) {
 	}
 
 	return &profile, nil
+}
+
+func (id CdnProfileId) ID(subscription string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s",
+		subscription, id.ResourceGroup, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_profile.go
+++ b/azurerm/internal/services/cdn/parse/cdn_profile.go
@@ -39,7 +39,7 @@ func CdnProfileID(input string) (*CdnProfileId, error) {
 	return &profile, nil
 }
 
-func (id CdnProfileId) ID(subscription string) string {
+func (id CdnProfileId) ID(subscriptionId string) string {
 	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s",
 		subscription, id.ResourceGroup, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_profile.go
+++ b/azurerm/internal/services/cdn/parse/cdn_profile.go
@@ -41,5 +41,5 @@ func CdnProfileID(input string) (*CdnProfileId, error) {
 
 func (id CdnProfileId) ID(subscriptionId string) string {
 	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s",
-		subscription, id.ResourceGroup, id.Name)
+		subscriptionId, id.ResourceGroup, id.Name)
 }

--- a/azurerm/internal/services/cdn/parse/cdn_profile_test.go
+++ b/azurerm/internal/services/cdn/parse/cdn_profile_test.go
@@ -2,7 +2,20 @@ package parse
 
 import (
 	"testing"
+
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/resourceid"
 )
+
+var _ resourceid.Formatter = CdnProfileId{}
+
+func TestCdnProfileIDFormatter(t *testing.T) {
+	subscriptionId := "12345678-1234-5678-1234-123456789012"
+	actual := NewCdnProfileID("group1", "profile1").ID(subscriptionId)
+	expected := "/subscriptions/12345678-1234-5678-1234-123456789012/resourceGroups/group1/providers/Microsoft.Cdn/profiles/profile1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
 
 func TestCdnProfileId(t *testing.T) {
 	testData := []struct {


### PR DESCRIPTION
This is a workaround for #Azure/azure-rest-api-specs#10576.

Fixes: #8191

## Test Result

```bash
💢 make testacc TEST=./azurerm/internal/services/cdn/tests TESTARGS="-run='TestAccAzureRMCdnEndpoint_dnsAlias'"
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...                                                                          
==> Checking that acceptance test packages are used...
TF_ACC=1 go test ./azurerm/internal/services/cdn/tests -v -run='TestAccAzureRMCdnEndpoint_dnsAlias' -timeout 180m -ldflags="-X=github.com/terraform-providers/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAzureRMCdnEndpoint_dnsAlias                                                                           
=== PAUSE TestAccAzureRMCdnEndpoint_dnsAlias            
=== CONT  TestAccAzureRMCdnEndpoint_dnsAlias               
--- PASS: TestAccAzureRMCdnEndpoint_dnsAlias (477.26s)
PASS                                                                                                                   
ok      github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/cdn/tests   477.286s
```