### PR TITLE
Update `azurerm_policy_set_definition` - Support to use non-string typed parameter values in `policy_definition_reference` block

### DIFF
--- a/azurerm/internal/services/policy/policy_set_definition_data_source.go
+++ b/azurerm/internal/services/policy/policy_set_definition_data_source.go
@@ -72,8 +72,13 @@ func dataSourceArmPolicySetDefinition() *schema.Resource {
 							Computed: true,
 						},
 
-						"parameters": {
+						"parameters": { // TODO -- remove this attribute in the next major version
 							Type:     schema.TypeMap,
+							Computed: true,
+						},
+
+						"parameter_values": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 
@@ -141,7 +146,11 @@ func dataSourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface
 	}
 	d.Set("policy_definitions", string(definitionBytes))
 
-	if err := d.Set("policy_definition_reference", flattenAzureRMPolicySetDefinitionPolicyDefinitions(setDefinition.PolicyDefinitions)); err != nil {
+	references, err := flattenAzureRMPolicySetDefinitionPolicyDefinitions(setDefinition.PolicyDefinitions)
+	if err != nil {
+		return fmt.Errorf("flattening `policy_definition_reference`: %+v", err)
+	}
+	if err := d.Set("policy_definition_reference", references); err != nil {
 		return fmt.Errorf("setting `policy_definition_reference`: %+v", err)
 	}
 

--- a/azurerm/internal/services/policy/policy_set_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_set_definition_resource.go
@@ -129,9 +129,19 @@ func resourceArmPolicySetDefinition() *schema.Resource {
 							ValidateFunc: validate.PolicyDefinitionID,
 						},
 
-						"parameters": {
-							Type:     schema.TypeMap,
-							Optional: true,
+						"parameters": { // TODO -- remove this attribute after the deprecation
+							Type:       schema.TypeMap,
+							Optional:   true,
+							Computed:   true,
+							Deprecated: "Deprecated in favor of `parameter_values`",
+						},
+
+						"parameter_values": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Computed:         true, // TODO -- remove Computed after the deprecation
+							ValidateFunc:     validation.StringIsJSON,
+							DiffSuppressFunc: structure.SuppressJsonDiff,
 						},
 
 						"reference_id": {
@@ -253,11 +263,14 @@ func resourceArmPolicySetDefinitionCreateUpdate(d *schema.ResourceData, meta int
 		properties.PolicyDefinitions = &policyDefinitions
 	}
 	if v, ok := d.GetOk("policy_definition_reference"); ok {
-		properties.PolicyDefinitions = expandAzureRMPolicySetDefinitionPolicyDefinitions(v.([]interface{}))
+		definitions, err := expandAzureRMPolicySetDefinitionPolicyDefinitions(v.([]interface{}))
+		if err != nil {
+			return fmt.Errorf("expanding `policy_definition_reference`: %+v", err)
+		}
+		properties.PolicyDefinitions = definitions
 	}
 
 	definition := policy.SetDefinition{
-		Name:                    utils.String(name),
 		SetDefinitionProperties: &properties,
 	}
 
@@ -367,7 +380,11 @@ func resourceArmPolicySetDefinitionRead(d *schema.ResourceData, meta interface{}
 
 			d.Set("policy_definitions", string(policyDefinitionsRes))
 		}
-		if err := d.Set("policy_definition_reference", flattenAzureRMPolicySetDefinitionPolicyDefinitions(props.PolicyDefinitions)); err != nil {
+		references, err := flattenAzureRMPolicySetDefinitionPolicyDefinitions(props.PolicyDefinitions)
+		if err != nil {
+			return fmt.Errorf("flattening `policy_definition_reference`: %+v", err)
+		}
+		if err := d.Set("policy_definition_reference", references); err != nil {
 			return fmt.Errorf("setting `policy_definition_reference`: %+v", err)
 		}
 	}
@@ -420,16 +437,25 @@ func policySetDefinitionRefreshFunc(ctx context.Context, client *policy.SetDefin
 	}
 }
 
-func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) *[]policy.DefinitionReference {
+func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) (*[]policy.DefinitionReference, error) {
 	result := make([]policy.DefinitionReference, 0)
 
 	for _, item := range input {
 		v := item.(map[string]interface{})
 
 		parameters := make(map[string]*policy.ParameterValuesValue)
-		for k, value := range v["parameters"].(map[string]interface{}) {
-			parameters[k] = &policy.ParameterValuesValue{
-				Value: value.(string),
+		if p, ok := v["parameter_values"]; ok {
+			_ = json.Unmarshal([]byte(p.(string)), &parameters) // this is ensured by schema validation
+		}
+		if p, ok := v["parameters"]; ok {
+			m := p.(map[string]interface{})
+			if len(parameters) > 0 && len(m) > 0 {
+				return nil, fmt.Errorf("cannot set both `parameters` and `parameter_values`")
+			}
+			for k, value := range p.(map[string]interface{}) {
+				parameters[k] = &policy.ParameterValuesValue{
+					Value: value,
+				}
 			}
 		}
 
@@ -440,13 +466,13 @@ func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) *[]p
 		})
 	}
 
