### PR TITLE
Fix wrong title for data source azurerm_key_vault_certificate

### DIFF
--- a/website/docs/d/key_vault_certificate.html.markdown
+++ b/website/docs/d/key_vault_certificate.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Gets information about an existing Key Vault Certificate.
 ---
 
-# Data Source: key_vault_certificate
+# Data Source: azurerm_key_vault_certificate
 
 Use this data source to access information about an existing Key Vault Certificate.
 

--- a/website/docs/d/key_vault_certificate.html.markdown
+++ b/website/docs/d/key_vault_certificate.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Gets information about an existing Key Vault Certificate.
 ---
 
-# Data Source: azurerm_key_vault_secret
+# Data Source: key_vault_certificate
 
 Use this data source to access information about an existing Key Vault Certificate.
 


### PR DESCRIPTION
Fixing wrong title.

There might be other things wrong here as well. The sample shows to retrieve thumbprint but the attribute reference further down does not mention this. Not sure what else might be missing.