### PR TITLE
`azurerm_kubernetes_cluster_node_pool` - `node_count`, `min_node`, and `max_node` can now be set to `0`

### DIFF
--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -352,7 +352,7 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 			return fmt.Errorf("`min_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
 
-		if minCount > maxCount {
+		if minCount >= maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")
 		}
 	} else if minCount > 0 || maxCount > 0 {
@@ -493,7 +493,7 @@ func resourceArmKubernetesClusterNodePoolUpdate(d *schema.ResourceData, meta int
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
 
-		if minCount > maxCount {
+		if minCount >= maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")
 		}
 	} else {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -352,7 +352,7 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 			return fmt.Errorf("`min_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
 
-		if minCount < maxCount {
+		if minCount >= maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")
 		}
 	} else if minCount > 0 || maxCount > 0 {
@@ -493,7 +493,7 @@ func resourceArmKubernetesClusterNodePoolUpdate(d *schema.ResourceData, meta int
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
 
-		if minCount < maxCount {
+		if minCount >= maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")
 		}
 	} else {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -340,7 +340,7 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 			profile.Count = utils.Int32(int32(minCount))
 		}
 
-		if maxCount > 0 {
+		if maxCount >= 0 {
 			profile.MaxCount = utils.Int32(int32(maxCount))
 		} else {
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -352,7 +352,7 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 			return fmt.Errorf("`min_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
 
-		if minCount >= maxCount {
+		if minCount < maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")
 		}
 	} else if minCount > 0 || maxCount > 0 {
@@ -493,7 +493,7 @@ func resourceArmKubernetesClusterNodePoolUpdate(d *schema.ResourceData, meta int
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
 
-		if minCount >= maxCount {
+		if minCount < maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")
 		}
 	} else {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -346,7 +346,7 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
 
-		if minCount > 0 {
+		if minCount >= 0 {
 			profile.MinCount = utils.Int32(int32(minCount))
 		} else {
 			return fmt.Errorf("`min_count` must be configured when `enable_auto_scaling` is set to `true`")

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -102,10 +102,9 @@ func resourceArmKubernetesClusterNodePool() *schema.Resource {
 			},
 
 			"max_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				// NOTE: rather than setting `0` users should instead pass `null` here
-				ValidateFunc: validation.IntBetween(1, 100),
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 
 			"max_pods": {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -340,10 +340,8 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 			profile.Count = utils.Int32(int32(minCount))
 		}
 
-		if maxCount >= 0 && maxCount >= minCount {
+		if maxCount >= 0 {
 			profile.MaxCount = utils.Int32(int32(maxCount))
-		} else if maxCount < minCount {
-			return fmt.Errorf("`max_count` must be higher or equal to `min_count`")
 		} else {
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -340,8 +340,10 @@ func resourceArmKubernetesClusterNodePoolCreate(d *schema.ResourceData, meta int
 			profile.Count = utils.Int32(int32(minCount))
 		}
 
-		if maxCount >= 0 {
+		if maxCount >= 0 && maxCount >= minCount {
 			profile.MaxCount = utils.Int32(int32(maxCount))
+		} else if maxCount < minCount {
+			return fmt.Errorf("`max_count` must be higher or equal to `min_count`")
 		} else {
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -57,11 +57,10 @@ func resourceArmKubernetesClusterNodePool() *schema.Resource {
 			},
 
 			"node_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				// TODO: this can go to 0 after the next version of the Azure SDK
-				ValidateFunc: validation.IntBetween(1, 100),
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 
 			"tags": tags.Schema(),
@@ -130,7 +129,7 @@ func resourceArmKubernetesClusterNodePool() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				// NOTE: rather than setting `0` users should instead pass `null` here
-				ValidateFunc: validation.IntBetween(1, 100),
+				ValidateFunc: validation.IntBetween(0, 100),
 			},
 
 			"node_labels": {

--- a/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/azurerm/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -492,9 +492,6 @@ func resourceArmKubernetesClusterNodePoolUpdate(d *schema.ResourceData, meta int
 		if maxCount == 0 {
 			return fmt.Errorf("`max_count` must be configured when `enable_auto_scaling` is set to `true`")
 		}
-		if minCount == 0 {
-			return fmt.Errorf("`min_count` must be configured when `enable_auto_scaling` is set to `true`")
-		}
 
 		if minCount > maxCount {
 			return fmt.Errorf("`max_count` must be >= `min_count`")

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_node_pool_resource_test.go
@@ -1618,7 +1618,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "test" {
   enable_auto_scaling   = true
   min_count             = 0
   max_count             = 3
-  node_count			= 0
+  node_count            = 0
 }
 `, template)
 }

--- a/azurerm/internal/services/containers/tests/kubernetes_cluster_node_pool_resource_test.go
+++ b/azurerm/internal/services/containers/tests/kubernetes_cluster_node_pool_resource_test.go
@@ -39,6 +39,7 @@ var kubernetesNodePoolTests = map[string]func(t *testing.T){
 	"virtualNetworkManual":           testAccAzureRMKubernetesClusterNodePool_virtualNetworkManual,
 	"windows":                        testAccAzureRMKubernetesClusterNodePool_windows,
 	"windowsAndLinux":                testAccAzureRMKubernetesClusterNodePool_windowsAndLinux,
+	"zeroSize":                       testAccAzureRMKubernetesClusterNodePool_zeroSize,
 }
 
 func TestAccAzureRMKubernetesClusterNodePool_autoScale(t *testing.T) {
@@ -113,7 +114,7 @@ func testAccAzureRMKubernetesClusterNodePool_autoScaleUpdate(t *testing.T) {
 			},
 			data.ImportStep(),
 			{
-				Config: testAccAzureRMKubernetesClusterNodePool_autoScaleNodeCountConfig(data, 1, 3),
+				Config: testAccAzureRMKubernetesClusterNodePool_autoScaleNodeCountConfig(data, 0, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMKubernetesNodePoolExists(data.ResourceName),
 				),
@@ -725,6 +726,30 @@ func testAccAzureRMKubernetesClusterNodePool_windowsAndLinux(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+		},
+	})
+}
+
+func TestAccAzureRMKubernetesClusterNodePool_zeroSize(t *testing.T) {
+	checkIfShouldRunTestsIndividually(t)
+	testAccAzureRMKubernetesClusterNodePool_zeroSize(t)
+}
+
+func testAccAzureRMKubernetesClusterNodePool_zeroSize(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acceptance.PreCheck(t) },
+		Providers:    acceptance.SupportedProviders,
+		CheckDestroy: testCheckAzureRMKubernetesClusterNodePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMKubernetesClusterNodePool_zeroSizeConfig(data),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMKubernetesNodePoolExists(data.ResourceName),
+				),
+			},
+			data.ImportStep(),
 		},
 	})
 }
@@ -1575,4 +1600,25 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func testAccAzureRMKubernetesClusterNodePool_zeroSizeConfig(data acceptance.TestData) string {
+	template := testAccAzureRMKubernetesClusterNodePool_templateConfig(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_kubernetes_cluster_node_pool" "test" {
+  name                  = "internal"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.test.id
+  vm_size               = "Standard_DS2_v2"
+  enable_auto_scaling   = true
+  min_count             = 0
+  max_count             = 3
+  node_count			= 0
+}
+`, template)
 }

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -131,7 +131,7 @@ If `enable_auto_scaling` is set to `true`, then the following fields can also be
 
 If `enable_auto_scaling` is set to `false`, then the following fields can also be configured:
 
-* `node_count` - (Required) The number of nodes which should exist within this Node Pool. Valid values are between `1` and `100`.
+* `node_count` - (Required) The number of nodes which should exist within this Node Pool. Valid values are between `0` and `100`.
 
 ## Attributes Reference
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -121,11 +121,11 @@ The following arguments are supported:
 
 If `enable_auto_scaling` is set to `true`, then the following fields can also be configured:
 
-* `max_count` - (Required) The maximum number of nodes which should exist within this Node Pool. Valid values are between `1` and `100` and must be greater than or equal to `min_count`.
+* `max_count` - (Required) The maximum number of nodes which should exist within this Node Pool. Valid values are between `0` and `100` and must be greater than or equal to `min_count`.
 
-* `min_count` - (Required) The minimum number of nodes which should exist within this Node Pool. Valid values are between `1` and `100` and must be less than or equal to `max_count`.
+* `min_count` - (Required) The minimum number of nodes which should exist within this Node Pool. Valid values are between `0` and `100` and must be less than or equal to `max_count`.
 
-* `node_count` - (Optional) The initial number of nodes which should exist within this Node Pool. Valid values are between `1` and `100` and must be a value in the range `min_count` - `max_count`.
+* `node_count` - (Optional) The initial number of nodes which should exist within this Node Pool. Valid values are between `0` and `100` and must be a value in the range `min_count` - `max_count`.
 
 -> **NOTE:** If you're specifying an initial number of nodes you may wish to use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/configuration/resources.html#ignore_changes) to ignore changes to this field.
 


### PR DESCRIPTION
This updates the validation rules for the new Azure SDK where you can create zero size nodepools

#8219 

If there's anything else i should do, let me know, first PR. I tested it locally by using it.