### PR TITLE
Simon/app gw probe port

### DIFF
--- a/azurerm/internal/services/network/application_gateway_resource.go
+++ b/azurerm/internal/services/network/application_gateway_resource.go
@@ -821,6 +821,12 @@ func resourceArmApplicationGateway() *schema.Resource {
 							}, true),
 						},
 
+						"port": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validate.PortNumber,
+						},
+
 						"path": {
 							Type:     schema.TypeString,
 							Required: true,

--- a/azurerm/internal/services/network/tests/application_gateway_resource_test.go
+++ b/azurerm/internal/services/network/tests/application_gateway_resource_test.go
@@ -502,6 +502,26 @@ func TestAccAzureRMApplicationGateway_probesPickHostNameFromBackendHTTPSettings(
 	})
 }
 
+func TestAccAzureRMApplicationGateway_probesWithPort(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMApplicationGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMApplicationGateway_probesWithPort(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMApplicationGatewayExists(data.ResourceName),
+					resource.TestCheckResourceAttr(data.ResourceName, "probe.0.port", "8082"),
+				),
+			},
+			data.ImportStep(),
+		},
+	})
+}
+
 func TestAccAzureRMApplicationGateway_backendHttpSettingsHostName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
 	hostName := "example.com"
@@ -3114,6 +3134,100 @@ resource "azurerm_application_gateway" "test" {
     interval                                  = 300
     unhealthy_threshold                       = 8
     pick_host_name_from_backend_http_settings = true
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = local.request_routing_rule_name
+    rule_type                  = "Basic"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func testAccAzureRMApplicationGateway_probesWithPort(data acceptance.TestData) string {
+	template := testAccAzureRMApplicationGateway_template(data)
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  probe1_name                    = "${azurerm_virtual_network.test.name}-probe1"
+  probe2_name                    = "${azurerm_virtual_network.test.name}-probe2"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_Small"
+    tier     = "Standard"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  backend_address_pool {
+    name = local.backend_address_pool_name
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    probe_name            = local.probe1_name
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  backend_http_settings {
+    name                  = "${local.http_setting_name}-2"
+    cookie_based_affinity = "Disabled"
+    port                  = 8080
+    probe_name            = local.probe2_name
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  probe {
+    name                = local.probe1_name
+    protocol            = "Http"
+    port                = "8082"
+    path                = "/test"
+    host                = "azure.com"
+    timeout             = 120
+    interval            = 300
+    unhealthy_threshold = 8
   }
 
   http_listener {


### PR DESCRIPTION
Add support for `probe.properties.port`.
From Azure API [doc](https://docs.microsoft.com/en-us/rest/api/application-gateway/applicationgateways/createorupdate#applicationgatewayprobe):

> Custom port which will be used for probing the backend servers. The valid value ranges from 1 to 65535. In case not set, port from http settings will be used.

* add support for the property
* create an acceptance test 

