### PR TITLE
allow SocketAddr to be used as a match_variable

### DIFF
--- a/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
+++ b/azurerm/internal/services/frontdoor/frontdoor_firewall_policy_resource.go
@@ -167,6 +167,7 @@ func resourceArmFrontDoorFirewallPolicy() *schema.Resource {
 											string(frontdoor.RequestHeader),
 											string(frontdoor.RequestMethod),
 											string(frontdoor.RequestURI),
+											string(frontdoor.SocketAddr),
 										}, false),
 									},
 

--- a/azurerm/internal/services/frontdoor/tests/frontdoor_firewall_policy_resource_test.go
+++ b/azurerm/internal/services/frontdoor/tests/frontdoor_firewall_policy_resource_test.go
@@ -72,6 +72,7 @@ func TestAccAzureRMFrontDoorFirewallPolicy_update(t *testing.T) {
 					resource.TestCheckResourceAttr(data.ResourceName, "name", fmt.Sprintf("testAccFrontDoorWAF%d", data.RandomInteger)),
 					resource.TestCheckResourceAttr(data.ResourceName, "mode", "Prevention"),
 					resource.TestCheckResourceAttr(data.ResourceName, "custom_rule.1.name", "Rule2"),
+					resource.TestCheckResourceAttr(data.ResourceName, "custom_rule.2.name", "Rule3"),
 				),
 			},
 			{
@@ -321,6 +322,32 @@ resource "azurerm_frontdoor_firewall_policy" "test" {
 
     match_condition {
       match_variable     = "RemoteAddr"
+      operator           = "IPMatch"
+      negation_condition = false
+      match_values       = ["192.168.1.0/24"]
+    }
+
+    match_condition {
+      match_variable     = "RequestHeader"
+      selector           = "UserAgent"
+      operator           = "Contains"
+      negation_condition = false
+      match_values       = ["windows"]
+      transforms         = ["Lowercase", "Trim"]
+    }
+  }
+
+  custom_rule {
+    name                           = "Rule3"
+    enabled                        = true
+    priority                       = 2
+    rate_limit_duration_in_minutes = 1
+    rate_limit_threshold           = 10
+    type                           = "MatchRule"
+    action                         = "Block"
+
+    match_condition {
+      match_variable     = "SocketAddr"
       operator           = "IPMatch"
       negation_condition = false
       match_values       = ["192.168.1.0/24"]

--- a/azurerm/internal/services/frontdoor/tests/frontdoor_firewall_policy_resource_test.go
+++ b/azurerm/internal/services/frontdoor/tests/frontdoor_firewall_policy_resource_test.go
@@ -340,7 +340,7 @@ resource "azurerm_frontdoor_firewall_policy" "test" {
   custom_rule {
     name                           = "Rule3"
     enabled                        = true
-    priority                       = 2
+    priority                       = 3
     rate_limit_duration_in_minutes = 1
     rate_limit_threshold           = 10
     type                           = "MatchRule"

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -167,7 +167,7 @@ The `custom_rule` block supports the following:
 
 The `match_condition` block supports the following:
 
-* `match_variable` - (Required) The request variable to compare with. Possible values are `Cookies`, `PostArgs`, `QueryString`, `RemoteAddr`, `RequestBody`, `RequestHeader`, `RequestMethod`, or `RequestUri`.
+* `match_variable` - (Required) The request variable to compare with. Possible values are `Cookies`, `PostArgs`, `QueryString`, `RemoteAddr`, `RequestBody`, `RequestHeader`, `RequestMethod`, `RequestUri`, or `SocketAddr`.
 
 * `match_values` - (Required) Up to `100` possible values to match.
 


### PR DESCRIPTION
This is already supported by the 2020-01-01 Front Door schema, which is an included module in v44.2.0+incompatible of azure-sdk-for-go, so this is a relatively simple change to the validation within the provider only and has a test

Fixes: #8121