### PR TITLE
r/network_interface_*association: handling the Network Interface being deleted during a refresh

### DIFF
--- a/azurerm/internal/services/network/network_interface_application_gateway_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_application_gateway_association_resource.go
@@ -84,6 +84,7 @@ func resourceArmNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationC
 	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
+
 			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
 		}
 
@@ -176,7 +177,9 @@ func resourceArmNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationR
 	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+			log.Printf("Network Interface %q (Resource Group %q) was not found - removing from state!", networkInterfaceName, resourceGroup)
+			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)

--- a/azurerm/internal/services/network/network_interface_application_gateway_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_application_gateway_association_resource.go
@@ -84,7 +84,6 @@ func resourceArmNetworkInterfaceApplicationGatewayBackendAddressPoolAssociationC
 	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
-
 			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
 		}
 

--- a/azurerm/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -144,7 +144,9 @@ func resourceArmNetworkInterfaceApplicationSecurityGroupAssociationRead(d *schem
 	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+			log.Printf("[DEBUG] Network Interface %q (Resource Group %q) was not found - removing from state!", networkInterfaceName, resourceGroup)
+			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)

--- a/azurerm/internal/services/network/network_interface_backend_address_pool_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_backend_address_pool_association_resource.go
@@ -176,7 +176,9 @@ func resourceArmNetworkInterfaceBackendAddressPoolAssociationRead(d *schema.Reso
 	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+			log.Printf("Network Interface %q (Resource Group %q) was not found - removing from state!", networkInterfaceName, resourceGroup)
+			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)

--- a/azurerm/internal/services/network/network_interface_nat_rule_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_nat_rule_association_resource.go
@@ -176,7 +176,9 @@ func resourceArmNetworkInterfaceNatRuleAssociationRead(d *schema.ResourceData, m
 	read, err := client.Get(ctx, resourceGroup, networkInterfaceName, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", networkInterfaceName, resourceGroup)
+			log.Printf("Network Interface %q (Resource Group %q) was not found - removing from state!", networkInterfaceName, resourceGroup)
+			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", networkInterfaceName, resourceGroup, err)

--- a/azurerm/internal/services/network/network_interface_network_security_group_association_resource.go
+++ b/azurerm/internal/services/network/network_interface_network_security_group_association_resource.go
@@ -143,7 +143,9 @@ func resourceArmNetworkInterfaceSecurityGroupAssociationRead(d *schema.ResourceD
 	read, err := client.Get(ctx, resourceGroup, name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
-			return fmt.Errorf("Network Interface %q (Resource Group %q) was not found!", name, resourceGroup)
+			log.Printf("Network Interface %q (Resource Group %q) was not found - removing from state!", name, resourceGroup)
+			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("Error retrieving Network Interface %q (Resource Group %q): %+v", name, resourceGroup, err)


### PR DESCRIPTION
changes:

* `azurerm_network_interface_application_gateway_association` - handling the Network Interface being deleted during a refresh
* `azurerm_network_interface_application_security_group_association` - handling the Network Interface being deleted during a refresh
* `azurerm_network_interface_backend_address_pool_association` - handling the Network Interface being deleted during a refresh
* `azurerm_network_interface_nat_rule_association_resource` - handling the Network Interface being deleted during a refresh
* `azurerm_network_interface_network_security_group_association` - handling the Network Interface being deleted during a refresh


fixes #2491