-	return &result
+	return &result, nil
 }
 
-func flattenAzureRMPolicySetDefinitionPolicyDefinitions(input *[]policy.DefinitionReference) []interface{} {
+func flattenAzureRMPolicySetDefinitionPolicyDefinitions(input *[]policy.DefinitionReference) ([]interface{}, error) {
 	result := make([]interface{}, 0)
 	if input == nil {
-		return result
+		return result, nil
 	}
 
 	for _, definition := range *input {
@@ -460,7 +486,12 @@ func flattenAzureRMPolicySetDefinitionPolicyDefinitions(input *[]policy.Definiti
 			if v == nil {
 				continue
 			}
-			parametersMap[k] = v.Value
+			parametersMap[k] = fmt.Sprintf("%v", v.Value) // map in terraform only accepts string as its values, therefore we have to convert the value to string
+		}
+
+		parameterValues, err := flattenParameterValuesValueToString(definition.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("serializing JSON from `parameter_values`: %+v", err)
 		}
 
 		policyDefinitionReference := ""
@@ -471,8 +502,9 @@ func flattenAzureRMPolicySetDefinitionPolicyDefinitions(input *[]policy.Definiti
 		result = append(result, map[string]interface{}{
 			"policy_definition_id": policyDefinitionID,
 			"parameters":           parametersMap,
+			"parameter_values":     parameterValues,
 			"reference_id":         policyDefinitionReference,
 		})
 	}
-	return result
+	return result, nil
 }

--- a/azurerm/internal/services/policy/policy_set_definition_resource.go
+++ b/azurerm/internal/services/policy/policy_set_definition_resource.go
@@ -133,7 +133,7 @@ func resourceArmPolicySetDefinition() *schema.Resource {
 							Type:       schema.TypeMap,
 							Optional:   true,
 							Computed:   true,
-							Deprecated: "Deprecated in favor of `parameter_values`",
+							Deprecated: "Deprecated in favour of `parameter_values`",
 						},
 
 						"parameter_values": {
@@ -445,7 +445,9 @@ func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) (*[]
 
 		parameters := make(map[string]*policy.ParameterValuesValue)
 		if p, ok := v["parameter_values"]; ok {
-			_ = json.Unmarshal([]byte(p.(string)), &parameters) // this is ensured by schema validation
+			if err := json.Unmarshal([]byte(p.(string)), &parameters); err != nil {
+				return nil, fmt.Errorf("unmarshalling `parameter_values`: %+v", err)
+			}
 		}
 		if p, ok := v["parameters"]; ok {
 			m := p.(map[string]interface{})

--- a/azurerm/internal/services/policy/tests/policy_set_definition_resource_test.go
+++ b/azurerm/internal/services/policy/tests/policy_set_definition_resource_test.go
@@ -260,9 +260,11 @@ PARAMETERS
 
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
-    parameters = {
-      listOfAllowedLocations = "[parameters('allowedLocations')]"
+    parameter_values     = <<VALUES
+	{
+      "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
+VALUES
   }
 }
 `, data.RandomInteger, data.RandomInteger)
@@ -281,9 +283,11 @@ resource "azurerm_policy_set_definition" "import" {
 
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
-    parameters = {
-      listOfAllowedLocations = "[parameters('allowedLocations')]"
+    parameter_values     = <<VALUES
+	{
+      "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
+VALUES
   }
 }
 `, template)
@@ -353,9 +357,11 @@ PARAMETERS
 
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
-    parameters = {
-      allowedLocations = "[parameters('allowedLocations')]"
+    parameter_values     = <<VALUES
+	{
+      "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
+VALUES
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)
@@ -437,9 +443,11 @@ PARAMETERS
 
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
-    parameters = {
-      listOfAllowedLocations = "[parameters('allowedLocations')]"
+    parameter_values     = <<VALUES
+	{
+      "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
+VALUES
   }
 }
 `, data.RandomInteger, data.RandomInteger, data.RandomInteger)
@@ -517,9 +525,11 @@ PARAMETERS
 
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
-    parameters = {
-      listOfAllowedLocations = "[parameters('allowedLocations')]"
+    parameter_values     = <<VALUES
+	{
+      "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
+VALUES
   }
 
   metadata = <<METADATA
@@ -556,10 +566,12 @@ PARAMETERS
 
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
-    parameters = {
-      allowedLocations = "[parameters('allowedLocations')]"
+    parameter_values     = <<VALUES
+	{
+      "allowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
-    reference_id = "TestRef"
+VALUES
+    reference_id         = "TestRef"
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)
@@ -592,7 +604,7 @@ resource "azurerm_policy_definition" "test" {
 POLICY_RULE
 
   parameters = <<PARAMETERS
-	{
+  {
     "allowedLocations": {
       "type": "Array",
       "metadata": {

--- a/website/docs/d/policy_set_definition.html.markdown
+++ b/website/docs/d/policy_set_definition.html.markdown
@@ -42,9 +42,25 @@ output "id" {
 
 * `policy_definitions` - The policy definitions contained within the policy set definition.
 
+* `policy_definition_reference` - One or more `policy_definition_reference` blocks as defined below.
+
 * `parameters` - Any Parameters defined in the Policy Set Definition.
 
 * `metadata` - Any Metadata defined in the Policy Set Definition.
+
+---
+
+An `policy_definition_reference` block exports the following:
+
+* `policy_definition_id` - The ID of the policy definition or policy set definition that is included in this policy set definition.
+
+* `parameters` - The mapping of the parameter values for the referenced policy rule. The keys are the parameter names.
+
+-> **NOTE:** Since Terraform's concept of a map requires all of the elements to be of the same type, the value in parameters will all be converted to string type.
+
+* `parameter_values` - The parameter values for the referenced policy rule. This field is a json object.
+
+* `reference_id` - The unique ID within this policy set definition for this policy definition reference.
 
 ## Timeouts
 

--- a/website/docs/d/policy_set_definition.html.markdown
+++ b/website/docs/d/policy_set_definition.html.markdown
@@ -58,6 +58,8 @@ An `policy_definition_reference` block exports the following:
 
 -> **NOTE:** Since Terraform's concept of a map requires all of the elements to be of the same type, the value in parameters will all be converted to string type.
 
+~> **Note:** This field only supports String fields and is deprecated in favour of the `parameters_values` field
+
 * `parameter_values` - The parameter values for the referenced policy rule. This field is a json object.
 
 * `reference_id` - The unique ID within this policy set definition for this policy definition reference.

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -35,9 +35,11 @@ PARAMETERS
 
   policy_definition_reference {
     policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988"
-    parameters = {
-      listOfAllowedLocations = "[parameters('allowedLocations')]"
+    parameter_values     = <<VALUE
+    {
+      "listOfAllowedLocations": {"value": "[parameters('allowedLocations')]"}
     }
+    VALUE
   }
 }
 ```
@@ -62,7 +64,7 @@ The following arguments are supported:
 
 * `management_group_id` - (Optional / **Deprecated in favour of `management_group_name`**) The name of the Management Group where this policy set definition should be defined. Changing this forces a new resource to be created.
 
-~> **Note:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `name` or `group_id` attribute, but not `id`.
+~> **NOTE:** if you are using `azurerm_management_group` to assign a value to `management_group_id`, be sure to use `name` or `group_id` attribute, but not `id`.
 
 * `metadata` - (Optional) The metadata for the policy set definition. This is a json object representing additional metadata that should be stored with the policy definition.
 
@@ -74,7 +76,11 @@ A `policy_definition_reference` block supports the following:
 
 * `policy_definition_id` - (Required) The ID of the policy definition or policy set definition that will be included in this policy set definition.
 
-* `parameters` - (Required) A mapping of the parameter values for the referenced policy rule. The keys are the parameter names.
+* `parameters` - (Optional / **Deprecated in favour of `parameter_values`**) A mapping of the parameter values for the referenced policy rule. The keys are the parameter names.
+
+-> **NOTE:** Since Terraform's concept of a map requires all of the elements to be of the same type, you could only assign string value as the parameter values when you are using the `parameters` attribute. Please use `parameter_values` instead.
+
+* `parameter_values` - (Optional) Parameter values for the referenced policy rule. This field is a json object that allows you to assign parameters to this policy rule. 
 
 * `reference_id` - (Optional) A unique ID within this policy set definition for this policy definition reference.
 

--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -76,10 +76,6 @@ A `policy_definition_reference` block supports the following:
 
 * `policy_definition_id` - (Required) The ID of the policy definition or policy set definition that will be included in this policy set definition.
 
-* `parameters` - (Optional / **Deprecated in favour of `parameter_values`**) A mapping of the parameter values for the referenced policy rule. The keys are the parameter names.
-
--> **NOTE:** Since Terraform's concept of a map requires all of the elements to be of the same type, you could only assign string value as the parameter values when you are using the `parameters` attribute. Please use `parameter_values` instead.
-
 * `parameter_values` - (Optional) Parameter values for the referenced policy rule. This field is a json object that allows you to assign parameters to this policy rule. 
 
 * `reference_id` - (Optional) A unique ID within this policy set definition for this policy definition reference.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/8159